### PR TITLE
fix: Send platform as int in scan message

### DIFF
--- a/frontend/src/components/Gallery/FabOverlay.vue
+++ b/frontend/src/components/Gallery/FabOverlay.vue
@@ -50,7 +50,7 @@ async function onScan() {
 
   if (!socket.connected) socket.connect();
   socket.emit("scan", {
-    platforms: [route.params.platform],
+    platforms: [Number(route.params.platform)],
     roms_ids: romsStore.selectedRoms.map((r) => r.id),
     type: "quick", // Quick scan so we can filter by selected roms
     apis: heartbeat.getMetadataOptions().map((s) => s.value),


### PR DESCRIPTION
The backend fails when a platform is sent as a string, and it's using PostgreSQL as the database engine. This change fixes the frontend to correctly send the platform_id as an integer value.