### PR TITLE
ci: fix escaping of strings in jq command

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -37,5 +37,5 @@ jobs:
 
       - name: Lockfile lint
         run: |
-          [ -z "$(jq -r '.packages | to_entries[] | select((.key | contains(\"node_modules\")) and (.value | has(\"resolved\") | not)) | .key' < package-lock.json)" ]
+          [ -z "$(jq -r '.packages | to_entries[] | select((.key | contains("node_modules")) and (.value | has("resolved") | not)) | .key' < package-lock.json)" ]
         working-directory: frontend


### PR DESCRIPTION
I messed up the escaping of strings in #1434 