### PR TITLE
feat: Add support for _FILE suffix in environment variables

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -152,5 +152,5 @@ VOLUME ["/romm/resources", "/romm/library", "/romm/assets", "/romm/config", "/re
 EXPOSE 8080 6379/tcp
 WORKDIR /romm
 
-ENTRYPOINT ["/sbin/tini", "--"]
+ENTRYPOINT ["/sbin/tini", "--", "/docker-entrypoint.sh"]
 CMD ["/init"]

--- a/docker/init_scripts/docker-entrypoint.sh
+++ b/docker/init_scripts/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Load environment variables from variants with a _FILE suffix.
+# The following logic reads variables with a _FILE suffix and
+# loads the contents of the file specified in the variable
+# into the variable without the suffix.
+for var_name in $(printenv | cut -d= -f1 | grep "_FILE$" || true); do
+	# If variable is empty, skip.
+	if [[ -z ${!var_name} ]]; then
+		continue
+	fi
+
+	var_name_no_suffix=${var_name%"_FILE"}
+
+	# If the variable without the suffix is already set, raise an error.
+	if [[ -n ${!var_name_no_suffix} ]]; then
+		echo "ERROR: Both ${var_name_no_suffix} and ${var_name} are set (but are exclusive)" >&2
+		exit 1
+	fi
+
+	file_path="${!var_name}"
+
+	# If file does not exist, raise an error.
+	if [[ ! -f ${file_path} ]]; then
+		echo "ERROR: File ${file_path} from ${var_name} does not exist" >&2
+		exit 1
+	fi
+
+	echo "Setting ${var_name_no_suffix} from ${var_name} at ${file_path}"
+	export "${var_name_no_suffix}"="$(cat "${file_path}")"
+
+	# Unset the _FILE variable.
+	unset "${var_name}"
+done
+
+exec "$@"


### PR DESCRIPTION
This change allows setting environment variables with a `_FILE` suffix, which will be used to load the contents of the file specified in the variable into the variable without the suffix.

For example, setting `ROMM_AUTH_SECRET_KEY_FILE=/run/secrets/romm_auth_secret_key` and creating a file with the secret key at the specified path will set `ROMM_AUTH_SECRET_KEY` to the contents of the file.

A common use case for this is to use secrets in Docker Compose [1], to avoid exposing secrets in the `docker-compose.yml` or `env` files.

[1] https://docs.docker.com/compose/how-tos/use-secrets/