### PR TITLE
fix: Correctly update state for cover deletion

### DIFF
--- a/frontend/src/components/common/Collection/Dialog/CreateCollection.vue
+++ b/frontend/src/components/common/Collection/Dialog/CreateCollection.vue
@@ -23,11 +23,12 @@ const removeCover = ref(false);
 const emitter = inject<Emitter<Events>>("emitter");
 emitter?.on("showCreateCollectionDialog", () => {
   show.value = true;
+  removeCover.value = false;
 });
 emitter?.on("updateUrlCover", (url_cover) => {
   if (!collection.value) return;
   collection.value.url_cover = url_cover;
-  imagePreviewUrl.value = url_cover;
+  setArtwork(url_cover);
 });
 
 // Functions
@@ -42,11 +43,17 @@ function previewImage(event: Event) {
 
   const reader = new FileReader();
   reader.onload = () => {
-    imagePreviewUrl.value = reader.result?.toString();
+    setArtwork(reader.result?.toString() || "");
   };
   if (input.files[0]) {
     reader.readAsDataURL(input.files[0]);
   }
+}
+
+function setArtwork(imageUrl: string) {
+  if (!imageUrl) return;
+  imagePreviewUrl.value = imageUrl;
+  removeCover.value = false;
 }
 
 async function removeArtwork() {

--- a/frontend/src/components/common/Collection/Dialog/EditCollection.vue
+++ b/frontend/src/components/common/Collection/Dialog/EditCollection.vue
@@ -23,11 +23,12 @@ const emitter = inject<Emitter<Events>>("emitter");
 emitter?.on("showEditCollectionDialog", (collectionToEdit: Collection) => {
   collection.value = collectionToEdit;
   show.value = true;
+  removeCover.value = false;
 });
 emitter?.on("updateUrlCover", (url_cover) => {
   if (!collection.value) return;
   collection.value.url_cover = url_cover;
-  imagePreviewUrl.value = url_cover;
+  setArtwork(url_cover);
 });
 
 // Functions
@@ -42,11 +43,17 @@ function previewImage(event: Event) {
 
   const reader = new FileReader();
   reader.onload = () => {
-    imagePreviewUrl.value = reader.result?.toString();
+    setArtwork(reader.result?.toString() || "");
   };
   if (input.files[0]) {
     reader.readAsDataURL(input.files[0]);
   }
+}
+
+function setArtwork(imageUrl: string) {
+  if (!imageUrl) return;
+  imagePreviewUrl.value = imageUrl;
+  removeCover.value = false;
 }
 
 async function removeArtwork() {
@@ -62,6 +69,7 @@ async function editCollection() {
   await collectionApi
     .updateCollection({
       collection: collection.value,
+      removeCover: removeCover.value,
     })
     .then(({ data }) => {
       storeCollection.update(data);

--- a/frontend/src/components/common/Game/Dialog/EditRom.vue
+++ b/frontend/src/components/common/Game/Dialog/EditRom.vue
@@ -24,11 +24,12 @@ const emitter = inject<Emitter<Events>>("emitter");
 emitter?.on("showEditRomDialog", (romToEdit: UpdateRom | undefined) => {
   show.value = true;
   rom.value = romToEdit;
+  removeCover.value = false;
 });
 emitter?.on("updateUrlCover", (url_cover) => {
   if (!rom.value) return;
   rom.value.url_cover = url_cover;
-  imagePreviewUrl.value = url_cover;
+  setArtwork(url_cover);
 });
 
 // Functions
@@ -43,11 +44,17 @@ function previewImage(event: Event) {
 
   const reader = new FileReader();
   reader.onload = () => {
-    imagePreviewUrl.value = reader.result?.toString();
+    setArtwork(reader.result?.toString() || "");
   };
   if (input.files[0]) {
     reader.readAsDataURL(input.files[0]);
   }
+}
+
+function setArtwork(imageUrl: string) {
+  if (!imageUrl) return;
+  imagePreviewUrl.value = imageUrl;
+  removeCover.value = false;
 }
 
 async function removeArtwork() {


### PR DESCRIPTION
* Initialize `removeCover` as `false` on each dialog render, so previous overrides don't affect the initial state.
* Make both file upload and cover online search update `removeCover` to false.
* Fix collection update to send `remove_cover` to the API.

Potential fix for #1169.