### PR TITLE
Revert PUID/GUID and use `user` property in docker-compose

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,8 +24,7 @@ RUN apk add --upgrade \
         mariadb-connector-c \
         netcat-openbsd \
         python3 \
-        tzdata \
-        shadow
+        tzdata
 
 # Install additional build dependencies
 RUN apk add --upgrade \
@@ -158,11 +157,11 @@ COPY --from=production-stage / /
 # User permissions
 RUN addgroup -g 1000 -S romm && adduser -u 1000 -D -S -G romm romm
 
-# Create root folder and set permissions
-RUN mkdir /romm && chown romm:romm /romm
+# Create the directories and set ownership and permissions
+RUN mkdir /romm /redis-data && \
+    chown romm:romm /romm /redis-data && \
+    chmod 777 /romm /redis-data
 
-# Create data volume for redis and set permissions
-RUN mkdir /redis-data && chown romm:romm /redis-data
 VOLUME /redis-data
 
 # Set user to run as

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -157,11 +157,16 @@ COPY --from=production-stage / /
 
 # User permissions
 RUN addgroup -g 1000 -S romm && adduser -u 1000 -D -S -G romm romm
+
+# Create root folder and set permissions
 RUN mkdir /romm && chown romm:romm /romm
 
 # Create data volume for redis and set permissions
 RUN mkdir /redis-data && chown romm:romm /redis-data
 VOLUME /redis-data
+
+# Set user to run as
+USER romm
 
 # Expose ports and start
 EXPOSE 8080

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -101,21 +101,6 @@ watchdog_process_pid () {
     fi
 }
 
-# Update the user/group IDs per environment variables
-if [ ! -z "${PUID:-}" ] && [ "${PUID:-}" != "$(id -u romm)" ]; then
-    usermod -o -u "$PUID" romm
-fi
-if [ ! -z "${PGID:-}" ] && [ "${PGID:-}" != "$(id -g romm)" ]; then
-    groupmod -o -g "$PGID" romm
-fi
-if [ ! -z "${UMASK:-}" ] && [ "${UMASK:-}" != "$(umask)" ]; then
-    umask "$UMASK"
-fi
-
-echo "Setting permissions and ownership for required directories..."
-chown -R romm:romm /romm /redis-data /backend
-chmod -R 755 /romm /redis-data /backend
-
 # switch to backend directory
 cd /backend || { error_log "/backend directory doesn't seem to exist"; }
 

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -102,13 +102,13 @@ watchdog_process_pid () {
 }
 
 # Update the user/group IDs per environment variables
-if [ ! -z "$PUID" ] && [ "$PUID" != "$(id -u romm)" ]; then
+if [ ! -z "${PUID:-}" ] && [ "${PUID:-}" != "$(id -u romm)" ]; then
     usermod -o -u "$PUID" romm
 fi
-if [ ! -z "$PGID" ] && [ "$PGID" != "$(id -g romm)" ]; then
+if [ ! -z "${PGID:-}" ] && [ "${PGID:-}" != "$(id -g romm)" ]; then
     groupmod -o -g "$PGID" romm
 fi
-if [ ! -z "$UMASK" ] && [ "$UMASK" != "$(umask)" ]; then
+if [ ! -z "${UMASK:-}" ] && [ "${UMASK:-}" != "$(umask)" ]; then
     umask "$UMASK"
 fi
 


### PR DESCRIPTION
Instead of PUID/GUID, run the image as the `romm` user and use `user: "XXXX:XXXX"` in docker-compose/`docker run` to set the owner of newly created file/folders and mounted volumes.