### PR TITLE
misc: Split database handler logic to get/list entities

### DIFF
--- a/backend/endpoints/firmware.py
+++ b/backend/endpoints/firmware.py
@@ -32,7 +32,7 @@ def add_firmware(
         AddFirmwareResponse: Standard message response
     """
 
-    db_platform = db_platform_handler.get_platforms(platform_id)
+    db_platform = db_platform_handler.get_platform(platform_id)
     log.info(f"Uploading firmware to {db_platform.fs_slug}")
     if files is None:
         log.error("No files were uploaded")
@@ -67,7 +67,7 @@ def add_firmware(
         db_firmware_handler.add_firmware(scanned_firmware)
         uploaded_firmware.append(scanned_firmware)
 
-    db_platform = db_platform_handler.get_platforms(platform_id)
+    db_platform = db_platform_handler.get_platform(platform_id)
 
     return {
         "uploaded": len(files),
@@ -88,7 +88,7 @@ def get_platform_firmware(
     Returns:
         list[FirmwareSchema]: Firmware stored in the database
     """
-    return db_firmware_handler.get_firmware(platform_id=platform_id)
+    return db_firmware_handler.list_firmware(platform_id=platform_id)
 
 
 @protected_route(

--- a/backend/endpoints/platform.py
+++ b/backend/endpoints/platform.py
@@ -100,7 +100,7 @@ def get_platform(request: Request, id: int) -> PlatformSchema:
         PlatformSchema: Platform
     """
 
-    return db_platform_handler.get_platforms(id)
+    return db_platform_handler.get_platform(id)
 
 
 @protected_route(router.put, "/platforms/{id}", ["platforms.write"])
@@ -134,9 +134,9 @@ async def delete_platforms(request: Request, id: int) -> MessageResponse:
         MessageResponse: Standard message response
     """
 
-    platform = db_platform_handler.get_platforms(id)
+    platform = db_platform_handler.get_platform(id)
     if not platform:
-        error = f"Platform {platform.name} - [{platform.fs_slug}] not found"
+        error = f"Platform id {id} not found"
         log.error(error)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=error)
 

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -51,7 +51,7 @@ def add_roms(
         AddRomsResponse: Standard message response
     """
 
-    platform_fs_slug = db_platform_handler.get_platforms(platform_id).fs_slug
+    platform_fs_slug = db_platform_handler.get_platform(platform_id).fs_slug
     log.info(f"Uploading roms to {platform_fs_slug}")
     if roms is None:
         log.error("No roms were uploaded")
@@ -134,7 +134,7 @@ def get_rom(request: Request, id: int) -> DetailedRomSchema:
     Returns:
         DetailedRomSchema: Rom stored in the database
     """
-    return DetailedRomSchema.from_orm_with_request(db_rom_handler.get_roms(id), request)
+    return DetailedRomSchema.from_orm_with_request(db_rom_handler.get_rom(id), request)
 
 
 @protected_route(
@@ -154,7 +154,7 @@ def head_rom_content(request: Request, id: int, file_name: str):
         FileResponse: Returns the response with headers
     """
 
-    rom = db_rom_handler.get_roms(id)
+    rom = db_rom_handler.get_rom(id)
     rom_path = f"{LIBRARY_BASE_PATH}/{rom.full_path}"
 
     return FileResponse(
@@ -189,7 +189,7 @@ def get_rom_content(
         CustomStreamingResponse: Streams a file for multi-part roms
     """
 
-    rom = db_rom_handler.get_roms(id)
+    rom = db_rom_handler.get_rom(id)
     rom_path = f"{LIBRARY_BASE_PATH}/{rom.full_path}"
     files_to_download = files or rom.files
 
@@ -273,7 +273,7 @@ async def update_rom(
 
     data = await request.form()
 
-    db_rom = db_rom_handler.get_roms(id)
+    db_rom = db_rom_handler.get_rom(id)
 
     cleaned_data = {}
     cleaned_data["igdb_id"] = data.get("igdb_id", None)
@@ -372,7 +372,7 @@ async def update_rom(
 
     db_rom_handler.update_rom(id, cleaned_data)
 
-    return DetailedRomSchema.from_orm_with_request(db_rom_handler.get_roms(id), request)
+    return DetailedRomSchema.from_orm_with_request(db_rom_handler.get_rom(id), request)
 
 
 @protected_route(router.post, "/roms/delete", ["roms.write"])
@@ -397,7 +397,7 @@ async def delete_roms(
     delete_from_fs: list = data["delete_from_fs"]
 
     for id in roms_ids:
-        rom = db_rom_handler.get_roms(id)
+        rom = db_rom_handler.get_rom(id)
         if not rom:
             error = f"Rom with id {id} not found"
             log.error(error)

--- a/backend/endpoints/saves.py
+++ b/backend/endpoints/saves.py
@@ -17,7 +17,7 @@ def add_saves(
     saves: list[UploadFile] = File(...),  # noqa: B008
     emulator: str | None = None,
 ) -> UploadedSavesResponse:
-    rom = db_rom_handler.get_roms(rom_id)
+    rom = db_rom_handler.get_rom(rom_id)
     current_user = request.user
     log.info(f"Uploading saves to {rom.name}")
 
@@ -56,7 +56,7 @@ def add_saves(
         scanned_save.emulator = emulator
         db_save_handler.add_save(scanned_save)
 
-    rom = db_rom_handler.get_roms(rom_id)
+    rom = db_rom_handler.get_rom(rom_id)
     return {
         "uploaded": len(saves),
         "saves": [s for s in rom.saves if s.user_id == current_user.id],

--- a/backend/endpoints/screenshots.py
+++ b/backend/endpoints/screenshots.py
@@ -15,7 +15,7 @@ def add_screenshots(
     rom_id: int,
     screenshots: list[UploadFile] = File(...),  # noqa: B008
 ) -> UploadedScreenshotsResponse:
-    rom = db_rom_handler.get_roms(rom_id)
+    rom = db_rom_handler.get_rom(rom_id)
     current_user = request.user
     log.info(f"Uploading screenshots to {rom.name}")
 
@@ -53,7 +53,7 @@ def add_screenshots(
         scanned_screenshot.user_id = current_user.id
         db_screenshot_handler.add_screenshot(scanned_screenshot)
 
-    rom = db_rom_handler.get_roms(rom_id)
+    rom = db_rom_handler.get_rom(rom_id)
     return {
         "uploaded": len(screenshots),
         "screenshots": [s for s in rom.screenshots if s.user_id == current_user.id],

--- a/backend/endpoints/search.py
+++ b/backend/endpoints/search.py
@@ -40,7 +40,7 @@ async def search_rom(
             detail="No metadata providers enabled",
         )
 
-    rom = db_rom_handler.get_roms(rom_id)
+    rom = db_rom_handler.get_rom(rom_id)
     if not rom:
         return []
 

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -118,7 +118,7 @@ async def scan_platforms(
 
     try:
         platform_list = [
-            db_platform_handler.get_platforms(s).fs_slug for s in platform_ids
+            db_platform_handler.get_platform(s).fs_slug for s in platform_ids
         ] or fs_platforms
 
         if len(platform_list) == 0:

--- a/backend/endpoints/states.py
+++ b/backend/endpoints/states.py
@@ -17,7 +17,7 @@ def add_states(
     states: list[UploadFile] = File(...),  # noqa: B008
     emulator: str | None = None,
 ) -> UploadedStatesResponse:
-    rom = db_rom_handler.get_roms(rom_id)
+    rom = db_rom_handler.get_rom(rom_id)
     current_user = request.user
     log.info(f"Uploading states to {rom.name}")
 
@@ -56,7 +56,7 @@ def add_states(
         scanned_state.emulator = emulator
         db_state_handler.add_state(scanned_state)
 
-    rom = db_rom_handler.get_roms(rom_id)
+    rom = db_rom_handler.get_rom(rom_id)
     return {
         "uploaded": len(states),
         "states": [s for s in rom.states if s.user_id == current_user.id],

--- a/backend/handler/database/firmware_handler.py
+++ b/backend/handler/database/firmware_handler.py
@@ -14,19 +14,24 @@ class DBFirmwareHandler(DBBaseHandler):
     @begin_session
     def get_firmware(
         self,
-        id: int | None = None,
+        id: int,
+        *,
+        session: Session = None,
+    ) -> Firmware | None:
+        return session.scalar(select(Firmware).filter_by(id=id).limit(1))
+
+    @begin_session
+    def list_firmware(
+        self,
+        *,
         platform_id: int | None = None,
         session: Session = None,
-    ) -> Firmware | list[Firmware] | None:
-        return (
-            session.scalar(select(Firmware).filter_by(id=id).limit(1))
-            if id
-            else session.scalars(
-                select(Firmware)
-                .filter_by(platform_id=platform_id)
-                .order_by(Firmware.file_name.asc())
-            ).all()
-        )
+    ) -> list[Firmware]:
+        return session.scalars(
+            select(Firmware)
+            .filter_by(platform_id=platform_id)
+            .order_by(Firmware.file_name.asc())
+        ).all()
 
     @begin_session
     def get_firmware_by_filename(

--- a/backend/handler/database/platforms_handler.py
+++ b/backend/handler/database/platforms_handler.py
@@ -3,7 +3,7 @@ import functools
 from decorators.database import begin_session
 from models.platform import Platform
 from models.rom import Rom
-from sqlalchemy import delete, or_, select
+from sqlalchemy import Select, delete, or_, select
 from sqlalchemy.orm import Query, Session, selectinload
 
 from .base_handler import DBBaseHandler
@@ -37,17 +37,17 @@ class DBPlatformsHandler(DBBaseHandler):
 
     @begin_session
     @with_roms
-    def get_platforms(
-        self, id: int | None = None, query: Query = None, session: Session = None
-    ) -> list[Platform] | Platform | None:
+    def get_platform(
+        self, id: int, *, query: Query = None, session: Session = None
+    ) -> Platform | None:
+        return session.scalar(query.filter_by(id=id).limit(1))
+
+    @begin_session
+    def get_platforms(self, *, session: Session = None) -> Select[tuple[Platform]]:
         return (
-            session.scalar(query.filter_by(id=id).limit(1))
-            if id
-            else (
-                session.scalars(select(Platform).order_by(Platform.name.asc()))  # type: ignore[attr-defined]
-                .unique()
-                .all()
-            )
+            session.scalars(select(Platform).order_by(Platform.name.asc()))  # type: ignore[attr-defined]
+            .unique()
+            .all()
         )
 
     @begin_session

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -2,7 +2,7 @@ import functools
 
 from decorators.database import begin_session
 from models.rom import Rom, RomNote
-from sqlalchemy import and_, delete, func, or_, select, update
+from sqlalchemy import Select, and_, delete, func, or_, select, update
 from sqlalchemy.orm import Query, Session, selectinload
 
 from .base_handler import DBBaseHandler
@@ -62,24 +62,23 @@ class DBRomsHandler(DBBaseHandler):
 
     @begin_session
     @with_assets
+    def get_rom(
+        self, id: int, *, query: Query = None, session: Session = None
+    ) -> Rom | None:
+        return session.scalar(query.filter_by(id=id).limit(1))
+
     def get_roms(
         self,
-        id: int | None = None,
+        *,
         platform_id: int | None = None,
         search_term: str = "",
         order_by: str = "name",
         order_dir: str = "asc",
-        query: Query = None,
-        session: Session = None,
-    ) -> list[Rom] | Rom | None:
-        return (
-            session.scalar(query.filter_by(id=id).limit(1))
-            if id
-            else self._order(
-                self._filter(select(Rom), platform_id, search_term),
-                order_by,
-                order_dir,
-            )
+    ) -> Select[tuple[Rom]]:
+        return self._order(
+            self._filter(select(Rom), platform_id, search_term),
+            order_by,
+            order_dir,
         )
 
     @begin_session

--- a/backend/handler/tests/test_db_handler.py
+++ b/backend/handler/tests/test_db_handler.py
@@ -50,11 +50,13 @@ def test_roms(rom: Rom, platform: Platform):
         roms = session.scalars(db_rom_handler.get_roms(platform_id=platform.id)).all()
         assert len(roms) == 2
 
-    rom = db_rom_handler.get_roms(id=roms[0].id)
+    rom = db_rom_handler.get_rom(roms[0].id)
+    assert rom is not None
     assert rom.file_name == "test_rom.zip"
 
     db_rom_handler.update_rom(roms[1].id, {"file_name": "test_rom_2_updated"})
-    rom_2 = db_rom_handler.get_roms(id=roms[1].id)
+    rom_2 = db_rom_handler.get_rom(roms[1].id)
+    assert rom_2 is not None
     assert rom_2.file_name == "test_rom_2_updated"
 
     db_rom_handler.delete_rom(rom.id)
@@ -134,7 +136,8 @@ def test_saves(save: Save, platform: Platform, admin_user: User):
         )
     )
 
-    rom = db_rom_handler.get_roms(id=save.rom_id)
+    rom = db_rom_handler.get_rom(save.rom_id)
+    assert rom is not None
     assert len(rom.saves) == 2
 
     save = db_save_handler.get_save(rom.saves[0].id)
@@ -146,7 +149,8 @@ def test_saves(save: Save, platform: Platform, admin_user: User):
 
     db_save_handler.delete_save(save.id)
 
-    rom = db_rom_handler.get_roms(id=save.rom_id)
+    rom = db_rom_handler.get_rom(save.rom_id)
+    assert rom is not None
     assert len(rom.saves) == 1
 
 
@@ -164,7 +168,8 @@ def test_states(state: State, platform: Platform, admin_user: User):
         )
     )
 
-    rom = db_rom_handler.get_roms(id=state.rom_id)
+    rom = db_rom_handler.get_rom(state.rom_id)
+    assert rom is not None
     assert len(rom.states) == 2
 
     state = db_state_handler.get_state(rom.states[0].id)
@@ -176,7 +181,8 @@ def test_states(state: State, platform: Platform, admin_user: User):
 
     db_state_handler.delete_state(state.id)
 
-    rom = db_rom_handler.get_roms(id=state.rom_id)
+    rom = db_rom_handler.get_rom(state.rom_id)
+    assert rom is not None
     assert len(rom.states) == 1
 
 
@@ -194,7 +200,8 @@ def test_screenshots(screenshot: Screenshot, platform: Platform, admin_user: Use
         )
     )
 
-    rom = db_rom_handler.get_roms(id=screenshot.rom_id)
+    rom = db_rom_handler.get_rom(screenshot.rom_id)
+    assert rom is not None
     assert len(rom.screenshots) == 2
 
     screenshot = db_screenshot_handler.get_screenshot(rom.screenshots[0].id)
@@ -208,5 +215,6 @@ def test_screenshots(screenshot: Screenshot, platform: Platform, admin_user: Use
 
     db_screenshot_handler.delete_screenshot(screenshot.id)
 
-    rom = db_rom_handler.get_roms(id=screenshot.rom_id)
+    rom = db_rom_handler.get_rom(screenshot.rom_id)
+    assert rom is not None
     assert len(rom.screenshots) == 1

--- a/backend/models/assets.py
+++ b/backend/models/assets.py
@@ -50,7 +50,10 @@ class Save(RomAsset):
     def screenshot(self) -> Optional["Screenshot"]:
         from handler.database import db_rom_handler
 
-        db_rom = db_rom_handler.get_roms(self.rom_id)
+        db_rom = db_rom_handler.get_rom(self.rom_id)
+        if db_rom is None:
+            return None
+
         for screenshot in db_rom.screenshots:
             if screenshot.file_name_no_ext == self.file_name:
                 return screenshot
@@ -71,7 +74,10 @@ class State(RomAsset):
     def screenshot(self) -> Optional["Screenshot"]:
         from handler.database import db_rom_handler
 
-        db_rom = db_rom_handler.get_roms(self.rom_id)
+        db_rom = db_rom_handler.get_rom(self.rom_id)
+        if db_rom is None:
+            return None
+
         for screenshot in db_rom.screenshots:
             if screenshot.file_name_no_ext == self.file_name:
                 return screenshot


### PR DESCRIPTION
The current implementation for some of the database handlers, where the same method is used to retrieve either a single entity (when an `id` is passed), a list of entities, or `None`, makes the typing and overall design more complex.

This change simplifies database handlers, by having two separate methods where appropiate:

* A method that receives an `id`, and returns either an entity, or `None`.
* A method that optionally receives filters, and returns (depending on the current handler implementation) a list of entities, or a `Select` object that allows chaining more SQLAlchemy operations.