### PR TITLE
fix: Correctly traverse SteamGridDB API pages

### DIFF
--- a/env.template
+++ b/env.template
@@ -12,6 +12,9 @@ IGDB_CLIENT_SECRET=
 # Mobygames
 MOBYGAMES_API_KEY=
 
+# SteamGridDB
+STEAMGRIDDB_API_KEY=
+
 # Database config
 DB_HOST=127.0.0.1
 DB_PORT=3306


### PR DESCRIPTION
The SteamGridDB API has a bug, where the `total` field for the paginated endpoint `/v2/grids/game/:gameId` sometimes double/triple counts results (e.g. returning `total=172` when there are actually 86 results).

To avoid this issue, this change relies on each page's number of results. If the received page has less than the requested amount of grids, we know that is the last page.