### PR TITLE
fix: Make some DB columns non-nullable

### DIFF
--- a/backend/alembic/versions/0023_make_columns_non_nullable.py
+++ b/backend/alembic/versions/0023_make_columns_non_nullable.py
@@ -1,0 +1,74 @@
+"""Make some columns non-nullable.
+
+Revision ID: 0023_make_columns_non_nullable
+Revises: 0022_collections
+Create Date: 2024-07-07 13:44:25.811184
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0023_make_columns_non_nullable"
+down_revision = "0022_collections"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("platforms", schema=None) as batch_op:
+        batch_op.execute("UPDATE platforms SET name = '' WHERE name IS NULL")
+        batch_op.alter_column(
+            "name", existing_type=sa.String(length=400), nullable=False
+        )
+
+    with op.batch_alter_table("rom_user", schema=None) as batch_op:
+        batch_op.execute(
+            "UPDATE rom_user SET note_is_public = 0 WHERE note_is_public IS NULL"
+        )
+        batch_op.alter_column(
+            "note_is_public", existing_type=sa.Boolean(), nullable=False
+        )
+        batch_op.execute(
+            "UPDATE rom_user SET is_main_sibling = 0 WHERE is_main_sibling IS NULL"
+        )
+        batch_op.alter_column(
+            "is_main_sibling", existing_type=sa.Boolean(), nullable=False
+        )
+
+    with op.batch_alter_table("roms", schema=None) as batch_op:
+        batch_op.execute("UPDATE roms SET multi = 0 WHERE multi IS NULL")
+        batch_op.alter_column("multi", existing_type=sa.Boolean(), nullable=False)
+
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.execute("UPDATE users SET username = '' WHERE username IS NULL")
+        batch_op.alter_column(
+            "username", existing_type=sa.String(length=255), nullable=False
+        )
+        batch_op.execute("UPDATE users SET enabled = 0 WHERE enabled IS NULL")
+        batch_op.alter_column("enabled", existing_type=sa.Boolean(), nullable=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.alter_column("enabled", existing_type=sa.Boolean(), nullable=True)
+        batch_op.alter_column(
+            "username", existing_type=sa.String(length=255), nullable=True
+        )
+
+    with op.batch_alter_table("roms", schema=None) as batch_op:
+        batch_op.alter_column("multi", existing_type=sa.Boolean(), nullable=True)
+
+    with op.batch_alter_table("rom_user", schema=None) as batch_op:
+        batch_op.alter_column(
+            "is_main_sibling", existing_type=sa.Boolean(), nullable=True
+        )
+        batch_op.alter_column(
+            "note_is_public", existing_type=sa.Boolean(), nullable=True
+        )
+
+    with op.batch_alter_table("platforms", schema=None) as batch_op:
+        batch_op.alter_column(
+            "name", existing_type=sa.String(length=400), nullable=True
+        )

--- a/backend/models/collection.py
+++ b/backend/models/collection.py
@@ -36,7 +36,7 @@ class Collection(BaseModel):
         return self.user.username
 
     @property
-    def rom_count(self):
+    def rom_count(self) -> int:
         return len(self.roms)
 
     @cached_property

--- a/backend/models/platform.py
+++ b/backend/models/platform.py
@@ -20,7 +20,7 @@ class Platform(BaseModel):
     moby_id: Mapped[int | None]
     slug: Mapped[str] = mapped_column(String(length=50))
     fs_slug: Mapped[str] = mapped_column(String(length=50))
-    name: Mapped[str | None] = mapped_column(String(length=400))
+    name: Mapped[str] = mapped_column(String(length=400))
     logo_path: Mapped[str | None] = mapped_column(String(length=1000), default="")
 
     roms: Mapped[list[Rom]] = relationship(back_populates="platform")

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -58,7 +58,7 @@ class Rom(BaseModel):
         JSON, default=[], doc="URLs to screenshots stored in IGDB"
     )
 
-    multi: Mapped[bool | None] = mapped_column(default=False)
+    multi: Mapped[bool] = mapped_column(default=False)
     files: Mapped[list[str] | None] = mapped_column(JSON, default=[])
 
     platform_id: Mapped[int] = mapped_column(
@@ -163,9 +163,9 @@ class RomUser(BaseModel):
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
 
     note_raw_markdown: Mapped[str] = mapped_column(Text, default="")
-    note_is_public: Mapped[bool | None] = mapped_column(default=False)
+    note_is_public: Mapped[bool] = mapped_column(default=False)
 
-    is_main_sibling: Mapped[bool | None] = mapped_column(default=False)
+    is_main_sibling: Mapped[bool] = mapped_column(default=False)
 
     rom_id: Mapped[int] = mapped_column(ForeignKey("roms.id", ondelete="CASCADE"))
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -27,11 +27,9 @@ class User(BaseModel, SimpleUser):
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
 
-    username: Mapped[str | None] = mapped_column(
-        String(length=255), unique=True, index=True
-    )
+    username: Mapped[str] = mapped_column(String(length=255), unique=True, index=True)
     hashed_password: Mapped[str | None] = mapped_column(String(length=255))
-    enabled: Mapped[bool | None] = mapped_column(default=True)
+    enabled: Mapped[bool] = mapped_column(default=True)
     role: Mapped[Role | None] = mapped_column(Enum(Role), default=Role.VIEWER)
     avatar_path: Mapped[str | None] = mapped_column(String(length=255), default="")
     last_login: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))


### PR DESCRIPTION
This change makes some database columns non-nullable, and includes the migration to seamlessly upgrade the schema.

It includes:
* User and Platform names
* Every boolean column