### PR TITLE
[ROMM-1505] Skip CSRF checks when request has Authorization header

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -389,8 +389,8 @@ async def update_rom(
         )
 
     cleaned_data = {
-        "igdb_id": data.get("igdb_id", None),
-        "moby_id": data.get("moby_id", None),
+        "igdb_id": data.get("igdb_id", rom.igdb_id),
+        "moby_id": data.get("moby_id", rom.moby_id),
     }
 
     if (

--- a/backend/handler/auth/middleware.py
+++ b/backend/handler/auth/middleware.py
@@ -20,7 +20,8 @@ class CustomCSRFMiddleware(CSRFMiddleware):
         request = Request(scope, receive)
 
         # Skip CSRF check if Authorization header is present
-        if "Authorization" in request.headers:
+        auth_scheme = request.headers.get("Authorization", "").split(" ", 1)[0].lower()
+        if auth_scheme == "bearer" or auth_scheme == "basic":
             await self.app(scope, receive, send)
             return
 


### PR DESCRIPTION
Also fixes igdb_id and moby_id getting unset when not provided to `update` endpoint.

Fixes #1505 