### PR TITLE
Remove stale call to update_mame_xml_task in backend run_tasks, since the mame xml update task doesn't exist

### DIFF
--- a/backend/endpoints/tasks.py
+++ b/backend/endpoints/tasks.py
@@ -16,7 +16,6 @@ async def run_tasks(request: Request) -> MessageResponse:
         RunTasksResponse: Standard message response
     """
 
-    await update_mame_xml_task.run()
     await update_switch_titledb_task.run()
     return {"msg": "All tasks ran successfully!"}
 


### PR DESCRIPTION
### Description
It's currently not possible to use the Run All button in Settings -> Control Panel because it's trying to run a task to fetch mame xml, which isn't a task defined anywhere in the codebase.

### Related Issues
<sup>List any related issues that are addressed or fixed by this pull request.</sup>

### Checklist
Please check all that apply.

- [ ] I've tested the changes locally
- [ ] I've updated the wiki accordingly
- [ ] I've have updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
- [ ] All existing tests are passing

### Additional Notes
<sup>Add any additional information or context about the pull request here.</sup>
```
