### PR TITLE
fix: Handle terminate signals in init script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -120,7 +120,6 @@ RUN apk add --no-cache \
     mariadb-connector-c \
     p7zip \
     python3 \
-    tini \
     tzdata \
     valkey
 
@@ -152,5 +151,5 @@ VOLUME ["/romm/resources", "/romm/library", "/romm/assets", "/romm/config", "/re
 EXPOSE 8080 6379/tcp
 WORKDIR /romm
 
-ENTRYPOINT ["/sbin/tini", "--", "/docker-entrypoint.sh"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/init"]

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -115,19 +115,43 @@ watchdog_process_pid() {
 	fi
 }
 
+stop_process_pid() {
+	PROCESS=$1
+	if [[ -f "/tmp/${PROCESS}.pid" ]]; then
+		PID=$(cat "/tmp/${PROCESS}.pid") || true
+		if [[ -d "/proc/${PID}" ]]; then
+			info_log "stopping ${PROCESS}"
+			kill "${PID}" || true
+			# wait for process exit
+			while [ -e "/proc/${PID}" ]; do sleep 0.1; done
+		fi
+	fi
+}
+
+shutdown() {
+	# shutdown in reverse order
+	stop_process_pid scheduler
+	stop_process_pid worker
+	stop_process_pid watcher
+	stop_process_pid nginx
+	stop_process_pid gunicorn
+	stop_process_pid valkey-server
+}
+
 # switch to backend directory
 cd /backend || { error_log "/backend directory doesn't seem to exist"; }
 
 info_log "Starting up, please wait..."
 
+# setup trap handler
+exited=0
+trap 'exited=1 && shutdown' SIGINT SIGTERM EXIT
+
 # clear any leftover PID files
 rm /tmp/*.pid -f
 
 # function definition done, lets start our main loop
-while true; do
-	# check for died processes every 5 seconds
-	sleep 5
-
+while ! ((exited)); do
 	# Start Valkey server if we dont have a corresponding PID file
 	# and REDIS_HOST is not set (which would mean we're using an external Redis/Valkey)
 	if [[ -z ${REDIS_HOST:=""} ]]; then
@@ -138,7 +162,7 @@ while true; do
 	# but only if it was not successful since the last full docker container start
 	if [[ ${ALEMBIC_SUCCESS:="false"} == "false" ]]; then
 		if alembic upgrade head; then
-			debug_log "database schema migrations suceeded"
+			debug_log "database schema migrations succeeded"
 			ALEMBIC_SUCCESS="true"
 		else
 			error_log "Something went horribly wrong with our database"
@@ -165,4 +189,7 @@ while true; do
 	watchdog_process_pid python worker
 	# Start scheduler if we dont have a corresponding PID file
 	watchdog_process_pid python scheduler
+
+	# check for died processes every 5 seconds
+	sleep 5
 done


### PR DESCRIPTION
`tini` (added in [PR](https://github.com/rommapp/romm/pull/1272)) does not wait for child processes to exit gracefully, so all processes will be killed immediately. This is why the container stops so fast.

Possible `tini` issue: https://github.com/krallin/tini/issues/180

This fix makes the `init` script listen and handle terminate signals. It also ensures that child processes are shut down in reverse order with proper waiting for completion.

## How to reproduce:

To see exit codes of processes I used  `exitsnoop-bpfcc` tool from this [toolset](https://github.com/iovisor/bcc). Not sure maybe it is possible in easier way.

This command started in terminal: `sudo exitsnoop-bpfcc | egrep '(gunicorn|valkey|nginx|python3)'`

### Before the fix

```
romm  | INFO:     [RomM][watcher][2024-12-26 02:04:50] Watching /romm/library for changes
romm exited with code 0
romm  | INFO:     [init][2024-12-26 02:07:04] Starting up, please wait...
romm  | INFO:     [init][2024-12-26 02:07:09] starting valkey-server
```

As you may see, in the logs there are only `exited with code 0` and `Starting up`, no any word about shutting down

Output of `exitsnoop-bpfcc`:
```
python3          3865231 3865103 3865231 0.08    0
nginx            3862396 3861987 3862396 134.66  signal 9 (KILL)
valkey-server    3862375 3861987 3862375 136.99  signal 9 (KILL)
gunicorn         3862388 3861987 3862388 135.68  signal 9 (KILL)
python3          3862416 3861987 3862416 134.66  signal 9 (KILL)
python3          3862424 3861987 3862424 134.67  signal 9 (KILL)
python3          3862408 3861987 3862408 134.68  signal 9 (KILL)
gunicorn         3862392 3861987 3862392 135.49  signal 9 (KILL)
gunicorn         3862391 3861987 3862391 135.58  signal 9 (KILL)
nginx            3862403 3861987 3862403 134.69  signal 9 (KILL)
nginx            3862412 3861987 3862412 134.69  signal 9 (KILL)
nginx            3862423 3861987 3862423 134.69  signal 9 (KILL)
nginx            3862407 3861987 3862407 134.69  signal 9 (KILL)
nginx            3862420 3861987 3862420 134.69  signal 9 (KILL)
nginx            3862405 3861987 3862405 134.70  signal 9 (KILL)
nginx            3862409 3861987 3862409 134.70  signal 9 (KILL)
nginx            3862397 3861987 3862397 134.70  signal 9 (KILL)
nginx            3862417 3861987 3862417 134.70  signal 9 (KILL)
nginx            3862427 3861987 3862427 134.69  signal 9 (KILL)
nginx            3862400 3861987 3862400 134.70  signal 9 (KILL)
nginx            3862421 3861987 3862421 134.70  signal 9 (KILL)
nginx            3862414 3861987 3862414 134.70  signal 9 (KILL)
nginx            3862425 3861987 3862425 134.70  signal 9 (KILL)
nginx            3862404 3861987 3862404 134.70  signal 9 (KILL)
nginx            3862415 3861987 3862415 134.70  signal 9 (KILL)
nginx            3862422 3861987 3862422 134.70  signal 9 (KILL)
nginx            3862418 3861987 3862418 134.70  signal 9 (KILL)
nginx            3862402 3861987 3862402 134.70  signal 9 (KILL)
nginx            3862399 3861987 3862399 134.70  signal 9 (KILL)
nginx            3862398 3861987 3862398 134.70  signal 9 (KILL)
nginx            3862410 3861987 3862410 134.70  signal 9 (KILL)
nginx            3862406 3861987 3862406 134.70  signal 9 (KILL)
nginx            3862413 3861987 3862413 134.70  signal 9 (KILL)
python3          3865836 3865711 3865836 0.08    0
nginx            3866197 3865702 3866197 0.01    0
```

Almost all processes killed and this is bad because some of these processes may write some data to the disk and operation will be interrupted, data can be written incomplete.

### After the fix

```
romm  | [2024-12-26 02:09:29 +0000] [25] [INFO] Application startup complete.
romm  | INFO:     [init][2024-12-26 02:09:48] stopping watcher
romm  | INFO:     [init][2024-12-26 02:09:48] stopping worker
romm  | 02:09:48 Worker a2e75a570ff74c5b8ae556b32ccf1ff7 [PID 49]: warm shut down requested
romm  | 02:09:48 Unsubscribing from channel rq:pubsub:a2e75a570ff74c5b8ae556b32ccf1ff7
romm  | INFO:     [init][2024-12-26 02:09:48] stopping nginx
romm  | INFO:     [init][2024-12-26 02:09:49] stopping gunicorn
romm  | [2024-12-26 02:09:49 +0000] [21] [INFO] Handling signal: term
romm  | [2024-12-26 02:09:49 +0000] [24] [INFO] Shutting down
romm  | [2024-12-26 02:09:49 +0000] [25] [INFO] Shutting down
romm  | [2024-12-26 02:09:49 +0000] [24] [INFO] Waiting for application shutdown.
romm  | [2024-12-26 02:09:49 +0000] [25] [INFO] Waiting for application shutdown.
romm  | [2024-12-26 02:09:49 +0000] [25] [INFO] Application shutdown complete.
romm  | [2024-12-26 02:09:49 +0000] [25] [INFO] Finished server process [25]
romm  | [2024-12-26 02:09:49 +0000] [24] [INFO] Application shutdown complete.
romm  | [2024-12-26 02:09:49 +0000] [24] [INFO] Finished server process [24]
romm  | [2024-12-26 02:09:49 +0000] [21] [ERROR] Worker (pid:25) was sent SIGTERM!
romm  | [2024-12-26 02:09:49 +0000] [21] [ERROR] Worker (pid:24) was sent SIGTERM!
romm  | [2024-12-26 02:09:49 +0000] [21] [INFO] Shutting down: Master
romm  | INFO:     [init][2024-12-26 02:09:49] stopping valkey-server
romm  | 14:signal-handler (1735178989) Received SIGTERM scheduling shutdown...
romm  | 14:M 26 Dec 2024 02:09:49.582 * User requested shutdown...
romm  | 14:M 26 Dec 2024 02:09:49.582 * Saving the final RDB snapshot before exiting.
romm  | 14:M 26 Dec 2024 02:09:49.763 * DB saved on disk
romm  | 14:M 26 Dec 2024 02:09:49.763 # Valkey is now ready to exit, bye bye...
romm exited with code 0
romm  | INFO:     [init][2024-12-26 02:09:50] Starting up, please wait...
romm  | INFO:     [init][2024-12-26 02:09:50] starting valkey-server
```

You may notice shutting down logs appeared in logs and shutdown handlers executed.

Output of `exitsnoop-bpfcc`:
```
python3          3870358 3870032 3870358 75.15   signal 15 (TERM)
python3          3870366 3870032 3870366 75.30   0
nginx            3870371 3870346 3870371 75.37   0
nginx            3870367 3870346 3870367 75.38   0
nginx            3870357 3870346 3870357 75.38   0
nginx            3870353 3870346 3870353 75.38   0
nginx            3870351 3870346 3870351 75.38   0
nginx            3870350 3870346 3870350 75.38   0
nginx            3870349 3870346 3870349 75.38   0
nginx            3870362 3870346 3870362 75.38   0
nginx            3870354 3870346 3870354 75.38   0
nginx            3870365 3870346 3870365 75.38   0
nginx            3870375 3870346 3870375 75.38   0
nginx            3870363 3870346 3870363 75.38   0
nginx            3870348 3870346 3870348 75.38   0
nginx            3870360 3870346 3870360 75.38   0
nginx            3870377 3870346 3870377 75.38   0
nginx            3870356 3870346 3870356 75.38   0
nginx            3870347 3870346 3870347 75.38   0
nginx            3870364 3870346 3870364 75.38   0
nginx            3870359 3870346 3870359 75.38   0
nginx            3870369 3870346 3870369 75.38   0
nginx            3870376 3870346 3870376 75.38   0
nginx            3870373 3870346 3870373 75.38   0
nginx            3870355 3870346 3870355 75.39   0
nginx            3870370 3870346 3870370 75.38   0
nginx            3870346 3870032 3870346 75.39   0
gunicorn         3870316 3870313 3870316 76.48   signal 15 (TERM)
gunicorn         3870317 3870313 3870317 76.50   signal 15 (TERM)
gunicorn         3870313 3870032 3870313 76.79   0
valkey-server    3870079 3870032 3870079 78.35   0
python3          3870372 3870032 3870372 76.07   signal 9 (KILL)
```
You may see almost all processes exited with `0` code or `TERM` which is also good I think. Only only process is finishing with `KILL` every time, not sure why. 


