### PR TITLE
fix: Adapt new migrations to supported database engines

### DIFF
--- a/backend/alembic/versions/0031_datetime_to_timestamp.py
+++ b/backend/alembic/versions/0031_datetime_to_timestamp.py
@@ -8,7 +8,6 @@ Create Date: 2025-01-14 04:13:33.209508
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
 revision = "0031_datetime_to_timestamp"
@@ -22,14 +21,14 @@ def upgrade() -> None:
     with op.batch_alter_table("collections", schema=None) as batch_op:
         batch_op.alter_column(
             "created_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "updated_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
@@ -38,14 +37,14 @@ def upgrade() -> None:
     with op.batch_alter_table("firmware", schema=None) as batch_op:
         batch_op.alter_column(
             "created_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "updated_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
@@ -54,14 +53,14 @@ def upgrade() -> None:
     with op.batch_alter_table("platforms", schema=None) as batch_op:
         batch_op.alter_column(
             "created_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "updated_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
@@ -70,20 +69,20 @@ def upgrade() -> None:
     with op.batch_alter_table("rom_user", schema=None) as batch_op:
         batch_op.alter_column(
             "last_played",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=True,
         )
         batch_op.alter_column(
             "created_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "updated_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
@@ -92,14 +91,14 @@ def upgrade() -> None:
     with op.batch_alter_table("roms", schema=None) as batch_op:
         batch_op.alter_column(
             "created_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "updated_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
@@ -108,14 +107,14 @@ def upgrade() -> None:
     with op.batch_alter_table("saves", schema=None) as batch_op:
         batch_op.alter_column(
             "created_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "updated_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
@@ -124,14 +123,14 @@ def upgrade() -> None:
     with op.batch_alter_table("screenshots", schema=None) as batch_op:
         batch_op.alter_column(
             "created_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "updated_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
@@ -140,14 +139,14 @@ def upgrade() -> None:
     with op.batch_alter_table("states", schema=None) as batch_op:
         batch_op.alter_column(
             "created_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "updated_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
@@ -156,26 +155,26 @@ def upgrade() -> None:
     with op.batch_alter_table("users", schema=None) as batch_op:
         batch_op.alter_column(
             "last_login",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=True,
         )
         batch_op.alter_column(
             "last_active",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=True,
         )
         batch_op.alter_column(
             "created_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "updated_at",
-            existing_type=mysql.DATETIME(),
+            existing_type=sa.DateTime(timezone=True),
             type_=sa.TIMESTAMP(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
@@ -190,27 +189,27 @@ def downgrade() -> None:
         batch_op.alter_column(
             "updated_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "created_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "last_active",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=True,
         )
         batch_op.alter_column(
             "last_login",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=True,
         )
 
@@ -218,14 +217,14 @@ def downgrade() -> None:
         batch_op.alter_column(
             "updated_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "created_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
@@ -234,14 +233,14 @@ def downgrade() -> None:
         batch_op.alter_column(
             "updated_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "created_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
@@ -250,14 +249,14 @@ def downgrade() -> None:
         batch_op.alter_column(
             "updated_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "created_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
@@ -266,14 +265,14 @@ def downgrade() -> None:
         batch_op.alter_column(
             "updated_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "created_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
@@ -282,21 +281,21 @@ def downgrade() -> None:
         batch_op.alter_column(
             "updated_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "created_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "last_played",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=True,
         )
 
@@ -304,14 +303,14 @@ def downgrade() -> None:
         batch_op.alter_column(
             "updated_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "created_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
@@ -320,14 +319,14 @@ def downgrade() -> None:
         batch_op.alter_column(
             "updated_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "created_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
@@ -336,14 +335,14 @@ def downgrade() -> None:
         batch_op.alter_column(
             "updated_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )
         batch_op.alter_column(
             "created_at",
             existing_type=sa.TIMESTAMP(timezone=True),
-            type_=mysql.DATETIME(),
+            type_=sa.DateTime(timezone=True),
             existing_nullable=False,
             existing_server_default=sa.text("now()"),
         )

--- a/backend/alembic/versions/0032_longer_fs_fields.py
+++ b/backend/alembic/versions/0032_longer_fs_fields.py
@@ -8,7 +8,6 @@ Create Date: 2025-01-24 02:18:30.069263
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
 revision = "0032_longer_fs_fields"
@@ -22,19 +21,19 @@ def upgrade() -> None:
     with op.batch_alter_table("platforms", schema=None) as batch_op:
         batch_op.alter_column(
             "slug",
-            existing_type=mysql.VARCHAR(length=50),
+            existing_type=sa.String(length=50),
             type_=sa.String(length=100),
             existing_nullable=False,
         )
         batch_op.alter_column(
             "fs_slug",
-            existing_type=mysql.VARCHAR(length=50),
+            existing_type=sa.String(length=50),
             type_=sa.String(length=100),
             existing_nullable=False,
         )
         batch_op.alter_column(
             "category",
-            existing_type=mysql.VARCHAR(length=50),
+            existing_type=sa.String(length=50),
             type_=sa.String(length=100),
             existing_nullable=True,
         )
@@ -47,19 +46,19 @@ def downgrade() -> None:
         batch_op.alter_column(
             "category",
             existing_type=sa.String(length=100),
-            type_=mysql.VARCHAR(length=50),
+            type_=sa.String(length=50),
             existing_nullable=True,
         )
         batch_op.alter_column(
             "fs_slug",
             existing_type=sa.String(length=100),
-            type_=mysql.VARCHAR(length=50),
+            type_=sa.String(length=50),
             existing_nullable=False,
         )
         batch_op.alter_column(
             "slug",
             existing_type=sa.String(length=100),
-            type_=mysql.VARCHAR(length=50),
+            type_=sa.String(length=50),
             existing_nullable=False,
         )
 

--- a/backend/alembic/versions/0033_rom_file_and_hashes.py
+++ b/backend/alembic/versions/0033_rom_file_and_hashes.py
@@ -12,7 +12,8 @@ from config import IS_PYTEST_RUN, SCAN_TIMEOUT
 from endpoints.sockets.scan import scan_platforms
 from handler.redis_handler import high_prio_queue
 from handler.scan_handler import ScanType
-from sqlalchemy.dialects import mysql
+from sqlalchemy.dialects.postgresql import ENUM
+from utils.database import CustomJSON, is_postgresql
 
 # revision identifiers, used by Alembic.
 revision = "0033_rom_file_and_hashes"
@@ -22,6 +23,37 @@ depends_on = None
 
 
 def upgrade() -> None:
+    connection = op.get_bind()
+
+    if is_postgresql(connection):
+        rom_file_category_enum = ENUM(
+            "DLC",
+            "HACK",
+            "MANUAL",
+            "PATCH",
+            "UPDATE",
+            "MOD",
+            "DEMO",
+            "TRANSLATION",
+            "PROTOTYPE",
+            name="romfilecategory",
+            create_type=False,
+        )
+        rom_file_category_enum.create(connection, checkfirst=False)
+    else:
+        rom_file_category_enum = sa.Enum(
+            "DLC",
+            "HACK",
+            "MANUAL",
+            "PATCH",
+            "UPDATE",
+            "MOD",
+            "DEMO",
+            "TRANSLATION",
+            "PROTOTYPE",
+            name="romfilecategory",
+        )
+
     op.create_table(
         "rom_files",
         sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
@@ -33,22 +65,7 @@ def upgrade() -> None:
         sa.Column("crc_hash", sa.String(length=100), nullable=True),
         sa.Column("md5_hash", sa.String(length=100), nullable=True),
         sa.Column("sha1_hash", sa.String(length=100), nullable=True),
-        sa.Column(
-            "category",
-            sa.Enum(
-                "DLC",
-                "HACK",
-                "MANUAL",
-                "PATCH",
-                "UPDATE",
-                "MOD",
-                "DEMO",
-                "TRANSLATION",
-                "PROTOTYPE",
-                name="romfilecategory",
-            ),
-            nullable=True,
-        ),
+        sa.Column("category", rom_file_category_enum, nullable=True),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -65,35 +82,62 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
     )
 
-    op.execute(
-        """
-        INSERT INTO rom_files (
-            rom_id,
-            file_name,
-            file_path,
-            file_size_bytes,
-            last_modified,
-            crc_hash,
-            md5_hash,
-            sha1_hash
-        )
-        SELECT
-            r.id AS rom_id,
-            JSON_UNQUOTE(JSON_EXTRACT(file_data, '$.filename')) AS file_name,
-            CASE WHEN r.multi = 0 THEN r.file_path ELSE CONCAT(r.file_path, r.file_name) END AS file_path,
-            JSON_UNQUOTE(JSON_EXTRACT(file_data, '$.size')) AS file_size_bytes,
-            JSON_UNQUOTE(JSON_EXTRACT(file_data, '$.last_modified')) AS last_modified,
-            CASE WHEN r.multi = 0 THEN r.crc_hash ELSE NULL END AS crc_hash,
-            CASE WHEN r.multi = 0 THEN r.md5_hash ELSE NULL END AS md5_hash,
-            CASE WHEN r.multi = 0 THEN r.sha1_hash ELSE NULL END AS sha1_hash
-        FROM roms r,
-        JSON_TABLE(r.files, '$[*]' 
-            COLUMNS (
-                file_data JSON PATH '$'
+    if is_postgresql(connection):
+        op.execute(
+            """
+            INSERT INTO rom_files (
+                rom_id,
+                file_name,
+                file_path,
+                file_size_bytes,
+                last_modified,
+                crc_hash,
+                md5_hash,
+                sha1_hash
             )
-        ) AS extracted_files;
-        """
-    )
+            SELECT
+                r.id AS rom_id,
+                file_data->>'filename' AS file_name,
+                CASE WHEN not r.multi THEN r.file_path ELSE CONCAT(TRIM(TRAILING '/' FROM r.file_path), '/', r.file_name) END AS file_path,
+                (file_data->>'size')::bigint AS file_size_bytes,
+                (file_data->>'last_modified')::float AS last_modified,
+                CASE WHEN NOT r.multi THEN r.crc_hash ELSE NULL END AS crc_hash,
+                CASE WHEN NOT r.multi THEN r.md5_hash ELSE NULL END AS md5_hash,
+                CASE WHEN NOT r.multi THEN r.sha1_hash ELSE NULL END AS sha1_hash
+            FROM roms r
+                CROSS JOIN jsonb_array_elements(r.files) AS file_data;
+            """
+        )
+    else:
+        op.execute(
+            """
+            INSERT INTO rom_files (
+                rom_id,
+                file_name,
+                file_path,
+                file_size_bytes,
+                last_modified,
+                crc_hash,
+                md5_hash,
+                sha1_hash
+            )
+            SELECT
+                r.id AS rom_id,
+                JSON_UNQUOTE(JSON_EXTRACT(file_data, '$.filename')) AS file_name,
+                CASE WHEN r.multi = 0 THEN r.file_path ELSE CONCAT(TRIM(TRAILING '/' FROM r.file_path), '/', r.file_name) END AS file_path,
+                JSON_UNQUOTE(JSON_EXTRACT(file_data, '$.size')) AS file_size_bytes,
+                JSON_UNQUOTE(JSON_EXTRACT(file_data, '$.last_modified')) AS last_modified,
+                CASE WHEN r.multi = 0 THEN r.crc_hash ELSE NULL END AS crc_hash,
+                CASE WHEN r.multi = 0 THEN r.md5_hash ELSE NULL END AS md5_hash,
+                CASE WHEN r.multi = 0 THEN r.sha1_hash ELSE NULL END AS sha1_hash
+            FROM roms r,
+            JSON_TABLE(r.files, '$[*]'
+                COLUMNS (
+                    file_data JSON PATH '$'
+                )
+            ) AS extracted_files;
+            """
+        )
 
     with op.batch_alter_table("roms", schema=None) as batch_op:
         batch_op.alter_column(
@@ -133,30 +177,20 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    connection = op.get_bind()
+
     with op.batch_alter_table("roms", schema=None) as batch_op:
         batch_op.add_column(
-            sa.Column(
-                "multi",
-                mysql.TINYINT(display_width=1),
-                autoincrement=False,
-                nullable=False,
-            )
+            sa.Column("multi", sa.Boolean(), nullable=False, server_default="0")
         )
+        batch_op.alter_column("multi", server_default=None)
+        batch_op.add_column(sa.Column("files", CustomJSON(), nullable=True))
         batch_op.add_column(
             sa.Column(
-                "files",
-                mysql.LONGTEXT(charset="utf8mb4", collation="utf8mb4_bin"),
-                nullable=True,
+                "file_size_bytes", sa.BigInteger(), nullable=False, server_default="0"
             )
         )
-        batch_op.add_column(
-            sa.Column(
-                "file_size_bytes",
-                mysql.BIGINT(display_width=20),
-                autoincrement=False,
-                nullable=False,
-            )
-        )
+        batch_op.alter_column("file_size_bytes", server_default=None)
         batch_op.alter_column(
             "fs_path", new_column_name="file_path", existing_type=sa.String(length=1000)
         )
@@ -179,30 +213,61 @@ def downgrade() -> None:
             "fs_name", new_column_name="file_name", existing_type=sa.String(length=450)
         )
 
-    op.execute(
-        """
-        UPDATE roms
-        JOIN (
-            SELECT 
-                rom_id,
-                JSON_ARRAYAGG(
-                    JSON_OBJECT(
-                        'filename', file_name,
-                        'size', file_size_bytes,
-                        'last_modified', last_modified
-                    )
-                ) AS files,
-                COUNT(*) > 1 AS multi,
-                COALESCE(SUM(file_size_bytes), 0) AS total_size
-            FROM rom_files
-            GROUP BY rom_id
-        ) AS aggregated_data
-        ON roms.id = aggregated_data.rom_id
-        SET 
-            roms.files = aggregated_data.files,
-            roms.multi = aggregated_data.multi,
-            roms.file_size_bytes = aggregated_data.total_size;
-        """
-    )
+    if is_postgresql(connection):
+        op.execute(
+            """
+            WITH aggregated_data AS (
+                SELECT
+                    rom_id,
+                    JSONB_AGG(
+                        JSONB_BUILD_OBJECT(
+                            'filename', file_name,
+                            'size', file_size_bytes,
+                            'last_modified', last_modified
+                        )
+                    ) AS files,
+                    COUNT(*) > 1 AS multi,
+                    COALESCE(SUM(file_size_bytes), 0) AS total_size
+                FROM rom_files
+                GROUP BY rom_id
+            )
+            UPDATE roms
+            SET
+                files = aggregated_data.files,
+                multi = aggregated_data.multi,
+                file_size_bytes = aggregated_data.total_size
+            FROM aggregated_data
+            WHERE roms.id = aggregated_data.rom_id;
+            """
+        )
+    else:
+        op.execute(
+            """
+            UPDATE roms
+            JOIN (
+                SELECT
+                    rom_id,
+                    JSON_ARRAYAGG(
+                        JSON_OBJECT(
+                            'filename', file_name,
+                            'size', file_size_bytes,
+                            'last_modified', last_modified
+                        )
+                    ) AS files,
+                    COUNT(*) > 1 AS multi,
+                    COALESCE(SUM(file_size_bytes), 0) AS total_size
+                FROM rom_files
+                GROUP BY rom_id
+            ) AS aggregated_data
+            ON roms.id = aggregated_data.rom_id
+            SET
+                roms.files = aggregated_data.files,
+                roms.multi = aggregated_data.multi,
+                roms.file_size_bytes = aggregated_data.total_size;
+            """
+        )
 
     op.drop_table("rom_files")
+
+    if is_postgresql(connection):
+        ENUM(name="romfilecategory").drop(connection, checkfirst=False)


### PR DESCRIPTION
* Remove MySQL specific dialect.
* Fix migration `0033` to run on PostgreSQL.
* Correctly concatenate file paths by inserting a slash between path and file name.