### PR TITLE
[ROMM-1029] Store and re-use last saved biois/save/state/core

### DIFF
--- a/frontend/src/views/Play/Base.vue
+++ b/frontend/src/views/Play/Base.vue
@@ -52,14 +52,18 @@ onMounted(async () => {
   supportedCores.value = [...getSupportedCores(rom.value.platform_slug)];
 
   // Load stored bios, save, state, and core
-  const storedSaveID = localStorage.getItem("player:save_id");
+  const storedSaveID = localStorage.getItem(`player:${rom.value.id}:save_id`);
   if (storedSaveID) {
-    saveRef.value = rom.value.user_saves?.find((s) => s.id === parseInt(storedSaveID)) ?? null;
+    saveRef.value =
+      rom.value.user_saves?.find((s) => s.id === parseInt(storedSaveID)) ??
+      null;
   }
 
-  const storedStateID = localStorage.getItem("player:state_id");
+  const storedStateID = localStorage.getItem(`player:${rom.value.id}:state_id`);
   if (storedStateID) {
-    stateRef.value = rom.value.user_states?.find((s) => s.id === parseInt(storedStateID)) ?? null;
+    stateRef.value =
+      rom.value.user_states?.find((s) => s.id === parseInt(storedStateID)) ??
+      null;
   } else if (rom.value.user_states) {
     // Otherwise auto select most recent state by last updated date
     stateRef.value = rom.value.user_states?.sort((a, b) =>
@@ -67,12 +71,18 @@ onMounted(async () => {
     )[0];
   }
 
-  const storedBiosID = localStorage.getItem("player:bios_id");
+  const storedBiosID = localStorage.getItem(
+    `player:${rom.value.platform_slug}:bios_id`
+  );
   if (storedBiosID) {
-    biosRef.value = firmwareOptions.value.find((f) => f.id === parseInt(storedBiosID)) ?? null;
+    biosRef.value =
+      firmwareOptions.value.find((f) => f.id === parseInt(storedBiosID)) ??
+      null;
   }
 
-  const storedCore = localStorage.getItem("player:core");
+  const storedCore = localStorage.getItem(
+    `player:${rom.value.platform_slug}:core`
+  );
   if (storedCore) {
     coreRef.value = storedCore;
   } else {
@@ -239,11 +249,11 @@ onMounted(async () => {
                     item.value.emulator
                   }}</v-chip>
                   <v-chip size="x-small" class="ml-1" label
-                  >{{ formatBytes(item.value.file_size_bytes) }}
-                </v-chip>
-                <v-chip size="small" class="ml-1" label>
-                  {{ formatTimestamp(item.value.updated_at) }}
-                </v-chip>
+                    >{{ formatBytes(item.value.file_size_bytes) }}
+                  </v-chip>
+                  <v-chip size="small" class="ml-1" label>
+                    {{ formatTimestamp(item.value.updated_at) }}
+                  </v-chip>
                 </template>
               </v-list-item>
             </template>
@@ -258,11 +268,11 @@ onMounted(async () => {
                     item.value.emulator
                   }}</v-chip>
                   <v-chip size="x-small" class="ml-1" label
-                  >{{ formatBytes(item.value.file_size_bytes) }}
-                </v-chip>
-                <v-chip size="small" class="ml-1" label>
-                  {{ formatTimestamp(item.value.updated_at) }}
-                </v-chip>
+                    >{{ formatBytes(item.value.file_size_bytes) }}
+                  </v-chip>
+                  <v-chip size="small" class="ml-1" label>
+                    {{ formatTimestamp(item.value.updated_at) }}
+                  </v-chip>
                 </template>
               </v-list-item>
             </template>

--- a/frontend/src/views/Play/Player.vue
+++ b/frontend/src/views/Play/Player.vue
@@ -28,21 +28,33 @@ onMounted(() => {
       `player:${props.rom.id}:save_id`,
       props.save.id.toString()
     );
+  } else {
+    localStorage.removeItem(`player:${props.rom.id}:save_id`);
   }
+
   if (props.state) {
     localStorage.setItem(
       `player:${props.rom.id}:state_id`,
       props.state.id.toString()
     );
+  } else {
+    localStorage.removeItem(`player:${props.rom.id}:state_id`);
   }
+
   if (props.bios) {
     localStorage.setItem(
       `player:${props.rom.platform_slug}:bios_id`,
       props.bios.id.toString()
     );
+  } else {
+    localStorage.removeItem(`player:${props.rom.platform_slug}:bios_id`);
   }
-  if (props.core)
+
+  if (props.core) {
     localStorage.setItem(`player:${props.rom.platform_slug}:core`, props.core);
+  } else {
+    localStorage.removeItem(`player:${props.rom.platform_slug}:core`);
+  }
 });
 
 // Declare global variables for EmulatorJS

--- a/frontend/src/views/Play/Player.vue
+++ b/frontend/src/views/Play/Player.vue
@@ -24,15 +24,25 @@ onBeforeUnmount(() => {
 
 onMounted(() => {
   if (props.save) {
-    localStorage.setItem("player:save_id", props.save.id.toString());
+    localStorage.setItem(
+      `player:${props.rom.id}:save_id`,
+      props.save.id.toString()
+    );
   }
   if (props.state) {
-    localStorage.setItem("player:state_id", props.state.id.toString());
+    localStorage.setItem(
+      `player:${props.rom.id}:state_id`,
+      props.state.id.toString()
+    );
   }
   if (props.bios) {
-    localStorage.setItem("player:bios_id", props.bios.id.toString());
+    localStorage.setItem(
+      `player:${props.rom.platform_slug}:bios_id`,
+      props.bios.id.toString()
+    );
   }
-  if (props.core) localStorage.setItem("player:core", props.core);
+  if (props.core)
+    localStorage.setItem(`player:${props.rom.platform_slug}:core`, props.core);
 });
 
 // Declare global variables for EmulatorJS

--- a/frontend/src/views/Play/Player.vue
+++ b/frontend/src/views/Play/Player.vue
@@ -5,7 +5,7 @@ import screenshotApi from "@/services/api/screenshot";
 import stateApi from "@/services/api/state";
 import type { DetailedRom } from "@/stores/roms";
 import { getSupportedCores } from "@/utils";
-import { onBeforeUnmount, ref } from "vue";
+import { onBeforeUnmount, onMounted, ref } from "vue";
 
 const props = defineProps<{
   rom: DetailedRom;
@@ -20,6 +20,19 @@ const stateRef = ref<StateSchema | null>(props.state);
 
 onBeforeUnmount(() => {
   window.location.reload();
+});
+
+onMounted(() => {
+  if (props.save) {
+    localStorage.setItem("player:save_id", props.save.id.toString());
+  }
+  if (props.state) {
+    localStorage.setItem("player:state_id", props.state.id.toString());
+  }
+  if (props.bios) {
+    localStorage.setItem("player:bios_id", props.bios.id.toString());
+  }
+  if (props.core) localStorage.setItem("player:core", props.core);
 });
 
 // Declare global variables for EmulatorJS


### PR DESCRIPTION
When starting a game with a selected core or BIOS, re-use that same core or BIOS for future plays. Same goes for individual save files, but specific to the game played.

Fixes #1029 