### PR TITLE
[ROMM-1442] Add OIDC_TLS_CACERTFILE path to mounted certfile

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -82,6 +82,7 @@ OIDC_CLIENT_ID: Final = os.environ.get("OIDC_CLIENT_ID", "")
 OIDC_CLIENT_SECRET: Final = os.environ.get("OIDC_CLIENT_SECRET", "")
 OIDC_REDIRECT_URI: Final = os.environ.get("OIDC_REDIRECT_URI", "")
 OIDC_SERVER_APPLICATION_URL: Final = os.environ.get("OIDC_SERVER_APPLICATION_URL", "")
+OIDC_TLS_CACERTFILE: Final = os.environ.get("OIDC_TLS_CACERTFILE", None)
 
 # SCANS
 SCAN_TIMEOUT: Final = int(os.environ.get("SCAN_TIMEOUT", 60 * 60 * 4))  # 4 hours

--- a/backend/decorators/auth.py
+++ b/backend/decorators/auth.py
@@ -9,6 +9,7 @@ from config import (
     OIDC_PROVIDER,
     OIDC_REDIRECT_URI,
     OIDC_SERVER_APPLICATION_URL,
+    OIDC_TLS_CACERTFILE,
 )
 from fastapi import Security
 from fastapi.security.http import HTTPBasic
@@ -53,7 +54,10 @@ oauth.register(
     server_metadata_url=get_well_known_url(
         config.get("OIDC_SERVER_APPLICATION_URL"), external=True
     ),
-    client_kwargs={"scope": "openid profile email"},
+    client_kwargs={
+        "scope": "openid profile email",
+        "verify": OIDC_TLS_CACERTFILE,
+    },
 )
 
 


### PR DESCRIPTION
Can't default the value to `/etc/ssl/certs/ca-certificates.crt` since it'll cause oauth to try and fetch it, which we don't want when not using encryption. 

Fixed #1442 