### PR TITLE
fix: Improve Docker layer caching on frontend changes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,12 @@
 # Build frontend
 FROM node:lts-alpine as front-build-stage
 WORKDIR /front
+
+COPY ./frontend/package*.json ./
+RUN npm ci
+
 COPY ./frontend ./
-RUN npm install && npm run build
+RUN npm run build
 
 # Setup frontend and backend
 FROM nginx:1.27.0-alpine3.19-slim as production-stage


### PR DESCRIPTION
Avoid any changes in the `frontend/` folder to trigger `npm install`. Instead, split the copies to have separate steps for install and build.