### PR TITLE
misc: Make backend handle URLs with trailing slash

### DIFF
--- a/backend/endpoints/auth.py
+++ b/backend/endpoints/auth.py
@@ -5,10 +5,11 @@ from endpoints.forms.identity import OAuth2RequestForm
 from endpoints.responses import MessageResponse
 from endpoints.responses.oauth import TokenResponse
 from exceptions.auth_exceptions import AuthCredentialsException, DisabledException
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security.http import HTTPBasic
 from handler.auth import auth_handler, oauth_handler
 from handler.database import db_user_handler
+from utils.router import APIRouter
 
 ACCESS_TOKEN_EXPIRE_MINUTES: Final = 30
 REFRESH_TOKEN_EXPIRE_DAYS: Final = 7

--- a/backend/endpoints/collections.py
+++ b/backend/endpoints/collections.py
@@ -11,13 +11,14 @@ from exceptions.endpoint_exceptions import (
     CollectionNotFoundInDatabaseException,
     CollectionPermissionError,
 )
-from fastapi import APIRouter, Request, UploadFile
+from fastapi import Request, UploadFile
 from handler.database import db_collection_handler
 from handler.filesystem import fs_resource_handler
 from handler.filesystem.base_handler import CoverSize
 from logger.logger import log
 from models.collection import Collection
 from sqlalchemy.inspection import inspect
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/endpoints/config.py
+++ b/backend/endpoints/config.py
@@ -6,8 +6,9 @@ from exceptions.config_exceptions import (
     ConfigNotReadableException,
     ConfigNotWritableException,
 )
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import HTTPException, Request, status
 from logger.logger import log
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/endpoints/feeds.py
+++ b/backend/endpoints/feeds.py
@@ -6,9 +6,10 @@ from endpoints.responses.feeds import (
     TinfoilFeedSchema,
     WebrcadeFeedSchema,
 )
-from fastapi import APIRouter, Request
+from fastapi import Request
 from handler.database import db_platform_handler, db_rom_handler
 from models.rom import Rom
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/endpoints/firmware.py
+++ b/backend/endpoints/firmware.py
@@ -2,12 +2,13 @@ from config import DISABLE_DOWNLOAD_ENDPOINT_AUTH, LIBRARY_BASE_PATH
 from decorators.auth import protected_route
 from endpoints.responses import MessageResponse
 from endpoints.responses.firmware import AddFirmwareResponse, FirmwareSchema
-from fastapi import APIRouter, File, HTTPException, Request, UploadFile, status
+from fastapi import File, HTTPException, Request, UploadFile, status
 from fastapi.responses import FileResponse
 from handler.database import db_firmware_handler, db_platform_handler
 from handler.filesystem import fs_firmware_handler
 from handler.scan_handler import scan_firmware
 from logger.logger import log
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/endpoints/heartbeat.py
+++ b/backend/endpoints/heartbeat.py
@@ -7,13 +7,13 @@ from config import (
     SCHEDULED_UPDATE_SWITCH_TITLEDB_CRON,
 )
 from endpoints.responses.heartbeat import HeartbeatResponse
-from fastapi import APIRouter
 from handler.database import db_user_handler
 from handler.filesystem import fs_platform_handler
 from handler.metadata.igdb_handler import IGDB_API_ENABLED
 from handler.metadata.moby_handler import MOBY_API_ENABLED
 from handler.metadata.sgdb_handler import STEAMGRIDDB_API_ENABLED
 from utils import get_version
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/endpoints/platform.py
+++ b/backend/endpoints/platform.py
@@ -5,13 +5,14 @@ from endpoints.responses import MessageResponse
 from endpoints.responses.platform import PlatformSchema
 from exceptions.endpoint_exceptions import PlatformNotFoundInDatabaseException
 from exceptions.fs_exceptions import PlatformAlreadyExistsException
-from fastapi import APIRouter, Request
+from fastapi import Request
 from handler.database import db_platform_handler
 from handler.filesystem import fs_platform_handler
 from handler.metadata.igdb_handler import IGDB_PLATFORM_LIST
 from handler.scan_handler import scan_platform
 from logger.logger import log
 from models.platform import Platform
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/endpoints/raw.py
+++ b/backend/endpoints/raw.py
@@ -1,7 +1,8 @@
 from config import ASSETS_BASE_PATH
 from decorators.auth import protected_route
-from fastapi import APIRouter, Request
+from fastapi import Request
 from fastapi.responses import FileResponse
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -22,7 +22,7 @@ from endpoints.responses.rom import (
 )
 from exceptions.endpoint_exceptions import RomNotFoundInDatabaseException
 from exceptions.fs_exceptions import RomAlreadyExistsException
-from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile, status
+from fastapi import File, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import FileResponse
 from handler.database import db_platform_handler, db_rom_handler
 from handler.filesystem import fs_resource_handler, fs_rom_handler
@@ -30,6 +30,7 @@ from handler.filesystem.base_handler import CoverSize
 from handler.metadata import meta_igdb_handler, meta_moby_handler
 from logger.logger import log
 from stream_zip import NO_COMPRESSION_32, ZIP_AUTO, AsyncMemberFile, async_stream_zip
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/endpoints/saves.py
+++ b/backend/endpoints/saves.py
@@ -1,11 +1,12 @@
 from decorators.auth import protected_route
 from endpoints.responses import MessageResponse
 from endpoints.responses.assets import SaveSchema, UploadedSavesResponse
-from fastapi import APIRouter, File, HTTPException, Request, UploadFile, status
+from fastapi import File, HTTPException, Request, UploadFile, status
 from handler.database import db_rom_handler, db_save_handler, db_screenshot_handler
 from handler.filesystem import fs_asset_handler
 from handler.scan_handler import scan_save
 from logger.logger import log
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/endpoints/screenshots.py
+++ b/backend/endpoints/screenshots.py
@@ -1,10 +1,11 @@
 from decorators.auth import protected_route
 from endpoints.responses.assets import UploadedScreenshotsResponse
-from fastapi import APIRouter, File, HTTPException, Request, UploadFile, status
+from fastapi import File, HTTPException, Request, UploadFile, status
 from handler.database import db_rom_handler, db_screenshot_handler
 from handler.filesystem import fs_asset_handler
 from handler.scan_handler import scan_screenshot
 from logger.logger import log
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/endpoints/search.py
+++ b/backend/endpoints/search.py
@@ -1,7 +1,7 @@
 import emoji
 from decorators.auth import protected_route
 from endpoints.responses.search import SearchCoverSchema, SearchRomSchema
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import HTTPException, Request, status
 from handler.database import db_rom_handler
 from handler.metadata import meta_igdb_handler, meta_moby_handler, meta_sgdb_handler
 from handler.metadata.igdb_handler import IGDB_API_ENABLED
@@ -9,6 +9,7 @@ from handler.metadata.moby_handler import MOBY_API_ENABLED
 from handler.metadata.sgdb_handler import STEAMGRIDDB_API_ENABLED
 from handler.scan_handler import _get_main_platform_igdb_id
 from logger.logger import log
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/endpoints/states.py
+++ b/backend/endpoints/states.py
@@ -1,11 +1,12 @@
 from decorators.auth import protected_route
 from endpoints.responses import MessageResponse
 from endpoints.responses.assets import StateSchema, UploadedStatesResponse
-from fastapi import APIRouter, File, HTTPException, Request, UploadFile, status
+from fastapi import File, HTTPException, Request, UploadFile, status
 from handler.database import db_rom_handler, db_screenshot_handler, db_state_handler
 from handler.filesystem import fs_asset_handler
 from handler.scan_handler import scan_state
 from logger.logger import log
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/endpoints/stats.py
+++ b/backend/endpoints/stats.py
@@ -1,6 +1,6 @@
 from endpoints.responses.stats import StatsReturn
-from fastapi import APIRouter
 from handler.database import db_stats_handler
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/endpoints/tasks.py
+++ b/backend/endpoints/tasks.py
@@ -1,7 +1,8 @@
 from decorators.auth import protected_route
 from endpoints.responses import MessageResponse
-from fastapi import APIRouter, Request
+from fastapi import Request
 from tasks.update_switch_titledb import update_switch_titledb_task
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/endpoints/user.py
+++ b/backend/endpoints/user.py
@@ -7,12 +7,13 @@ from decorators.auth import protected_route
 from endpoints.forms.identity import UserForm
 from endpoints.responses import MessageResponse
 from endpoints.responses.identity import UserSchema
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import Depends, HTTPException, Request, status
 from handler.auth import auth_handler
 from handler.database import db_user_handler
 from handler.filesystem import fs_asset_handler
 from logger.logger import log
 from models.user import Role, User
+from utils.router import APIRouter
 
 router = APIRouter()
 

--- a/backend/handler/auth/tests/test_oauth.py
+++ b/backend/handler/auth/tests/test_oauth.py
@@ -1,9 +1,10 @@
 import pytest
 from decorators.auth import protected_route
-from fastapi import APIRouter, Request
+from fastapi import Request
 from fastapi.exceptions import HTTPException
 from handler.auth import oauth_handler
 from handler.database import db_user_handler
+from utils.router import APIRouter
 
 
 def test_create_oauth_token():

--- a/backend/utils/router.py
+++ b/backend/utils/router.py
@@ -1,0 +1,35 @@
+from typing import Any, Callable
+
+from fastapi import APIRouter as FastAPIRouter
+from fastapi.types import DecoratedCallable
+
+
+class APIRouter(FastAPIRouter):
+    """FastAPI router that automatically adds an alternate route with a trailing slash.
+
+    This is needed as FastAPI does not include a built-in way to handle routes with and without
+    trailing slashes, without requiring a redirect or duplicating the route definition.
+
+    Reference: https://github.com/fastapi/fastapi/discussions/7298
+    """
+
+    def api_route(
+        self, path: str, *, include_in_schema: bool = True, **kwargs: Any
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        if path.endswith("/") and len(path) > 1:
+            path = path[:-1]
+
+        add_path = super().api_route(
+            path, include_in_schema=include_in_schema, **kwargs
+        )
+
+        alternate_path = path + "/"
+        add_alternate_path = super().api_route(
+            alternate_path, include_in_schema=False, **kwargs
+        )
+
+        def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            add_alternate_path(func)
+            return add_path(func)
+
+        return decorator

--- a/backend/utils/test_router.py
+++ b/backend/utils/test_router.py
@@ -1,0 +1,31 @@
+import itertools
+
+import pytest
+from fastapi import Request
+from utils.router import APIRouter
+
+
+@pytest.mark.parametrize(
+    "method, route_path",
+    itertools.product(
+        ("get", "post", "put", "delete", "patch"),
+        ("/test", "/test/"),
+    ),
+)
+def test_route_path_with_trailing_slash(method, route_path):
+    router = APIRouter()
+
+    @router.get(route_path)
+    @router.post(route_path)
+    @router.put(route_path)
+    @router.delete(route_path)
+    @router.patch(route_path)
+    def test_route(request: Request):
+        return {"test": "test"}
+
+    assert test_route(Request({"type": "http", "method": method, "url": "/test"})) == {
+        "test": "test"
+    }
+    assert test_route(Request({"type": "http", "method": method, "url": "/test/"})) == {
+        "test": "test"
+    }


### PR DESCRIPTION
According to multiple FastAPI discussions [1], FastAPI only includes a built-in mechanism to redirect requests including a trailing slash, to its variation without slash, using a `307` status code.

This can be an issue when certain clients do not send the same headers on the redirected request.

This change adds a custom FastAPI `APIRouter`, that registers both route path variations (with and without trailing slash), while only marking the path without slash for being included in the OpenAPI schema.

[1] https://github.com/fastapi/fastapi/discussions/7298