### PR TITLE
misc: Add MariaDB healthcheck recommendation to Docker Compose config

### DIFF
--- a/examples/docker-compose.example.yml
+++ b/examples/docker-compose.example.yml
@@ -29,10 +29,12 @@ services:
     ports:
       - 80:8080
     depends_on:
-      - romm-db
+      romm-db:
+        condition: service_healthy
+        restart: true
 
   romm-db:
-    image: mariadb:latest # if you experience issues, try: linuxserver/mariadb:latest
+    image: mariadb:latest
     container_name: romm-db
     restart: unless-stopped
     environment:
@@ -42,3 +44,10 @@ services:
       - MARIADB_PASSWORD=
     volumes:
       - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 30s
+      start_interval: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
This commit adds a healthcheck configuration to the MariaDB service in the Docker Compose example configuration. The healthcheck script is a simple shell script that checks if the MariaDB server is ready to accept connections.

The application will wait for the MariaDB service to be healthy before starting the application service. This should solve issues where the database takes longer to start than the application, and logs some `Something went horribly wrong with our database` errors.

This change also stops recommending the `linuxserver/mariadb` image as an alternative. We have had users that change the image because of the first time run triggering those errors, but the `linuxserver/mariadb` image requires a different configuration that could be confusing for new users (e.g. volume mountpoint needs to be `/config` instead of `/var/lib/mysql`).