### PR TITLE
[ROMM-1022] Add button to show duplicates

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -41,7 +41,7 @@ lint:
   ignore:
     - linters: [ALL]
       paths:
-        - src/__generated__/**
+        - frontend/src/__generated__/**
         - docker/Dockerfile
   definitions:
     - name: eslint

--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -114,6 +114,7 @@ class RomSchema(BaseModel):
     updated_at: datetime
 
     rom_user: RomUserSchema | None = Field(default=None)
+    sibling_roms: list[RomSchema] = Field(default_factory=list)
 
     class Config:
         from_attributes = True
@@ -124,6 +125,9 @@ class RomSchema(BaseModel):
         user_id = request.user.id
 
         rom.rom_user = RomUserSchema.for_user(user_id, db_rom)
+        rom.sibling_roms = [
+            RomSchema.model_validate(r) for r in db_rom.get_sibling_roms()
+        ]
 
         return rom
 

--- a/frontend/src/__generated__/index.ts
+++ b/frontend/src/__generated__/index.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type { AddFirmwareResponse } from "./models/AddFirmwareResponse";
 export type { AddRomsResponse } from "./models/AddRomsResponse";

--- a/frontend/src/__generated__/models/AddFirmwareResponse.ts
+++ b/frontend/src/__generated__/models/AddFirmwareResponse.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 import type { FirmwareSchema } from "./FirmwareSchema";
 

--- a/frontend/src/__generated__/models/AddRomsResponse.ts
+++ b/frontend/src/__generated__/models/AddRomsResponse.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type AddRomsResponse = {
   uploaded_roms: Array<string>;

--- a/frontend/src/__generated__/models/Body_add_collection_collections_post.ts
+++ b/frontend/src/__generated__/models/Body_add_collection_collections_post.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type Body_add_collection_collections_post = {
   artwork?: Blob | null;

--- a/frontend/src/__generated__/models/Body_add_firmware_firmware_post.ts
+++ b/frontend/src/__generated__/models/Body_add_firmware_firmware_post.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type Body_add_firmware_firmware_post = {
   files: Array<Blob>;

--- a/frontend/src/__generated__/models/Body_add_roms_roms_post.ts
+++ b/frontend/src/__generated__/models/Body_add_roms_roms_post.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type Body_add_roms_roms_post = {
   roms: Array<Blob>;

--- a/frontend/src/__generated__/models/Body_add_saves_saves_post.ts
+++ b/frontend/src/__generated__/models/Body_add_saves_saves_post.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type Body_add_saves_saves_post = {
   saves: Array<Blob>;

--- a/frontend/src/__generated__/models/Body_add_screenshots_screenshots_post.ts
+++ b/frontend/src/__generated__/models/Body_add_screenshots_screenshots_post.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type Body_add_screenshots_screenshots_post = {
   screenshots: Array<Blob>;

--- a/frontend/src/__generated__/models/Body_add_states_states_post.ts
+++ b/frontend/src/__generated__/models/Body_add_states_states_post.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type Body_add_states_states_post = {
   states: Array<Blob>;

--- a/frontend/src/__generated__/models/Body_token_token_post.ts
+++ b/frontend/src/__generated__/models/Body_token_token_post.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type Body_token_token_post = {
   grant_type?: string;

--- a/frontend/src/__generated__/models/Body_update_collection_collections__id__put.ts
+++ b/frontend/src/__generated__/models/Body_update_collection_collections__id__put.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type Body_update_collection_collections__id__put = {
   artwork?: Blob | null;

--- a/frontend/src/__generated__/models/Body_update_rom_roms__id__put.ts
+++ b/frontend/src/__generated__/models/Body_update_rom_roms__id__put.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type Body_update_rom_roms__id__put = {
   artwork?: Blob | null;

--- a/frontend/src/__generated__/models/Body_update_user_users__id__put.ts
+++ b/frontend/src/__generated__/models/Body_update_user_users__id__put.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type Body_update_user_users__id__put = {
   avatar?: Blob | null;

--- a/frontend/src/__generated__/models/CollectionSchema.ts
+++ b/frontend/src/__generated__/models/CollectionSchema.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type CollectionSchema = {
   id: number;

--- a/frontend/src/__generated__/models/ConfigResponse.ts
+++ b/frontend/src/__generated__/models/ConfigResponse.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type ConfigResponse = {
   EXCLUDED_PLATFORMS: Array<string>;

--- a/frontend/src/__generated__/models/DetailedRomSchema.ts
+++ b/frontend/src/__generated__/models/DetailedRomSchema.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 import type { CollectionSchema } from "./CollectionSchema";
 import type { RomIGDBMetadata } from "./RomIGDBMetadata";
@@ -52,8 +53,8 @@ export type DetailedRomSchema = {
   created_at: string;
   updated_at: string;
   rom_user?: RomUserSchema | null;
-  merged_screenshots: Array<string>;
   sibling_roms?: Array<RomSchema>;
+  merged_screenshots: Array<string>;
   user_saves?: Array<SaveSchema>;
   user_states?: Array<StateSchema>;
   user_screenshots?: Array<ScreenshotSchema>;

--- a/frontend/src/__generated__/models/FirmwareSchema.ts
+++ b/frontend/src/__generated__/models/FirmwareSchema.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type FirmwareSchema = {
   id: number;

--- a/frontend/src/__generated__/models/HTTPValidationError.ts
+++ b/frontend/src/__generated__/models/HTTPValidationError.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 import type { ValidationError } from "./ValidationError";
 

--- a/frontend/src/__generated__/models/IGDBMetadataPlatform.ts
+++ b/frontend/src/__generated__/models/IGDBMetadataPlatform.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type IGDBMetadataPlatform = {
   igdb_id: number;

--- a/frontend/src/__generated__/models/IGDBRelatedGame.ts
+++ b/frontend/src/__generated__/models/IGDBRelatedGame.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type IGDBRelatedGame = {
   id: number;

--- a/frontend/src/__generated__/models/MessageResponse.ts
+++ b/frontend/src/__generated__/models/MessageResponse.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type MessageResponse = {
   msg: string;

--- a/frontend/src/__generated__/models/MetadataSourcesDict.ts
+++ b/frontend/src/__generated__/models/MetadataSourcesDict.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type MetadataSourcesDict = {
   IGDB_API_ENABLED: boolean;

--- a/frontend/src/__generated__/models/MobyMetadataPlatform.ts
+++ b/frontend/src/__generated__/models/MobyMetadataPlatform.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type MobyMetadataPlatform = {
   moby_id: number;

--- a/frontend/src/__generated__/models/PlatformSchema.ts
+++ b/frontend/src/__generated__/models/PlatformSchema.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 import type { FirmwareSchema } from "./FirmwareSchema";
 

--- a/frontend/src/__generated__/models/Role.ts
+++ b/frontend/src/__generated__/models/Role.ts
@@ -1,5 +1,6 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type Role = "viewer" | "editor" | "admin";

--- a/frontend/src/__generated__/models/RomIGDBMetadata.ts
+++ b/frontend/src/__generated__/models/RomIGDBMetadata.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 import type { IGDBMetadataPlatform } from "./IGDBMetadataPlatform";
 import type { IGDBRelatedGame } from "./IGDBRelatedGame";

--- a/frontend/src/__generated__/models/RomMobyMetadata.ts
+++ b/frontend/src/__generated__/models/RomMobyMetadata.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 import type { MobyMetadataPlatform } from "./MobyMetadataPlatform";
 

--- a/frontend/src/__generated__/models/RomSchema.ts
+++ b/frontend/src/__generated__/models/RomSchema.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 import type { RomIGDBMetadata } from "./RomIGDBMetadata";
 import type { RomMobyMetadata } from "./RomMobyMetadata";
@@ -46,5 +47,6 @@ export type RomSchema = {
   created_at: string;
   updated_at: string;
   rom_user?: RomUserSchema | null;
+  sibling_roms?: Array<RomSchema>;
   readonly sort_comparator: string;
 };

--- a/frontend/src/__generated__/models/RomUserSchema.ts
+++ b/frontend/src/__generated__/models/RomUserSchema.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type RomUserSchema = {
   id: number;

--- a/frontend/src/__generated__/models/SaveSchema.ts
+++ b/frontend/src/__generated__/models/SaveSchema.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 import type { ScreenshotSchema } from "./ScreenshotSchema";
 

--- a/frontend/src/__generated__/models/SchedulerDict.ts
+++ b/frontend/src/__generated__/models/SchedulerDict.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 import type { TaskDict } from "./TaskDict";
 

--- a/frontend/src/__generated__/models/ScreenshotSchema.ts
+++ b/frontend/src/__generated__/models/ScreenshotSchema.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type ScreenshotSchema = {
   id: number;

--- a/frontend/src/__generated__/models/SearchRomSchema.ts
+++ b/frontend/src/__generated__/models/SearchRomSchema.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type SearchRomSchema = {
   igdb_id?: number | null;

--- a/frontend/src/__generated__/models/StateSchema.ts
+++ b/frontend/src/__generated__/models/StateSchema.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 import type { ScreenshotSchema } from "./ScreenshotSchema";
 

--- a/frontend/src/__generated__/models/StatsReturn.ts
+++ b/frontend/src/__generated__/models/StatsReturn.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type StatsReturn = {
   PLATFORMS: number;

--- a/frontend/src/__generated__/models/TaskDict.ts
+++ b/frontend/src/__generated__/models/TaskDict.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type TaskDict = {
   ENABLED: boolean;

--- a/frontend/src/__generated__/models/TokenResponse.ts
+++ b/frontend/src/__generated__/models/TokenResponse.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type TokenResponse = {
   access_token: string;

--- a/frontend/src/__generated__/models/UploadedSavesResponse.ts
+++ b/frontend/src/__generated__/models/UploadedSavesResponse.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 import type { SaveSchema } from "./SaveSchema";
 

--- a/frontend/src/__generated__/models/UploadedScreenshotsResponse.ts
+++ b/frontend/src/__generated__/models/UploadedScreenshotsResponse.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 import type { ScreenshotSchema } from "./ScreenshotSchema";
 

--- a/frontend/src/__generated__/models/UploadedStatesResponse.ts
+++ b/frontend/src/__generated__/models/UploadedStatesResponse.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 import type { StateSchema } from "./StateSchema";
 

--- a/frontend/src/__generated__/models/UserNotesSchema.ts
+++ b/frontend/src/__generated__/models/UserNotesSchema.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type UserNotesSchema = {
   user_id: number;

--- a/frontend/src/__generated__/models/UserSchema.ts
+++ b/frontend/src/__generated__/models/UserSchema.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 import type { Role } from "./Role";
 

--- a/frontend/src/__generated__/models/ValidationError.ts
+++ b/frontend/src/__generated__/models/ValidationError.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type ValidationError = {
   loc: Array<string | number>;

--- a/frontend/src/__generated__/models/WatcherDict.ts
+++ b/frontend/src/__generated__/models/WatcherDict.ts
@@ -1,6 +1,7 @@
 /* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
+/* eslint-disable */
 
 export type WatcherDict = {
   ENABLED: boolean;

--- a/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
+++ b/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import FilterUnmatchedBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterUnmatchedBtn.vue";
 import FilterFavouritesBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterFavouritesBtn.vue";
+import FilterDuplicatesBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterDuplicatesBtn.vue";
 import storeGalleryFilter from "@/stores/galleryFilter";
 import type { Events } from "@/types/emitter";
 import type { Emitter } from "mitt";
@@ -69,6 +70,7 @@ function resetFilters() {
       <v-list-item>
         <filter-unmatched-btn />
         <filter-favourites-btn class="mt-2" />
+        <filter-duplicates-btn class="mt-2" />
       </v-list-item>
       <v-list-item v-for="filter in filters">
         <v-autocomplete

--- a/frontend/src/components/Gallery/AppBar/common/FilterDrawer/FilterDuplicatesBtn.vue
+++ b/frontend/src/components/Gallery/AppBar/common/FilterDrawer/FilterDuplicatesBtn.vue
@@ -7,10 +7,10 @@ import { inject } from "vue";
 
 // Props
 const galleryFilterStore = storeGalleryFilter();
-const { filterFavourites } = storeToRefs(galleryFilterStore);
+const { filterDuplicates } = storeToRefs(galleryFilterStore);
 const emitter = inject<Emitter<Events>>("emitter");
-function setFavourites() {
-  galleryFilterStore.switchFilterFavourites();
+function setDuplicates() {
+  galleryFilterStore.switchFilterDuplicates();
   emitter?.emit("filter", null);
 }
 </script>
@@ -20,18 +20,18 @@ function setFavourites() {
     block
     variant="tonal"
     rounded="0"
-    :color="filterFavourites ? 'romm-accent-1' : 'romm-gray'"
-    @click="setFavourites()"
+    :color="filterDuplicates ? 'romm-accent-1' : 'romm-gray'"
+    @click="setDuplicates()"
   >
-    <v-icon :color="filterFavourites ? 'romm-accent-1' : 'romm-white'"
-      >mdi-star</v-icon
+    <v-icon :color="filterDuplicates ? 'romm-accent-1' : 'romm-white'"
+      >mdi-content-duplicate</v-icon
     ><span
       class="ml-2"
       :class="{
-        'text-romm-white': !filterFavourites,
-        'text-romm-accent-1': filterFavourites,
+        'text-romm-white': !filterDuplicates,
+        'text-romm-accent-1': filterDuplicates,
       }"
-      >Show favourites</span
+      >Show duplicates</span
     ></v-btn
   >
 </template>

--- a/frontend/src/components/Gallery/AppBar/common/FilterDrawer/FilterUnmatchedBtn.vue
+++ b/frontend/src/components/Gallery/AppBar/common/FilterDrawer/FilterUnmatchedBtn.vue
@@ -31,7 +31,7 @@ function setUnmatched() {
         'text-romm-white': !filterUnmatched,
         'text-romm-accent-1': filterUnmatched,
       }"
-      >Filter unmatched</span
+      >Show unmatched</span
     ></v-btn
   >
 </template>

--- a/frontend/src/components/common/Game/Card/Flags.vue
+++ b/frontend/src/components/common/Game/Card/Flags.vue
@@ -39,10 +39,10 @@ const showSiblings = isNull(localStorage.getItem("settings.showSiblings"))
     </span>
   </v-chip>
   <v-chip
-    v-if="rom.siblings && rom.siblings.length > 0 && showSiblings"
+    v-if="rom.sibling_roms && rom.sibling_roms.length > 0 && showSiblings"
     class="translucent-dark mr-1 mt-1"
     density="compact"
   >
-    +{{ rom.siblings.length }}
+    +{{ rom.sibling_roms.length }}
   </v-chip>
 </template>

--- a/frontend/src/components/common/Game/Table.vue
+++ b/frontend/src/components/common/Game/Table.vue
@@ -136,11 +136,11 @@ onMounted(() => {
           >
           <template #append>
             <v-chip
-              v-if="item.siblings && item.siblings.length > 0 && showSiblings"
+              v-if="item.sibling_roms && item.sibling_roms.length > 0 && showSiblings"
               class="translucent-dark ml-2"
               size="x-small"
             >
-              <span class="text-caption">+{{ item.siblings.length }}</span>
+              <span class="text-caption">+{{ item.sibling_roms.length }}</span>
             </v-chip>
           </template>
         </v-list-item>

--- a/frontend/src/stores/galleryFilter.ts
+++ b/frontend/src/stores/galleryFilter.ts
@@ -12,6 +12,7 @@ export default defineStore("galleryFilter", {
     filterCompanies: [] as string[],
     filterUnmatched: false,
     filterFavourites: false,
+    filterDuplicates: false,
     selectedGenre: null as string | null,
     selectedFranchise: null as string | null,
     selectedCollection: null as string | null,
@@ -61,11 +62,18 @@ export default defineStore("galleryFilter", {
     disableFilterFavourites() {
       this.filterFavourites = false;
     },
+    switchFilterDuplicates() {
+      this.filterDuplicates = !this.filterDuplicates;
+    },
+    disableFilterDuplicates() {
+      this.filterDuplicates = false;
+    },
     isFiltered() {
       return Boolean(
         normalizeString(this.filterSearch).trim() != "" ||
           this.filterUnmatched ||
           this.filterFavourites ||
+          this.filterDuplicates ||
           this.selectedGenre ||
           this.selectedFranchise ||
           this.selectedCollection ||


### PR DESCRIPTION
Add a button to only display duplicate games (even then grouped). This could be handy for finding games that were marked as duplicate, but are actually different games (like different IGDB/Moby IDs). Eventually this should also toss hashes into the mix, once that work is complete.

Fixes #1022 

<img width="305" alt="Screenshot 2024-07-28 at 8 30 51 PM" src="https://github.com/user-attachments/assets/c7380cce-5675-41a6-a8d7-328e990871e5">