### PR TITLE
Fix #1283 - properly default groupRoms if it doesn't exist in localStorage

### DIFF
--- a/frontend/src/stores/roms.ts
+++ b/frontend/src/stores/roms.ts
@@ -3,7 +3,7 @@ import type { DetailedRomSchema, SimpleRomSchema } from "@/__generated__/";
 import { type Platform } from "@/stores/platforms";
 import { type Collection } from "@/stores/collections";
 import type { ExtractPiniaStoreType } from "@/types";
-import { groupBy, uniqBy } from "lodash";
+import { groupBy, isNull, uniqBy } from "lodash";
 import { nanoid } from "nanoid";
 import { defineStore } from "pinia";
 import storeGalleryFilter from "./galleryFilter";
@@ -47,7 +47,9 @@ export default defineStore("roms", {
       });
 
       // Check if roms should be grouped
-      const groupRoms = localStorage.getItem("settings.groupRoms") === "true";
+      const groupRoms = isNull(localStorage.getItem("settings.groupRoms"))
+        ? true
+        : localStorage.getItem("settings.groupRoms") === "true";
       if (!groupRoms) {
         this._grouped = this.allRoms;
         return;


### PR DESCRIPTION
Makes the read from localStorage consistent with reads of the other settings elsewhere in the codebase.

Would probably be nice to have grouping happen in the "recents" view too, but that would take more substantial changes and a deeper understanding of the codebase by me.  :)   If I get more time, maybe I will submit a separate PR for that.