### PR TITLE
Bypass nginx proxy buffering when uploading roms

### DIFF
--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -165,12 +165,16 @@ class SimpleRomSchema(RomSchema):
     rom_user: RomUserSchema
 
     @classmethod
-    def from_orm_with_request(
-        cls, db_rom: Rom, request: Request
-    ) -> SimpleRomSchema | None:
+    def from_orm_with_request(cls, db_rom: Rom, request: Request) -> SimpleRomSchema:
         user_id = request.user.id
 
         db_rom.rom_user = RomUserSchema.for_user(user_id, db_rom)
+
+        return cls.model_validate(db_rom)
+
+    @classmethod
+    def from_orm_with_factory(cls, db_rom: Rom) -> SimpleRomSchema:
+        db_rom.rom_user = rom_user_schema_factory()
 
         return cls.model_validate(db_rom)
 

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -373,7 +373,7 @@ async def _identify_rom(
         {
             "platform_name": platform.name,
             "platform_slug": platform.slug,
-            **SimpleRomSchema.model_validate(_added_rom).model_dump(
+            **SimpleRomSchema.from_orm_with_factory(_added_rom).model_dump(
                 exclude={"created_at", "updated_at", "rom_user"}
             ),
         },

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -21,8 +21,9 @@ http {
         client_max_body_size 0;
         client_header_buffer_size 1k;
         large_client_header_buffers 4 16k;
-        send_timeout 60s;
-        keepalive_timeout 65s;
+        send_timeout 600s;
+        keepalive_timeout 600s;
+        client_body_timeout 600s;
         tcp_nopush on;
         tcp_nodelay on;
 
@@ -97,6 +98,8 @@ http {
             # Backend api calls
             location /api {
                 proxy_pass http://wsgi_server;
+                proxy_request_buffering off;
+                proxy_buffering off;
             }
             location /ws {
                 proxy_pass http://wsgi_server;

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -36,6 +36,7 @@ async function uploadRoms({
             "X-Upload-Platform": platformId.toString(),
             "X-Upload-Filename": file.name,
           },
+          timeout: 600000,
           params: {},
           onUploadProgress: (progressEvent: AxiosProgressEvent) => {
             uploadStore.update(file.name, progressEvent);

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -32,7 +32,7 @@ async function uploadRoms({
       api
         .post("/roms", formData, {
           headers: {
-            "Content-Type": "multipart/form-data; boundary=boundary",
+            "Content-Type": "multipart/form-data",
             "X-Upload-Platform": platformId.toString(),
             "X-Upload-Filename": file.name,
           },


### PR DESCRIPTION
The core changes are in the nginx config, where we increase the timeout for any calls to the api to 600 seconds (10 minutes), and tell nginx not to buffer requests. This should allow for direct upload streaming, which I've confirmed by testing on my server.