### PR TITLE
fix: Set Gunicorn option forwarded-allow-ips

### DIFF
--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -52,6 +52,7 @@ start_bin_gunicorn() {
 		--bind=0.0.0.0:5000 \
 		--bind=unix:/tmp/gunicorn.sock \
 		--pid=/tmp/gunicorn.pid \
+		--forwarded-allow-ips="*" \
 		--workers "${GUNICORN_WORKERS:=2}" \
 		main:app &
 }


### PR DESCRIPTION
Currently, the `request.url_for` and `URLPath.make_absolute_url` methods always build URLs with "http" scheme, even when the original requested URL is using "https".

The reason for this is that Gunicorn does not allow IPs other than 127.0.0.1 to set secure headers by default. As regular RomM installations don't know which frontend IPs will try to set security headers in advance, we can disable this validation, and fix URL building.

A simple way to test this change is to access any of the `feed` endpoints, which generate URLs using the mentioned methods. Accessing the endpoint using "https" scheme must generate "https" URLs.

Reference:
* https://github.com/encode/starlette/issues/538#issuecomment-2054013679
* https://docs.gunicorn.org/en/stable/settings.html#forwarded-allow-ips