### PR TITLE
fix: Crash on new instance from previous installation

### DIFF
--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -58,7 +58,7 @@ CFLAGS="-Wno-error=incompatible-pointer-types" poetry install --sync
 #### - Spin up mariadb in docker
 
 ```sh
-docker-compose up -d
+docker compose up -d
 ```
 
 #### - Run the backend
@@ -125,7 +125,7 @@ trunk check
 ### - Create the test user and database with root user
 
 ```sh
-docker exec -i mariadb mariadb -u root -p<root password> < backend/romm_test/setup.sql
+docker exec -i romm-mariadb-dev mariadb -uroot -p<root password> < backend/romm_test/setup.sql
 ```
 
 ### - Run tests

--- a/backend/handler/auth/middleware.py
+++ b/backend/handler/auth/middleware.py
@@ -1,6 +1,8 @@
 import time
 from collections import namedtuple
 
+from fastapi import HTTPException
+from handler.database.users_handler import DBUsersHandler
 from joserfc import jwt
 from joserfc.errors import BadSignatureError
 from joserfc.jwk import OctKey
@@ -107,7 +109,15 @@ class SessionMiddleware:
                 jwt_claims = self._validate_jwt_payload(jwt_payload)
                 scope["session"] = jwt_claims
                 initial_session_was_empty = False
-            except BadSignatureError:
+
+                # Check if the user exists
+                db_user_handler = DBUsersHandler()
+                user = db_user_handler.get_user_by_username(jwt_claims.get("sub"))
+                if not user:
+                    scope["session"] = {}
+                    initial_session_was_empty = True
+
+            except (BadSignatureError, HTTPException):
                 scope["session"] = {}
         else:
             scope["session"] = {}

--- a/backend/handler/auth/middleware.py
+++ b/backend/handler/auth/middleware.py
@@ -1,7 +1,6 @@
 import time
 from collections import namedtuple
 
-from fastapi import HTTPException
 from joserfc import jwt
 from joserfc.errors import BadSignatureError
 from joserfc.jwk import OctKey
@@ -109,7 +108,7 @@ class SessionMiddleware:
                 scope["session"] = jwt_claims
                 initial_session_was_empty = False
 
-            except (BadSignatureError, HTTPException):
+            except BadSignatureError:
                 scope["session"] = {}
         else:
             scope["session"] = {}

--- a/backend/handler/auth/middleware.py
+++ b/backend/handler/auth/middleware.py
@@ -2,7 +2,6 @@ import time
 from collections import namedtuple
 
 from fastapi import HTTPException
-from handler.database.users_handler import DBUsersHandler
 from joserfc import jwt
 from joserfc.errors import BadSignatureError
 from joserfc.jwk import OctKey
@@ -109,14 +108,6 @@ class SessionMiddleware:
                 jwt_claims = self._validate_jwt_payload(jwt_payload)
                 scope["session"] = jwt_claims
                 initial_session_was_empty = False
-
-                # Check if the user exists only for /api/heartbeat endpoint
-                if scope["path"] == "/api/heartbeat":
-                    db_user_handler = DBUsersHandler()
-                    user = db_user_handler.get_user_by_username(jwt_claims.get("sub"))
-                    if not user:
-                        scope["session"] = {}
-                        initial_session_was_empty = True
 
             except (BadSignatureError, HTTPException):
                 scope["session"] = {}

--- a/backend/handler/auth/middleware.py
+++ b/backend/handler/auth/middleware.py
@@ -110,12 +110,13 @@ class SessionMiddleware:
                 scope["session"] = jwt_claims
                 initial_session_was_empty = False
 
-                # Check if the user exists
-                db_user_handler = DBUsersHandler()
-                user = db_user_handler.get_user_by_username(jwt_claims.get("sub"))
-                if not user:
-                    scope["session"] = {}
-                    initial_session_was_empty = True
+                # Check if the user exists only for /api/heartbeat endpoint
+                if scope["path"] == "/api/heartbeat":
+                    db_user_handler = DBUsersHandler()
+                    user = db_user_handler.get_user_by_username(jwt_claims.get("sub"))
+                    if not user:
+                        scope["session"] = {}
+                        initial_session_was_empty = True
 
             except (BadSignatureError, HTTPException):
                 scope["session"] = {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 # Please see the full example under examples/docker-compose.example.yml
 
 services:
-  mariadb:
-    image: mariadb:latest
-    container_name: mariadb
+  romm-mariadb-dev:
+    image: mariadb:11.3.2
+    container_name: romm-mariadb-dev
     restart: unless-stopped
     environment:
       - MARIADB_ROOT_PASSWORD=$DB_ROOT_PASSWD
@@ -13,9 +13,9 @@ services:
     ports:
       - $DB_PORT:3306
 
-  valkey:
+  romm-valkey-dev:
     image: valkey/valkey:8
-    container_name: valkey
+    container_name: romm-valkey-dev
     restart: unless-stopped
     ports:
       - $REDIS_PORT:6379

--- a/frontend/src/components/common/Navigation/SettingsDrawer.vue
+++ b/frontend/src/components/common/Navigation/SettingsDrawer.vue
@@ -32,6 +32,7 @@ async function logout() {
       icon: "mdi-check-bold",
       color: "green",
     });
+    navigationStore.switchActiveSettingsDrawer();
   });
 
   await router.push({ name: "login" });

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.vue"],
   "types": ["node", "file-saver", "lodash", "js-cookie", "vue-router", "vue"],
   "compilerOptions": {
     "composite": true,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "include": ["src/**/*.ts", "src/**/*.vue"],
+  "include": ["src/**/*.ts"],
   "types": ["node", "file-saver", "lodash", "js-cookie", "vue-router", "vue"],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
When setting up a new installation, if the browser has old cookies (romm_session cookie specifically) from an old instance or from an user that no longer exists in the database, RomM crashes without recover. This fix adds a check in the middleware to avoid the crash and clean the session cookies gracefully.

Closes #1266 