### PR TITLE
fix: Avoid query during import time to set add_user endpoint scopes

### DIFF
--- a/backend/endpoints/tests/test_identity.py
+++ b/backend/endpoints/tests/test_identity.py
@@ -1,7 +1,13 @@
 import base64
+from datetime import timedelta
+from http import HTTPStatus
+from unittest import mock
 
 import pytest
+from endpoints.auth import ACCESS_TOKEN_EXPIRE_MINUTES
 from fastapi.testclient import TestClient
+from handler.auth import oauth_handler
+from handler.database.users_handler import DBUsersHandler
 from handler.redis_handler import sync_cache
 from main import app
 from models.user import Role
@@ -61,21 +67,68 @@ def test_get_user(client, access_token, editor_user):
     assert user["username"] == "test_editor"
 
 
-def test_create_user(client, access_token):
+@pytest.mark.parametrize("new_user_role", [Role.VIEWER, Role.EDITOR, Role.ADMIN])
+def test_add_user_from_admin_user(client, access_token, new_user_role):
     response = client.post(
         "/api/users",
         params={
             "username": "new_user",
             "password": "new_user_password",
-            "role": "viewer",
+            "role": new_user_role.value,
         },
         headers={"Authorization": f"Bearer {access_token}"},
     )
-    assert response.status_code == 201
+    assert response.status_code == HTTPStatus.CREATED
 
     user = response.json()
     assert user["username"] == "new_user"
-    assert user["role"] == "viewer"
+    assert user["role"] == new_user_role.value
+
+
+@pytest.mark.parametrize(
+    "fixture_requesting_user, existing_admin_users, expected_status_code",
+    [
+        ("editor_user", False, HTTPStatus.CREATED),
+        ("editor_user", True, HTTPStatus.FORBIDDEN),
+        ("viewer_user", False, HTTPStatus.CREATED),
+        ("viewer_user", True, HTTPStatus.FORBIDDEN),
+    ],
+)
+def test_add_user_from_unauthorized_user(
+    request,
+    client,
+    admin_user,
+    fixture_requesting_user,
+    existing_admin_users,
+    expected_status_code,
+):
+    requesting_user = request.getfixturevalue(fixture_requesting_user)
+
+    data = {
+        "sub": requesting_user.username,
+        "iss": "romm:oauth",
+        "scopes": " ".join(requesting_user.oauth_scopes),
+        "type": "access",
+    }
+    access_token = oauth_handler.create_oauth_token(
+        data=data, expires_delta=timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+
+    with mock.patch.object(
+        DBUsersHandler,
+        "get_admin_users",
+        return_value=[admin_user] if existing_admin_users else [],
+    ):
+        response = client.post(
+            "/api/users",
+            params={
+                "username": "new_user",
+                "password": "new_user_password",
+                "role": Role.VIEWER.value,
+            },
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == expected_status_code
 
 
 def test_update_user(client, access_token, editor_user):


### PR DESCRIPTION
The `add_user` endpoint was querying the database at import time, to decide whether to enforce the `users.write` scope or not. This is problematic because the database might not be ready at import time.

Also, the decided `scopes` was being maintained for the entire application lifetime, which is not ideal, as users can be created without having the `users.write` scope, until the application is restarted.