### PR TITLE
[ROMM-1484] Manually set control scheme for sega games

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -283,6 +283,18 @@ async def get_rom_content(
     log.info(f"User {current_username} is downloading {rom.file_name}")
 
     if not rom.multi:
+        # Serve the file directly in development mode for emulatorjs
+        if DEV_MODE:
+            return FileResponse(
+                path=rom_path,
+                filename=rom.file_name,
+                headers={
+                    "Content-Disposition": f'attachment; filename="{quote(rom.file_name)}"',
+                    "Content-Type": "application/octet-stream",
+                    "Content-Length": str(rom.file_size_bytes),
+                },
+            )
+
         return FileRedirectResponse(
             download_path=Path(f"/library/{rom.full_path}"),
             filename=rom.file_name,

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -363,7 +363,7 @@ const _EJS_CORES_MAP = {
   ps: ["pcsx_rearmed", "mednafen_psx_hw"],
   psp: ["ppsspp"],
   segacd: ["genesis_plus_gx", "picodrive"],
-  // sega32: ["picodrive"], // Broken: https://github.com/EmulatorJS/EmulatorJS/issues/579
+  sega32: ["picodrive"],
   gamegear: ["genesis_plus_gx"],
   sms: ["genesis_plus_gx"],
   "sega-mark-iii": ["genesis_plus_gx"],
@@ -451,6 +451,41 @@ export function isEJSEmulationSupported(
  */
 export function isEJSThreadsSupported(): boolean {
   return typeof SharedArrayBuffer !== "undefined";
+}
+
+// This is a workaround to set the control scheme for Sega systems using the same cores
+const _EJS_CONTROL_SCHEMES = {
+  segacd: "segaCD",
+  sega32: "sega32x",
+  gamegear: "segaGG",
+  sms: "segaMS",
+  "sega-mark-iii": "segaMS",
+  "sega-master-system-ii": "segaMS",
+  "master-system-super-compact": "segaMS",
+  "master-system-girl": "segaMS",
+  "genesis-slash-megadrive": "segaMD",
+  "sega-mega-drive-2-slash-genesis": "segaMD",
+  "sega-mega-jet": "segaMD",
+  "mega-pc": "segaMD",
+  "tera-drive": "segaMD",
+  "sega-nomad": "segaMD",
+  saturn: "segaSaturn",
+};
+
+type EJSControlSlug = keyof typeof _EJS_CONTROL_SCHEMES;
+
+/**
+ * Get the control scheme for a given platform.
+ *
+ * @param platformSlug The platform slug.
+ * @returns The control scheme.
+ */
+export function getControlSchemeForPlatform(
+  platformSlug: string,
+): string | null {
+  return platformSlug in _EJS_CONTROL_SCHEMES
+    ? _EJS_CONTROL_SCHEMES[platformSlug as EJSControlSlug]
+    : null;
 }
 
 /**

--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -4,7 +4,11 @@ import saveApi, { saveApi as api } from "@/services/api/save";
 import screenshotApi from "@/services/api/screenshot";
 import stateApi from "@/services/api/state";
 import type { DetailedRom } from "@/stores/roms";
-import { areThreadsRequiredForEJSCore, getSupportedEJSCores } from "@/utils";
+import {
+  areThreadsRequiredForEJSCore,
+  getSupportedEJSCores,
+  getControlSchemeForPlatform,
+} from "@/utils";
 import { onBeforeUnmount, onMounted, ref } from "vue";
 
 const props = defineProps<{
@@ -39,6 +43,7 @@ declare global {
     EJS_startOnLoaded: boolean;
     EJS_fullscreenOnLoaded: boolean;
     EJS_threads: boolean;
+    EJS_controlScheme: string | null;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     EJS_emulator: any;
     EJS_onGameStart: () => void;
@@ -52,6 +57,9 @@ declare global {
 const supportedCores = getSupportedEJSCores(romRef.value.platform_slug);
 window.EJS_core =
   supportedCores.find((core) => core === props.core) ?? supportedCores[0];
+window.EJS_controlScheme = getControlSchemeForPlatform(
+  romRef.value.platform_slug,
+);
 window.EJS_threads = areThreadsRequiredForEJSCore(window.EJS_core);
 window.EJS_gameID = romRef.value.id;
 window.EJS_gameUrl = `/api/roms/${romRef.value.id}/content/${romRef.value.file_name}`;


### PR DESCRIPTION
The way EmulatorJS checks for control schemes is based on the core, but since we pass in `EJS_core` values that are used by multiple platforms, it matches against the wrong platform when trying to build the controller button list. This PR bypasses the issue for the problem systems (those using `genesis_plus_gx` or `picodrive` cores).

Also re-enabled sega32X now that it's working again, and returns a `FileResponse` in dev mode to get emujs working again locally.

Fixes #1484 