### PR TITLE
fix: Remove sibling roms from Recently Added.

### DIFF
--- a/frontend/src/stores/roms.ts
+++ b/frontend/src/stores/roms.ts
@@ -41,6 +41,23 @@ export default defineStore("roms", {
   },
 
   actions: {
+    _getGroupedRoms(roms: SimpleRom[]): SimpleRom[] {
+      // Group roms by external id.
+      return Object.values(
+        groupBy(
+          roms,
+          (game) =>
+            // If external id is null, generate a random id so that the roms are not grouped
+            game.igdb_id || game.moby_id || nanoid(),
+        ),
+      )
+        .map((games) => {
+          // Find the index of the game where the 'rom_user' property has 'is_main_sibling' set to true.
+          return (
+            games.find((game) => game.rom_user?.is_main_sibling) || games[0]
+          );
+        });
+    },
     _reorder() {
       // Sort roms by comparator string
       this.allRoms = uniqBy(this.allRoms, "id").sort((a, b) => {
@@ -57,20 +74,7 @@ export default defineStore("roms", {
       }
 
       // Group roms by external id
-      this._grouped = Object.values(
-        groupBy(
-          this.allRoms,
-          (game) =>
-            // If external id is null, generate a random id so that the roms are not grouped
-            game.igdb_id || game.moby_id || nanoid(),
-        ),
-      )
-        .map((games) => {
-          // Find the index of the game where the 'rom_user' property has 'is_main_sibling' set to true.
-          return (
-            games.find((game) => game.rom_user?.is_main_sibling) || games[0]
-          );
-        })
+      this._grouped = this._getGroupedRoms(this.allRoms)
         .sort((a, b) => {
           return a.sort_comparator.localeCompare(b.sort_comparator);
         });
@@ -82,7 +86,10 @@ export default defineStore("roms", {
       this.currentRom = rom;
     },
     setRecentRoms(roms: SimpleRom[]) {
-      this.recentRoms = roms;
+      // Set the recent roms.
+      // Group by external ID to only display a single entry per sibling,
+      // and sorted on rom ID in descending order.
+      this.recentRoms = this._getGroupedRoms(roms).sort((a, b) => b.id - a.id);
     },
     setContinuePlayedRoms(roms: SimpleRom[]) {
       this.continuePlayingRoms = roms;

--- a/frontend/src/stores/roms.ts
+++ b/frontend/src/stores/roms.ts
@@ -41,6 +41,11 @@ export default defineStore("roms", {
   },
 
   actions: {
+    _shouldGroupRoms(): boolean {
+      return isNull(localStorage.getItem("settings.groupRoms"))
+        ? true
+        : localStorage.getItem("settings.groupRoms") === "true";
+    },
     _getGroupedRoms(roms: SimpleRom[]): SimpleRom[] {
       // Group roms by external id.
       return Object.values(
@@ -65,10 +70,7 @@ export default defineStore("roms", {
       });
 
       // Check if roms should be grouped
-      const groupRoms = isNull(localStorage.getItem("settings.groupRoms"))
-        ? true
-        : localStorage.getItem("settings.groupRoms") === "true";
-      if (!groupRoms) {
+      if (!this._shouldGroupRoms()) {
         this._grouped = this.allRoms;
         return;
       }
@@ -86,10 +88,15 @@ export default defineStore("roms", {
       this.currentRom = rom;
     },
     setRecentRoms(roms: SimpleRom[]) {
-      // Set the recent roms.
-      // Group by external ID to only display a single entry per sibling,
-      // and sorted on rom ID in descending order.
-      this.recentRoms = this._getGroupedRoms(roms).sort((a, b) => b.id - a.id);
+      if (this._shouldGroupRoms()) {
+        // Group by external ID to only display a single entry per sibling,
+        // and sorted on rom ID in descending order.
+        this.recentRoms = this._getGroupedRoms(roms).sort(
+          (a, b) => b.id - a.id
+        );
+      } else {
+        this.recentRoms = roms;
+      }
     },
     setContinuePlayedRoms(roms: SimpleRom[]) {
       this.continuePlayingRoms = roms;


### PR DESCRIPTION
Small UI change.

The Recently Added element displays every sibling whereas the Platform pages do not, this streamlines that by making the roms under Recently Added behave similarly, it will only display the main sibling (or the first entry) per metadata id. Continue Playing will still show the individual siblings.

A cleaner solution would obviously be a dropdown in the UI to select the specific version (perhaps more so for Continue Playing) but I don't feel like going that far right now. Feel free to decline if this is intended behavior though.

Before:
![Screenshot_20250127_205658](https://github.com/user-attachments/assets/6bee8d37-9fac-43c5-ad16-30476f0385be)
The displayed ids in order: `17, 16, 15, 13, 12, 10, 9`

After:
![Screenshot_20250127_204937](https://github.com/user-attachments/assets/f8f72fa9-4a5a-4740-b6ed-b938697fb147)
The displayed ids in order: `17, 16, 15, 13`