### PR TITLE
fix: Typo in parallel_n64 core name

### DIFF
--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -334,7 +334,7 @@ const _EJS_CORES_MAP = {
   fds: ["fceumm", "nestopia"],
   "game-televisison": ["fceumm"],
   "new-style-nes": ["fceumm"],
-  n64: ["mupen64plus_next", "parallel-n64"],
+  n64: ["mupen64plus_next", "parallel_n64"],
   "ique-player": ["mupen64plus_next"],
   nds: ["melonds", "desmume2015"],
   "nintendo-ds-lite": ["melonds", "desmume2015"],


### PR DESCRIPTION
Fixes #1219. Typo found by @Subtixx in that same issue.