### PR TITLE
fix: Use filename without tags or extension when matching unmatched game

### DIFF
--- a/frontend/src/components/common/Game/Dialog/MatchRom.vue
+++ b/frontend/src/components/common/Game/Dialog/MatchRom.vue
@@ -39,13 +39,15 @@ const isIGDBFiltered = ref(true);
 const isMobyFiltered = ref(true);
 emitter?.on("showMatchRomDialog", (romToSearch) => {
   rom.value = romToSearch;
-  // Use rom name as search term, only when it's matched; otherwise use the filename without tags
-  // and extension.
+  show.value = true;
+
+  // Use name as search term, only when it's matched
+  // Otherwise use the filename without tags and extensions
   searchTerm.value =
     romToSearch.igdb_id || romToSearch.moby_id
-      ? romToSearch.name || ""
-      : romToSearch.file_name_no_tags || "";
-  show.value = true;
+      ? (romToSearch.name ?? "")
+      : romToSearch.file_name_no_tags;
+
   if (searchTerm.value) {
     searchRom();
   }

--- a/frontend/src/components/common/Game/Dialog/MatchRom.vue
+++ b/frontend/src/components/common/Game/Dialog/MatchRom.vue
@@ -39,9 +39,14 @@ const isIGDBFiltered = ref(true);
 const isMobyFiltered = ref(true);
 emitter?.on("showMatchRomDialog", (romToSearch) => {
   rom.value = romToSearch;
-  searchTerm.value = romToSearch.name || romToSearch.file_name_no_tags || "";
+  // Use rom name as search term, only when it's matched; otherwise use the filename without tags
+  // and extension.
+  searchTerm.value =
+    romToSearch.igdb_id || romToSearch.moby_id
+      ? romToSearch.name || ""
+      : romToSearch.file_name_no_tags || "";
   show.value = true;
-  if (rom.value.igdb_id || rom.value.moby_id) {
+  if (searchTerm.value) {
     searchRom();
   }
 });


### PR DESCRIPTION
If a game is manually unmatched, we update its `name` field to `file_name` (which includes both tags and extension). After that, if we go to the Rom list, and click on "Manual match" for that rom, the search field is populated with that Rom name, which commonly won't retrieve any results from the metadata providers.

This change makes the "Manual match" search term to use the filename without tags or extension, when the Rom is currently not matched. It also triggers the search automatically when a search term was set.

Potential fix for #1167.