### PR TITLE
feat: Use async requests to retrieve SteamGridDB covers

### DIFF
--- a/backend/endpoints/search.py
+++ b/backend/endpoints/search.py
@@ -123,7 +123,8 @@ async def search_cover(
             detail="No SteamGridDB enabled",
         )
 
-    return [
-        SearchCoverSchema.model_validate(cover)
-        for cover in meta_sgdb_handler.get_details(search_term)
-    ]
+    covers = await meta_sgdb_handler.get_details(
+        requests_client=request.app.requests_client, search_term=search_term
+    )
+
+    return [SearchCoverSchema.model_validate(cover) for cover in covers]


### PR DESCRIPTION
This change avoids blocking requests when retrieving covers from SteamGridDB, which is the main bottleneck as the current implementation iterates over paginated results for multiple games.

Using an asynchronous client like `httpx` provides a good performance improvement, and reduces the latency when calling this endpoint. Also, the inclusion of FastAPI `lifespan` allows instantiating a single client on startup.

When testing with "Final Fantasy V Advance", the endpoint goes from ~9s to ~1.5s to retrieve all covers.