### PR TITLE
Fixed Docker compose to allow Romm to connect to MariaDB.

### DIFF
--- a/examples/docker-compose.example.yml
+++ b/examples/docker-compose.example.yml
@@ -43,3 +43,5 @@ services:
       - MYSQL_PASSWORD=
     volumes:
       - mysql_data:/var/lib/mysql
+    ports:
+      - "3306:3306"


### PR DESCRIPTION
### Description

The current example for Docker Compose fails due to not opening the MariaDB ports.

### Related Issues

ROMM Docker container can now connect to the MariaDB container.

### Checklist
Please check all that apply.

- [x] I've tested the changes locally
- [-] I've updated the wiki accordingly
- [-] I've have updated relevant comments
- [-] I've assigned reviewers for this PR
- [-] I've added unit tests that cover the changes
- [-] All existing tests are passing

### Additional Notes

None.
```
