### PR TITLE
Fix MySQL json_contains Error by Converting Non-String Values to JSON Strings

### DIFF
--- a/backend/utils/database.py
+++ b/backend/utils/database.py
@@ -16,6 +16,10 @@ def is_postgresql(conn: sa.Connection) -> bool:
     return conn.engine.name == "postgresql"
 
 
+def is_mysql(conn: sa.Connection) -> bool:
+    return conn.engine.name == "mysql"
+
+
 def json_array_contains_value(
     column: sa.Column, value: Any, *, session: Session
 ) -> ColumnElement:
@@ -29,7 +33,10 @@ def json_array_contains_value(
         return sa.type_coerce(column, sa_pg.JSONB).contains(
             func.cast(value, sa_pg.JSONB)
         )
-    return func.json_contains(column, json.dumps(value))
+    elif is_mysql(conn):
+        # In MySQL, JSON.contains() requires a JSON-formatted string (even if it's an int)
+        return func.json_contains(column, json.dumps(value))
+    return func.json_contains(column, value)
 
 
 def safe_float(value, default=0.0):

--- a/backend/utils/database.py
+++ b/backend/utils/database.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import json
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as sa_pg
 from sqlalchemy.orm import Session
@@ -28,7 +29,7 @@ def json_array_contains_value(
         return sa.type_coerce(column, sa_pg.JSONB).contains(
             func.cast(value, sa_pg.JSONB)
         )
-    return func.json_contains(column, value)
+    return func.json_contains(column, json.dumps(value))
 
 
 def safe_float(value, default=0.0):

--- a/backend/utils/database.py
+++ b/backend/utils/database.py
@@ -1,6 +1,6 @@
+import json
 from typing import Any
 
-import json
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as sa_pg
 from sqlalchemy.orm import Session


### PR DESCRIPTION
Loving the project so far 😎! Thanks for adding MySQL support!

I am running into an issue using MySQL. When viewing a ROM, it yields the error:

```
(mysql.connector.errors.DataError) 3146 (22032): Invalid data type for JSON data in argument 1 to function json_contains; a JSON string or JSON type is required.
```

This is beacuse for mySQL, the driver expects a string here, and receives an int. This PR fixes it by calling json.dumps(value) before passing the value to json_contains. This doesn’t affect Postgres, which uses different logic (has_key/contains).

I have tested and verified this running Romm 3.7.2 with mySQL ~8.0~ 9.1.0 on Unraid 🚀 