### PR TITLE
misc: Use PYTEST_VERSION variable to detect Pytest runs

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -85,3 +85,6 @@ SCHEDULED_UPDATE_SWITCH_TITLEDB_CRON: Final = os.environ.get(
     "SCHEDULED_UPDATE_SWITCH_TITLEDB_CRON",
     "0 4 * * *",  # At 4:00 AM every day
 )
+
+# TESTING
+IS_PYTEST_RUN: Final = bool(os.environ.get("PYTEST_VERSION", False))

--- a/backend/endpoints/user.py
+++ b/backend/endpoints/user.py
@@ -1,9 +1,8 @@
-import sys
 from pathlib import Path
 from typing import Annotated
 
 from anyio import open_file
-from config import ASSETS_BASE_PATH
+from config import ASSETS_BASE_PATH, IS_PYTEST_RUN
 from decorators.auth import protected_route
 from endpoints.forms.identity import UserForm
 from endpoints.responses import MessageResponse
@@ -23,7 +22,7 @@ router = APIRouter()
     "/users",
     (
         []
-        if "pytest" not in sys.modules and len(db_user_handler.get_admin_users()) == 0
+        if not IS_PYTEST_RUN and len(db_user_handler.get_admin_users()) == 0
         else ["users.write"]
     ),
     status_code=status.HTTP_201_CREATED,

--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -1,12 +1,11 @@
 import functools
 import re
-import sys
 import time
 from typing import Final, NotRequired
 
 import httpx
 import pydash
-from config import IGDB_CLIENT_ID, IGDB_CLIENT_SECRET
+from config import IGDB_CLIENT_ID, IGDB_CLIENT_SECRET, IS_PYTEST_RUN
 from fastapi import HTTPException, status
 from handler.redis_handler import sync_cache
 from logger.logger import log
@@ -609,7 +608,7 @@ class TwitchAuth:
 
     async def get_oauth_token(self) -> str:
         # Use a fake token when running tests
-        if "pytest" in sys.modules:
+        if IS_PYTEST_RUN:
             return "test_token"
 
         if not IGDB_API_ENABLED:

--- a/backend/handler/redis_handler.py
+++ b/backend/handler/redis_handler.py
@@ -1,7 +1,14 @@
 import sys
 from enum import Enum
 
-from config import REDIS_DB, REDIS_HOST, REDIS_PASSWORD, REDIS_PORT, REDIS_USERNAME
+from config import (
+    IS_PYTEST_RUN,
+    REDIS_DB,
+    REDIS_HOST,
+    REDIS_PASSWORD,
+    REDIS_PORT,
+    REDIS_USERNAME,
+)
 from logger.logger import log
 from redis import Redis
 from redis.asyncio import Redis as AsyncRedis
@@ -33,7 +40,7 @@ low_prio_queue = Queue(name=QueuePrio.LOW.value, connection=redis_client)
 
 
 def __get_sync_cache() -> Redis:
-    if "pytest" in sys.modules:
+    if IS_PYTEST_RUN:
         # Only import fakeredis when running tests, as it is a test dependency.
         from fakeredis import FakeRedis
 
@@ -54,7 +61,7 @@ def __get_sync_cache() -> Redis:
 
 
 def __get_async_cache() -> AsyncRedis:
-    if "pytest" in sys.modules:
+    if IS_PYTEST_RUN:
         # Only import fakeredis when running tests, as it is a test dependency.
         from fakeredis import FakeAsyncRedis
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,17 @@
 import re
-import sys
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import alembic.config
 import endpoints.sockets.scan  # noqa
 import uvicorn
-from config import DEV_HOST, DEV_PORT, DISABLE_CSRF_PROTECTION, ROMM_AUTH_SECRET_KEY
+from config import (
+    DEV_HOST,
+    DEV_PORT,
+    DISABLE_CSRF_PROTECTION,
+    IS_PYTEST_RUN,
+    ROMM_AUTH_SECRET_KEY,
+)
 from endpoints import (
     auth,
     collections,
@@ -54,7 +59,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-if "pytest" not in sys.modules and not DISABLE_CSRF_PROTECTION:
+if not IS_PYTEST_RUN and not DISABLE_CSRF_PROTECTION:
     # CSRF protection (except endpoints listed in exempt_urls)
     app.add_middleware(
         CustomCSRFMiddleware,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1547,20 +1547,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.2.2"
+version = "8.3.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.2.2-py3-none-any.whl", hash = "sha256:c434598117762e2bd304e526244f67bf66bbd7b5d6cf22138be51ff661980343"},
-    {file = "pytest-8.2.2.tar.gz", hash = "sha256:de4bb8104e201939ccdc688b27a89a7be2079b22e2bd2b07f806b6ba71117977"},
+    {file = "pytest-8.3.2-py3-none-any.whl", hash = "sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5"},
+    {file = "pytest-8.3.2.tar.gz", hash = "sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce"},
 ]
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=1.5,<2.0"
+pluggy = ">=1.5,<2"
 
 [package.extras]
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -2695,4 +2695,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "4124ad616d221d89b7e65980356cd9b5ba9b4710149fe0d8aee676a1fe8bb171"
+content-hash = "d4564c67bc8f59fcaa0d4e1e4a6cc02de669f6a6d99dec3e2b0f8147e1a6152e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ certifi = "2024.07.04"
 
 [tool.poetry.group.test.dependencies]
 fakeredis = "^2.21.3"
-pytest = "^8.1.1"
+pytest = "^8.3"
 pytest-env = "^1.1.3"
 pytest-mock = "^3.12.0"
 pytest-asyncio = "^0.23.5"


### PR DESCRIPTION
Pytest v8.2 introduced the `PYTEST_VERSION` environment variable [1], that can be used to check if code is running from within a pytest run.

This way, we can avoid checking the loaded `sys` modules.

[1] https://docs.pytest.org/en/stable/changelog.html#id57