### PR TITLE
Add offset parameter to get_roms endpoint

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -104,6 +104,7 @@ def get_roms(
     collection_id: int | None = None,
     search_term: str = "",
     limit: int | None = None,
+    offset: int | None = None,
     order_by: str = "name",
     order_dir: str = "asc",
 ) -> list[SimpleRomSchema]:
@@ -124,6 +125,7 @@ def get_roms(
         order_by=order_by.lower(),
         order_dir=order_dir.lower(),
         limit=limit,
+        offset=offset,
     )
 
     roms = [SimpleRomSchema.from_orm_with_request(rom, request) for rom in roms]

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -115,6 +115,7 @@ class DBRomsHandler(DBBaseHandler):
         order_by: str = "name",
         order_dir: str = "asc",
         limit: int | None = None,
+        offset: int | None = None,
         query: Query = None,
         session: Session = None,
     ) -> list[Rom]:
@@ -122,7 +123,8 @@ class DBRomsHandler(DBBaseHandler):
             query, platform_id, collection_id, search_term, session
         )
         ordered_query = self._order(filtered_query, order_by, order_dir)
-        limited_query = ordered_query.limit(limit)
+        offset_query = ordered_query.offset(offset)
+        limited_query = offset_query.limit(limit)
         return session.scalars(limited_query).unique().all()
 
     @begin_session


### PR DESCRIPTION
Related to #1123

I'm modifying local ROM management software (such as ES-DE) to query a RomM server for ROMs, as well as to download them for use on the local machine's emulators. Huge database sizes came to be an issue as there would be a timeout when attempting to make a query to the database, but would also create a better user experience of having some list of ROMs available immediately rather than waiting for the query for the entire set of requested ROMs to be completed.

The frontend making use of this is not a part of this pull request, but I would assume this can be used for pagination as mentioned in the referenced issue.