### PR TITLE
feat: Use nginx mod_zip to generate multi-file zip downloads

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -43,6 +43,7 @@ lint:
       paths:
         - frontend/src/__generated__/**
         - docker/Dockerfile
+        - docker/nginx/js/**
   definitions:
     - name: eslint
       files: [typescript, javascript]

--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -7,10 +7,8 @@ from typing import NotRequired, TypedDict, get_type_hints
 from endpoints.responses.assets import SaveSchema, ScreenshotSchema, StateSchema
 from endpoints.responses.collection import CollectionSchema
 from fastapi import Request
-from fastapi.responses import StreamingResponse
 from handler.metadata.igdb_handler import IGDBMetadata
 from handler.metadata.moby_handler import MobyMetadata
-from handler.socket_handler import socket_handler
 from models.rom import Rom, RomFile
 from pydantic import BaseModel, Field, computed_field
 
@@ -184,13 +182,3 @@ class UserNotesSchema(TypedDict):
     user_id: int
     username: str
     note_raw_markdown: str
-
-
-class CustomStreamingResponse(StreamingResponse):
-    def __init__(self, *args, **kwargs) -> None:
-        self.emit_body = kwargs.pop("emit_body", None)
-        super().__init__(*args, **kwargs)
-
-    async def stream_response(self, *args, **kwargs) -> None:
-        await super().stream_response(*args, **kwargs)
-        await socket_handler.socket_server.emit("download:complete", self.emit_body)

--- a/backend/handler/filesystem/firmware_handler.py
+++ b/backend/handler/filesystem/firmware_handler.py
@@ -12,6 +12,7 @@ from exceptions.fs_exceptions import (
 from fastapi import UploadFile
 from logger.logger import log
 from utils.filesystem import iter_files
+from utils.hashing import crc32_to_hex
 
 from .base_handler import FSHandler
 
@@ -61,7 +62,7 @@ class FSFirmwareHandler(FSHandler):
                 crc_c = binascii.crc32(chunk, crc_c)
 
             return {
-                "crc_hash": (crc_c & 0xFFFFFFFF).to_bytes(4, byteorder="big").hex(),
+                "crc_hash": crc32_to_hex(crc_c),
                 "md5_hash": md5_h.hexdigest(),
                 "sha1_hash": sha1_h.hexdigest(),
             }

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -17,6 +17,7 @@ from config.config_manager import config_manager as cm
 from exceptions.fs_exceptions import RomAlreadyExistsException, RomsNotFoundException
 from models.rom import RomFile
 from utils.filesystem import iter_directories, iter_files
+from utils.hashing import crc32_to_hex
 
 from .base_handler import (
     LANGUAGES_BY_SHORTCODE,
@@ -271,7 +272,7 @@ class FSRomsHandler(FSHandler):
             )
 
         return {
-            "crc_hash": (crc_c & 0xFFFFFFFF).to_bytes(4, byteorder="big").hex(),
+            "crc_hash": crc32_to_hex(crc_c),
             "md5_hash": md5_h.hexdigest(),
             "sha1_hash": sha1_h.hexdigest(),
         }

--- a/backend/utils/hashing.py
+++ b/backend/utils/hashing.py
@@ -1,0 +1,2 @@
+def crc32_to_hex(value: int) -> str:
+    return (value & 0xFFFFFFFF).to_bytes(4, byteorder="big").hex()

--- a/backend/utils/nginx.py
+++ b/backend/utils/nginx.py
@@ -1,0 +1,49 @@
+import dataclasses
+from collections.abc import Collection
+from typing import Any
+
+from fastapi.responses import Response
+
+
+@dataclasses.dataclass(frozen=True)
+class ZipContentLine:
+    """Dataclass for lines returned in the response body, for usage with the `mod_zip` module.
+
+    Reference:
+    https://github.com/evanmiller/mod_zip?tab=readme-ov-file#usage
+    """
+
+    crc32: str | None
+    size_bytes: int
+    encoded_location: str
+    filename: str
+
+    def __str__(self) -> str:
+        crc32 = self.crc32 or "-"
+        return f"{crc32} {self.size_bytes} {self.encoded_location} {self.filename}"
+
+
+class ZipResponse(Response):
+    """Response class for returning a ZIP archive with multiple files, using the `mod_zip` module."""
+
+    def __init__(
+        self,
+        *,
+        content_lines: Collection[ZipContentLine],
+        filename: str,
+        **kwargs: Any,
+    ):
+        if kwargs.get("content"):
+            raise ValueError(
+                "Argument 'content' must not be provided, as it is generated from 'content_lines'"
+            )
+
+        kwargs["content"] = "\n".join(str(line) for line in content_lines)
+        kwargs.setdefault("headers", {}).update(
+            {
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "X-Archive-Files": "zip",
+            }
+        )
+
+        super().__init__(**kwargs)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,8 +45,14 @@ RUN apk add --no-cache \
     zlib-dev
 
 ARG NGINX_VERSION
+# The specified commit SHA is the latest commit on the `master` branch at the time of writing.
+# It includes a fix to correctly calculate CRC-32 checksums when using upstream subrequests.
+# TODO: Move to a tagged release of `mod_zip`, once a version newer than 1.3.0 is released.
 ARG NGINX_MOD_ZIP_SHA=8e65b82c82c7890f67a6107271c127e9881b6313
 
+# Clone both nginx and `ngx_http_zip_module` repositories, needed to compile the module from source.
+# This is needed to be able to dinamically load it as a module in the final image. `nginx` Docker
+# images do not have a simple way to include third-party modules.
 RUN git clone https://github.com/evanmiller/mod_zip.git && \
     cd ./mod_zip && \
     git checkout "${NGINX_MOD_ZIP_SHA}" && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,9 +33,35 @@ WORKDIR /src
 COPY ./pyproject.toml ./poetry.lock /src/
 RUN poetry install --no-ansi --no-cache --only main
 
+# Build nginx modules
+FROM alpine:${ALPINE_VERSION} AS nginx-build
+
+RUN apk add --no-cache \
+    gcc \
+    git \
+    libc-dev \
+    make \
+    pcre-dev \
+    zlib-dev
+
+ARG NGINX_VERSION
+ARG NGINX_MOD_ZIP_SHA=8e65b82c82c7890f67a6107271c127e9881b6313
+
+RUN git clone https://github.com/evanmiller/mod_zip.git && \
+    cd ./mod_zip && \
+    git checkout "${NGINX_MOD_ZIP_SHA}" && \
+    cd ../ && \
+    git clone --branch "release-${NGINX_VERSION}" --depth 1 https://github.com/nginx/nginx.git && \
+    cd ./nginx && \
+    ./auto/configure --with-compat --add-dynamic-module=../mod_zip/ && \
+    make -f ./objs/Makefile modules && \
+    chmod 644 ./objs/ngx_http_zip_module.so
+
 # Setup frontend and backend
-FROM nginx:${NGINX_VERSION}-alpine${ALPINE_VERSION}-slim AS production-stage
+FROM nginx:${NGINX_VERSION}-alpine${ALPINE_VERSION} AS production-stage
 ARG WEBSERVER_FOLDER=/var/www/html
+
+COPY --from=nginx-build ./nginx/objs/ngx_http_zip_module.so /usr/lib/nginx/modules/
 
 COPY --from=front-build-stage /front/dist ${WEBSERVER_FOLDER}
 COPY ./frontend/assets/default ${WEBSERVER_FOLDER}/assets/default
@@ -62,6 +88,7 @@ COPY ./backend /backend
 
 # Setup init script and config files
 COPY ./docker/init_scripts/* /
+COPY ./docker/nginx/js/ /etc/nginx/js/
 COPY ./docker/nginx/default.conf /etc/nginx/nginx.conf
 
 # User permissions

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,3 +1,6 @@
+load_module modules/ngx_http_js_module.so;
+load_module modules/ngx_http_zip_module.so;
+
 worker_processes auto;
 pid /tmp/nginx.pid;
 
@@ -28,6 +31,8 @@ http {
 
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
         ssl_prefer_server_ciphers on;
+
+        js_import /etc/nginx/js/decode.js;
 
         map $time_iso8601 $date {
             ~([^+]+)T $1;
@@ -103,6 +108,36 @@ http {
             # Internally redirect download requests
             location /library {
                 internal;
+                alias /romm/library;
+            }
+
+            # This location, and the related server at port 8081, are used to serve files when
+            # using the `mod_zip` module. This is because the `mod_zip` module does not support
+            # calculating CRC-32 values when using subrequests pointing directly to internal
+            # locations that access the filesystem.
+            # TODO: If that gets fixed, this workaround can be removed, and the `/library` location
+            # can be used directly (also removing the server at port 8081).
+            # Related issue: https://github.com/evanmiller/mod_zip/issues/90
+            location /library-zip {
+                internal;
+                rewrite ^/library-zip/(.*)$ /library/$1 break;
+                proxy_pass http://localhost:8081;
+                # Proxy buffering must be disabled, for the module to correctly calculate CRC-32 values.
+                proxy_buffering off;
+            }
+
+            # Internal decoding endpoint, used to decode base64 encoded data
+            location /decode {
+                internal;
+                js_content decode.decodeBase64;
+            }
+        }
+
+        server {
+            listen 8081;
+            server_name localhost;
+
+            location /library {
                 alias /romm/library;
             }
         }

--- a/docker/nginx/js/decode.js
+++ b/docker/nginx/js/decode.js
@@ -1,0 +1,19 @@
+// Decode a Base64 encoded string received as a query parameter named 'value',
+// and return the decoded value in the response body.
+function decodeBase64(r) {
+  var encodedValue = r.args.value;
+
+  if (!encodedValue) {
+    r.return(400, "Missing 'value' query parameter");
+    return;
+  }
+
+  try {
+    var decodedValue = atob(encodedValue);
+    r.return(200, decodedValue);
+  } catch (e) {
+    r.return(400, "Invalid Base64 encoding");
+  }
+}
+
+export default { decodeBase64 };

--- a/poetry.lock
+++ b/poetry.lock
@@ -1637,47 +1637,6 @@ files = [
 ]
 
 [[package]]
-name = "pycryptodome"
-version = "3.20.0"
-description = "Cryptographic library for Python"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "pycryptodome-3.20.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:f0e6d631bae3f231d3634f91ae4da7a960f7ff87f2865b2d2b831af1dfb04e9a"},
-    {file = "pycryptodome-3.20.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:baee115a9ba6c5d2709a1e88ffe62b73ecc044852a925dcb67713a288c4ec70f"},
-    {file = "pycryptodome-3.20.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:417a276aaa9cb3be91f9014e9d18d10e840a7a9b9a9be64a42f553c5b50b4d1d"},
-    {file = "pycryptodome-3.20.0-cp27-cp27m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2a1250b7ea809f752b68e3e6f3fd946b5939a52eaeea18c73bdab53e9ba3c2dd"},
-    {file = "pycryptodome-3.20.0-cp27-cp27m-musllinux_1_1_aarch64.whl", hash = "sha256:d5954acfe9e00bc83ed9f5cb082ed22c592fbbef86dc48b907238be64ead5c33"},
-    {file = "pycryptodome-3.20.0-cp27-cp27m-win32.whl", hash = "sha256:06d6de87c19f967f03b4cf9b34e538ef46e99a337e9a61a77dbe44b2cbcf0690"},
-    {file = "pycryptodome-3.20.0-cp27-cp27m-win_amd64.whl", hash = "sha256:ec0bb1188c1d13426039af8ffcb4dbe3aad1d7680c35a62d8eaf2a529b5d3d4f"},
-    {file = "pycryptodome-3.20.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:5601c934c498cd267640b57569e73793cb9a83506f7c73a8ec57a516f5b0b091"},
-    {file = "pycryptodome-3.20.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:d29daa681517f4bc318cd8a23af87e1f2a7bad2fe361e8aa29c77d652a065de4"},
-    {file = "pycryptodome-3.20.0-cp27-cp27mu-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3427d9e5310af6680678f4cce149f54e0bb4af60101c7f2c16fdf878b39ccccc"},
-    {file = "pycryptodome-3.20.0-cp27-cp27mu-musllinux_1_1_aarch64.whl", hash = "sha256:3cd3ef3aee1079ae44afaeee13393cf68b1058f70576b11439483e34f93cf818"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-macosx_10_9_universal2.whl", hash = "sha256:ac1c7c0624a862f2e53438a15c9259d1655325fc2ec4392e66dc46cdae24d044"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-macosx_10_9_x86_64.whl", hash = "sha256:76658f0d942051d12a9bd08ca1b6b34fd762a8ee4240984f7c06ddfb55eaf15a"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f35d6cee81fa145333137009d9c8ba90951d7d77b67c79cbe5f03c7eb74d8fe2"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76cb39afede7055127e35a444c1c041d2e8d2f1f9c121ecef573757ba4cd2c3c"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49a4c4dc60b78ec41d2afa392491d788c2e06edf48580fbfb0dd0f828af49d25"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:fb3b87461fa35afa19c971b0a2b7456a7b1db7b4eba9a8424666104925b78128"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-musllinux_1_1_i686.whl", hash = "sha256:acc2614e2e5346a4a4eab6e199203034924313626f9620b7b4b38e9ad74b7e0c"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:210ba1b647837bfc42dd5a813cdecb5b86193ae11a3f5d972b9a0ae2c7e9e4b4"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-win32.whl", hash = "sha256:8d6b98d0d83d21fb757a182d52940d028564efe8147baa9ce0f38d057104ae72"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-win_amd64.whl", hash = "sha256:9b3ae153c89a480a0ec402e23db8d8d84a3833b65fa4b15b81b83be9d637aab9"},
-    {file = "pycryptodome-3.20.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:4401564ebf37dfde45d096974c7a159b52eeabd9969135f0426907db367a652a"},
-    {file = "pycryptodome-3.20.0-pp27-pypy_73-win32.whl", hash = "sha256:ec1f93feb3bb93380ab0ebf8b859e8e5678c0f010d2d78367cf6bc30bfeb148e"},
-    {file = "pycryptodome-3.20.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:acae12b9ede49f38eb0ef76fdec2df2e94aad85ae46ec85be3648a57f0a7db04"},
-    {file = "pycryptodome-3.20.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f47888542a0633baff535a04726948e876bf1ed880fddb7c10a736fa99146ab3"},
-    {file = "pycryptodome-3.20.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e0e4a987d38cfc2e71b4a1b591bae4891eeabe5fa0f56154f576e26287bfdea"},
-    {file = "pycryptodome-3.20.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:c18b381553638414b38705f07d1ef0a7cf301bc78a5f9bc17a957eb19446834b"},
-    {file = "pycryptodome-3.20.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a60fedd2b37b4cb11ccb5d0399efe26db9e0dd149016c1cc6c8161974ceac2d6"},
-    {file = "pycryptodome-3.20.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:405002eafad114a2f9a930f5db65feef7b53c4784495dd8758069b89baf68eab"},
-    {file = "pycryptodome-3.20.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2ab6ab0cb755154ad14e507d1df72de9897e99fd2d4922851a276ccc14f4f1a5"},
-    {file = "pycryptodome-3.20.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:acf6e43fa75aca2d33e93409f2dafe386fe051818ee79ee8a3e21de9caa2ac9e"},
-    {file = "pycryptodome-3.20.0.tar.gz", hash = "sha256:09609209ed7de61c2b560cc5c8c4fbf892f8b15b1faf7e4cbffac97db1fffda7"},
-]
-
-[[package]]
 name = "pycryptodomex"
 version = "3.20.0"
 description = "Cryptographic library for Python"
@@ -2189,6 +2148,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -2697,24 +2657,6 @@ files = [
 [package.dependencies]
 itsdangerous = ">=2.0.1,<3.0.0"
 starlette = ">=0.14.2"
-
-[[package]]
-name = "stream-zip"
-version = "0.0.81"
-description = "Python function to construct a ZIP archive with stream processing - without having to store the entire ZIP in memory or disk"
-optional = false
-python-versions = ">=3.6.7"
-files = [
-    {file = "stream_zip-0.0.81-py3-none-any.whl", hash = "sha256:29ffcad046e16219da16b57e5129bd4e2bc9a9acce222556de6ffe0a27a748f9"},
-    {file = "stream_zip-0.0.81.tar.gz", hash = "sha256:ad5aa0dc8c21c014073ca27eb4b28fe8b5e2108ccab8b099462362c1ec973e0f"},
-]
-
-[package.dependencies]
-pycryptodome = ">=3.10.1"
-
-[package.extras]
-ci = ["coverage (==6.2)", "mypy (==0.971)", "pycryptodome (==3.10.1)", "pytest (==7.0.1)", "pytest-cov (==3.0.0)", "pyzipper (==0.3.6)", "stream-unzip (==0.0.86)", "types-contextvars (==2.4.7.3)"]
-dev = ["coverage (>=6.2)", "mypy (>=0.971)", "pytest (>=7.0.1)", "pytest-cov (>=3.0.0)", "pyzipper (>=0.3.6)", "stream-unzip (>=0.0.86)", "types-contextvars (>=2.4.7.3)"]
 
 [[package]]
 name = "streaming-form-data"
@@ -3290,4 +3232,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "fb58ed11d1fd6dc414d7c2c5f16c9d578a07160128bd6d5d09cbd885a2804141"
+content-hash = "cfe0cc6ccf4d75141fa2c4c5ebce9011b17040ff09171595a579d317710b9789"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ types-pyyaml = "^6.0.12.20240311"
 types-redis = "^4.6.0.20240311 "
 passlib = { extras = ["bcrypt"], version = "^1.7.4" }
 itsdangerous = "^2.1.2"
-stream-zip = "^0.0.81"
 rq-scheduler = "^0.13.1"
 starlette-csrf = "^3.0.0"
 httpx = "^0.27.0"


### PR DESCRIPTION
This change installs and configures the `mod_zip` nginx module [1], which allows nginx to stream ZIP files directly.

It includes a workaround needed to correctly calculate CRC-32 values for included files, by including a new `server` section listening at port 8081, only used for the file requests to be upstream subrequests that correctly trigger the CRC-32 calculation logic.

Also, to be able to provide a `m3u` file generated on the fly, we add a `/decode` endpoint fully implemented in nginx using NJS, which receives a `value` URL param, and decodes it using base64. The decoded value is returned as the response.

That way, the contents of the `m3u` file is base64-encoded, and set as part of the response, for `mod_zip` to include it in the ZIP file.

[1] https://github.com/evanmiller/mod_zip