### PR TITLE
fix: Avoid image requests for undefined.ico platform icon

### DIFF
--- a/frontend/src/components/common/Platform/Icon.vue
+++ b/frontend/src/components/common/Platform/Icon.vue
@@ -18,9 +18,11 @@ const { config } = storeToRefs(configStore);
 <template>
   <v-avatar :size="size" :rounded="rounded" :title="name || slug">
     <v-img
-      :src="`/assets/platforms/${config.PLATFORMS_VERSIONS?.[
-        props.slug
-      ]?.toLowerCase()}.ico`"
+      :src="
+        config.PLATFORMS_VERSIONS?.[props.slug]?.toLowerCase()
+          ? `/assets/platforms/${config.PLATFORMS_VERSIONS?.[props.slug]?.toLowerCase()}.ico`
+          : `/assets/platforms/${props.slug.toLowerCase()}.ico`
+      "
     >
       <template #error>
         <v-img :src="`/assets/platforms/${props.slug.toLowerCase()}.ico`">


### PR DESCRIPTION
When a platform slug is not present in `PLATFORMS_VERSIONS`, which is the common case overall, the component was trying to fetch an `undefined.ico` image.

Instead of that, we should check if the platform slug is present in `PLATFORMS_VERSIONS` and if not, fallback to the platform slug itself.