### PR TITLE
fix: Speed up scan for matched roms without filesystem changes

### DIFF
--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -342,11 +342,16 @@ async def _identify_rom(
     rom = db_rom_handler.get_rom_by_filename(platform.id, fs_rom["file_name"])
 
     if not _should_scan_rom(scan_type=scan_type, rom=rom, roms_ids=roms_ids):
-        # Just to update the filesystem data
-        rom.file_name = fs_rom["file_name"]
-        rom.multi = fs_rom["multi"]
-        rom.files = fs_rom["files"]
-        db_rom_handler.add_rom(rom)
+        if (
+            rom.file_name != fs_rom["file_name"]
+            or rom.multi != fs_rom["multi"]
+            or rom.files != fs_rom["files"]
+        ):
+            # Just to update the filesystem data
+            rom.file_name = fs_rom["file_name"]
+            rom.multi = fs_rom["multi"]
+            rom.files = fs_rom["files"]
+            db_rom_handler.add_rom(rom)
 
         return scan_stats
 


### PR DESCRIPTION
When the scanning process fiends that a rom should not be scanned, it was still updating the rom data in the database.

This database update is only needed when the existing data is different to the newly found filesystem data, so we can avoid most of the updates for already existing library roms.