### PR TITLE
[ROMM-1335] Check for webGL when testing emulatorjs supported

### DIFF
--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -430,9 +430,14 @@ export function isEJSEmulationSupported(
   platformSlug: string,
   heartbeat: Heartbeat,
 ) {
+  const canvas = document.createElement("canvas");
+  const gl =
+    canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+
   return (
     !heartbeat.EMULATION.DISABLE_EMULATOR_JS &&
-    getSupportedEJSCores(platformSlug).length > 0
+    getSupportedEJSCores(platformSlug).length > 0 &&
+    gl instanceof WebGLRenderingContext
   );
 }
 


### PR DESCRIPTION
Only a simple check since webGL is fairly well supported across all major engines.