### PR TITLE
[ROMM-1154] Fix setting main sibling

### DIFF
--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -227,13 +227,13 @@ class DBRomsHandler(DBBaseHandler):
         rom_user = self.get_rom_user_by_id(id)
 
         if data["is_main_sibling"]:
+            rom = self.get_rom(rom_user.rom_id)
+
             session.execute(
                 update(RomUser)
                 .where(
                     and_(
-                        RomUser.rom_id.in_(
-                            [rom.id for rom in rom_user.rom.get_sibling_roms()]
-                        ),
+                        RomUser.rom_id.in_(r.id for r in rom.sibling_roms),
                         RomUser.user_id == rom_user.user_id,
                     )
                 )


### PR DESCRIPTION
`get_sibling_roms` no longer exists, and we need to explicitly fetch the rom from the db (otherwise the connection closes early)