### PR TITLE
misc: Tag Docker image with major version only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
           labels: |
             org.opencontainers.image.version={{version}}
             org.opencontainers.image.title="rommapp/romm"


### PR DESCRIPTION
Add Docker image tag that only includes its major version, for users to be able to decide whether to pin their stacks to a patch, minor, or major version.

Closes #1130.