### PR TITLE
fix: Use namespaced cookie for session

### DIFF
--- a/backend/endpoints/tests/test_identity.py
+++ b/backend/endpoints/tests/test_identity.py
@@ -24,7 +24,7 @@ def test_login_logout(admin_user):
     response = client.post("/login", headers={"Authorization": f"Basic {basic_auth}"})
 
     assert response.status_code == 200
-    assert response.cookies.get("session")
+    assert response.cookies.get("romm_session")
     assert response.json()["msg"] == "Successfully logged in"
 
     response = client.post("/logout")

--- a/backend/main.py
+++ b/backend/main.py
@@ -75,6 +75,7 @@ app.add_middleware(
 app.add_middleware(
     SessionMiddleware,
     secret_key=ROMM_AUTH_SECRET_KEY,
+    session_cookie="romm_session",
     same_site="strict",
     https_only=False,
     jwt_alg=ALGORITHM,


### PR DESCRIPTION
Avoid conflicting cookie names when RomM runs in the same host as other applications, by adding a `romm_` namespace to the session cookie.