### PR TITLE
fix: Poetry dependency installation during pytest job

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          poetry install --sync
+          poetry sync --extras test
 
       - name: Initiate database
         run: |

--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -45,14 +45,14 @@ Then create the virtual environment
 ```sh
 # Fix disable parallel installation stuck: $> poetry config experimental.new-installer false
 # Fix Loading macOS/linux stuck: $> export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
-poetry install --sync
+poetry sync
 ```
 
 If you are on Arch Linux or another Arch-based distro, you need to run the command as follows:
 
 ```sh
 # https://bbs.archlinux.org/viewtopic.php?id=296542
-CFLAGS="-Wno-error=incompatible-pointer-types" poetry install --sync
+CFLAGS="-Wno-error=incompatible-pointer-types" poetry sync
 ```
 
 #### - Spin up mariadb in docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,4 @@ Source = "https://github.com/rommapp/romm"
 
 [tool.poetry]
 package-mode = false
+requires-poetry = ">=2.0"


### PR DESCRIPTION
With Poetry 2.0, we now need to explicitly tell it to install the `test` extra.