### PR TITLE
Hack to get emujs working in dev mode

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -12,8 +12,9 @@ def str_to_bool(value: str) -> bool:
 
 
 # GUNICORN
-DEV_PORT: Final = int(os.environ.get("VITE_BACKEND_DEV_PORT", "5000"))
-DEV_HOST: Final = "127.0.0.1"
+DEV_MODE: Final = str_to_bool(os.environ.get("DEV_MODE", "false"))
+DEV_HOST: Final = os.environ.get("DEV_HOST", "127.0.0.1")
+DEV_PORT: Final = int(os.environ.get("DEV_PORT", "5000"))
 GUNICORN_WORKERS: Final = int(os.environ.get("GUNICORN_WORKERS", 2))
 
 # PATHS

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -6,6 +6,7 @@ from urllib.parse import quote
 
 from anyio import Path, open_file
 from config import (
+    DEV_MODE,
     DISABLE_DOWNLOAD_ENDPOINT_AUTH,
     LIBRARY_BASE_PATH,
     RESOURCES_BASE_PATH,
@@ -23,6 +24,7 @@ from handler.filesystem.base_handler import CoverSize
 from handler.metadata import meta_igdb_handler, meta_moby_handler
 from logger.logger import log
 from starlette.requests import ClientDisconnect
+from starlette.responses import FileResponse
 from streaming_form_data import StreamingFormDataParser
 from streaming_form_data.targets import FileTarget, NullTarget
 from utils.filesystem import sanitize_filename
@@ -178,9 +180,22 @@ async def head_rom_content(
     if not rom:
         raise RomNotFoundInDatabaseException(id)
 
+    rom_path = f"{LIBRARY_BASE_PATH}/{rom.full_path}"
     files_to_check = files or [r["filename"] for r in rom.files]
 
     if not rom.multi:
+        # Serve the file directly in development mode for emulatorjs
+        if DEV_MODE:
+            return FileResponse(
+                path=rom_path,
+                filename=rom.file_name,
+                headers={
+                    "Content-Disposition": f'attachment; filename="{quote(rom.file_name)}"',
+                    "Content-Type": "application/octet-stream",
+                    "Content-Length": str(rom.file_size_bytes),
+                },
+            )
+
         return Response(
             media_type="application/octet-stream",
             headers={

--- a/env.template
+++ b/env.template
@@ -1,5 +1,5 @@
 ROMM_BASE_PATH=/path/to/romm_mock
-VITE_BACKEND_DEV_PORT=5000
+DEV_MODE=true
 
 # Gunicorn (optional)
 GUNICORN_WORKERS=4 # (2 × CPU cores) + 1

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -12,7 +12,7 @@ import { defineConfig, loadEnv } from "vite";
 export default defineConfig(({ mode }) => {
   // Load ENV variables from the parent directory and the current directory.
   const env = { ...loadEnv(mode, "../"), ...loadEnv(mode, "./") };
-  const backendPort = env.VITE_BACKEND_DEV_PORT ?? "5000";
+  const backendPort = env.DEV_PORT ?? "5000";
 
   return {
     build: {


### PR DESCRIPTION
New `DEV_MODE` env variable explicitly set in `.env` and defaults to false. Since emujs only needs HEAD requests to fetch content location, then direct downloads to browser, change is only needed in `head_rom_content`.