### PR TITLE
misc: Migrate IGDBBaseHandler to async

### DIFF
--- a/backend/endpoints/platform.py
+++ b/backend/endpoints/platform.py
@@ -33,7 +33,7 @@ async def add_platforms(request: Request) -> PlatformSchema:
         fs_platform_handler.add_platforms(fs_slug=fs_slug)
     except PlatformAlreadyExistsException:
         log.info(f"Detected platform: {fs_slug}")
-    scanned_platform = scan_platform(fs_slug, [fs_slug])
+    scanned_platform = await scan_platform(fs_slug, [fs_slug])
     return db_platform_handler.add_platform(scanned_platform)
 
 

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -317,7 +317,7 @@ async def update_rom(
         cleaned_data.get("igdb_id", "")
         and int(cleaned_data.get("igdb_id", "")) != rom.igdb_id
     ):
-        igdb_rom = meta_igdb_handler.get_rom_by_id(cleaned_data["igdb_id"])
+        igdb_rom = await meta_igdb_handler.get_rom_by_id(cleaned_data["igdb_id"])
         cleaned_data.update(igdb_rom)
         path_screenshots = await fs_resource_handler.get_rom_screenshots(
             rom=rom,

--- a/backend/endpoints/search.py
+++ b/backend/endpoints/search.py
@@ -58,7 +58,7 @@ async def search_rom(
     log.info(emoji.emojize(f":video_game: {rom.platform_slug}: {rom.file_name}"))
     if search_by.lower() == "id":
         try:
-            igdb_matched_roms = meta_igdb_handler.get_matched_roms_by_id(
+            igdb_matched_roms = await meta_igdb_handler.get_matched_roms_by_id(
                 int(search_term)
             )
             moby_matched_roms = await meta_moby_handler.get_matched_roms_by_id(
@@ -71,8 +71,8 @@ async def search_rom(
                 detail=f"Tried searching by ID, but '{search_term}' is not a valid ID",
             ) from exc
     elif search_by.lower() == "name":
-        igdb_matched_roms = meta_igdb_handler.get_matched_roms_by_name(
-            search_term, _get_main_platform_igdb_id(rom.platform)
+        igdb_matched_roms = await meta_igdb_handler.get_matched_roms_by_name(
+            search_term, (await _get_main_platform_igdb_id(rom.platform))
         )
         moby_matched_roms = await meta_moby_handler.get_matched_roms_by_name(
             search_term, rom.platform.moby_id

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -197,7 +197,7 @@ async def _identify_platform(
     if platform and scan_type == ScanType.NEW_PLATFORMS:
         return scan_stats
 
-    scanned_platform = scan_platform(
+    scanned_platform = await scan_platform(
         platform_slug, fs_platforms, metadata_sources=metadata_sources
     )
     if platform:

--- a/backend/endpoints/tests/test_rom.py
+++ b/backend/endpoints/tests/test_rom.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 from handler.filesystem.roms_handler import FSRomsHandler
-from handler.metadata.igdb_handler import IGDBBaseHandler
+from handler.metadata.igdb_handler import IGDBBaseHandler, IGDBRom
 from main import app
 
 
@@ -38,7 +38,7 @@ def test_get_all_roms(client, access_token, rom, platform):
 
 
 @patch.object(FSRomsHandler, "rename_file")
-@patch.object(IGDBBaseHandler, "get_rom_by_id")
+@patch.object(IGDBBaseHandler, "get_rom_by_id", return_value=IGDBRom(igdb_id=None))
 def test_update_rom(rename_file_mock, get_rom_by_id_mock, client, access_token, rom):
     response = client.put(
         f"/roms/{rom.id}",

--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -73,6 +73,8 @@ class FSResourcesHandler(FSHandler):
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail=f"Unable to fetch cover at {url_cover}: {str(exc)}",
             ) from exc
+        except httpx.ProtocolError:
+            log.warning(f"Failure writing cover {url_cover} to file (ProtocolError)")
 
         if size == CoverSize.SMALL:
             self.resize_cover_to_small(f"{cover_path}/{cover_file}")
@@ -175,6 +177,8 @@ class FSResourcesHandler(FSHandler):
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail=f"Unable to fetch screenshot at {url}: {str(exc)}",
             ) from exc
+        except httpx.ProtocolError:
+            log.warning(f"Failure writing screenshot {url} to file (ProtocolError)")
 
     @staticmethod
     def _get_screenshot_path(rom: Rom, idx: str):

--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -8,7 +8,6 @@ from logger.logger import log
 from models.collection import Collection
 from models.rom import Rom
 from PIL import Image
-from urllib3.exceptions import ProtocolError
 from utils.context import ctx_httpx_client
 
 from .base_handler import CoverSize, FSHandler
@@ -176,8 +175,6 @@ class FSResourcesHandler(FSHandler):
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail=f"Unable to fetch screenshot at {url}: {str(exc)}",
             ) from exc
-        except ProtocolError:
-            log.warning(f"Failure writing screenshot {url} to file (ProtocolError)")
 
     @staticmethod
     def _get_screenshot_path(rom: Rom, idx: str):

--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -4,15 +4,15 @@ import sys
 import time
 from typing import Final, NotRequired
 
+import httpx
 import pydash
-import requests
 from config import IGDB_CLIENT_ID, IGDB_CLIENT_SECRET
 from fastapi import HTTPException, status
 from handler.redis_handler import sync_cache
 from logger.logger import log
-from requests.exceptions import HTTPError, Timeout
 from typing_extensions import TypedDict
 from unidecode import unidecode as uc
+from utils.context import ctx_httpx_client
 
 from .base_hander import (
     PS2_OPL_REGEX,
@@ -191,39 +191,38 @@ class IGDBBaseHandler(MetadataHandler):
         self.twitch_auth = TwitchAuth()
         self.headers = {
             "Client-ID": IGDB_CLIENT_ID,
-            "Authorization": f"Bearer {self.twitch_auth.get_oauth_token()}",
             "Accept": "application/json",
         }
 
     @staticmethod
     def check_twitch_token(func):
         @functools.wraps(func)
-        def wrapper(*args):
-            args[0].headers[
-                "Authorization"
-            ] = f"Bearer {args[0].twitch_auth.get_oauth_token()}"
-            return func(*args)
+        async def wrapper(*args):
+            token = await args[0].twitch_auth.get_oauth_token()
+            args[0].headers["Authorization"] = f"Bearer {token}"
+            return await func(*args)
 
         return wrapper
 
-    def _request(self, url: str, data: str, timeout: int = 120) -> list:
+    async def _request(self, url: str, data: str, timeout: int = 120) -> list:
+        httpx_client = ctx_httpx_client.get()
         try:
-            res = requests.post(
+            res = await httpx_client.post(
                 url,
-                f"{data} limit {self.pagination_limit};",
+                content=f"{data} limit {self.pagination_limit};",
                 headers=self.headers,
                 timeout=timeout,
             )
 
             res.raise_for_status()
             return res.json()
-        except requests.exceptions.ConnectionError as exc:
+        except httpx.NetworkError as exc:
             log.critical("Connection error: can't connect to IGDB", exc_info=True)
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Can't connect to IGDB, check your internet connection",
             ) from exc
-        except HTTPError as err:
+        except httpx.HTTPStatusError as err:
             # Retry once if the auth token is invalid
             if err.response.status_code != 401:
                 log.error(err)
@@ -231,28 +230,28 @@ class IGDBBaseHandler(MetadataHandler):
 
             # Attempt to force a token refresh if the token is invalid
             log.warning("Twitch token invalid: fetching a new one...")
-            token = self.twitch_auth._update_twitch_token()
+            token = await self.twitch_auth._update_twitch_token()
             self.headers["Authorization"] = f"Bearer {token}"
-        except Timeout:
+        except httpx.TimeoutException:
             # Retry once the request if it times out
             pass
 
         try:
-            res = requests.post(
+            res = await httpx_client.post(
                 url,
-                f"{data} limit {self.pagination_limit};",
+                content=f"{data} limit {self.pagination_limit};",
                 headers=self.headers,
                 timeout=timeout,
             )
             res.raise_for_status()
-        except (HTTPError, Timeout) as err:
+        except httpx.HTTPError as err:
             # Log the error and return an empty list if the request fails again
             log.error(err)
             return []
 
         return res.json()
 
-    def _search_rom(
+    async def _search_rom(
         self, search_term: str, platform_igdb_id: int, with_category: bool = False
     ) -> dict | None:
         if not platform_igdb_id:
@@ -264,17 +263,17 @@ class IGDBBaseHandler(MetadataHandler):
             if with_category
             else ""
         )
-        roms = self._request(
+        roms = await self._request(
             self.games_endpoint,
             data=f'search "{search_term}"; fields {",".join(self.games_fields)}; where platforms=[{platform_igdb_id}] {category_filter};',
         )
-        roms_expanded = self._request(
+        roms_expanded = await self._request(
             self.search_endpoint,
             data=f'fields {",".join(self.search_fields)}; where game.platforms=[{platform_igdb_id}] & (name ~ *"{search_term}"* | alternative_name ~ *"{search_term}"*);',
         )
         if roms_expanded:
             roms.extend(
-                self._request(
+                await self._request(
                     self.games_endpoint,
                     f'fields {",".join(self.games_fields)}; where id={roms_expanded[0]["game"]["id"]};',
                 )
@@ -296,11 +295,11 @@ class IGDBBaseHandler(MetadataHandler):
         return pydash.get(exact_matches or roms, "[0]", None)
 
     @check_twitch_token
-    def get_platform(self, slug: str) -> IGDBPlatform:
+    async def get_platform(self, slug: str) -> IGDBPlatform:
         if not IGDB_API_ENABLED:
             return IGDBPlatform(igdb_id=None, slug=slug)
 
-        platforms = self._request(
+        platforms = await self._request(
             self.platform_endpoint,
             data=f'fields {",".join(self.platforms_fields)}; where slug="{slug.lower()}";',
         )
@@ -314,7 +313,7 @@ class IGDBBaseHandler(MetadataHandler):
             )
 
         # Check if platform is a version if not found
-        platform_versions = self._request(
+        platform_versions = await self._request(
             self.platform_version_endpoint,
             data=f'fields {",".join(self.platforms_fields)}; where slug="{slug.lower()}";',
         )
@@ -398,21 +397,21 @@ class IGDBBaseHandler(MetadataHandler):
 
         search_term = self.normalize_search_term(search_term)
 
-        rom = self._search_rom(
-            search_term, platform_igdb_id, with_category=True
-        ) or self._search_rom(search_term, platform_igdb_id)
+        rom = await self._search_rom(search_term, platform_igdb_id, with_category=True)
+        if not rom:
+            rom = await self._search_rom(search_term, platform_igdb_id)
 
         # Split the search term since igdb struggles with colons
         if not rom and ":" in search_term:
             for term in search_term.split(":")[::-1]:
-                rom = self._search_rom(term, platform_igdb_id)
+                rom = await self._search_rom(term, platform_igdb_id)
                 if rom:
                     break
 
         # Some MAME games have two titles split by a slash
         if not rom and "/" in search_term:
             for term in search_term.split("/"):
-                rom = self._search_rom(term.strip(), platform_igdb_id)
+                rom = await self._search_rom(term.strip(), platform_igdb_id)
                 if rom:
                     break
 
@@ -437,11 +436,11 @@ class IGDBBaseHandler(MetadataHandler):
         )
 
     @check_twitch_token
-    def get_rom_by_id(self, igdb_id: int) -> IGDBRom:
+    async def get_rom_by_id(self, igdb_id: int) -> IGDBRom:
         if not IGDB_API_ENABLED:
             return IGDBRom(igdb_id=None)
 
-        roms = self._request(
+        roms = await self._request(
             self.games_endpoint,
             f'fields {",".join(self.games_fields)}; where id={igdb_id};',
         )
@@ -468,15 +467,15 @@ class IGDBBaseHandler(MetadataHandler):
         )
 
     @check_twitch_token
-    def get_matched_roms_by_id(self, igdb_id: int) -> list[IGDBRom]:
+    async def get_matched_roms_by_id(self, igdb_id: int) -> list[IGDBRom]:
         if not IGDB_API_ENABLED:
             return []
 
-        rom = self.get_rom_by_id(igdb_id)
+        rom = await self.get_rom_by_id(igdb_id)
         return [rom] if rom["igdb_id"] else []
 
     @check_twitch_token
-    def get_matched_roms_by_name(
+    async def get_matched_roms_by_name(
         self, search_term: str, platform_igdb_id: int
     ) -> list[IGDBRom]:
         if not IGDB_API_ENABLED:
@@ -486,12 +485,12 @@ class IGDBBaseHandler(MetadataHandler):
             return []
 
         search_term = uc(search_term)
-        matched_roms = self._request(
+        matched_roms = await self._request(
             self.games_endpoint,
             data=f'search "{search_term}"; fields {",".join(self.games_fields)}; where platforms=[{platform_igdb_id}];',
         )
 
-        alternative_matched_roms = self._request(
+        alternative_matched_roms = await self._request(
             self.search_endpoint,
             data=f'fields {",".join(self.search_fields)}; where game.platforms=[{platform_igdb_id}] & (name ~ *"{search_term}"* | alternative_name ~ *"{search_term}"*);',
         )
@@ -516,7 +515,7 @@ class IGDBBaseHandler(MetadataHandler):
                     )
                 )
             )
-            alternative_matched_roms = self._request(
+            alternative_matched_roms = await self._request(
                 self.games_endpoint,
                 f'fields {",".join(self.games_fields)}; where {id_filter};',
             )
@@ -560,15 +559,16 @@ class IGDBBaseHandler(MetadataHandler):
 
 
 class TwitchAuth:
-    def _update_twitch_token(self) -> str:
+    async def _update_twitch_token(self) -> str:
         token = None
         expires_in = 0
 
         if not IGDB_API_ENABLED:
             return ""
 
+        httpx_client = ctx_httpx_client.get()
         try:
-            res = requests.post(
+            res = await httpx_client.post(
                 url="https://id.twitch.tv/oauth2/token",
                 params={
                     "client_id": IGDB_CLIENT_ID,
@@ -581,10 +581,11 @@ class TwitchAuth:
             if res.status_code == 400:
                 log.critical("IGDB Error: Invalid IGDB_CLIENT_ID or IGDB_CLIENT_SECRET")
                 return ""
-            else:
-                token = res.json().get("access_token", "")
-                expires_in = res.json().get("expires_in", 0)
-        except requests.exceptions.ConnectionError:
+
+            response_json = res.json()
+            token = response_json.get("access_token", "")
+            expires_in = response_json.get("expires_in", 0)
+        except httpx.NetworkError:
             log.critical("Can't connect to IGDB, check your internet connection.")
             return ""
 
@@ -599,7 +600,7 @@ class TwitchAuth:
 
         return token
 
-    def get_oauth_token(self) -> str:
+    async def get_oauth_token(self) -> str:
         # Use a fake token when running tests
         if "pytest" in sys.modules:
             return "test_token"
@@ -613,7 +614,7 @@ class TwitchAuth:
 
         if not token or time.time() > float(token_expires_at or 0):
             log.warning("Twitch token invalid: fetching a new one...")
-            return self._update_twitch_token()
+            return await self._update_twitch_token()
 
         return token
 

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -24,7 +24,7 @@ class ScanType(Enum):
     COMPLETE = "complete"
 
 
-def _get_main_platform_igdb_id(platform: Platform):
+async def _get_main_platform_igdb_id(platform: Platform):
     cnfg = cm.get_config()
 
     if platform.fs_slug in cnfg.PLATFORMS_VERSIONS.keys():
@@ -33,9 +33,9 @@ def _get_main_platform_igdb_id(platform: Platform):
         if main_platform:
             main_platform_igdb_id = main_platform.igdb_id
         else:
-            main_platform_igdb_id = meta_igdb_handler.get_platform(main_platform_slug)[
-                "igdb_id"
-            ]
+            main_platform_igdb_id = (
+                await meta_igdb_handler.get_platform(main_platform_slug)
+            )["igdb_id"]
             if not main_platform_igdb_id:
                 main_platform_igdb_id = platform.igdb_id
     else:
@@ -43,7 +43,7 @@ def _get_main_platform_igdb_id(platform: Platform):
     return main_platform_igdb_id
 
 
-def scan_platform(
+async def scan_platform(
     fs_slug: str,
     fs_platforms: list[str],
     metadata_sources: list[str] | None = None,
@@ -86,7 +86,7 @@ def scan_platform(
         platform_attrs["slug"] = fs_slug
 
     igdb_platform = (
-        meta_igdb_handler.get_platform(platform_attrs["slug"])
+        (await meta_igdb_handler.get_platform(platform_attrs["slug"]))
         if "igdb" in metadata_sources
         else IGDBPlatform(igdb_id=None, slug=platform_attrs["slug"])
     )
@@ -246,7 +246,7 @@ async def scan_rom(
             or (scan_type == ScanType.UNIDENTIFIED and not rom.igdb_id)
         )
     ):
-        main_platform_igdb_id = _get_main_platform_igdb_id(platform)
+        main_platform_igdb_id = await _get_main_platform_igdb_id(platform)
         igdb_handler_rom = await meta_igdb_handler.get_rom(
             rom_attrs["file_name"], main_platform_igdb_id
         )

--- a/backend/handler/tests/cassettes/test_fastapi/test_scan_platform.yaml
+++ b/backend/handler/tests/cassettes/test_fastapi/test_scan_platform.yaml
@@ -137,8 +137,6 @@ interactions:
           - 895445746e561cd8-BUD
         Connection:
           - keep-alive
-        Content-Encoding:
-          - gzip
         Content-Type:
           - application/json
         Date:

--- a/backend/handler/tests/cassettes/test_fastapi/test_scan_rom.yaml
+++ b/backend/handler/tests/cassettes/test_fastapi/test_scan_rom.yaml
@@ -217,8 +217,6 @@ interactions:
           - 8954459468d768bb-BUD
         Connection:
           - keep-alive
-        Content-Encoding:
-          - gzip
         Content-Length:
           - "1529"
         Content-Type:
@@ -311,8 +309,6 @@ interactions:
           - 89544596b8d6684c-BUD
         Connection:
           - keep-alive
-        Content-Encoding:
-          - gzip
         Content-Type:
           - application/json
         Date:
@@ -459,8 +455,6 @@ interactions:
           - 8954459c292fc1bc-BUD
         Connection:
           - keep-alive
-        Content-Encoding:
-          - gzip
         Content-Length:
           - "1529"
         Content-Type:

--- a/backend/handler/tests/test_fastapi.py
+++ b/backend/handler/tests/test_fastapi.py
@@ -1,5 +1,4 @@
 import pytest
-from exceptions.fs_exceptions import RomsNotFoundException
 from handler.scan_handler import ScanType, scan_platform, scan_rom
 from models.platform import Platform
 from models.rom import Rom
@@ -7,8 +6,9 @@ from utils.context import initialize_context
 
 
 @pytest.mark.vcr
-def test_scan_platform():
-    platform = scan_platform("n64", ["n64"])
+async def test_scan_platform():
+    async with initialize_context():
+        platform = await scan_platform("n64", ["n64"])
 
     assert type(platform) is Platform
     assert platform.fs_slug == "n64"
@@ -16,10 +16,13 @@ def test_scan_platform():
     assert platform.name == "Nintendo 64"
     assert platform.igdb_id == 4
 
-    try:
-        platform = scan_platform("", [])
-    except RomsNotFoundException as e:
-        assert "Roms not found for platform" in str(e)
+    async with initialize_context():
+        platform = await scan_platform("", [])
+
+    assert platform.fs_slug == ""
+    assert platform.slug == ""
+    assert platform.name == ""
+    assert platform.igdb_id is None
 
 
 @pytest.mark.vcr

--- a/poetry.lock
+++ b/poetry.lock
@@ -217,105 +217,6 @@ files = [
 pycparser = "*"
 
 [[package]]
-name = "charset-normalizer"
-version = "3.3.2"
-description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-optional = false
-python-versions = ">=3.7.0"
-files = [
-    {file = "charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-win32.whl", hash = "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73"},
-    {file = "charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-win32.whl", hash = "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-win32.whl", hash = "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7"},
-    {file = "charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-win32.whl", hash = "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4"},
-    {file = "charset_normalizer-3.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-win32.whl", hash = "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25"},
-    {file = "charset_normalizer-3.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-win32.whl", hash = "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f"},
-    {file = "charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"},
-    {file = "charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"},
-]
-
-[[package]]
 name = "click"
 version = "8.1.7"
 description = "Composable command line interface toolkit"
@@ -2018,27 +1919,6 @@ hiredis = ["hiredis (>=1.0.0)"]
 ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
 
 [[package]]
-name = "requests"
-version = "2.32.3"
-description = "Python HTTP for Humans."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
-    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
-]
-
-[package.dependencies]
-certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<4"
-idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<3"
-
-[package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
-
-[[package]]
 name = "rq"
 version = "1.16.2"
 description = "RQ is a simple, lightweight, library for creating background jobs, and processing them."
@@ -2395,20 +2275,6 @@ cryptography = ">=35.0.0"
 types-pyOpenSSL = "*"
 
 [[package]]
-name = "types-requests"
-version = "2.32.0.20240622"
-description = "Typing stubs for requests"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "types-requests-2.32.0.20240622.tar.gz", hash = "sha256:ed5e8a412fcc39159d6319385c009d642845f250c63902718f605cd90faade31"},
-    {file = "types_requests-2.32.0.20240622-py3-none-any.whl", hash = "sha256:97bac6b54b5bd4cf91d407e62f0932a74821bc2211f22116d9ee1dd643826caf"},
-]
-
-[package.dependencies]
-urllib3 = ">=2"
-
-[[package]]
 name = "types-setuptools"
 version = "70.2.0.20240704"
 description = "Typing stubs for setuptools"
@@ -2443,20 +2309,19 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.2"
+version = "1.26.19"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.8"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 files = [
-    {file = "urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"},
-    {file = "urllib3-2.2.2.tar.gz", hash = "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"},
+    {file = "urllib3-1.26.19-py2.py3-none-any.whl", hash = "sha256:37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3"},
+    {file = "urllib3-1.26.19.tar.gz", hash = "sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
-h2 = ["h2 (>=4,<5)"]
-socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uvicorn"
@@ -2478,19 +2343,22 @@ standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)",
 
 [[package]]
 name = "vcrpy"
-version = "5.1.0"
+version = "6.0.1"
 description = "Automatically mock your HTTP interactions to simplify and speed up testing"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "vcrpy-5.1.0-py2.py3-none-any.whl", hash = "sha256:605e7b7a63dcd940db1df3ab2697ca7faf0e835c0852882142bafb19649d599e"},
-    {file = "vcrpy-5.1.0.tar.gz", hash = "sha256:bbf1532f2618a04f11bce2a99af3a9647a32c880957293ff91e0a5f187b6b3d2"},
+    {file = "vcrpy-6.0.1.tar.gz", hash = "sha256:9e023fee7f892baa0bbda2f7da7c8ac51165c1c6e38ff8688683a12a4bde9278"},
 ]
 
 [package.dependencies]
 PyYAML = "*"
+urllib3 = {version = "<2", markers = "platform_python_implementation == \"PyPy\""}
 wrapt = "*"
 yarl = "*"
+
+[package.extras]
+tests = ["Werkzeug (==2.0.3)", "aiohttp", "boto3", "httplib2", "httpx", "pytest", "pytest-aiohttp", "pytest-asyncio", "pytest-cov", "pytest-httpbin", "requests (>=2.22.0)", "tornado", "urllib3"]
 
 [[package]]
 name = "watchdog"
@@ -2827,4 +2695,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "743c70f463d5596bd9b312368e166ef3a65b1d3aafbf51b4fc3f3e033446d845"
+content-hash = "4124ad616d221d89b7e65980356cd9b5ba9b4710149fe0d8aee676a1fe8bb171"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ authors = ["Zurdi <zurdi@romm.app>", "Arcane <arcane@romm.app>"]
 [tool.poetry.dependencies]
 python = "^3.11"
 anyio = "^4.4"
-requests = "^2.32.2"
 fastapi = "0.110.0"
 uvicorn = "0.29.0"
 gunicorn = "22.0.0"
@@ -28,7 +27,6 @@ mariadb = "1.1.10"
 rq = "^1.16.1"
 redis = "^5.0"
 types-pyyaml = "^6.0.12.20240311"
-types-requests = "^2.31.0.20240311"
 types-redis = "^4.6.0.20240311 "
 passlib = { extras = ["bcrypt"], version = "^1.7.4" }
 itsdangerous = "^2.1.2"


### PR DESCRIPTION
Convert `IGDBBaseHandler` methods to be asynchronous, and use an `httpx` async client, instead of `requests` sync client.

This change also removes the direct dependency with `requests`, as the project no longer uses it, preferring `httpx` instead.