### PR TITLE
misc: Sort roms in get_roms method

### DIFF
--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -346,14 +346,17 @@ class FSRomsHandler(FSHandler):
             for rom in self._exclude_multi_roms(fs_multi_roms)
         ]
 
-        return [
-            FSRom(
-                multi=rom["multi"],
-                file_name=rom["file_name"],
-                files=self.get_rom_files(rom["file_name"], roms_file_path),
-            )
-            for rom in fs_roms
-        ]
+        return sorted(
+            [
+                FSRom(
+                    multi=rom["multi"],
+                    file_name=rom["file_name"],
+                    files=self.get_rom_files(rom["file_name"], roms_file_path),
+                )
+                for rom in fs_roms
+            ],
+            key=lambda rom: rom["file_name"],
+        )
 
     def file_exists(self, path: str, file_name: str) -> bool:
         """Check if file exists in filesystem


### PR DESCRIPTION
The `get_roms` method is used during scanning and to generate feeds. Sorting by filename is not perfect (e.g. prefixes like "The" or "A"), but should be good enough for users to better visualize how the scanning process is going, and how close it's to finish.