### PR TITLE
misc: Improve Docker layer caching by installing dependencies before copying

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Stages:
-#   - front-build-stage: Build frontend
+#   - frontend-build: Build frontend
 #   - backend-build: Build backend environment
 #   - rahasher-build: Build RAHasher
 #   - nginx-build: Build nginx modules
@@ -13,7 +13,7 @@ ARG NODE_VERSION=20.16
 ARG PYTHON_VERSION=3.12
 
 
-FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS front-build-stage
+FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS frontend-build
 WORKDIR /front
 
 COPY ./frontend/package*.json ./
@@ -99,20 +99,6 @@ RUN git clone https://github.com/evanmiller/mod_zip.git && \
 FROM nginx:${NGINX_VERSION}-alpine${ALPINE_VERSION} AS production-stage
 ARG WEBSERVER_FOLDER=/var/www/html
 
-COPY --from=rahasher-build /RALibretro/bin64/RAHasher /usr/bin/RAHasher
-COPY --from=nginx-build ./nginx/objs/ngx_http_zip_module.so /usr/lib/nginx/modules/
-
-COPY --from=front-build-stage /front/dist ${WEBSERVER_FOLDER}
-COPY ./frontend/assets/default ${WEBSERVER_FOLDER}/assets/default
-COPY ./frontend/assets/emulatorjs ${WEBSERVER_FOLDER}/assets/emulatorjs
-COPY ./frontend/assets/ruffle ${WEBSERVER_FOLDER}/assets/ruffle
-COPY ./frontend/assets/scrappers ${WEBSERVER_FOLDER}/assets/scrappers
-COPY ./frontend/assets/platforms ${WEBSERVER_FOLDER}/assets/platforms
-COPY ./frontend/assets/webrcade/feed ${WEBSERVER_FOLDER}/assets/webrcade/feed
-RUN mkdir -p ${WEBSERVER_FOLDER}/assets/romm && \
-    ln -s /romm/resources ${WEBSERVER_FOLDER}/assets/romm/resources && \
-    ln -s /romm/assets ${WEBSERVER_FOLDER}/assets/romm/assets
-
 # Install required packages and dependencies
 RUN apk add --no-cache \
     bash \
@@ -122,6 +108,20 @@ RUN apk add --no-cache \
     python3 \
     tzdata \
     valkey
+
+COPY --from=rahasher-build /RALibretro/bin64/RAHasher /usr/bin/RAHasher
+COPY --from=nginx-build ./nginx/objs/ngx_http_zip_module.so /usr/lib/nginx/modules/
+
+COPY --from=frontend-build /front/dist ${WEBSERVER_FOLDER}
+COPY ./frontend/assets/default ${WEBSERVER_FOLDER}/assets/default
+COPY ./frontend/assets/emulatorjs ${WEBSERVER_FOLDER}/assets/emulatorjs
+COPY ./frontend/assets/ruffle ${WEBSERVER_FOLDER}/assets/ruffle
+COPY ./frontend/assets/scrappers ${WEBSERVER_FOLDER}/assets/scrappers
+COPY ./frontend/assets/platforms ${WEBSERVER_FOLDER}/assets/platforms
+COPY ./frontend/assets/webrcade/feed ${WEBSERVER_FOLDER}/assets/webrcade/feed
+RUN mkdir -p ${WEBSERVER_FOLDER}/assets/romm && \
+    ln -s /romm/resources ${WEBSERVER_FOLDER}/assets/romm/resources && \
+    ln -s /romm/assets ${WEBSERVER_FOLDER}/assets/romm/assets
 
 COPY ./backend /backend
 


### PR DESCRIPTION
This commit improves Docker layer caching by installing the required packages in the `production-stage` stage, before copying files from other stages.

This way, dependency installation will remain cached unless there's a change in the required `apk` packages (or the stage's base image).