### PR TITLE
misc: Migrate filesystem resource handler to async

### DIFF
--- a/backend/endpoints/collections.py
+++ b/backend/endpoints/collections.py
@@ -58,7 +58,7 @@ async def add_collection(
             path_cover_l,
             path_cover_s,
             artwork_path,
-        ) = fs_resource_handler.build_artwork_path(_added_collection, file_ext)
+        ) = await fs_resource_handler.build_artwork_path(_added_collection, file_ext)
 
         artwork_file = artwork.file.read()
         file_location_s = f"{artwork_path}/small.{file_ext}"
@@ -70,7 +70,7 @@ async def add_collection(
         with open(file_location_l, "wb+") as artwork_l:
             artwork_l.write(artwork_file)
     else:
-        path_cover_s, path_cover_l = fs_resource_handler.get_cover(
+        path_cover_s, path_cover_l = await fs_resource_handler.get_cover(
             overwrite=True,
             entity=_added_collection,
             url_cover=_added_collection.url_cover,
@@ -174,7 +174,7 @@ async def update_collection(
                 path_cover_l,
                 path_cover_s,
                 artwork_path,
-            ) = fs_resource_handler.build_artwork_path(collection, file_ext)
+            ) = await fs_resource_handler.build_artwork_path(collection, file_ext)
 
             cleaned_data["path_cover_l"] = path_cover_l
             cleaned_data["path_cover_s"] = path_cover_s
@@ -190,15 +190,13 @@ async def update_collection(
                 artwork_l.write(artwork_file)
             cleaned_data.update({"url_cover": ""})
         else:
-            if data.get(
-                "url_cover", ""
-            ) != collection.url_cover or not fs_resource_handler.cover_exists(
-                collection, CoverSize.BIG
+            if data.get("url_cover", "") != collection.url_cover or not (
+                await fs_resource_handler.cover_exists(collection, CoverSize.BIG)
             ):
                 cleaned_data.update(
                     {"url_cover": data.get("url_cover", collection.url_cover)}
                 )
-                path_cover_s, path_cover_l = fs_resource_handler.get_cover(
+                path_cover_s, path_cover_l = await fs_resource_handler.get_cover(
                     overwrite=True,
                     entity=collection,
                     url_cover=data.get("url_cover", ""),

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -307,7 +307,7 @@ async def update_rom(
     ):
         moby_rom = await meta_moby_handler.get_rom_by_id(cleaned_data["moby_id"])
         cleaned_data.update(moby_rom)
-        path_screenshots = fs_resource_handler.get_rom_screenshots(
+        path_screenshots = await fs_resource_handler.get_rom_screenshots(
             rom=rom,
             url_screenshots=cleaned_data.get("url_screenshots", []),
         )
@@ -319,7 +319,7 @@ async def update_rom(
     ):
         igdb_rom = meta_igdb_handler.get_rom_by_id(cleaned_data["igdb_id"])
         cleaned_data.update(igdb_rom)
-        path_screenshots = fs_resource_handler.get_rom_screenshots(
+        path_screenshots = await fs_resource_handler.get_rom_screenshots(
             rom=rom,
             url_screenshots=cleaned_data.get("url_screenshots", []),
         )
@@ -375,7 +375,7 @@ async def update_rom(
                 path_cover_l,
                 path_cover_s,
                 artwork_path,
-            ) = fs_resource_handler.build_artwork_path(rom, file_ext)
+            ) = await fs_resource_handler.build_artwork_path(rom, file_ext)
 
             cleaned_data.update(
                 {"path_cover_s": path_cover_s, "path_cover_l": path_cover_l}
@@ -392,13 +392,11 @@ async def update_rom(
                 artwork_l.write(artwork_file)
             cleaned_data.update({"url_cover": ""})
         else:
-            if data.get(
-                "url_cover", ""
-            ) != rom.url_cover or not fs_resource_handler.cover_exists(
-                rom, CoverSize.BIG
+            if data.get("url_cover", "") != rom.url_cover or not (
+                await fs_resource_handler.cover_exists(rom, CoverSize.BIG)
             ):
                 cleaned_data.update({"url_cover": data.get("url_cover", rom.url_cover)})
-                path_cover_s, path_cover_l = fs_resource_handler.get_cover(
+                path_cover_s, path_cover_l = await fs_resource_handler.get_cover(
                     overwrite=True,
                     entity=rom,
                     url_cover=data.get("url_cover", ""),

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -245,13 +245,13 @@ async def scan_platforms(
 
                     _added_rom = db_rom_handler.add_rom(scanned_rom)
 
-                    path_cover_s, path_cover_l = fs_resource_handler.get_cover(
+                    path_cover_s, path_cover_l = await fs_resource_handler.get_cover(
                         overwrite=True,
                         entity=_added_rom,
                         url_cover=_added_rom.url_cover,
                     )
 
-                    path_screenshots = fs_resource_handler.get_rom_screenshots(
+                    path_screenshots = await fs_resource_handler.get_rom_screenshots(
                         rom=_added_rom,
                         url_screenshots=_added_rom.url_screenshots,
                     )

--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -1,8 +1,7 @@
-import glob
 import shutil
-from pathlib import Path
 
-import requests
+import httpx
+from anyio import Path, open_file
 from config import RESOURCES_BASE_PATH
 from fastapi import HTTPException, status
 from logger.logger import log
@@ -10,16 +9,14 @@ from models.collection import Collection
 from models.rom import Rom
 from PIL import Image
 from urllib3.exceptions import ProtocolError
+from utils.context import ctx_httpx_client
 
 from .base_handler import CoverSize, FSHandler
 
 
 class FSResourcesHandler(FSHandler):
-    def __init__(self) -> None:
-        pass
-
     @staticmethod
-    def cover_exists(entity: Rom | Collection, size: CoverSize) -> bool:
+    async def cover_exists(entity: Rom | Collection, size: CoverSize) -> bool:
         """Check if rom cover exists in filesystem
 
         Args:
@@ -29,10 +26,12 @@ class FSResourcesHandler(FSHandler):
         Returns
             True if cover exists in filesystem else False
         """
-        matched_files = glob.glob(
-            f"{RESOURCES_BASE_PATH}/{entity.fs_resources_path}/cover/{size.value}.*"
-        )
-        return len(matched_files) > 0
+        async for _ in Path(
+            f"{RESOURCES_BASE_PATH}/{entity.fs_resources_path}/cover"
+        ).glob(f"{size.value}.*"):
+            # At least one file found.
+            return True
+        return False
 
     @staticmethod
     def resize_cover_to_small(cover_path: str) -> None:
@@ -48,7 +47,7 @@ class FSResourcesHandler(FSHandler):
         small_img = cover.resize(small_size)
         small_img.save(cover_path)
 
-    def _store_cover(
+    async def _store_cover(
         self, entity: Rom | Collection, url_cover: str, size: CoverSize
     ) -> None:
         """Store roms resources in filesystem
@@ -62,27 +61,25 @@ class FSResourcesHandler(FSHandler):
         cover_file = f"{size.value}.png"
         cover_path = f"{RESOURCES_BASE_PATH}/{entity.fs_resources_path}/cover"
 
+        httpx_client = ctx_httpx_client.get()
         try:
-            res = requests.get(
-                url_cover,
-                stream=True,
-                timeout=120,
-            )
-        except requests.exceptions.ConnectionError as exc:
+            async with httpx_client.stream("GET", url_cover, timeout=120) as response:
+                if response.status_code == 200:
+                    await Path(cover_path).mkdir(parents=True, exist_ok=True)
+                    async with await open_file(f"{cover_path}/{cover_file}", "wb") as f:
+                        async for chunk in response.aiter_raw():
+                            await f.write(chunk)
+        except httpx.NetworkError as exc:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail=f"Unable to fetch cover at {url_cover}: {str(exc)}",
             ) from exc
 
-        if res.status_code == 200:
-            Path(cover_path).mkdir(parents=True, exist_ok=True)
-            with open(f"{cover_path}/{cover_file}", "wb") as f:
-                shutil.copyfileobj(res.raw, f)
-            if size == CoverSize.SMALL:
-                self.resize_cover_to_small(f"{cover_path}/{cover_file}")
+        if size == CoverSize.SMALL:
+            self.resize_cover_to_small(f"{cover_path}/{cover_file}")
 
     @staticmethod
-    def _get_cover_path(entity: Rom | Collection, size: CoverSize) -> str:
+    async def _get_cover_path(entity: Rom | Collection, size: CoverSize) -> str:
         """Returns rom cover filesystem path adapted to frontend folder structure
 
         Args:
@@ -90,33 +87,35 @@ class FSResourcesHandler(FSHandler):
             file_name: name of rom file
             size: size of the cover
         """
-        file_path = (
-            f"{RESOURCES_BASE_PATH}/{entity.fs_resources_path}/cover/{size.value}.*"
-        )
-        matched_files = glob.glob(file_path, recursive=True)
-        return (
-            matched_files[0].replace(RESOURCES_BASE_PATH, "") if matched_files else ""
-        )
+        async for matched_file in Path(
+            f"{RESOURCES_BASE_PATH}/{entity.fs_resources_path}/cover"
+        ).glob(f"{size.value}.*"):
+            return str(matched_file.relative_to(RESOURCES_BASE_PATH))
+        return ""
 
-    def get_cover(
+    async def get_cover(
         self, entity: Rom | Collection | None, overwrite: bool, url_cover: str = ""
     ) -> tuple[str, str]:
         if not entity:
             return "", ""
 
-        if (overwrite or not self.cover_exists(entity, CoverSize.SMALL)) and url_cover:
-            self._store_cover(entity, url_cover, CoverSize.SMALL)
+        small_cover_exists = await self.cover_exists(entity, CoverSize.SMALL)
+        if url_cover and (overwrite or not small_cover_exists):
+            await self._store_cover(entity, url_cover, CoverSize.SMALL)
+            small_cover_exists = await self.cover_exists(entity, CoverSize.SMALL)
         path_cover_s = (
-            self._get_cover_path(entity, CoverSize.SMALL)
-            if self.cover_exists(entity, CoverSize.SMALL)
+            (await self._get_cover_path(entity, CoverSize.SMALL))
+            if small_cover_exists
             else ""
         )
 
-        if (overwrite or not self.cover_exists(entity, CoverSize.BIG)) and url_cover:
-            self._store_cover(entity, url_cover, CoverSize.BIG)
+        big_cover_exists = await self.cover_exists(entity, CoverSize.BIG)
+        if url_cover and (overwrite or not big_cover_exists):
+            await self._store_cover(entity, url_cover, CoverSize.BIG)
+            big_cover_exists = await self.cover_exists(entity, CoverSize.BIG)
         path_cover_l = (
-            self._get_cover_path(entity, CoverSize.BIG)
-            if self.cover_exists(entity, CoverSize.BIG)
+            (await self._get_cover_path(entity, CoverSize.BIG))
+            if big_cover_exists
             else ""
         )
 
@@ -127,8 +126,8 @@ class FSResourcesHandler(FSHandler):
         if not entity:
             return {"path_cover_s": "", "path_cover_l": ""}
 
+        cover_path = f"{RESOURCES_BASE_PATH}/{entity.fs_resources_path}/cover"
         try:
-            cover_path = f"{RESOURCES_BASE_PATH}/{entity.fs_resources_path}/cover"
             shutil.rmtree(cover_path)
         except FileNotFoundError:
             log.warning(
@@ -138,23 +137,20 @@ class FSResourcesHandler(FSHandler):
         return {"path_cover_s": "", "path_cover_l": ""}
 
     @staticmethod
-    def build_artwork_path(entity: Rom | Collection | None, file_ext: str):
+    async def build_artwork_path(entity: Rom | Collection | None, file_ext: str):
         if not entity:
             return "", "", ""
 
-        path_cover_l = (
-            f"{entity.fs_resources_path}/cover/{CoverSize.BIG.value}.{file_ext}"
-        )
-        path_cover_s = (
-            f"{entity.fs_resources_path}/cover/{CoverSize.SMALL.value}.{file_ext}"
-        )
+        path_cover = f"{entity.fs_resources_path}/cover"
+        path_cover_l = f"{path_cover}/{CoverSize.BIG.value}.{file_ext}"
+        path_cover_s = f"{path_cover}/{CoverSize.SMALL.value}.{file_ext}"
         artwork_path = f"{RESOURCES_BASE_PATH}/{entity.fs_resources_path}/cover"
-        Path(artwork_path).mkdir(parents=True, exist_ok=True)
+        await Path(artwork_path).mkdir(parents=True, exist_ok=True)
 
         return path_cover_l, path_cover_s, artwork_path
 
     @staticmethod
-    def _store_screenshot(rom: Rom, url: str, idx: int):
+    async def _store_screenshot(rom: Rom, url: str, idx: int):
         """Store roms resources in filesystem
 
         Args:
@@ -165,23 +161,23 @@ class FSResourcesHandler(FSHandler):
         screenshot_file = f"{idx}.jpg"
         screenshot_path = f"{RESOURCES_BASE_PATH}/{rom.fs_resources_path}/screenshots"
 
+        httpx_client = ctx_httpx_client.get()
         try:
-            res = requests.get(url, stream=True, timeout=120)
-        except requests.exceptions.ConnectionError as exc:
+            async with httpx_client.stream("GET", url, timeout=120) as response:
+                if response.status_code == 200:
+                    await Path(screenshot_path).mkdir(parents=True, exist_ok=True)
+                    async with await open_file(
+                        f"{screenshot_path}/{screenshot_file}", "wb"
+                    ) as f:
+                        async for chunk in response.aiter_raw():
+                            await f.write(chunk)
+        except httpx.NetworkError as exc:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail=f"Unable to fetch screenshot at {url}: {str(exc)}",
             ) from exc
-
-        if res.status_code == 200:
-            Path(screenshot_path).mkdir(parents=True, exist_ok=True)
-            with open(f"{screenshot_path}/{screenshot_file}", "wb") as f:
-                try:
-                    shutil.copyfileobj(res.raw, f)
-                except ProtocolError:
-                    log.warning(
-                        f"Failure writing screenshot {url} to file (ProtocolError)"
-                    )
+        except ProtocolError:
+            log.warning(f"Failure writing screenshot {url} to file (ProtocolError)")
 
     @staticmethod
     def _get_screenshot_path(rom: Rom, idx: str):
@@ -194,13 +190,15 @@ class FSResourcesHandler(FSHandler):
         """
         return f"{rom.fs_resources_path}/screenshots/{idx}.jpg"
 
-    def get_rom_screenshots(self, rom: Rom | None, url_screenshots: list) -> list[str]:
+    async def get_rom_screenshots(
+        self, rom: Rom | None, url_screenshots: list
+    ) -> list[str]:
         if not rom:
             return []
 
         path_screenshots: list[str] = []
         for idx, url in enumerate(url_screenshots):
-            self._store_screenshot(rom, url, idx)
+            await self._store_screenshot(rom, url, idx)
             path_screenshots.append(self._get_screenshot_path(rom, str(idx)))
 
         return path_screenshots

--- a/backend/handler/filesystem/tests/test_fs.py
+++ b/backend/handler/filesystem/tests/test_fs.py
@@ -7,8 +7,8 @@ from models.platform import Platform
 
 
 @pytest.mark.vcr
-def test_get_rom_cover():
-    path_cover_s, path_cover_l = fs_resource_handler.get_cover(
+async def test_get_rom_cover():
+    path_cover_s, path_cover_l = await fs_resource_handler.get_cover(
         overwrite=False, entity=None, url_cover=""
     )
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2823,4 +2823,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "8f13b0b7fcf9c4bcbd0441a17570c971b1aed71ef5a6091ab84587e4f2429b0a"
+content-hash = "14e7f9efeb7e1dac6acd66ed74dffa914ed4fcc3a4fc44dbcd87b96f3779b9c0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = ["Zurdi <zurdi@romm.app>", "Arcane <arcane@romm.app>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
+anyio = "^4.4"
 requests = "^2.32.2"
 fastapi = "0.110.0"
 uvicorn = "0.29.0"


### PR DESCRIPTION
For filesystem resource handler, `requests` calls have been replaced with `httpx`, and file I/O has been replaced with `anyio` utils.

The existing approach to save covers and screenshots, by calling `shutil.copyfileobj` with the raw response is no longer needed. `httpx` does not provide a file-like object when streaming [1], so there's no easy drop-in replacement.

However, the applied solution correctly builds the file iteratively, by consuming the response in chunks.

[1] https://github.com/encode/httpx/discussions/2296