### PR TITLE
fix: Download IGDB screenshots with right aspect ratio

### DIFF
--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -456,9 +456,7 @@ class IGDBBaseHandler(MetadataHandler):
                 rom.get("cover", {}).get("url", "")
             ).replace("t_thumb", "t_1080p"),
             url_screenshots=[
-                self._normalize_cover_url(s.get("url", "")).replace(
-                    "t_thumb", "t_screenshot_huge"
-                )
+                self._normalize_cover_url(s.get("url", "")).replace("t_thumb", "t_720p")
                 for s in rom.get("screenshots", [])
             ],
             igdb_metadata=extract_metadata_from_igdb_rom(rom, video_id),
@@ -494,9 +492,7 @@ class IGDBBaseHandler(MetadataHandler):
                 rom.get("cover", {}).get("url", "")
             ).replace("t_thumb", "t_1080p"),
             url_screenshots=[
-                self._normalize_cover_url(s.get("url", "")).replace(
-                    "t_thumb", "t_screenshot_huge"
-                )
+                self._normalize_cover_url(s.get("url", "")).replace("t_thumb", "t_720p")
                 for s in rom.get("screenshots", [])
             ],
             igdb_metadata=extract_metadata_from_igdb_rom(rom, video_id),
@@ -578,11 +574,13 @@ class IGDBBaseHandler(MetadataHandler):
                         "summary": rom.get("summary", ""),
                         "url_cover": self._normalize_cover_url(
                             pydash.get(rom, "cover.url", "").replace(
-                                "t_thumb", "t_cover_big"
+                                "t_thumb", "t_1080p"
                             )
                         ),
                         "url_screenshots": [
-                            self._normalize_cover_url(s.get("url", ""))  # type: ignore[arg-type]
+                            self._normalize_cover_url(s.get("url", "")).replace(
+                                "t_thumb", "t_720p"
+                            )
                             for s in rom.get("screenshots", [])
                         ],
                         "igdb_metadata": extract_metadata_from_igdb_rom(rom),


### PR DESCRIPTION
The IGDB API provides screenshots in 720p resolution, when either `screenshot_huge` or `720p` size values are used [1]. The `screenshot_huge` uses `Lfill`, while `720p` uses `Fit` as the resizing method.

That means that either `screenshot_huge` or `720p` will provide the correct aspect ratio for 16:9 platforms. However, for platforms with a different aspect ratio, we need to use the `720p` size value to get the correct image instead of a cropped one.

Example:
- [`screenshot_huge`](https://images.igdb.com/igdb/image/upload/t_screenshot_huge/c77bodnkwu73gs2jwhw4.jpg)
- [`720p`](https://images.igdb.com/igdb/image/upload/t_720p/c77bodnkwu73gs2jwhw4.jpg)

[1] https://api-docs.igdb.com/#images