### PR TITLE
Added more configuration for external redis

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -29,6 +29,8 @@ DB_NAME: Final = os.environ.get("DB_NAME", "romm")
 REDIS_HOST: Final = os.environ.get("REDIS_HOST", "127.0.0.1")
 REDIS_PORT: Final = os.environ.get("REDIS_PORT", 6379)
 REDIS_PASSWORD: Final = os.environ.get("REDIS_PASSWORD")
+REDIS_USERNAME: Final = os.environ.get("REDIS_USERNAME", "")
+REDIS_DB: Final = int(os.environ.get("REDIS_DB", 0))
 
 # IGDB
 IGDB_CLIENT_ID: Final = os.environ.get(

--- a/backend/handler/redis_handler.py
+++ b/backend/handler/redis_handler.py
@@ -1,7 +1,7 @@
 import sys
 from enum import Enum
 
-from config import REDIS_HOST, REDIS_PORT, REDIS_PASSWORD
+from config import REDIS_HOST, REDIS_PORT, REDIS_PASSWORD, REDIS_USERNAME, REDIS_DB
 from logger.logger import log
 from redis import Redis
 from fakeredis import FakeStrictRedis
@@ -14,8 +14,8 @@ class QueuePrio(Enum):
     LOW = "low"
 
 
-redis_client = Redis(host=REDIS_HOST, port=REDIS_PORT, password=REDIS_PASSWORD, db=0)
-redis_url = f"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}" if REDIS_PASSWORD else f"redis://{REDIS_HOST}:{REDIS_PORT}"
+redis_client = Redis(host=REDIS_HOST, port=REDIS_PORT, password=REDIS_PASSWORD, username=REDIS_USERNAME, db=REDIS_DB)
+redis_url = f"redis://{REDIS_USERNAME}:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}" if REDIS_PASSWORD else f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}"
 
 high_prio_queue = Queue(name=QueuePrio.HIGH.value, connection=redis_client)
 default_queue = Queue(name=QueuePrio.DEFAULT.value, connection=redis_client)
@@ -30,7 +30,8 @@ else:
         host=REDIS_HOST,
         port=REDIS_PORT,
         password=REDIS_PASSWORD,
-        db=0,
+        username=REDIS_USERNAME,
+        db=REDIS_DB,
         decode_responses=True,
     )
     log.info(f"Redis connection established in {sys.argv[0]}!")

--- a/unraid_template/romm.xml
+++ b/unraid_template/romm.xml
@@ -39,7 +39,9 @@
    <Config Name="DB_PASSWD" Target="DB_PASSWD" Default="" Mode="" Description="Database password for DB_USER" Type="Variable" Display="advanced" Required="true" Mask="true"/>
    <Config Name="REDIS_HOST" Target="REDIS_HOST" Default="127.0.0.1" Mode="" Description="Redis host" Type="Variable" Display="advanced" Required="false" Mask="false"/>
    <Config Name="REDIS_PORT" Target="REDIS_PORT" Default="6379" Mode="" Description="Redis port" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-   <Config Name="REDIS_PASSWORD" Target="REDIS_PASSWORD" Default="" Mode="" Description="Redis password" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+   <Config Name="REDIS_PASSWORD" Target="REDIS_PASSWORD" Default="" Mode="" Description="Redis password" Type="Variable" Display="advanced" Required="false" Mask="true"/>
+   <Config Name="REDIS_USERNAME" Target="REDIS_USERNAME" Default="" Mode="" Description="Redis username" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+   <Config Name="REDIS_DB" Target="REDIS_DB" Default="0" Mode="" Description="Redis database" Type="Variable" Display="advanced" Required="false" Mask="false"/>
    <Config Name="ROMM_AUTH_USERNAME" Target="ROMM_AUTH_USERNAME" Default="admin" Mode="" Description="Default admin username" Type="Variable" Display="advanced" Required="false" Mask="false"/>
    <Config Name="ROMM_AUTH_PASSWORD" Target="ROMM_AUTH_PASSWORD" Default="" Mode="" Description="Default admin password" Type="Variable" Display="advanced" Required="false" Mask="true"/>
    <Config Name="ROMM_AUTH_SECRET_KEY" Target="ROMM_AUTH_SECRET_KEY" Default="" Mode="" Description="Generate a key with `openssl rand -hex 32`" Type="Variable" Display="advanced" Required="false" Mask="true"/>


### PR DESCRIPTION
This PR adds more configuration for the external redis instance.
adds two new env vars:

`REDIS_USERNAME`: allows to specify username when using password (requirepass arg for redis creates "default" user)

`REDIS_DB`: helps separating databases when using single redis shared between multiple apps
