### PR TITLE
OIDC fix auk

### DIFF
--- a/backend/endpoints/auth.py
+++ b/backend/endpoints/auth.py
@@ -248,7 +248,7 @@ async def auth_openid(request: Request):
         raise OIDCNotConfiguredException
 
     token = await oauth.openid.authorize_access_token(request)
-    potential_user, _claims = (
+    potential_user, _userinfo = (
         await oidc_handler.get_current_active_user_from_openid_token(token)
     )
     if not potential_user:

--- a/backend/handler/auth/base_handler.py
+++ b/backend/handler/auth/base_handler.py
@@ -183,7 +183,7 @@ class OpenIDHandler:
                 detail="Email is not verified.",
             )
 
-        preferred_username = payload.claims.get("preferred_username")
+        preferred_username = userinfo.get("preferred_username")
 
         user = db_user_handler.get_user_by_email(email)
         if user is None:

--- a/backend/handler/auth/tests/test_oidc.py
+++ b/backend/handler/auth/tests/test_oidc.py
@@ -1,10 +1,8 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException
-from handler.auth.base_handler import OpenIDHandler, ctx_httpx_client
-from httpx import Request, RequestError, Response
-from joserfc.errors import BadSignatureError
+from handler.auth.base_handler import OpenIDHandler
 from joserfc.jwt import Token
 
 # Mock constants
@@ -19,93 +17,74 @@ def mock_oidc_disabled(mocker):
 
 @pytest.fixture
 def mock_oidc_enabled(mocker):
-    mocker.patch(
-        "handler.auth.base_handler.OIDC_SERVER_APPLICATION_URL",
-        OIDC_SERVER_APPLICATION_URL,
-    )
     mocker.patch("handler.auth.base_handler.OIDC_ENABLED", True)
 
 
 @pytest.fixture
-def mock_httpx_client():
-    """Fixture to mock the httpx.AsyncClient and set it in the ContextVar."""
-    mock_client = AsyncMock()
-    token = ctx_httpx_client.set(mock_client)
-    yield mock_client
-    ctx_httpx_client.reset(token)
+def mock_token():
+    return {
+        "access_token": "",
+        "token_type": "Bearer",
+        "expires_in": 300,
+        "id_token": "",
+        "expires_at": 1735397872,
+        "userinfo": {
+            "iss": "http://localhost:9000/application/o/romm/",
+            "sub": "",
+            "aud": "",
+            "exp": 1735397871,
+            "iat": 1735397571,
+            "auth_time": 1735397571,
+            "acr": "goauthentik.io/providers/oauth2/default",
+            "amr": ["pwd"],
+            "nonce": "",
+            "sid": "",
+            "email": "test@example.com",
+            "email_verified": True,
+            "name": "Test User",
+            "given_name": "Test User",
+            "preferred_username": "testuser",
+            "nickname": "testuser",
+            "groups": ["Default Users"],
+        },
+    }
 
 
-@pytest.fixture
-def mock_request():
-    return Request("GET", f"{OIDC_SERVER_APPLICATION_URL}/jwks/")
-
-
-def test_oidc_disabled_initialization(mock_oidc_disabled):
-    """Test that the handler initializes correctly when OIDC is disabled."""
+async def test_oidc_disabled(mock_oidc_disabled, mock_token):
+    """Test that OIDC is disabled."""
     oidc_handler = OpenIDHandler()
-    assert oidc_handler._rsa_key is None
-
-
-async def test_oidc_enabled_server_unreachable(
-    mock_httpx_client, mock_request, mock_oidc_enabled
-):
-    """Test that initialization raises an HTTPException when the OIDC server is unreachable."""
-    mock_httpx_client.get.side_effect = RequestError(
-        "Mocked error", request=mock_request
+    user, userinfo = await oidc_handler.get_current_active_user_from_openid_token(
+        mock_token
     )
-
-    oidc_handler = OpenIDHandler()
-    token = {"id_token": "invalid_signature_token"}
-    with pytest.raises(HTTPException):
-        await oidc_handler.get_current_active_user_from_openid_token(token)
+    assert user is None
+    assert userinfo is None
 
 
-async def test_oidc_valid_token_decoding(
-    mocker, mock_httpx_client, mock_request, mock_oidc_enabled
-):
+async def test_oidc_valid_token_decoding(mocker, mock_oidc_enabled, mock_token):
     """Test token decoding with valid RSA key and token."""
-    mock_httpx_client.get.return_value = Response(
-        200,
-        request=mock_request,
-        json={"keys": [{"kty": "RSA", "n": "fake", "e": "AQAB"}]},
-    )
-    mock_rsa_key = MagicMock()
-    mocker.patch(
-        "handler.auth.base_handler.RSAKey.import_key", return_value=mock_rsa_key
-    )
     mock_jwt_payload = Token(
         header={"alg": "RS256"},
         claims={"iss": OIDC_SERVER_APPLICATION_URL, "email": "test@example.com"},
     )
-    mocker.patch("joserfc.jwt.decode", return_value=mock_jwt_payload)
     mock_user = MagicMock(enabled=True)
     mocker.patch(
         "handler.database.db_user_handler.get_user_by_email", return_value=mock_user
     )
 
     oidc_handler = OpenIDHandler()
-    token = {"id_token": "valid_token"}
-    user, claims = await oidc_handler.get_current_active_user_from_openid_token(token)
+    user, userinfo = await oidc_handler.get_current_active_user_from_openid_token(
+        mock_token
+    )
+
+    assert user is not None
+    assert userinfo is not None
 
     assert user == mock_user
-    assert claims == mock_jwt_payload.claims
+    assert userinfo.get("email") == mock_jwt_payload.claims.get("email")
 
 
-async def test_oidc_invalid_token_signature(
-    mocker, mock_httpx_client, mock_request, mock_oidc_enabled
-):
+async def test_oidc_invalid_token_signature(mock_oidc_enabled):
     """Test token decoding raises exception for invalid signature."""
-    mock_httpx_client.get.return_value = Response(
-        200,
-        request=mock_request,
-        json={"keys": [{"kty": "RSA", "n": "fake", "e": "AQAB"}]},
-    )
-    mock_rsa_key = MagicMock()
-    mocker.patch(
-        "handler.auth.base_handler.RSAKey.import_key", return_value=mock_rsa_key
-    )
-    mocker.patch("joserfc.jwt.decode", side_effect=BadSignatureError)
-
     oidc_handler = OpenIDHandler()
     token = {"id_token": "invalid_signature_token"}
     with pytest.raises(HTTPException):


### PR DESCRIPTION
This patch removes quite a bit of code that is unnecessary because the relevant checks are already done in authlib (specifically in https://github.com/lepture/authlib/blob/master/authlib/integrations/base_client/sync_openid.py - the parse_id_token is called when we invoke oauth.openid.authorize_access_token). Therefore it is not necessary for us to do this check again.

This also fixes an issue where the IdP jwks_url returns more than one valid key and it is necessary to use the kid to get the correct key (see line 72 of the aforementioned source).

I also verify that email_verified is set True for security reasons.