### PR TITLE
misc: Remove mentions to unneeded Poetry fork

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install poetry
         run: |
-          pipx install git+https://github.com/radoering/poetry.git@non-package-mode
+          pipx install poetry
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v4

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,19 +10,19 @@
 		{
 			"label": "Launch backend",
 			"type": "shell",
-			"command": "cd backend && poetry_npm run python3 main.py",
+			"command": "cd backend && poetry run python3 main.py",
 			"problemMatcher": []
 		},
 		{
 			"label": "Launch worker",
 			"type": "shell",
-			"command": "cd backend && poetry_npm run python3 worker.py",
+			"command": "cd backend && poetry run python3 worker.py",
 			"problemMatcher": []
 		},
 		{
 			"label": "Execute tests",
 			"type": "shell",
-			"command": "cd backend && poetry_npm run pytest -vv -c ../pytest.ini",
+			"command": "cd backend && poetry run pytest -vv -c ../pytest.ini",
 			"problemMatcher": []
 		},
 		{

--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -34,20 +34,16 @@ You'll need poetry installed
 
 https://python-poetry.org/docs/#installing-with-the-official-installer
 
-**_WARNING:_** Until poetry 1.8.0 version is released, poetry needs to be installed with the new non-package-mode feature branch:
-
 ```sh
-pipx install --suffix _npm git+https://github.com/radoering/poetry.git@non-package-mode
+pipx install poetry
 ```
-
-More info: https://github.com/python-poetry/poetry/pull/8650
 
 Then create the virtual environment
 
 ```sh
-# Fix disable parallel installation stuck: $> poetry_npm config experimental.new-installer false
+# Fix disable parallel installation stuck: $> poetry config experimental.new-installer false
 # Fix Loading macOS/linux stuck: $> export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
-poetry_npm install --sync
+poetry install --sync
 ```
 
 ### - Spin up mariadb in docker
@@ -62,14 +58,14 @@ docker-compose up -d
 
 ```sh
 cd backend
-poetry_npm run python3 main.py
+poetry run python3 main.py
 ```
 
 ### - Start a worker
 
 ```sh
 cd backend
-poetry_npm run python3 worker.py
+poetry run python3 worker.py
 ```
 
 ## Setting up the frontend
@@ -130,5 +126,5 @@ docker exec -i mariadb mariadb -u root -p<root password> < backend/romm_test/set
 ```sh
 cd backend
 # path or test file can be passed as argument to test only a subset
-poetry_npm run pytest [path/file]
+poetry run pytest [path/file]
 ```

--- a/backend/utils/generate_supported_platforms.py
+++ b/backend/utils/generate_supported_platforms.py
@@ -1,4 +1,4 @@
-# poetry_npm run python3 -m utils.generate_supported_platforms
+# poetry run python3 -m utils.generate_supported_platforms
 from typing import TypedDict
 
 from handler.metadata.igdb_handler import IGDB_PLATFORM_LIST


### PR DESCRIPTION
Poetry 1.8.0 already includes support for `package-mode = false`, so there's no need to install a Poetry fork anymore.