### PR TITLE
misc: Use bundled Valkey instead of Redis server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,9 @@ services:
     ports:
       - $DB_PORT:3306
 
-  redis:
-    image: redis:alpine
-    container_name: redis
+  valkey:
+    image: valkey/valkey:8
+    container_name: valkey
     restart: unless-stopped
     ports:
       - $REDIS_PORT:6379

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,12 +83,12 @@ RUN mkdir -p ${WEBSERVER_FOLDER}/assets/romm && \
 # Install required packages and dependencies
 RUN apk add --no-cache \
     bash \
+    libmagic \
     mariadb-connector-c \
+    p7zip \
     python3 \
     tzdata \
-    redis \
-    libmagic \
-    p7zip
+    valkey
 
 COPY ./backend /backend
 

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -70,16 +70,16 @@ start_bin_nginx() {
 	fi
 }
 
-start_bin_redis-server() {
-	info_log "starting redis-server"
-	# Check if /usr/local/etc/redis/redis.conf exists and use it if so
-	if [[ -f /usr/local/etc/redis/redis.conf ]]; then
-		redis-server /usr/local/etc/redis/redis.conf &
+start_bin_valkey-server() {
+	info_log "starting valkey-server"
+	# Check if /usr/local/etc/valkey/valkey.conf exists and use it if so
+	if [[ -f /usr/local/etc/valkey/valkey.conf ]]; then
+		valkey-server /usr/local/etc/valkey/valkey.conf &
 	else
-		redis-server --dir /redis-data &
+		valkey-server --dir /redis-data &
 	fi
-	REDIS_PID=$!
-	echo "${REDIS_PID}" >/tmp/redis-server.pid
+	VALKEY_PID=$!
+	echo "${VALKEY_PID}" >/tmp/valkey-server.pid
 }
 
 # function that runs our independent python scripts and creates corresponding PID files,
@@ -128,10 +128,10 @@ while true; do
 	# check for died processes every 5 seconds
 	sleep 5
 
-	# Start redis server if we dont have a corresponding PID file
-	# and REDIS_HOST is not set (which would mean we're using an external redis)
+	# Start Valkey server if we dont have a corresponding PID file
+	# and REDIS_HOST is not set (which would mean we're using an external Redis/Valkey)
 	if [[ -z ${REDIS_HOST:=""} ]]; then
-		watchdog_process_pid bin redis-server
+		watchdog_process_pid bin valkey-server
 	fi
 
 	# Run needed database migrations on startup,


### PR DESCRIPTION
This change replaces the bundled Redis server with Valkey. No breaking changes are introduced, as considered environment variables still maintain the `REDIS_` prefix.

Fixes #925.