### PR TITLE
[ROMM-1431] Allow downloading .3DS files with QR code

### DIFF
--- a/frontend/src/components/Details/ActionBar.vue
+++ b/frontend/src/components/Details/ActionBar.vue
@@ -29,7 +29,7 @@ const ejsEmulationSupported = computed(() =>
 const ruffleEmulationSupported = computed(() =>
   isRuffleEmulationSupported(props.rom.platform_slug, heartbeatStore.value),
 );
-const isCIARom = computed(() => {
+const is3DSRom = computed(() => {
   return is3DSCIARom(props.rom);
 });
 
@@ -110,7 +110,7 @@ async function copyDownloadLink(rom: DetailedRom) {
         <v-icon :icon="playInfoIcon" />
       </v-btn>
       <v-btn
-        v-if="isCIARom"
+        v-if="is3DSRom"
         class="flex-grow-1"
         @click="emitter?.emit('showQRCodeDialog', rom)"
       >

--- a/frontend/src/components/common/Game/Card/ActionBar.vue
+++ b/frontend/src/components/common/Game/Card/ActionBar.vue
@@ -30,7 +30,7 @@ const ruffleEmulationSupported = computed(() => {
   );
 });
 
-const isCIARom = computed(() => {
+const is3DSRom = computed(() => {
   return is3DSCIARom(props.rom);
 });
 </script>
@@ -83,7 +83,7 @@ const isCIARom = computed(() => {
         variant="text"
       />
     </v-col>
-    <v-col v-if="isCIARom" class="d-flex">
+    <v-col v-if="is3DSRom" class="d-flex">
       <v-btn
         @click.prevent
         class="action-bar-btn-small flex-grow-1"

--- a/frontend/src/components/common/Game/Dialog/ShowQRCode.vue
+++ b/frontend/src/components/common/Game/Dialog/ShowQRCode.vue
@@ -2,7 +2,7 @@
 import type { SimpleRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import RDialog from "@/components/common/RDialog.vue";
-import { getDownloadLink } from "@/utils";
+import { get3DSCIAFiles, getDownloadLink, is3DSCIAFile } from "@/utils";
 import type { Emitter } from "mitt";
 import { inject, nextTick, ref } from "vue";
 import { useDisplay } from "vuetify";
@@ -17,19 +17,13 @@ emitter?.on("showQRCodeDialog", async (romToView: SimpleRom) => {
 
   await nextTick();
 
-  const downloadLink =
-    romToView.file_extension.toLowerCase() === "cia"
-      ? getDownloadLink({
-          rom: romToView,
-          files: [],
-        })
-      : getDownloadLink({
-          rom: romToView,
-          files: [
-            romToView.files.filter((f) => f["filename"].endsWith(".cia"))[0]
-              .filename,
-          ],
-        });
+  const is3DSFile = is3DSCIAFile(romToView);
+  const matchingFiles = get3DSCIAFiles(romToView);
+
+  const downloadLink = getDownloadLink({
+    rom: romToView,
+    files: is3DSFile ? [] : [matchingFiles[0].filename],
+  });
 
   const qrCode = document.getElementById("qr-code");
   qrcode.toCanvas(qrCode, downloadLink, {

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,7 +1,7 @@
 import cronstrue from "cronstrue";
 import type { SimpleRom } from "@/stores/roms";
 import type { Heartbeat } from "@/stores/heartbeat";
-import type { RomUserStatus } from "@/__generated__";
+import type { RomFile, RomUserStatus } from "@/__generated__";
 
 /**
  * Views configuration object.
@@ -543,13 +543,26 @@ export function getStatusKeyForText(text: string) {
   return inverseRomStatusMap[text];
 }
 
+export function is3DSCIAFile(rom: SimpleRom): boolean {
+  return ["cia", "3ds"].includes(rom.file_extension.toLowerCase());
+}
+
+export function get3DSCIAFiles(rom: SimpleRom): RomFile[] {
+  return rom.files.filter((file) =>
+    [".cia", ".3ds"].some((ext) => file.filename.toLowerCase().endsWith(ext)),
+  );
+}
+
 /**
- * Check if a ROM is a 3DS .CIA file
+ * Check if a ROM is a valid 3DS game
  * @param rom The ROM object.
- * @returns True if the ROM is a 3DS .CIA file, false otherwise.
+ * @returns True if the ROM is a valid 3DS game, false otherwise.
  */
-export function is3DSCIARom(rom: SimpleRom) {
+export function is3DSCIARom(rom: SimpleRom): boolean {
   if (rom.platform_slug !== "3ds") return false;
-  if (rom.file_extension.toLowerCase() === "cia") return true;
-  return rom.files.some((f) => f["filename"].toLowerCase().endsWith(".cia"));
+
+  const hasValidExtension = is3DSCIAFile(rom);
+  const hasValidFile = get3DSCIAFiles(rom).length > 0;
+
+  return hasValidExtension || hasValidFile;
 }


### PR DESCRIPTION
A bit of refactoring so it also checks for `.3ds` files and marks the game as "qrcode-able".