### PR TITLE
fix: Correctly resize and save small artwork

### DIFF
--- a/backend/endpoints/collections.py
+++ b/backend/endpoints/collections.py
@@ -1,7 +1,8 @@
 import json
+from io import BytesIO
 from shutil import rmtree
 
-from anyio import open_file
+from anyio import Path
 from config import RESOURCES_BASE_PATH
 from decorators.auth import protected_route
 from endpoints.responses import MessageResponse
@@ -17,6 +18,7 @@ from handler.filesystem import fs_resource_handler
 from handler.filesystem.base_handler import CoverSize
 from logger.logger import log
 from models.collection import Collection
+from PIL import Image
 from sqlalchemy.inspection import inspect
 from utils.router import APIRouter
 
@@ -62,15 +64,14 @@ async def add_collection(
             artwork_path,
         ) = await fs_resource_handler.build_artwork_path(_added_collection, file_ext)
 
-        artwork_file = artwork.file.read()
-        file_location_s = f"{artwork_path}/small.{file_ext}"
-        async with await open_file(file_location_s, "wb+") as artwork_s:
-            await artwork_s.write(artwork_file)
-            fs_resource_handler.resize_cover_to_small(file_location_s)
-
-        file_location_l = f"{artwork_path}/big.{file_ext}"
-        async with await open_file(file_location_l, "wb+") as artwork_l:
-            await artwork_l.write(artwork_file)
+        artwork_content = BytesIO(await artwork.read())
+        file_location_small = Path(f"{artwork_path}/small.{file_ext}")
+        file_location_large = Path(f"{artwork_path}/big.{file_ext}")
+        with Image.open(artwork_content) as img:
+            img.save(file_location_large)
+            fs_resource_handler.resize_cover_to_small(
+                img, save_path=file_location_small
+            )
     else:
         path_cover_s, path_cover_l = await fs_resource_handler.get_cover(
             overwrite=True,
@@ -183,15 +184,15 @@ async def update_collection(
             cleaned_data["path_cover_l"] = path_cover_l
             cleaned_data["path_cover_s"] = path_cover_s
 
-            artwork_file = artwork.file.read()
-            file_location_s = f"{artwork_path}/small.{file_ext}"
-            async with await open_file(file_location_s, "wb+") as artwork_s:
-                await artwork_s.write(artwork_file)
-                fs_resource_handler.resize_cover_to_small(file_location_s)
+            artwork_content = BytesIO(await artwork.read())
+            file_location_small = Path(f"{artwork_path}/small.{file_ext}")
+            file_location_large = Path(f"{artwork_path}/big.{file_ext}")
+            with Image.open(artwork_content) as img:
+                img.save(file_location_large)
+                fs_resource_handler.resize_cover_to_small(
+                    img, save_path=file_location_small
+                )
 
-            file_location_l = f"{artwork_path}/big.{file_ext}"
-            async with await open_file(file_location_l, "wb+") as artwork_l:
-                await artwork_l.write(artwork_file)
             cleaned_data.update({"url_cover": ""})
         else:
             if data.get("url_cover", "") != collection.url_cover or not (


### PR DESCRIPTION
The previous implementation was calling `resize_cover_to_small` within the context manager that was writing the image to the filesystem. This was causing `PIL` to raise an error because it could not identify the open and temporarily created file as a valid image.

Instead of saving the original image to the filesystem and then resizing it, we now open the image in memory, resize it, and then save it to the filesystem. We also avoid reading the `BytesIO` object twice by saving small and big images from the same initial `Image` object.

Fixes #1191.