### PR TITLE
fix: Make tar decompression only consider regular files

### DIFF
--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -93,6 +93,10 @@ def read_tar_file(file_path: Path, mode: str = "r") -> Iterator[bytes]:
     try:
         with tarfile.open(file_path, mode) as f:
             for member in f.getmembers():
+                # Ignore directories and any other non-regular files
+                if not member.isfile():
+                    continue
+
                 # Ignore metadata files created by macOS
                 if member.name.startswith("._"):
                     continue


### PR DESCRIPTION
The `tar` decompression function was failing for some users, with error message:

```
'NoneType' object does not support the context manager protocol
```

As explained in the official documentation [1], the `extractfile` method returns `None` if the member is not a regular file or a link. This change skips any member that is not a regular file.

[1] https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractfile