### PR TITLE
Fix tinfoil authentication & improvements

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -88,3 +88,6 @@ SCHEDULED_UPDATE_SWITCH_TITLEDB_CRON: Final = os.environ.get(
 
 # TESTING
 IS_PYTEST_RUN: Final = bool(os.environ.get("PYTEST_VERSION", False))
+
+#TINFOIL
+TINFOIL_WELCOME_MESSAGE: Final = os.environ.get("TINFOIL_WELCOME_MESSAGE", "RomM Switch Library")

--- a/backend/endpoints/feeds.py
+++ b/backend/endpoints/feeds.py
@@ -81,7 +81,7 @@ def tinfoil_index_feed(request: Request, slug: str = "switch") -> TinfoilFeedSch
     return {
         "files": [
             {
-                "url": f"{ROMM_HOST}/api/roms/{file.id}/content/{file.file_name}",
+                "url": f"../../roms/{file.id}/content/{file.file_name}",
                 "size": file.file_size_bytes,
             }
             for file in files

--- a/backend/endpoints/feeds.py
+++ b/backend/endpoints/feeds.py
@@ -1,4 +1,4 @@
-from config import DISABLE_DOWNLOAD_ENDPOINT_AUTH, ROMM_HOST
+from config import DISABLE_DOWNLOAD_ENDPOINT_AUTH, ROMM_HOST, TINFOIL_WELCOME_MESSAGE
 from decorators.auth import protected_route
 from endpoints.responses.feeds import (
     WEBRCADE_SLUG_TO_TYPE_MAP,
@@ -87,5 +87,5 @@ def tinfoil_index_feed(request: Request, slug: str = "switch") -> TinfoilFeedSch
             for file in files
         ],
         "directories": [],
-        "success": "RomM Switch Library",
+        "success": TINFOIL_WELCOME_MESSAGE,
     }


### PR DESCRIPTION
The pull requests fixes the authentication error when using tinfoil to access roms.

Tinfoil uses the format `https://<user>:<pass>@<domain.com>/<file>` to access protected files using Basic Auth.

Previously, the path to the rom file given by Romm was hardcoded, and Tinfoil could not inject the Basic Auth parameters.
With this pull request, the path is now set relative to the Tinfoil endpoint. With this, Tinfoil can inject the login data and can access the file.

Also I added a new environment variable `TINFOIL_WELCOME_MESSAGE`, with which a custom message can be set, which will be displayed to the user when opening Tinfoil.

Related to https://github.com/rommapp/romm/issues/1051