### PR TITLE
fix: Do not set Ruffle's renderer explicitly

### DIFF
--- a/frontend/src/views/RuffleRS/Base.vue
+++ b/frontend/src/views/RuffleRS/Base.vue
@@ -37,9 +37,7 @@ function onPlay() {
       allowFullScreen: true,
       autoplay: "on",
       backgroundColor: "#0D1117",
-      logLevel: "debug",
       openUrlMode: "confirm",
-      preferredRenderer: "webgl",
       publicPath: "/assets/ruffle/",
       url: `/api/roms/${rom.value?.id}/content/${rom.value?.file_name}`,
     });


### PR DESCRIPTION
According to Ruffle documentation [1], the `preferredRenderer` option is only needed if a renderer needs to be enforced. When not provided:

> By default, Ruffle chooses the most featureful backend supported by the user's system, falling back to more basic backends if necessary.

This commit removes the `preferredRenderer` option from the Ruffle configuration in the frontend, so that the default behavior is used.

It also removes the noisy `logLevel` option, which was set to `debug`.

Fixes rendering issue for `Boxhead: The Rooms`, reported in #1216.

[1] https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle