### PR TITLE
Replace illegal fs chars in filenames

### DIFF
--- a/backend/utils/filesystem.py
+++ b/backend/utils/filesystem.py
@@ -30,7 +30,8 @@ def iter_directories(path: str, recursive: bool = False) -> Iterator[tuple[Path,
             break
 
 
-INVALID_CHARS = r'[\\/:*?"<>|]'
+INVALID_CHARS_HYPHENS = re.compile(r"[\\/:|]")
+INVALUD_CHARS_EMPTY = re.compile(r'[*?"<>]')
 
 
 def sanitize_filename(filename):
@@ -44,10 +45,10 @@ def sanitize_filename(filename):
     - str: The sanitized filename.
     """
     # Replace some invalid characters with hyphen
-    sanitized_filename = re.sub(r"[\\/:|]", "-", filename)
+    sanitized_filename = INVALID_CHARS_HYPHENS.sub("-", filename)
 
     # Remove other invalid characters
-    sanitized_filename = re.sub(r'[*?"<>]', "", sanitized_filename)
+    sanitized_filename = INVALUD_CHARS_EMPTY.sub("", sanitized_filename)
 
     # Ensure null bytes are not included (ZFS allows any characters except null bytes)
     sanitized_filename = sanitized_filename.replace("\0", "")

--- a/frontend/src/components/common/Game/Dialog/EditRom.vue
+++ b/frontend/src/components/common/Game/Dialog/EditRom.vue
@@ -20,10 +20,6 @@ const rom = ref<UpdateRom>();
 const romsStore = storeRoms();
 const imagePreviewUrl = ref<string | undefined>("");
 const removeCover = ref(false);
-const fileNameInputRules = {
-  required: (value: string) => !!value || "Required",
-  newFileName: (value: string) => !value.includes("/") || "Invalid characters",
-};
 const emitter = inject<Emitter<Events>>("emitter");
 emitter?.on("showEditRomDialog", (romToEdit: UpdateRom | undefined) => {
   show.value = true;
@@ -62,16 +58,9 @@ async function removeArtwork() {
 async function updateRom() {
   if (!rom.value) return;
 
-  if (rom.value.file_name.includes("/")) {
+  if (!rom.value.file_name) {
     emitter?.emit("snackbarShow", {
-      msg: "Couldn't edit rom: invalid file name characters",
-      icon: "mdi-close-circle",
-      color: "red",
-    });
-    return;
-  } else if (!rom.value.file_name) {
-    emitter?.emit("snackbarShow", {
-      msg: "Couldn't edit rom: file name required",
+      msg: "Cannot save: file name is required",
       icon: "mdi-close-circle",
       color: "red",
     });
@@ -145,8 +134,7 @@ function closeDialog() {
                 v-model="rom.file_name"
                 class="py-2"
                 :rules="[
-                  fileNameInputRules.newFileName,
-                  fileNameInputRules.required,
+                  (value: string) => !!value
                 ]"
                 label="File name"
                 variant="outlined"
@@ -177,7 +165,9 @@ function closeDialog() {
                 <template #append-inner-right>
                   <v-btn-group rounded="0" divided density="compact">
                     <v-btn
-                      :disabled="!heartbeat.value.METADATA_SOURCES?.STEAMGRIDDB_ENABLED"
+                      :disabled="
+                        !heartbeat.value.METADATA_SOURCES?.STEAMGRIDDB_ENABLED
+                      "
                       size="small"
                       class="translucent-dark"
                       @click="


### PR DESCRIPTION
Some filesystems and OSs can't handle certain characters, so we remove-or-replace them when a) manually editing the filename or b) setting the filename to IGDB/Moby field value.

Fixes #392 