### PR TITLE
Revert "Update rom.py to Fix Filename error"

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -209,7 +209,7 @@ async def head_rom_content(
             media_type="application/octet-stream",
             headers={
                 "Content-Disposition": f'attachment; filename="{quote(files_to_check[0])}"',
-                "X-Accel-Redirect": f"/library/{quote(rom.full_path)}/{quote(files_to_check[0])}",
+                "X-Accel-Redirect": f"/library/{rom.full_path}/{files_to_check[0]}",
             },
         )
 


### PR DESCRIPTION
This reverts commit e2bfbacfbc5d4035f6f95ba2b6d76815b587c811. The fix has been applied to the `master` branch in PR #1224.