### PR TITLE
Better performance for large collections

### DIFF
--- a/frontend/src/stores/roms.ts
+++ b/frontend/src/stores/roms.ts
@@ -23,8 +23,8 @@ export default defineStore("roms", {
     currentRom: null as DetailedRom | null,
     allRoms: [] as SimpleRom[],
     _grouped: [] as SimpleRom[],
-    _filteredIDs: [] as number[],
-    _selectedIDs: [] as number[],
+    _filteredIDs: new Set<number>(),
+    _selectedIDs: new Set<number>(),
     recentRoms: [] as SimpleRom[],
     lastSelectedIndex: -1,
     selecting: false,
@@ -34,9 +34,9 @@ export default defineStore("roms", {
 
   getters: {
     filteredRoms: (state) =>
-      state._grouped.filter((rom) => state._filteredIDs.includes(rom.id)),
+      state._grouped.filter((rom) => state._filteredIDs.has(rom.id)),
     selectedRoms: (state) =>
-      state._grouped.filter((rom) => state._selectedIDs.includes(rom.id)),
+      state._grouped.filter((rom) => state._selectedIDs.has(rom.id)),
   },
 
   actions: {
@@ -115,22 +115,18 @@ export default defineStore("roms", {
           return rom.id === value.id;
         });
       });
-      this._filteredIDs = this._filteredIDs.filter((value) => {
-        return !roms.find((rom) => {
-          return rom.id === value;
-        });
-      });
+      roms.forEach((rom) => this._filteredIDs.delete(rom.id));
     },
     reset() {
       this.allRoms = [];
       this._grouped = [];
-      this._filteredIDs = [];
-      this._selectedIDs = [];
+      this._filteredIDs = new Set<number>();
+      this._selectedIDs = new Set<number>();
       this.lastSelectedIndex = -1;
     },
     // Filter roms by gallery filter store state
     setFiltered(roms: SimpleRom[], galleryFilter: GalleryFilterStore) {
-      this._filteredIDs = roms.map((rom) => rom.id);
+      this._filteredIDs = new Set(roms.map((rom) => rom.id));
       if (galleryFilter.filterSearch) {
         this._filterSearch(galleryFilter.filterSearch);
       }
@@ -157,68 +153,108 @@ export default defineStore("roms", {
       }
     },
     _filterSearch(searchFilter: string) {
-      this._filteredIDs = this.filteredRoms
-        .filter(
-          (rom) =>
-            rom.name?.toLowerCase().includes(searchFilter.toLowerCase()) ||
-            rom.file_name?.toLowerCase().includes(searchFilter.toLowerCase()),
-        )
-        .map((roms) => roms.id);
+      const bySearch = new Set(
+        this.filteredRoms
+          .filter(
+            (rom) =>
+              rom.name?.toLowerCase().includes(searchFilter.toLowerCase()) ||
+              rom.file_name?.toLowerCase().includes(searchFilter.toLowerCase()),
+          )
+          .map((roms) => roms.id),
+      );
+
+      // @ts-expect-error intersection is recently defined on Set
+      this._filteredIDs = bySearch.intersection(this._filteredIDs);
     },
     _filterUnmatched() {
-      this._filteredIDs = this.filteredRoms
-        .filter((rom) => !rom.igdb_id && !rom.moby_id)
-        .map((roms) => roms.id);
+      const byUnmatched = new Set(
+        this.filteredRoms
+          .filter((rom) => !rom.igdb_id && !rom.moby_id)
+          .map((roms) => roms.id),
+      );
+
+      // @ts-expect-error intersection is recently defined on Set
+      this._filteredIDs = byUnmatched.intersection(this._filteredIDs);
     },
     _filterFavourites() {
-      this._filteredIDs = this.filteredRoms
-        .filter((rom) => collectionStore.favCollection?.roms?.includes(rom.id))
-        .map((roms) => roms.id);
+      const byFavourites = new Set(
+        this.filteredRoms
+          .filter((rom) =>
+            collectionStore.favCollection?.roms?.includes(rom.id),
+          )
+          .map((roms) => roms.id),
+      );
+
+      // @ts-expect-error intersection is recently defined on Set
+      this._filteredIDs = byFavourites.intersection(this._filteredIDs);
     },
     _filterDuplicates() {
-      this._filteredIDs = this.filteredRoms
-        .filter((rom) => rom.sibling_roms?.length)
-        .map((rom) => rom.id);
+      const byDuplicates = new Set(
+        this.filteredRoms
+          .filter((rom) => rom.sibling_roms?.length)
+          .map((rom) => rom.id),
+      );
+
+      // @ts-expect-error intersection is recently defined on Set
+      this._filteredIDs = byDuplicates.intersection(this._filteredIDs);
     },
     _filterGenre(genreToFilter: string) {
-      this._filteredIDs = this.filteredRoms
-        .filter((rom) => rom.genres.some((genre) => genre === genreToFilter))
-        .map((rom) => rom.id);
+      const byGenre = new Set(
+        this.filteredRoms
+          .filter((rom) => rom.genres.some((genre) => genre === genreToFilter))
+          .map((rom) => rom.id),
+      );
+
+      // @ts-expect-error intersection is recently defined on Set
+      this._filteredIDs = byGenre.intersection(this._filteredIDs);
     },
     _filterFranchise(franchiseToFilter: string) {
-      this._filteredIDs = this.filteredRoms
-        .filter((rom) =>
-          rom.franchises.some((franchise) => franchise === franchiseToFilter),
-        )
-        .map((rom) => rom.id);
+      const byFranchise = new Set(
+        this.filteredRoms
+          .filter((rom) =>
+            rom.franchises.some((franchise) => franchise === franchiseToFilter),
+          )
+          .map((rom) => rom.id),
+      );
+
+      // @ts-expect-error intersection is recently defined on Set
+      this._filteredIDs = byFranchise.intersection(this._filteredIDs);
     },
     _filterCollection(collectionToFilter: string) {
-      this._filteredIDs = this.filteredRoms
-        .filter((rom) =>
-          rom.collections.some(
-            (collection) => collection === collectionToFilter,
-          ),
-        )
-        .map((rom) => rom.id);
+      const byCollection = new Set(
+        this.filteredRoms
+          .filter((rom) =>
+            rom.collections.some(
+              (collection) => collection === collectionToFilter,
+            ),
+          )
+          .map((rom) => rom.id),
+      );
+
+      // @ts-expect-error intersection is recently defined on Set
+      this._filteredIDs = byCollection.intersection(this._filteredIDs);
     },
     _filterCompany(companyToFilter: string) {
-      this._filteredIDs = this.filteredRoms
-        .filter((rom) =>
-          rom.companies.some((company) => company === companyToFilter),
-        )
-        .map((rom) => rom.id);
+      const byCompany = new Set(
+        this.filteredRoms
+          .filter((rom) =>
+            rom.companies.some((company) => company === companyToFilter),
+          )
+          .map((rom) => rom.id),
+      );
+
+      // @ts-expect-error intersection is recently defined on Set
+      this._filteredIDs = byCompany.intersection(this._filteredIDs);
     },
     // Selected roms
     setSelection(roms: SimpleRom[]) {
-      this._selectedIDs = roms.map((rom) => rom.id);
+      this._selectedIDs = new Set(roms.map((rom) => rom.id));
     },
     addToSelection(rom: SimpleRom) {
-      this._selectedIDs.push(rom.id);
+      this._selectedIDs.add(rom.id);
     },
     removeFromSelection(rom: SimpleRom) {
-      this._selectedIDs = this._selectedIDs.filter((id) => {
-        return id !== rom.id;
-      });
+      this._selectedIDs.delete(rom.id);
     },
     updateLastSelected(index: number) {
       this.lastSelectedIndex = index;
@@ -227,7 +263,7 @@ export default defineStore("roms", {
       this.selecting = !this.selecting;
     },
     resetSelection() {
-      this._selectedIDs = [];
+      this._selectedIDs = new Set<number>();
       this.lastSelectedIndex = -1;
     },
     isSimpleRom(rom: SimpleRom | SearchRomSchema): rom is SimpleRom {


### PR DESCRIPTION
This PR removes the selectin load for platforms, which is no longer needed since we now calculate rom count using a `column_property`. It also switches to using `Set` when managing the filtered lists of games, which is way faster then nested array filters.