### PR TITLE
misc: Use tini as container entrypoint

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -118,6 +118,7 @@ RUN apk add --no-cache \
     mariadb-connector-c \
     p7zip \
     python3 \
+    tini \
     tzdata \
     valkey
 
@@ -148,4 +149,6 @@ VOLUME ["/romm/resources", "/romm/library", "/romm/assets", "/romm/config", "/re
 # Expose ports and start
 EXPOSE 8080 6379/tcp
 WORKDIR /romm
+
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/init"]


### PR DESCRIPTION
Use `tini` [1] as the container entrypoint to ensure that the container process is properly reaped when the container is stopped.

This is needed as the main container command is a shell script.

A simple way to test this change is to:

1. Build the container image and run it using `docker compose up`.
2. Within the same terminal, stop the container using `Ctrl+C`.
3. Verify that the container is properly stopped right away.

Without `tini`, the container takes a few seconds to stop, and it makes one CPU core to be used at 100% during that time.

[1] https://github.com/krallin/tini