### PR TITLE
[ROMM-852] Purge platforms correctly on scan

### DIFF
--- a/backend/handler/database/platforms_handler.py
+++ b/backend/handler/database/platforms_handler.py
@@ -55,12 +55,5 @@ class DBPlatformsHandler(DBBaseHandler):
         return session.execute(
             delete(Platform)
             .where(or_(Platform.fs_slug.not_in(fs_platforms), Platform.slug.is_(None)))
-            .where(
-                select(func.count())
-                .select_from(Rom)
-                .filter_by(platform_id=Platform.id)
-                .as_scalar()
-                == 0
-            )
             .execution_options(synchronize_session="fetch")
         )


### PR DESCRIPTION
If the entire folder gets removed from the filesystem, we should just purge the entire platform.