### PR TITLE
Bump emulatorjs to 4.1.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,7 @@
         "axios": "^1.6.8",
         "core-js": "^3.37.1",
         "cronstrue": "^2.50.0",
-        "emulatorjs": "github:emulatorjs/emulatorjs#v4.0.12",
+        "emulatorjs": "github:emulatorjs/emulatorjs#v4.1.1",
         "file-saver": "^2.0.5",
         "js-cookie": "^3.0.5",
         "jszip": "^3.10.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3225,7 +3225,8 @@
     },
     "node_modules/async": {
       "version": "2.6.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -3316,7 +3317,8 @@
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "dependencies": {
         "safe-buffer": "5.1.2"
       },
@@ -3623,7 +3625,8 @@
     },
     "node_modules/corser": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -3842,9 +3845,8 @@
     },
     "node_modules/emulatorjs": {
       "name": "@emulatorjs/emulatorjs",
-      "version": "4.0.11",
-      "resolved": "git+ssh://git@github.com/emulatorjs/emulatorjs.git#62c0424e68c3382932237b36b0b03b56e7171c1e",
-      "license": "GPL-3.0",
+      "version": "4.0.12",
+      "resolved": "git+ssh://git@github.com/emulatorjs/emulatorjs.git#a7b59f19a3e9415c2a42121461da3df03b25d3b5",
       "dependencies": {
         "http-server": "^14.1.1"
       }
@@ -4255,7 +4257,8 @@
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4751,7 +4754,8 @@
     },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
       "dependencies": {
         "whatwg-encoding": "^2.0.0"
       },
@@ -4761,7 +4765,8 @@
     },
     "node_modules/http-proxy": {
       "version": "1.18.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dependencies": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -4773,7 +4778,8 @@
     },
     "node_modules/http-server": {
       "version": "14.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
       "dependencies": {
         "basic-auth": "^2.0.1",
         "chalk": "^4.1.2",
@@ -4798,7 +4804,8 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -5507,7 +5514,8 @@
     },
     "node_modules/mime": {
       "version": "1.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "bin": {
         "mime": "cli.js"
       },
@@ -5556,7 +5564,8 @@
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -5680,7 +5689,8 @@
     },
     "node_modules/opener": {
       "version": "1.5.2",
-      "license": "(WTFPL OR MIT)",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "bin": {
         "opener": "bin/opener-bin.js"
       }
@@ -5919,7 +5929,8 @@
     },
     "node_modules/portfinder": {
       "version": "1.0.32",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
       "dependencies": {
         "async": "^2.6.4",
         "debug": "^3.2.7",
@@ -5931,7 +5942,8 @@
     },
     "node_modules/portfinder/node_modules/debug": {
       "version": "3.2.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -6040,8 +6052,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.12.1",
-      "license": "BSD-3-Clause",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -6193,7 +6206,8 @@
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -6343,7 +6357,8 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
       "version": "1.77.1",
@@ -6363,7 +6378,8 @@
     },
     "node_modules/secure-compare": {
       "version": "3.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw=="
     },
     "node_modules/semver": {
       "version": "7.6.2",
@@ -6974,6 +6990,8 @@
     },
     "node_modules/union": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
       "dependencies": {
         "qs": "^6.4.0"
       },
@@ -7048,7 +7066,8 @@
     },
     "node_modules/url-join": {
       "version": "4.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -7336,7 +7355,8 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
       "dependencies": {
         "iconv-lite": "0.6.3"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
     "axios": "^1.6.8",
     "core-js": "^3.37.1",
     "cronstrue": "^2.50.0",
-    "emulatorjs": "github:emulatorjs/emulatorjs#v4.0.12",
+    "emulatorjs": "github:emulatorjs/emulatorjs#v4.1.1",
     "file-saver": "^2.0.5",
     "js-cookie": "^3.0.5",
     "jszip": "^3.10.1",

--- a/frontend/src/views/EmulatorJS/Player.vue
+++ b/frontend/src/views/EmulatorJS/Player.vue
@@ -304,7 +304,7 @@ async function fetchSave(): Promise<Uint8Array> {
 
 window.EJS_onLoadSave = async function () {
   const sav = await fetchSave();
-  const FS = window.EJS_emulator.Module.FS;
+  const FS = window.EJS_emulator.gameManager.FS;
   const path = window.EJS_emulator.gameManager.getSaveFilePath();
   const paths = path.split("/");
   let cp = "";


### PR DESCRIPTION
Emulation is currently broken since they purged 4.0.12 from the releases (and cores in the CDN), so we need to bump this up ASAP.