### PR TITLE
misc: Use Python future annotations

### DIFF
--- a/backend/alembic/versions/0020_created_and_updated.py
+++ b/backend/alembic/versions/0020_created_and_updated.py
@@ -8,7 +8,6 @@ Create Date: 2024-06-27 12:08:13.886766
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
 revision = "0020_created_and_updated"

--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from datetime import datetime
 from typing import NotRequired, get_type_hints
@@ -39,7 +41,7 @@ class RomNoteSchema(BaseModel):
         from_attributes = True
 
     @classmethod
-    def for_user(cls, db_rom: Rom, user_id: int) -> list["RomNoteSchema"]:
+    def for_user(cls, db_rom: Rom, user_id: int) -> list[RomNoteSchema]:
         return [
             cls.model_validate(n)
             for n in db_rom.notes
@@ -115,16 +117,14 @@ class RomSchema(BaseModel):
 
 class DetailedRomSchema(RomSchema):
     merged_screenshots: list[str]
-    sibling_roms: list["RomSchema"] = Field(default_factory=list)
+    sibling_roms: list[RomSchema] = Field(default_factory=list)
     user_saves: list[SaveSchema] = Field(default_factory=list)
     user_states: list[StateSchema] = Field(default_factory=list)
     user_screenshots: list[ScreenshotSchema] = Field(default_factory=list)
     user_notes: list[RomNoteSchema] = Field(default_factory=list)
 
     @classmethod
-    def from_orm_with_request(
-        cls, db_rom: Rom, request: Request
-    ) -> "DetailedRomSchema":
+    def from_orm_with_request(cls, db_rom: Rom, request: Request) -> DetailedRomSchema:
         rom = cls.model_validate(db_rom)
         user_id = request.user.id
 

--- a/backend/models/assets.py
+++ b/backend/models/assets.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from functools import cached_property
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from models.base import BaseModel
 from sqlalchemy import BigInteger, ForeignKey, String
@@ -43,11 +45,11 @@ class Save(RomAsset):
 
     emulator: Mapped[str | None] = mapped_column(String(length=50))
 
-    rom: Mapped["Rom"] = relationship(lazy="joined", back_populates="saves")
-    user: Mapped["User"] = relationship(lazy="joined", back_populates="saves")
+    rom: Mapped[Rom] = relationship(lazy="joined", back_populates="saves")
+    user: Mapped[User] = relationship(lazy="joined", back_populates="saves")
 
     @cached_property
-    def screenshot(self) -> Optional["Screenshot"]:
+    def screenshot(self) -> Screenshot | None:
         from handler.database import db_rom_handler
 
         db_rom = db_rom_handler.get_roms(self.rom_id)
@@ -64,11 +66,11 @@ class State(RomAsset):
 
     emulator: Mapped[str | None] = mapped_column(String(length=50))
 
-    rom: Mapped["Rom"] = relationship(lazy="joined", back_populates="states")
-    user: Mapped["User"] = relationship(lazy="joined", back_populates="states")
+    rom: Mapped[Rom] = relationship(lazy="joined", back_populates="states")
+    user: Mapped[User] = relationship(lazy="joined", back_populates="states")
 
     @cached_property
-    def screenshot(self) -> Optional["Screenshot"]:
+    def screenshot(self) -> Screenshot | None:
         from handler.database import db_rom_handler
 
         db_rom = db_rom_handler.get_roms(self.rom_id)
@@ -83,5 +85,5 @@ class Screenshot(RomAsset):
     __tablename__ = "screenshots"
     __table_args__ = {"extend_existing": True}
 
-    rom: Mapped["Rom"] = relationship(lazy="joined", back_populates="screenshots")
-    user: Mapped["User"] = relationship(lazy="joined", back_populates="screenshots")
+    rom: Mapped[Rom] = relationship(lazy="joined", back_populates="screenshots")
+    user: Mapped[User] = relationship(lazy="joined", back_populates="screenshots")

--- a/backend/models/firmware.py
+++ b/backend/models/firmware.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 from functools import cached_property
@@ -37,9 +39,7 @@ class Firmware(BaseModel):
     md5_hash: Mapped[str] = mapped_column(String(length=100))
     sha1_hash: Mapped[str] = mapped_column(String(length=100))
 
-    platform: Mapped["Platform"] = relationship(
-        lazy="joined", back_populates="firmware"
-    )
+    platform: Mapped[Platform] = relationship(lazy="joined", back_populates="firmware")
 
     @property
     def platform_slug(self) -> str:

--- a/backend/models/platform.py
+++ b/backend/models/platform.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from models.base import BaseModel
@@ -21,8 +23,8 @@ class Platform(BaseModel):
     name: Mapped[str | None] = mapped_column(String(length=400))
     logo_path: Mapped[str | None] = mapped_column(String(length=1000), default="")
 
-    roms: Mapped[list["Rom"]] = relationship(back_populates="platform")
-    firmware: Mapped[list["Firmware"]] = relationship(
+    roms: Mapped[list[Rom]] = relationship(back_populates="platform")
+    firmware: Mapped[list[Firmware]] = relationship(
         lazy="selectin", back_populates="platform"
     )
 

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
@@ -75,12 +77,12 @@ class Rom(BaseModel):
         ForeignKey("platforms.id", ondelete="CASCADE")
     )
 
-    platform: Mapped["Platform"] = relationship(lazy="immediate")
+    platform: Mapped[Platform] = relationship(lazy="immediate")
 
-    saves: Mapped[list["Save"]] = relationship(back_populates="rom")
-    states: Mapped[list["State"]] = relationship(back_populates="rom")
-    screenshots: Mapped[list["Screenshot"]] = relationship(back_populates="rom")
-    notes: Mapped[list["RomNote"]] = relationship(back_populates="rom")
+    saves: Mapped[list[Save]] = relationship(back_populates="rom")
+    states: Mapped[list[State]] = relationship(back_populates="rom")
+    screenshots: Mapped[list[Screenshot]] = relationship(back_populates="rom")
+    notes: Mapped[list[RomNote]] = relationship(back_populates="rom")
 
     @property
     def platform_slug(self) -> str:
@@ -109,7 +111,7 @@ class Rom(BaseModel):
         ]
 
     # This is an expensive operation so don't call it on a list of roms
-    def get_sibling_roms(self) -> list["Rom"]:
+    def get_sibling_roms(self) -> list[Rom]:
         from handler.database import db_rom_handler
 
         with db_rom_handler.session.begin() as session:
@@ -195,8 +197,8 @@ class RomNote(BaseModel):
     rom_id: Mapped[int] = mapped_column(ForeignKey("roms.id", ondelete="CASCADE"))
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
 
-    rom: Mapped["Rom"] = relationship(lazy="joined", back_populates="notes")
-    user: Mapped["User"] = relationship(lazy="joined", back_populates="notes")
+    rom: Mapped[Rom] = relationship(lazy="joined", back_populates="notes")
+    user: Mapped[User] = relationship(lazy="joined", back_populates="notes")
 
     @property
     def user__username(self) -> str:

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -34,10 +36,10 @@ class User(BaseModel, SimpleUser):
     last_login: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     last_active: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
-    saves: Mapped[list["Save"]] = relationship(back_populates="user")
-    states: Mapped[list["State"]] = relationship(back_populates="user")
-    screenshots: Mapped[list["Screenshot"]] = relationship(back_populates="user")
-    notes: Mapped[list["RomNote"]] = relationship(back_populates="user")
+    saves: Mapped[list[Save]] = relationship(back_populates="user")
+    states: Mapped[list[State]] = relationship(back_populates="user")
+    screenshots: Mapped[list[Screenshot]] = relationship(back_populates="user")
+    notes: Mapped[list[RomNote]] = relationship(back_populates="user")
 
     @property
     def oauth_scopes(self):

--- a/backend/utils/iterators.py
+++ b/backend/utils/iterators.py
@@ -3,9 +3,9 @@ import sys
 if sys.version_info >= (3, 12):
     from itertools import batched  # noqa: F401
 else:
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
     from itertools import islice
-    from typing import Iterable, TypeVar
+    from typing import TypeVar
 
     T = TypeVar("T")
 


### PR DESCRIPTION
Simplify annotations by using `__future__.annotations`, so there's no need to add typing using types as strings.