### PR TITLE
Add titledb field to tinfoil response

### DIFF
--- a/backend/endpoints/responses/feeds.py
+++ b/backend/endpoints/responses/feeds.py
@@ -102,8 +102,22 @@ class TinfoilFeedFileSchema(TypedDict):
     size: int
 
 
+class TinfoilFeedTitleDBSchema(TypedDict):
+    id: str
+    name: str
+    version: int
+    region: str
+    releaseDate: int
+    rating: int
+    publisher: str
+    description: str
+    size: int
+    rank: int
+
+
 class TinfoilFeedSchema(TypedDict):
     files: list[TinfoilFeedFileSchema]
     directories: list[str]
+    titledb: NotRequired[dict[str, TinfoilFeedTitleDBSchema]]
     success: NotRequired[str]
     error: NotRequired[str]


### PR DESCRIPTION
If the game already has a productID in the file name, try to match it against the internal XML list. If a match is found, add an entry in the `titledb` field, as per the [the tinfoil docs](https://blawar.github.io/tinfoil/custom_index/#adding-metadata).