### PR TITLE
misc: Migrate MobyGamesHandler to async

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -305,10 +305,7 @@ async def update_rom(
         cleaned_data.get("moby_id", "")
         and int(cleaned_data.get("moby_id", "")) != rom.moby_id
     ):
-        moby_rom = await meta_moby_handler.get_rom_by_id(
-            requests_client=request.app.requests_client,
-            moby_id=cleaned_data["moby_id"],
-        )
+        moby_rom = await meta_moby_handler.get_rom_by_id(cleaned_data["moby_id"])
         cleaned_data.update(moby_rom)
         path_screenshots = fs_resource_handler.get_rom_screenshots(
             rom=rom,

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -305,7 +305,10 @@ async def update_rom(
         cleaned_data.get("moby_id", "")
         and int(cleaned_data.get("moby_id", "")) != rom.moby_id
     ):
-        moby_rom = meta_moby_handler.get_rom_by_id(cleaned_data["moby_id"])
+        moby_rom = await meta_moby_handler.get_rom_by_id(
+            requests_client=request.app.requests_client,
+            moby_id=cleaned_data["moby_id"],
+        )
         cleaned_data.update(moby_rom)
         path_screenshots = fs_resource_handler.get_rom_screenshots(
             rom=rom,

--- a/backend/endpoints/search.py
+++ b/backend/endpoints/search.py
@@ -62,7 +62,7 @@ async def search_rom(
                 int(search_term)
             )
             moby_matched_roms = await meta_moby_handler.get_matched_roms_by_id(
-                requests_client=request.app.requests_client, moby_id=int(search_term)
+                int(search_term)
             )
         except ValueError as exc:
             log.error(f"Search error: invalid ID '{search_term}'")
@@ -75,9 +75,7 @@ async def search_rom(
             search_term, _get_main_platform_igdb_id(rom.platform)
         )
         moby_matched_roms = await meta_moby_handler.get_matched_roms_by_name(
-            requests_client=request.app.requests_client,
-            search_term=search_term,
-            platform_moby_id=rom.platform.moby_id,
+            search_term, rom.platform.moby_id
         )
 
     merged_dict = {
@@ -125,8 +123,6 @@ async def search_cover(
             detail="No SteamGridDB enabled",
         )
 
-    covers = await meta_sgdb_handler.get_details(
-        requests_client=request.app.requests_client, search_term=search_term
-    )
+    covers = await meta_sgdb_handler.get_details(search_term=search_term)
 
     return [SearchCoverSchema.model_validate(cover) for cover in covers]

--- a/backend/endpoints/search.py
+++ b/backend/endpoints/search.py
@@ -61,8 +61,8 @@ async def search_rom(
             igdb_matched_roms = meta_igdb_handler.get_matched_roms_by_id(
                 int(search_term)
             )
-            moby_matched_roms = meta_moby_handler.get_matched_roms_by_id(
-                int(search_term)
+            moby_matched_roms = await meta_moby_handler.get_matched_roms_by_id(
+                requests_client=request.app.requests_client, moby_id=int(search_term)
             )
         except ValueError as exc:
             log.error(f"Search error: invalid ID '{search_term}'")
@@ -74,8 +74,10 @@ async def search_rom(
         igdb_matched_roms = meta_igdb_handler.get_matched_roms_by_name(
             search_term, _get_main_platform_igdb_id(rom.platform)
         )
-        moby_matched_roms = meta_moby_handler.get_matched_roms_by_name(
-            search_term, rom.platform.moby_id
+        moby_matched_roms = await meta_moby_handler.get_matched_roms_by_name(
+            requests_client=request.app.requests_client,
+            search_term=search_term,
+            platform_moby_id=rom.platform.moby_id,
         )
 
     merged_dict = {

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -1,6 +1,7 @@
 from typing import Final
 
 import emoji
+import httpx
 import socketio  # type: ignore
 from config import SCAN_TIMEOUT
 from endpoints.responses.platform import PlatformSchema
@@ -132,172 +133,178 @@ async def scan_platforms(
         else:
             log.info(f"Found {len(platform_list)} platforms in file system ")
 
-        for platform_slug in platform_list:
-            # Stop the scan if the flag is set
-            if redis_client.get(STOP_SCAN_FLAG):
-                await stop_scan()
-                break
-
-            platform = db_platform_handler.get_platform_by_fs_slug(platform_slug)
-            if platform and scan_type == ScanType.NEW_PLATFORMS:
-                continue
-
-            scanned_platform = scan_platform(
-                platform_slug, fs_platforms, metadata_sources=metadata_sources
-            )
-            if platform:
-                scanned_platform.id = platform.id
-                # Keep the existing ids if they exist on the platform
-                scanned_platform.igdb_id = scanned_platform.igdb_id or platform.igdb_id
-                scanned_platform.moby_id = scanned_platform.moby_id or platform.moby_id
-
-            scan_stats.scanned_platforms += 1
-            scan_stats.added_platforms += 1 if not platform else 0
-            scan_stats.metadata_platforms += (
-                1 if scanned_platform.igdb_id or scanned_platform.moby_id else 0
-            )
-
-            platform = db_platform_handler.add_platform(scanned_platform)
-
-            await sm.emit(
-                "scan:scanning_platform",
-                PlatformSchema.model_validate(platform).model_dump(
-                    include={"id", "name", "slug"}
-                ),
-            )
-            await sm.emit("", None)
-
-            # Scanning firmware
-            try:
-                fs_firmware = fs_firmware_handler.get_firmware(platform)
-            except FirmwareNotFoundException:
-                fs_firmware = []
-
-            if len(fs_firmware) == 0:
-                log.warning(
-                    "  ⚠️ No firmware found, skipping firmware scan for this platform"
-                )
-            else:
-                log.info(f"  {len(fs_firmware)} firmware files found")
-
-            for fs_fw in fs_firmware:
-                # Break early if the flag is set
+        async with httpx.AsyncClient() as requests_client:
+            for platform_slug in platform_list:
+                # Stop the scan if the flag is set
                 if redis_client.get(STOP_SCAN_FLAG):
+                    await stop_scan()
                     break
 
-                firmware = db_firmware_handler.get_firmware_by_filename(
-                    platform.id, fs_fw
+                platform = db_platform_handler.get_platform_by_fs_slug(platform_slug)
+                if platform and scan_type == ScanType.NEW_PLATFORMS:
+                    continue
+
+                scanned_platform = scan_platform(
+                    platform_slug, fs_platforms, metadata_sources=metadata_sources
+                )
+                if platform:
+                    scanned_platform.id = platform.id
+                    # Keep the existing ids if they exist on the platform
+                    scanned_platform.igdb_id = (
+                        scanned_platform.igdb_id or platform.igdb_id
+                    )
+                    scanned_platform.moby_id = (
+                        scanned_platform.moby_id or platform.moby_id
+                    )
+
+                scan_stats.scanned_platforms += 1
+                scan_stats.added_platforms += 1 if not platform else 0
+                scan_stats.metadata_platforms += (
+                    1 if scanned_platform.igdb_id or scanned_platform.moby_id else 0
                 )
 
-                scanned_firmware = scan_firmware(
-                    platform=platform,
-                    file_name=fs_fw,
-                    firmware=firmware,
+                platform = db_platform_handler.add_platform(scanned_platform)
+
+                await sm.emit(
+                    "scan:scanning_platform",
+                    PlatformSchema.model_validate(platform).model_dump(
+                        include={"id", "name", "slug"}
+                    ),
                 )
+                await sm.emit("", None)
 
-                scan_stats.scanned_firmware += 1
-                scan_stats.added_firmware += 1 if not firmware else 0
+                # Scanning firmware
+                try:
+                    fs_firmware = fs_firmware_handler.get_firmware(platform)
+                except FirmwareNotFoundException:
+                    fs_firmware = []
 
-                _added_firmware = db_firmware_handler.add_firmware(scanned_firmware)
-                firmware = db_firmware_handler.get_firmware(_added_firmware.id)
+                if len(fs_firmware) == 0:
+                    log.warning(
+                        "  ⚠️ No firmware found, skipping firmware scan for this platform"
+                    )
+                else:
+                    log.info(f"  {len(fs_firmware)} firmware files found")
 
-            # Scanning roms
-            try:
-                fs_roms = fs_rom_handler.get_roms(platform)
-            except RomsNotFoundException as e:
-                log.error(e)
-                continue
+                for fs_fw in fs_firmware:
+                    # Break early if the flag is set
+                    if redis_client.get(STOP_SCAN_FLAG):
+                        break
 
-            if len(fs_roms) == 0:
-                log.warning(
-                    "  ⚠️ No roms found, verify that the folder structure is correct"
-                )
-            else:
-                log.info(f"  {len(fs_roms)} roms found")
+                    firmware = db_firmware_handler.get_firmware_by_filename(
+                        platform.id, fs_fw
+                    )
 
-            for fs_rom in fs_roms:
-                # Break early if the flag is set
-                if redis_client.get(STOP_SCAN_FLAG):
-                    break
-
-                rom = db_rom_handler.get_rom_by_filename(
-                    platform.id, fs_rom["file_name"]
-                )
-
-                if _should_scan_rom(
-                    scan_type=scan_type, rom=rom, selected_roms=selected_roms
-                ):
-                    scanned_rom = await scan_rom(
+                    scanned_firmware = scan_firmware(
                         platform=platform,
-                        rom_attrs=fs_rom,
-                        scan_type=scan_type,
-                        rom=rom,
-                        metadata_sources=metadata_sources,
+                        file_name=fs_fw,
+                        firmware=firmware,
                     )
 
-                    scan_stats.scanned_roms += 1
-                    scan_stats.added_roms += 1 if not rom else 0
-                    scan_stats.metadata_roms += (
-                        1 if scanned_rom.igdb_id or scanned_rom.moby_id else 0
+                    scan_stats.scanned_firmware += 1
+                    scan_stats.added_firmware += 1 if not firmware else 0
+
+                    _added_firmware = db_firmware_handler.add_firmware(scanned_firmware)
+                    firmware = db_firmware_handler.get_firmware(_added_firmware.id)
+
+                # Scanning roms
+                try:
+                    fs_roms = fs_rom_handler.get_roms(platform)
+                except RomsNotFoundException as e:
+                    log.error(e)
+                    continue
+
+                if len(fs_roms) == 0:
+                    log.warning(
+                        "  ⚠️ No roms found, verify that the folder structure is correct"
+                    )
+                else:
+                    log.info(f"  {len(fs_roms)} roms found")
+
+                for fs_rom in fs_roms:
+                    # Break early if the flag is set
+                    if redis_client.get(STOP_SCAN_FLAG):
+                        break
+
+                    rom = db_rom_handler.get_rom_by_filename(
+                        platform.id, fs_rom["file_name"]
                     )
 
-                    _added_rom = db_rom_handler.add_rom(scanned_rom)
+                    if _should_scan_rom(
+                        scan_type=scan_type, rom=rom, selected_roms=selected_roms
+                    ):
+                        scanned_rom = await scan_rom(
+                            requests_client=requests_client,
+                            platform=platform,
+                            rom_attrs=fs_rom,
+                            scan_type=scan_type,
+                            rom=rom,
+                            metadata_sources=metadata_sources,
+                        )
 
-                    path_cover_s, path_cover_l = fs_resource_handler.get_cover(
-                        overwrite=True,
-                        entity=_added_rom,
-                        url_cover=_added_rom.url_cover,
+                        scan_stats.scanned_roms += 1
+                        scan_stats.added_roms += 1 if not rom else 0
+                        scan_stats.metadata_roms += (
+                            1 if scanned_rom.igdb_id or scanned_rom.moby_id else 0
+                        )
+
+                        _added_rom = db_rom_handler.add_rom(scanned_rom)
+
+                        path_cover_s, path_cover_l = fs_resource_handler.get_cover(
+                            overwrite=True,
+                            entity=_added_rom,
+                            url_cover=_added_rom.url_cover,
+                        )
+
+                        path_screenshots = fs_resource_handler.get_rom_screenshots(
+                            rom=_added_rom,
+                            url_screenshots=_added_rom.url_screenshots,
+                        )
+
+                        _added_rom.path_cover_s = path_cover_s
+                        _added_rom.path_cover_l = path_cover_l
+                        _added_rom.path_screenshots = path_screenshots
+                        # Update the scanned rom with the cover and screenshots paths and update database
+                        db_rom_handler.update_rom(
+                            _added_rom.id,
+                            {
+                                c: getattr(_added_rom, c)
+                                for c in inspect(_added_rom).mapper.column_attrs.keys()
+                            },
+                        )
+
+                        await sm.emit(
+                            "scan:scanning_rom",
+                            {
+                                "platform_name": platform.name,
+                                "platform_slug": platform.slug,
+                                **RomSchema.model_validate(_added_rom).model_dump(
+                                    exclude={"created_at", "updated_at", "rom_user"}
+                                ),
+                            },
+                        )
+                        await sm.emit("", None)
+
+                # Only purge entries if there are some file remaining in the library
+                # This protects against accidental deletion of entries when
+                # the folder structure is not correct or the drive is not mounted
+                if len(fs_roms) > 0:
+                    db_rom_handler.purge_roms(
+                        platform.id, [rom["file_name"] for rom in fs_roms]
                     )
 
-                    path_screenshots = fs_resource_handler.get_rom_screenshots(
-                        rom=_added_rom,
-                        url_screenshots=_added_rom.url_screenshots,
+                # Same protection for firmware
+                if len(fs_firmware) > 0:
+                    db_firmware_handler.purge_firmware(
+                        platform.id, [fw for fw in fs_firmware]
                     )
 
-                    _added_rom.path_cover_s = path_cover_s
-                    _added_rom.path_cover_l = path_cover_l
-                    _added_rom.path_screenshots = path_screenshots
-                    # Update the scanned rom with the cover and screenshots paths and update database
-                    db_rom_handler.update_rom(
-                        _added_rom.id,
-                        {
-                            c: getattr(_added_rom, c)
-                            for c in inspect(_added_rom).mapper.column_attrs.keys()
-                        },
-                    )
+            # Same protection for platforms
+            if len(fs_platforms) > 0:
+                db_platform_handler.purge_platforms(fs_platforms)
 
-                    await sm.emit(
-                        "scan:scanning_rom",
-                        {
-                            "platform_name": platform.name,
-                            "platform_slug": platform.slug,
-                            **RomSchema.model_validate(_added_rom).model_dump(
-                                exclude={"created_at", "updated_at", "rom_user"}
-                            ),
-                        },
-                    )
-                    await sm.emit("", None)
-
-            # Only purge entries if there are some file remaining in the library
-            # This protects against accidental deletion of entries when
-            # the folder structure is not correct or the drive is not mounted
-            if len(fs_roms) > 0:
-                db_rom_handler.purge_roms(
-                    platform.id, [rom["file_name"] for rom in fs_roms]
-                )
-
-            # Same protection for firmware
-            if len(fs_firmware) > 0:
-                db_firmware_handler.purge_firmware(
-                    platform.id, [fw for fw in fs_firmware]
-                )
-
-        # Same protection for platforms
-        if len(fs_platforms) > 0:
-            db_platform_handler.purge_platforms(fs_platforms)
-
-        log.info(emoji.emojize(":check_mark: Scan completed "))
-        await sm.emit("scan:done", scan_stats.__dict__)
+            log.info(emoji.emojize(":check_mark: Scan completed "))
+            await sm.emit("scan:done", scan_stats.__dict__)
     except Exception as e:
         log.error(e)
         # Catch all exceptions and emit error to the client

--- a/backend/endpoints/tests/test_assets.py
+++ b/backend/endpoints/tests/test_assets.py
@@ -1,10 +1,15 @@
+import pytest
 from fastapi.testclient import TestClient
 from main import app
 
-client = TestClient(app)
+
+@pytest.fixture
+def client():
+    with TestClient(app) as client:
+        yield client
 
 
-def test_delete_saves(access_token, save):
+def test_delete_saves(client, access_token, save):
     response = client.post(
         "/saves/delete",
         headers={"Authorization": f"Bearer {access_token}"},
@@ -16,7 +21,7 @@ def test_delete_saves(access_token, save):
     assert body["msg"] == "Successfully deleted 1 saves"
 
 
-def test_delete_states(access_token, state):
+def test_delete_states(client, access_token, state):
     response = client.post(
         "/states/delete",
         headers={"Authorization": f"Bearer {access_token}"},

--- a/backend/endpoints/tests/test_config.py
+++ b/backend/endpoints/tests/test_config.py
@@ -1,10 +1,15 @@
+import pytest
 from fastapi.testclient import TestClient
 from main import app
 
-client = TestClient(app)
+
+@pytest.fixture
+def client():
+    with TestClient(app) as client:
+        yield client
 
 
-def test_config():
+def test_config(client):
     response = client.get("/config")
     assert response.status_code == 200
 

--- a/backend/endpoints/tests/test_heartbeat.py
+++ b/backend/endpoints/tests/test_heartbeat.py
@@ -1,11 +1,16 @@
+import pytest
 from fastapi.testclient import TestClient
 from main import app
 from utils import get_version
 
-client = TestClient(app)
+
+@pytest.fixture
+def client():
+    with TestClient(app) as client:
+        yield client
 
 
-def test_heartbeat():
+def test_heartbeat(client):
     response = client.get("/heartbeat")
     assert response.status_code == 200
 

--- a/backend/endpoints/tests/test_identity.py
+++ b/backend/endpoints/tests/test_identity.py
@@ -6,7 +6,11 @@ from handler.redis_handler import sync_cache
 from main import app
 from models.user import Role
 
-client = TestClient(app)
+
+@pytest.fixture
+def client():
+    with TestClient(app) as client:
+        yield client
 
 
 @pytest.fixture(autouse=True)
@@ -15,7 +19,7 @@ def clear_cache():
     sync_cache.flushall()
 
 
-def test_login_logout(admin_user):
+def test_login_logout(client, admin_user):
     response = client.get("/login")
 
     assert response.status_code == 405
@@ -33,7 +37,7 @@ def test_login_logout(admin_user):
     assert response.json()["msg"] == "Successfully logged out"
 
 
-def test_get_all_users(access_token):
+def test_get_all_users(client, access_token):
     response = client.get("/users", headers={"Authorization": f"Bearer {access_token}"})
     assert response.status_code == 200
 
@@ -42,7 +46,7 @@ def test_get_all_users(access_token):
     assert users[0]["username"] == "test_admin"
 
 
-def test_get_user(access_token, editor_user):
+def test_get_user(client, access_token, editor_user):
     response = client.get(
         f"/users/{editor_user.id}", headers={"Authorization": f"Bearer {access_token}"}
     )
@@ -52,7 +56,7 @@ def test_get_user(access_token, editor_user):
     assert user["username"] == "test_editor"
 
 
-def test_create_user(access_token):
+def test_create_user(client, access_token):
     response = client.post(
         "/users",
         params={
@@ -69,7 +73,7 @@ def test_create_user(access_token):
     assert user["role"] == "viewer"
 
 
-def test_update_user(access_token, editor_user):
+def test_update_user(client, access_token, editor_user):
     assert editor_user.role == Role.EDITOR
 
     response = client.put(
@@ -83,7 +87,7 @@ def test_update_user(access_token, editor_user):
     assert user["role"] == "viewer"
 
 
-def test_delete_user(access_token, editor_user):
+def test_delete_user(client, access_token, editor_user):
     response = client.delete(
         f"/users/{editor_user.id}", headers={"Authorization": f"Bearer {access_token}"}
     )

--- a/backend/endpoints/tests/test_platform.py
+++ b/backend/endpoints/tests/test_platform.py
@@ -1,10 +1,15 @@
+import pytest
 from fastapi.testclient import TestClient
 from main import app
 
-client = TestClient(app)
+
+@pytest.fixture
+def client():
+    with TestClient(app) as client:
+        yield client
 
 
-def test_get_platforms(access_token, platform):
+def test_get_platforms(client, access_token, platform):
     response = client.get("/platforms")
     assert response.status_code == 403
 

--- a/backend/endpoints/tests/test_raw.py
+++ b/backend/endpoints/tests/test_raw.py
@@ -1,10 +1,15 @@
+import pytest
 from fastapi.testclient import TestClient
 from main import app
 
-client = TestClient(app)
+
+@pytest.fixture
+def client():
+    with TestClient(app) as client:
+        yield client
 
 
-def test_get_raw_asset(access_token):
+def test_get_raw_asset(client, access_token):
     response = client.get(
         "/raw/assets/users/557365723a31/saves/n64/mupen64/Super Mario 64 (J) (Rev A).sav"
     )

--- a/backend/handler/metadata/moby_handler.py
+++ b/backend/handler/metadata/moby_handler.py
@@ -1,15 +1,15 @@
+import asyncio
+import http
 import re
-import time
 from typing import Final, NotRequired
 from urllib.parse import quote
 
+import httpx
 import pydash
-import requests
 import yarl
 from config import MOBYGAMES_API_KEY
 from fastapi import HTTPException, status
 from logger.logger import log
-from requests.exceptions import HTTPError, Timeout
 from typing_extensions import TypedDict
 from unidecode import unidecode as uc
 
@@ -81,38 +81,44 @@ class MobyGamesHandler(MetadataHandler):
         self.platform_url = "https://api.mobygames.com/v1/platforms"
         self.games_url = "https://api.mobygames.com/v1/games"
 
-    def _request(self, url: str, timeout: int = 120) -> dict:
+    async def _request(
+        self, requests_client: httpx.AsyncClient, url: str, timeout: int = 120
+    ) -> dict:
         authorized_url = yarl.URL(url).update_query(api_key=MOBYGAMES_API_KEY)
         try:
-            res = requests.get(authorized_url, timeout=timeout)
+            res = await requests_client.get(str(authorized_url), timeout=timeout)
             res.raise_for_status()
             return res.json()
-        except requests.exceptions.ConnectionError as exc:
+        except httpx.NetworkError as exc:
             log.critical("Connection error: can't connect to Mobygames", exc_info=True)
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Can't connect to Mobygames, check your internet connection",
             ) from exc
-        except HTTPError as err:
-            if err.response.status_code == 401:
+        except httpx.HTTPStatusError as err:
+            if err.response.status_code == http.HTTPStatus.UNAUTHORIZED:
                 # Sometimes Mobygames returns 401 even with a valid API key
+                log.error(err)
                 return {}
-            elif err.response.status_code == 429:
+            elif err.response.status_code == http.HTTPStatus.TOO_MANY_REQUESTS:
                 # Retry after 2 seconds if rate limit hit
-                time.sleep(2)
+                await asyncio.sleep(2)
             else:
                 # Log the error and return an empty dict if the request fails with a different code
                 log.error(err)
                 return {}
-        except Timeout:
+        except httpx.TimeoutException:
             # Retry the request once if it times out
             pass
 
         try:
-            res = requests.get(url, timeout=timeout)
+            res = await requests_client.get(url, timeout=timeout)
             res.raise_for_status()
-        except (HTTPError, Timeout) as err:
-            if err.response.status_code == 401:
+        except (httpx.HTTPStatusError, httpx.TimeoutException) as err:
+            if (
+                isinstance(err, httpx.HTTPStatusError)
+                and err.response.status_code == http.HTTPStatus.UNAUTHORIZED
+            ):
                 # Sometimes Mobygames returns 401 even with a valid API key
                 return {}
 
@@ -122,7 +128,12 @@ class MobyGamesHandler(MetadataHandler):
 
         return res.json()
 
-    def _search_rom(self, search_term: str, platform_moby_id: int) -> dict | None:
+    async def _search_rom(
+        self,
+        requests_client: httpx.AsyncClient,
+        search_term: str,
+        platform_moby_id: int,
+    ) -> dict | None:
         if not platform_moby_id:
             return None
 
@@ -131,7 +142,9 @@ class MobyGamesHandler(MetadataHandler):
             platform=[platform_moby_id],
             title=quote(search_term, safe="/ "),
         )
-        roms = self._request(str(url)).get("games", [])
+        roms = (await self._request(requests_client=requests_client, url=str(url))).get(
+            "games", []
+        )
 
         exact_matches = [
             rom
@@ -159,7 +172,9 @@ class MobyGamesHandler(MetadataHandler):
             name=platform["name"],
         )
 
-    async def get_rom(self, file_name: str, platform_moby_id: int) -> MobyGamesRom:
+    async def get_rom(
+        self, requests_client: httpx.AsyncClient, file_name: str, platform_moby_id: int
+    ) -> MobyGamesRom:
         from handler.filesystem import fs_rom_handler
 
         if not MOBY_API_ENABLED:
@@ -227,19 +242,31 @@ class MobyGamesHandler(MetadataHandler):
             fallback_rom = MobyGamesRom(moby_id=None, name=search_term)
 
         search_term = self.normalize_search_term(search_term)
-        res = self._search_rom(search_term, platform_moby_id)
+        res = await self._search_rom(
+            requests_client=requests_client,
+            search_term=search_term,
+            platform_moby_id=platform_moby_id,
+        )
 
         # Split the search term since mobygames search doesn't support special caracters
         if not res and ":" in search_term:
             for term in search_term.split(":")[::-1]:
-                res = self._search_rom(term, platform_moby_id)
+                res = await self._search_rom(
+                    requests_client=requests_client,
+                    search_term=term,
+                    platform_moby_id=platform_moby_id,
+                )
                 if res:
                     break
 
         # Some MAME games have two titles split by a slash
         if not res and "/" in search_term:
             for term in search_term.split("/"):
-                res = self._search_rom(term.strip(), platform_moby_id)
+                res = await self._search_rom(
+                    requests_client=requests_client,
+                    search_term=term.strip(),
+                    platform_moby_id=platform_moby_id,
+                )
                 if res:
                     break
 
@@ -258,12 +285,16 @@ class MobyGamesHandler(MetadataHandler):
 
         return MobyGamesRom({k: v for k, v in rom.items() if v})  # type: ignore[misc]
 
-    def get_rom_by_id(self, moby_id: int) -> MobyGamesRom:
+    async def get_rom_by_id(
+        self, requests_client: httpx.AsyncClient, moby_id: int
+    ) -> MobyGamesRom:
         if not MOBY_API_ENABLED:
             return MobyGamesRom(moby_id=None)
 
         url = yarl.URL(self.games_url).with_query(id=moby_id)
-        roms = self._request(str(url)).get("games", [])
+        roms = (await self._request(requests_client=requests_client, url=str(url))).get(
+            "games", []
+        )
         res = pydash.get(roms, "[0]", None)
 
         if not res:
@@ -281,15 +312,20 @@ class MobyGamesHandler(MetadataHandler):
 
         return MobyGamesRom({k: v for k, v in rom.items() if v})  # type: ignore[misc]
 
-    def get_matched_roms_by_id(self, moby_id: int) -> list[MobyGamesRom]:
+    async def get_matched_roms_by_id(
+        self, requests_client: httpx.AsyncClient, moby_id: int
+    ) -> list[MobyGamesRom]:
         if not MOBY_API_ENABLED:
             return []
 
-        rom = self.get_rom_by_id(moby_id)
+        rom = await self.get_rom_by_id(requests_client=requests_client, moby_id=moby_id)
         return [rom] if rom["moby_id"] else []
 
-    def get_matched_roms_by_name(
-        self, search_term: str, platform_moby_id: int
+    async def get_matched_roms_by_name(
+        self,
+        requests_client: httpx.AsyncClient,
+        search_term: str,
+        platform_moby_id: int,
     ) -> list[MobyGamesRom]:
         if not MOBY_API_ENABLED:
             return []
@@ -301,7 +337,9 @@ class MobyGamesHandler(MetadataHandler):
         url = yarl.URL(self.games_url).with_query(
             platform=[platform_moby_id], title=quote(search_term, safe="/ ")
         )
-        matched_roms = self._request(str(url)).get("games", [])
+        matched_roms = (
+            await self._request(requests_client=requests_client, url=str(url))
+        ).get("games", [])
 
         return [
             MobyGamesRom(  # type: ignore[misc]

--- a/backend/handler/metadata/moby_handler.py
+++ b/backend/handler/metadata/moby_handler.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException, status
 from logger.logger import log
 from typing_extensions import TypedDict
 from unidecode import unidecode as uc
+from utils.context import ctx_httpx_client
 
 from .base_hander import (
     PS2_OPL_REGEX,
@@ -81,12 +82,11 @@ class MobyGamesHandler(MetadataHandler):
         self.platform_url = "https://api.mobygames.com/v1/platforms"
         self.games_url = "https://api.mobygames.com/v1/games"
 
-    async def _request(
-        self, requests_client: httpx.AsyncClient, url: str, timeout: int = 120
-    ) -> dict:
+    async def _request(self, url: str, timeout: int = 120) -> dict:
+        httpx_client = ctx_httpx_client.get()
         authorized_url = yarl.URL(url).update_query(api_key=MOBYGAMES_API_KEY)
         try:
-            res = await requests_client.get(str(authorized_url), timeout=timeout)
+            res = await httpx_client.get(str(authorized_url), timeout=timeout)
             res.raise_for_status()
             return res.json()
         except httpx.NetworkError as exc:
@@ -112,7 +112,7 @@ class MobyGamesHandler(MetadataHandler):
             pass
 
         try:
-            res = await requests_client.get(url, timeout=timeout)
+            res = await httpx_client.get(url, timeout=timeout)
             res.raise_for_status()
         except (httpx.HTTPStatusError, httpx.TimeoutException) as err:
             if (
@@ -128,12 +128,7 @@ class MobyGamesHandler(MetadataHandler):
 
         return res.json()
 
-    async def _search_rom(
-        self,
-        requests_client: httpx.AsyncClient,
-        search_term: str,
-        platform_moby_id: int,
-    ) -> dict | None:
+    async def _search_rom(self, search_term: str, platform_moby_id: int) -> dict | None:
         if not platform_moby_id:
             return None
 
@@ -142,9 +137,7 @@ class MobyGamesHandler(MetadataHandler):
             platform=[platform_moby_id],
             title=quote(search_term, safe="/ "),
         )
-        roms = (await self._request(requests_client=requests_client, url=str(url))).get(
-            "games", []
-        )
+        roms = (await self._request(str(url))).get("games", [])
 
         exact_matches = [
             rom
@@ -172,9 +165,7 @@ class MobyGamesHandler(MetadataHandler):
             name=platform["name"],
         )
 
-    async def get_rom(
-        self, requests_client: httpx.AsyncClient, file_name: str, platform_moby_id: int
-    ) -> MobyGamesRom:
+    async def get_rom(self, file_name: str, platform_moby_id: int) -> MobyGamesRom:
         from handler.filesystem import fs_rom_handler
 
         if not MOBY_API_ENABLED:
@@ -242,31 +233,19 @@ class MobyGamesHandler(MetadataHandler):
             fallback_rom = MobyGamesRom(moby_id=None, name=search_term)
 
         search_term = self.normalize_search_term(search_term)
-        res = await self._search_rom(
-            requests_client=requests_client,
-            search_term=search_term,
-            platform_moby_id=platform_moby_id,
-        )
+        res = await self._search_rom(search_term, platform_moby_id)
 
         # Split the search term since mobygames search doesn't support special caracters
         if not res and ":" in search_term:
             for term in search_term.split(":")[::-1]:
-                res = await self._search_rom(
-                    requests_client=requests_client,
-                    search_term=term,
-                    platform_moby_id=platform_moby_id,
-                )
+                res = await self._search_rom(term, platform_moby_id)
                 if res:
                     break
 
         # Some MAME games have two titles split by a slash
         if not res and "/" in search_term:
             for term in search_term.split("/"):
-                res = await self._search_rom(
-                    requests_client=requests_client,
-                    search_term=term.strip(),
-                    platform_moby_id=platform_moby_id,
-                )
+                res = await self._search_rom(term.strip(), platform_moby_id)
                 if res:
                     break
 
@@ -285,16 +264,12 @@ class MobyGamesHandler(MetadataHandler):
 
         return MobyGamesRom({k: v for k, v in rom.items() if v})  # type: ignore[misc]
 
-    async def get_rom_by_id(
-        self, requests_client: httpx.AsyncClient, moby_id: int
-    ) -> MobyGamesRom:
+    async def get_rom_by_id(self, moby_id: int) -> MobyGamesRom:
         if not MOBY_API_ENABLED:
             return MobyGamesRom(moby_id=None)
 
         url = yarl.URL(self.games_url).with_query(id=moby_id)
-        roms = (await self._request(requests_client=requests_client, url=str(url))).get(
-            "games", []
-        )
+        roms = (await self._request(str(url))).get("games", [])
         res = pydash.get(roms, "[0]", None)
 
         if not res:
@@ -312,20 +287,15 @@ class MobyGamesHandler(MetadataHandler):
 
         return MobyGamesRom({k: v for k, v in rom.items() if v})  # type: ignore[misc]
 
-    async def get_matched_roms_by_id(
-        self, requests_client: httpx.AsyncClient, moby_id: int
-    ) -> list[MobyGamesRom]:
+    async def get_matched_roms_by_id(self, moby_id: int) -> list[MobyGamesRom]:
         if not MOBY_API_ENABLED:
             return []
 
-        rom = await self.get_rom_by_id(requests_client=requests_client, moby_id=moby_id)
+        rom = await self.get_rom_by_id(moby_id)
         return [rom] if rom["moby_id"] else []
 
     async def get_matched_roms_by_name(
-        self,
-        requests_client: httpx.AsyncClient,
-        search_term: str,
-        platform_moby_id: int,
+        self, search_term: str, platform_moby_id: int
     ) -> list[MobyGamesRom]:
         if not MOBY_API_ENABLED:
             return []
@@ -337,9 +307,7 @@ class MobyGamesHandler(MetadataHandler):
         url = yarl.URL(self.games_url).with_query(
             platform=[platform_moby_id], title=quote(search_term, safe="/ ")
         )
-        matched_roms = (
-            await self._request(requests_client=requests_client, url=str(url))
-        ).get("games", [])
+        matched_roms = (await self._request(str(url))).get("games", [])
 
         return [
             MobyGamesRom(  # type: ignore[misc]

--- a/backend/handler/metadata/sgdb_handler.py
+++ b/backend/handler/metadata/sgdb_handler.py
@@ -2,9 +2,9 @@ import asyncio
 import itertools
 from typing import Any, Final
 
-import httpx
 from config import STEAMGRIDDB_API_KEY
 from logger.logger import log
+from utils.context import ctx_httpx_client
 
 # Used to display the Mobygames API status in the frontend
 STEAMGRIDDB_API_ENABLED: Final = bool(STEAMGRIDDB_API_KEY)
@@ -33,11 +33,10 @@ class SGDBBaseHandler:
             "Accept": "*/*",
         }
 
-    async def get_details(
-        self, requests_client: httpx.AsyncClient, search_term: str
-    ) -> list[dict[str, Any]]:
+    async def get_details(self, search_term: str) -> list[dict[str, Any]]:
+        httpx_client = ctx_httpx_client.get()
         search_response = (
-            await requests_client.get(
+            await httpx_client.get(
                 f"{self.search_endpoint}/{search_term}",
                 headers=self.headers,
                 timeout=120,
@@ -49,11 +48,7 @@ class SGDBBaseHandler:
             return []
 
         tasks = [
-            self._get_game_covers(
-                requests_client=requests_client,
-                game_id=game["id"],
-                game_name=game["name"],
-            )
+            self._get_game_covers(game_id=game["id"], game_name=game["name"])
             for game in search_response["data"]
         ]
         results = await asyncio.gather(*tasks)
@@ -61,12 +56,13 @@ class SGDBBaseHandler:
         return list(filter(None, results))
 
     async def _get_game_covers(
-        self, requests_client: httpx.AsyncClient, game_id: int, game_name: str
+        self, game_id: int, game_name: str
     ) -> dict[str, Any] | None:
+        httpx_client = ctx_httpx_client.get()
         game_covers = []
         for page in itertools.count(start=0):
             covers_response = (
-                await requests_client.get(
+                await httpx_client.get(
                     f"{self.grid_endpoint}/{game_id}",
                     headers=self.headers,
                     timeout=120,

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -2,7 +2,6 @@ from enum import Enum
 from typing import Any
 
 import emoji
-import httpx
 from config.config_manager import config_manager as cm
 from handler.database import db_platform_handler
 from handler.filesystem import fs_asset_handler, fs_firmware_handler, fs_rom_handler
@@ -156,7 +155,6 @@ def scan_firmware(
 
 
 async def scan_rom(
-    requests_client: httpx.AsyncClient,
     platform: Platform,
     rom_attrs: dict,
     scan_type: ScanType,
@@ -264,9 +262,7 @@ async def scan_rom(
         )
     ):
         moby_handler_rom = await meta_moby_handler.get_rom(
-            requests_client=requests_client,
-            file_name=rom_attrs["file_name"],
-            platform_moby_id=platform.moby_id,
+            rom_attrs["file_name"], platform_moby_id=platform.moby_id
         )
 
     # Reversed to prioritize IGDB

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Any
 
 import emoji
+import httpx
 from config.config_manager import config_manager as cm
 from handler.database import db_platform_handler
 from handler.filesystem import fs_asset_handler, fs_firmware_handler, fs_rom_handler
@@ -155,6 +156,7 @@ def scan_firmware(
 
 
 async def scan_rom(
+    requests_client: httpx.AsyncClient,
     platform: Platform,
     rom_attrs: dict,
     scan_type: ScanType,
@@ -262,7 +264,9 @@ async def scan_rom(
         )
     ):
         moby_handler_rom = await meta_moby_handler.get_rom(
-            rom_attrs["file_name"], platform.moby_id
+            requests_client=requests_client,
+            file_name=rom_attrs["file_name"],
+            platform_moby_id=platform.moby_id,
         )
 
     # Reversed to prioritize IGDB

--- a/backend/handler/tests/test_fastapi.py
+++ b/backend/handler/tests/test_fastapi.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 from exceptions.fs_exceptions import RomsNotFoundException
 from handler.scan_handler import ScanType, scan_platform, scan_rom
@@ -24,15 +25,18 @@ def test_scan_platform():
 @pytest.mark.vcr
 async def test_scan_rom():
     platform = Platform(fs_slug="n64", igdb_id=4)
-    rom = await scan_rom(
-        platform,
-        {
-            "file_name": "Paper Mario (USA).z64",
-            "multi": False,
-            "files": ["Paper Mario (USA).z64"],
-        },
-        ScanType.QUICK,
-    )
+
+    async with httpx.AsyncClient() as client:
+        rom = await scan_rom(
+            requests_client=client,
+            platform=platform,
+            rom_attrs={
+                "file_name": "Paper Mario (USA).z64",
+                "multi": False,
+                "files": ["Paper Mario (USA).z64"],
+            },
+            scan_type=ScanType.QUICK,
+        )
 
     assert rom.__class__ == Rom
     assert rom.file_name == "Paper Mario (USA).z64"

--- a/backend/handler/tests/test_fastapi.py
+++ b/backend/handler/tests/test_fastapi.py
@@ -1,16 +1,16 @@
-import httpx
 import pytest
 from exceptions.fs_exceptions import RomsNotFoundException
 from handler.scan_handler import ScanType, scan_platform, scan_rom
 from models.platform import Platform
 from models.rom import Rom
+from utils.context import initialize_context
 
 
 @pytest.mark.vcr
 def test_scan_platform():
     platform = scan_platform("n64", ["n64"])
 
-    assert platform.__class__ == Platform
+    assert type(platform) is Platform
     assert platform.fs_slug == "n64"
     assert platform.slug == "n64"
     assert platform.name == "Nintendo 64"
@@ -26,19 +26,18 @@ def test_scan_platform():
 async def test_scan_rom():
     platform = Platform(fs_slug="n64", igdb_id=4)
 
-    async with httpx.AsyncClient() as client:
+    async with initialize_context():
         rom = await scan_rom(
-            requests_client=client,
-            platform=platform,
-            rom_attrs={
+            platform,
+            {
                 "file_name": "Paper Mario (USA).z64",
                 "multi": False,
                 "files": ["Paper Mario (USA).z64"],
             },
-            scan_type=ScanType.QUICK,
+            ScanType.QUICK,
         )
 
-    assert rom.__class__ == Rom
+    assert type(rom) is Rom
     assert rom.file_name == "Paper Mario (USA).z64"
     assert rom.name == "Paper Mario"
     assert rom.igdb_id == 3340

--- a/backend/utils/context.py
+++ b/backend/utils/context.py
@@ -1,0 +1,41 @@
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from contextvars import ContextVar, Token
+from typing import TypeVar
+
+import httpx
+from fastapi import Request, Response
+
+_T = TypeVar("_T")
+
+ctx_httpx_client: ContextVar[httpx.AsyncClient] = ContextVar("httpx_client")
+
+
+@asynccontextmanager
+async def set_context_var(
+    var: ContextVar[_T], value: _T
+) -> AsyncGenerator[Token[_T], None]:
+    """Temporarily set a context variables."""
+    token = var.set(value)
+    yield token
+    var.reset(token)
+
+
+@asynccontextmanager
+async def initialize_context() -> AsyncGenerator[None, None]:
+    """Initialize context variables."""
+    async with httpx.AsyncClient() as httpx_client:
+        async with set_context_var(ctx_httpx_client, httpx_client):
+            yield
+
+
+async def set_context_middleware(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    """Initialize context variables in FastAPI request-response cycle.
+
+    This middleware is needed because the context initialized during the lifespan
+    process is not available in the request-response cycle.
+    """
+    async with set_context_var(ctx_httpx_client, request.app.state.httpx_client):
+        return await call_next(request)


### PR DESCRIPTION
Convert `MobyGamesHandler` methods to be asynchronous, and use an `httpx` async client, instead of `requests` sync client.

This change also introduces a `ContextVar` and the concept of a context shared between requests. The context is automatically instrumented for FastAPI requests, by using a middleware.

For processes that do not run from within requests, the `@initialize_context()` decorator must be used. For example, for tasks triggered from `rq` workers.