### PR TITLE
Hotfixes for some sqlalchemy models

### DIFF
--- a/backend/models/platform.py
+++ b/backend/models/platform.py
@@ -38,7 +38,7 @@ class Platform(BaseModel):
     )
 
     aspect_ratio: Mapped[str] = mapped_column(
-        String, server_default=DEFAULT_COVER_ASPECT_RATIO
+        String(length=10), server_default=DEFAULT_COVER_ASPECT_RATIO
     )
 
     # This runs a subquery to get the count of roms for the platform

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     DateTime,
     Enum,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
@@ -42,6 +43,11 @@ class Rom(BaseModel):
     igdb_id: Mapped[int | None]
     sgdb_id: Mapped[int | None]
     moby_id: Mapped[int | None]
+
+    __table_args__ = (
+        Index("idx_roms_igdb_id", "igdb_id"),
+        Index("idx_roms_moby_id", "moby_id"),
+    )
 
     file_name: Mapped[str] = mapped_column(String(length=450))
     file_name_no_tags: Mapped[str] = mapped_column(String(length=450))


### PR DESCRIPTION
* `Platform.aspect_ratio` needs a string length, otherwise we get `sqlalchemy.exc.CompileError: VARCHAR requires a length on dialect mariadb`
* Add two indexes that are created in `0024_sibling_roms_db_view.py` but never added to the models