### PR TITLE
misc: Change signature for get_matched_rom_by_id function

### DIFF
--- a/backend/endpoints/search.py
+++ b/backend/endpoints/search.py
@@ -58,20 +58,23 @@ async def search_rom(
 
     log.info(f"Searching by {search_by.lower()}: {search_term}")
     log.info(emoji.emojize(f":video_game: {rom.platform_slug}: {rom.file_name}"))
+
+    igdb_matched_roms = []
+    moby_matched_roms = []
+
     if search_by.lower() == "id":
         try:
-            igdb_matched_roms = await meta_igdb_handler.get_matched_roms_by_id(
-                int(search_term)
-            )
-            moby_matched_roms = await meta_moby_handler.get_matched_roms_by_id(
-                int(search_term)
-            )
+            igdb_rom = await meta_igdb_handler.get_matched_rom_by_id(int(search_term))
+            moby_rom = await meta_moby_handler.get_matched_rom_by_id(int(search_term))
         except ValueError as exc:
             log.error(f"Search error: invalid ID '{search_term}'")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Tried searching by ID, but '{search_term}' is not a valid ID",
             ) from exc
+        else:
+            igdb_matched_roms = [igdb_rom] if igdb_rom else []
+            moby_matched_roms = [moby_rom] if moby_rom else []
     elif search_by.lower() == "name":
         igdb_matched_roms = await meta_igdb_handler.get_matched_roms_by_name(
             search_term, (await _get_main_platform_igdb_id(rom.platform))

--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -558,12 +558,12 @@ class IGDBBaseHandler(MetadataHandler):
         )
 
     @check_twitch_token
-    async def get_matched_roms_by_id(self, igdb_id: int) -> list[IGDBRom]:
+    async def get_matched_rom_by_id(self, igdb_id: int) -> IGDBRom | None:
         if not IGDB_API_ENABLED:
-            return []
+            return None
 
         rom = await self.get_rom_by_id(igdb_id)
-        return [rom] if rom["igdb_id"] else []
+        return rom if rom["igdb_id"] else None
 
     @check_twitch_token
     async def get_matched_roms_by_name(

--- a/backend/handler/metadata/moby_handler.py
+++ b/backend/handler/metadata/moby_handler.py
@@ -302,12 +302,12 @@ class MobyGamesHandler(MetadataHandler):
 
         return MobyGamesRom({k: v for k, v in rom.items() if v})  # type: ignore[misc]
 
-    async def get_matched_roms_by_id(self, moby_id: int) -> list[MobyGamesRom]:
+    async def get_matched_rom_by_id(self, moby_id: int) -> MobyGamesRom | None:
         if not MOBY_API_ENABLED:
-            return []
+            return None
 
         rom = await self.get_rom_by_id(moby_id)
-        return [rom] if rom["moby_id"] else []
+        return rom if rom["moby_id"] else None
 
     async def get_matched_roms_by_name(
         self, search_term: str, platform_moby_id: int


### PR DESCRIPTION
The previous function name `get_matched_roms_by_id` was misleading as it returned a list of matched ROMs, but searching by ID should always return either one result or none.