### PR TITLE
fix: Skip scanning task by checking against the correct function name

### DIFF
--- a/backend/watcher.py
+++ b/backend/watcher.py
@@ -50,7 +50,7 @@ class EventHandler(FileSystemEventHandler):
 
         # Skip if a scan is already scheduled
         for job in tasks_scheduler.get_jobs():
-            if job.func_name == "endpoints.scan.scan_platforms":
+            if job.func_name == "endpoints.sockets.scan.scan_platforms":
                 if job.args[0] == []:
                     log.info("Full rescan already scheduled")
                     return


### PR DESCRIPTION
The `scan.py` module was moved to the `sockets` package, but this line was not updated to reflect that change. This currently causes the watcher to not skip queuing a new `scan_platforms` task if one is already scheduled.