### PR TITLE
misc: Do not fail if LOGLEVEL is not uppercase

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -117,7 +117,7 @@ DISABLE_RUFFLE_RS = str_to_bool(os.environ.get("DISABLE_RUFFLE_RS", "false"))
 UPLOAD_TIMEOUT = int(os.environ.get("UPLOAD_TIMEOUT", 600))
 
 # LOGGING
-LOGLEVEL: Final = os.environ.get("LOGLEVEL", "INFO")
+LOGLEVEL: Final = os.environ.get("LOGLEVEL", "INFO").upper()
 FORCE_COLOR: Final = str_to_bool(os.environ.get("FORCE_COLOR", "false"))
 NO_COLOR: Final = str_to_bool(os.environ.get("NO_COLOR", "false"))
 


### PR DESCRIPTION
The `logging.setLevel` method expects the log level to be in uppercase. This change ensures that the `LOGLEVEL` config value is always in uppercase.