### PR TITLE
fix: Show source image on each result for Manual match

### DIFF
--- a/frontend/src/components/common/Game/Dialog/MatchRom.vue
+++ b/frontend/src/components/common/Game/Dialog/MatchRom.vue
@@ -14,6 +14,7 @@ import { useDisplay, useTheme } from "vuetify";
 type MatchedSource = {
   url_cover: string | undefined;
   name: "IGDB" | "Mobygames";
+  logo_path: string;
 };
 
 // Props
@@ -126,10 +127,12 @@ function showSources(matchedRom: SearchRomSchema) {
   sources.value.push({
     url_cover: matchedRom.igdb_url_cover,
     name: "IGDB",
+    logo_path: "/assets/scrappers/igdb.png",
   });
   sources.value.push({
     url_cover: matchedRom.moby_url_cover,
     name: "Mobygames",
+    logo_path: "/assets/scrappers/moby.png",
   });
 }
 
@@ -408,9 +411,7 @@ onBeforeUnmount(() => {
                       </template>
                       <v-row no-gutters class="text-white pa-1">
                         <v-avatar class="mr-1" size="30" rounded="1">
-                          <v-img
-                            :src="`/assets/scrappers/${source.name}.png`"
-                          />
+                          <v-img :src="source.logo_path" />
                         </v-avatar>
                       </v-row>
                     </v-img>


### PR DESCRIPTION
The source image was not being shown on the results of the manual match dialog, because scrapper image names do not match the source names. To avoid this issue, the `MatchedSource` type was updated to include a `logo_path` property, which will be used to set the correct image path.

Before:
![romm-before](https://github.com/user-attachments/assets/b11db8d2-b26f-47cf-9e69-bb711ff8f533)

After:
![romm-after](https://github.com/user-attachments/assets/0986e970-2ee0-403f-a90a-556a8ac9428e)
