### PR TITLE
v3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Changed
  - Added scrolling to scan logs
  - Disabled amiga emulator until bios support added
+ - Updated [docker-compose.example.yml file](https://github.com/rommapp/romm/blob/3.0.1/examples/docker-compose.example.yml) to match new dockerhub ``rommapp`` organization
 
 ## Fixed
  - Normalized IGDB search for better results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v3.0.1 (_13-03-2024_)
+# v3.0.2 (_13-03-2024_)
 
 > [!WARNING]  
 > RomM has been organized in ``github`` and ``dockerhub``! New images will be upload to ``rommapp/romm`` repository on dockerhub and ghcr.


### PR DESCRIPTION
Hotfix for ``PUID/GUID`` environment variables. Those are removed and not used anymore, instead using the ``user: "XXXX:XXXX"`` entry in docker-compose.