### PR TITLE
fix: Filter Switch titledb entries with empty id

### DIFF
--- a/backend/tasks/update_switch_titledb.py
+++ b/backend/tasks/update_switch_titledb.py
@@ -38,9 +38,12 @@ class UpdateSwitchTitleDBTask(RemoteFilePullTask):
                 pipe.hset(SWITCH_TITLEDB_INDEX_KEY, mapping=titledb_map)
             for data_batch in batched(relevant_data.items(), 2000):
                 product_map = {
-                    v["id"]: json.dumps(v) for v in dict(data_batch).values()
+                    v["id"]: json.dumps(v)
+                    for v in dict(data_batch).values()
+                    if v.get("id")
                 }
-                pipe.hset(SWITCH_PRODUCT_ID_KEY, mapping=product_map)
+                if product_map:
+                    pipe.hset(SWITCH_PRODUCT_ID_KEY, mapping=product_map)
             pipe.execute()
 
         log.info("Scheduled switch titledb update completed!")


### PR DESCRIPTION
The existing code was failing after changes on the upstream JSON file that included entries with `null` ID.