### PR TITLE
[HOTFIX] Lower permission on update user endpoint and check perms internally

### DIFF
--- a/backend/endpoints/user.py
+++ b/backend/endpoints/user.py
@@ -112,7 +112,7 @@ def get_user(request: Request, id: int) -> UserSchema:
     return user
 
 
-@protected_route(router.put, "/users/{id}", [Scope.USERS_WRITE])
+@protected_route(router.put, "/users/{id}", [Scope.ME_WRITE])
 async def update_user(
     request: Request, id: int, form_data: Annotated[UserForm, Depends()]
 ) -> UserSchema:


### PR DESCRIPTION
The previous version didn't allow users to update their own password. This keeps the endpoint to authed users only, and the check on L141 actually checks for perms to update the user.