### PR TITLE
fix: Enable flake8-async rules in ruff and fix warnings

### DIFF
--- a/.trunk/configs/ruff.toml
+++ b/.trunk/configs/ruff.toml
@@ -1,5 +1,11 @@
+[lint]
 # Generic, formatter-friendly config.
-select = ["B", "D3", "E", "F"]
+# ASYNC: flake8-async.
+# B: flake8-bugbear.
+# D3: flake8-docstrings (D3xx).
+# E: pycodestyle errors.
+# F: Pyflakes.
+select = ["ASYNC", "B", "D3", "E", "F"]
 
 # Never enforce `E501` (line length violations). This should be handled by formatters.
 ignore = ["E501"]

--- a/backend/endpoints/collections.py
+++ b/backend/endpoints/collections.py
@@ -1,6 +1,7 @@
 import json
 from shutil import rmtree
 
+from anyio import open_file
 from config import RESOURCES_BASE_PATH
 from decorators.auth import protected_route
 from endpoints.responses import MessageResponse
@@ -62,12 +63,12 @@ async def add_collection(
 
         artwork_file = artwork.file.read()
         file_location_s = f"{artwork_path}/small.{file_ext}"
-        with open(file_location_s, "wb+") as artwork_s:
+        async with await open_file(file_location_s, "wb+") as artwork_s:
             artwork_s.write(artwork_file)
             fs_resource_handler.resize_cover_to_small(file_location_s)
 
         file_location_l = f"{artwork_path}/big.{file_ext}"
-        with open(file_location_l, "wb+") as artwork_l:
+        async with await open_file(file_location_l, "wb+") as artwork_l:
             artwork_l.write(artwork_file)
     else:
         path_cover_s, path_cover_l = await fs_resource_handler.get_cover(
@@ -183,12 +184,12 @@ async def update_collection(
 
             artwork_file = artwork.file.read()
             file_location_s = f"{artwork_path}/small.{file_ext}"
-            with open(file_location_s, "wb+") as artwork_s:
+            async with await open_file(file_location_s, "wb+") as artwork_s:
                 artwork_s.write(artwork_file)
                 fs_resource_handler.resize_cover_to_small(file_location_s)
 
             file_location_l = f"{artwork_path}/big.{file_ext}"
-            with open(file_location_l, "wb+") as artwork_l:
+            async with await open_file(file_location_l, "wb+") as artwork_l:
                 artwork_l.write(artwork_file)
             cleaned_data.update({"url_cover": ""})
         else:

--- a/backend/endpoints/collections.py
+++ b/backend/endpoints/collections.py
@@ -64,12 +64,12 @@ async def add_collection(
         artwork_file = artwork.file.read()
         file_location_s = f"{artwork_path}/small.{file_ext}"
         async with await open_file(file_location_s, "wb+") as artwork_s:
-            artwork_s.write(artwork_file)
+            await artwork_s.write(artwork_file)
             fs_resource_handler.resize_cover_to_small(file_location_s)
 
         file_location_l = f"{artwork_path}/big.{file_ext}"
         async with await open_file(file_location_l, "wb+") as artwork_l:
-            artwork_l.write(artwork_file)
+            await artwork_l.write(artwork_file)
     else:
         path_cover_s, path_cover_l = await fs_resource_handler.get_cover(
             overwrite=True,
@@ -185,12 +185,12 @@ async def update_collection(
             artwork_file = artwork.file.read()
             file_location_s = f"{artwork_path}/small.{file_ext}"
             async with await open_file(file_location_s, "wb+") as artwork_s:
-                artwork_s.write(artwork_file)
+                await artwork_s.write(artwork_file)
                 fs_resource_handler.resize_cover_to_small(file_location_s)
 
             file_location_l = f"{artwork_path}/big.{file_ext}"
             async with await open_file(file_location_l, "wb+") as artwork_l:
-                artwork_l.write(artwork_file)
+                await artwork_l.write(artwork_file)
             cleaned_data.update({"url_cover": ""})
         else:
             if data.get("url_cover", "") != collection.url_cover or not (

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -83,7 +83,7 @@ async def add_roms(
                 chunk = rom.file.read(1024)
                 if not chunk:
                     break
-                f.write(chunk)
+                await f.write(chunk)
 
         uploaded_roms.append(rom.filename)
 
@@ -385,12 +385,12 @@ async def update_rom(
             artwork_file = artwork.file.read()
             file_location_s = f"{artwork_path}/small.{file_ext}"
             async with await open_file(file_location_s, "wb+") as artwork_s:
-                artwork_s.write(artwork_file)
+                await artwork_s.write(artwork_file)
                 fs_resource_handler.resize_cover_to_small(file_location_s)
 
             file_location_l = f"{artwork_path}/big.{file_ext}"
             async with await open_file(file_location_l, "wb+") as artwork_l:
-                artwork_l.write(artwork_file)
+                await artwork_l.write(artwork_file)
             cleaned_data.update({"url_cover": ""})
         else:
             if data.get("url_cover", "") != rom.url_cover or not (

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -6,6 +6,7 @@ from stat import S_IFREG
 from typing import Annotated
 from urllib.parse import quote
 
+from anyio import open_file
 from config import (
     DISABLE_DOWNLOAD_ENDPOINT_AUTH,
     LIBRARY_BASE_PATH,
@@ -35,7 +36,7 @@ router = APIRouter()
 
 
 @protected_route(router.post, "/roms", ["roms.write"])
-def add_roms(
+async def add_roms(
     request: Request,
     platform_id: int,
     roms: list[UploadFile] = File(...),  # noqa: B008
@@ -77,7 +78,7 @@ def add_roms(
         log.info(f" - Uploading {rom.filename}")
         file_location = f"{roms_path}/{rom.filename}"
 
-        with open(file_location, "wb+") as f:
+        async with await open_file(file_location, "wb+") as f:
             while True:
                 chunk = rom.file.read(1024)
                 if not chunk:
@@ -383,12 +384,12 @@ async def update_rom(
 
             artwork_file = artwork.file.read()
             file_location_s = f"{artwork_path}/small.{file_ext}"
-            with open(file_location_s, "wb+") as artwork_s:
+            async with await open_file(file_location_s, "wb+") as artwork_s:
                 artwork_s.write(artwork_file)
                 fs_resource_handler.resize_cover_to_small(file_location_s)
 
             file_location_l = f"{artwork_path}/big.{file_ext}"
-            with open(file_location_l, "wb+") as artwork_l:
+            async with await open_file(file_location_l, "wb+") as artwork_l:
                 artwork_l.write(artwork_file)
             cleaned_data.update({"url_cover": ""})
         else:

--- a/backend/endpoints/user.py
+++ b/backend/endpoints/user.py
@@ -170,7 +170,7 @@ async def update_user(
         async with await open_file(
             f"{ASSETS_BASE_PATH}/{file_location}", "wb+"
         ) as file_object:
-            file_object.write(form_data.avatar.file.read())
+            await file_object.write(form_data.avatar.file.read())
 
     if cleaned_data:
         db_user_handler.update_user(id, cleaned_data)

--- a/backend/endpoints/user.py
+++ b/backend/endpoints/user.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 from typing import Annotated
 
+from anyio import open_file
 from config import ASSETS_BASE_PATH
 from decorators.auth import protected_route
 from endpoints.forms.identity import UserForm
@@ -104,7 +105,7 @@ def get_user(request: Request, id: int) -> UserSchema:
 
 
 @protected_route(router.put, "/users/{id}", ["me.write"])
-def update_user(
+async def update_user(
     request: Request, id: int, form_data: Annotated[UserForm, Depends()]
 ) -> UserSchema:
     """Update user endpoint
@@ -166,7 +167,9 @@ def update_user(
         Path(f"{ASSETS_BASE_PATH}/{user_avatar_path}").mkdir(
             parents=True, exist_ok=True
         )
-        with open(f"{ASSETS_BASE_PATH}/{file_location}", "wb+") as file_object:
+        async with await open_file(
+            f"{ASSETS_BASE_PATH}/{file_location}", "wb+"
+        ) as file_object:
             file_object.write(form_data.avatar.file.read())
 
     if cleaned_data:


### PR DESCRIPTION
`ASYNC` rules [1] try to find issues regarding asynchronous code. This change enables `ruff` to start reporting these issues, and fixes existing warnings.

[1] https://docs.astral.sh/ruff/rules/#flake8-async-async