### PR TITLE
fix: Consider more categories when matching IGDB games

### DIFF
--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -271,11 +271,17 @@ class IGDBBaseHandler(MetadataHandler):
             return None
 
         search_term = uc(search_term)
-        category_filter: str = (
-            f"& (category={GameCategory.MAIN_GAME} | category={GameCategory.EXPANDED_GAME})"
-            if with_category
-            else ""
-        )
+        if with_category:
+            categories = (
+                GameCategory.EXPANDED_GAME,
+                GameCategory.MAIN_GAME,
+                GameCategory.PORT,
+                GameCategory.REMAKE,
+                GameCategory.REMASTER,
+            )
+            category_filter = f"& category=({','.join(map(str, categories))})"
+        else:
+            category_filter = ""
 
         def is_exact_match(rom: dict, search_term: str) -> bool:
             return (


### PR DESCRIPTION
This change includes more categories when matching IGDB games. While testing, some games were incorrectly matched to the wrong game, and the reason was that the game was a Port (e.g. `Arkanoid`, `Contra`, `Double Dragon`, `Metal Gear` for NES), a Remake (e.g. `Adventure Island` for NES), or a Remaster.