### PR TITLE
Read-only kiosk mode for viewers

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -115,6 +115,7 @@ DISABLE_RUFFLE_RS = str_to_bool(os.environ.get("DISABLE_RUFFLE_RS", "false"))
 
 # FRONTEND
 UPLOAD_TIMEOUT = int(os.environ.get("UPLOAD_TIMEOUT", 600))
+KIOSK_MODE = str_to_bool(os.environ.get("KIOSK_MODE", "false"))
 
 # LOGGING
 LOGLEVEL: Final = os.environ.get("LOGLEVEL", "INFO").upper()

--- a/backend/decorators/auth.py
+++ b/backend/decorators/auth.py
@@ -16,8 +16,9 @@ from fastapi.security.http import HTTPBasic
 from fastapi.security.oauth2 import OAuth2PasswordBearer
 from fastapi.types import DecoratedCallable
 from handler.auth.constants import (
-    DEFAULT_SCOPES_MAP,
+    EDIT_SCOPES_MAP,
     FULL_SCOPES_MAP,
+    READ_SCOPES_MAP,
     WRITE_SCOPES_MAP,
     Scope,
 )
@@ -29,8 +30,9 @@ oauth2_password_bearer = OAuth2PasswordBearer(
     tokenUrl="/token",
     auto_error=False,
     scopes={
-        **DEFAULT_SCOPES_MAP,
+        **READ_SCOPES_MAP,
         **WRITE_SCOPES_MAP,
+        **EDIT_SCOPES_MAP,
         **FULL_SCOPES_MAP,
     },
 )

--- a/backend/endpoints/tests/test_oauth.py
+++ b/backend/endpoints/tests/test_oauth.py
@@ -2,7 +2,7 @@ import pytest
 from endpoints.auth import ACCESS_TOKEN_EXPIRE_MINUTES
 from fastapi.exceptions import HTTPException
 from fastapi.testclient import TestClient
-from handler.auth.constants import WRITE_SCOPES
+from handler.auth.constants import EDIT_SCOPES
 from main import app
 
 
@@ -96,7 +96,7 @@ def test_auth_via_upass_with_excess_scopes(client, viewer_user):
                 "grant_type": "password",
                 "username": "test_viewer",
                 "password": "test_viewer_password",
-                "scopes": WRITE_SCOPES,
+                "scopes": EDIT_SCOPES,
             },
         )
     except HTTPException as e:

--- a/backend/handler/auth/constants.py
+++ b/backend/handler/auth/constants.py
@@ -2,6 +2,8 @@ import enum
 from datetime import timedelta
 from typing import Final
 
+from config import KIOSK_MODE
+
 ALGORITHM: Final = "HS256"
 DEFAULT_OAUTH_TOKEN_EXPIRY: Final = timedelta(minutes=15)
 
@@ -26,21 +28,24 @@ class Scope(enum.StrEnum):
     TASKS_RUN = "tasks.run"
 
 
-DEFAULT_SCOPES_MAP: Final = {
+READ_SCOPES_MAP: Final = {
     Scope.ME_READ: "View your profile",
-    Scope.ME_WRITE: "Modify your profile",
     Scope.ROMS_READ: "View ROMs",
     Scope.PLATFORMS_READ: "View platforms",
     Scope.ASSETS_READ: "View assets",
-    Scope.ASSETS_WRITE: "Modify assets",
     Scope.FIRMWARE_READ: "View firmware",
     Scope.ROMS_USER_READ: "View user-rom properties",
-    Scope.ROMS_USER_WRITE: "Modify user-rom properties",
     Scope.COLLECTIONS_READ: "View collections",
-    Scope.COLLECTIONS_WRITE: "Modify collections",
 }
 
 WRITE_SCOPES_MAP: Final = {
+    Scope.ME_WRITE: "Modify your profile",
+    Scope.ASSETS_WRITE: "Modify assets",
+    Scope.ROMS_USER_WRITE: "Modify user-rom properties",
+    Scope.COLLECTIONS_WRITE: "Modify collections",
+}
+
+EDIT_SCOPES_MAP: Final = {
     Scope.ROMS_WRITE: "Modify ROMs",
     Scope.PLATFORMS_WRITE: "Modify platforms",
     Scope.FIRMWARE_WRITE: "Modify firmware",
@@ -52,6 +57,14 @@ FULL_SCOPES_MAP: Final = {
     Scope.TASKS_RUN: "Run tasks",
 }
 
-DEFAULT_SCOPES: Final = list(DEFAULT_SCOPES_MAP.keys())
-WRITE_SCOPES: Final = DEFAULT_SCOPES + list(WRITE_SCOPES_MAP.keys())
-FULL_SCOPES: Final = WRITE_SCOPES + list(FULL_SCOPES_MAP.keys())
+DEFAULT_SCOPES: Final = (
+    list(READ_SCOPES_MAP.keys())
+    if KIOSK_MODE
+    else list(READ_SCOPES_MAP.keys()) + list(WRITE_SCOPES_MAP.keys())
+)
+EDIT_SCOPES: Final = (
+    list(READ_SCOPES_MAP.keys())
+    + list(WRITE_SCOPES_MAP.keys())
+    + list(EDIT_SCOPES_MAP.keys())
+)
+FULL_SCOPES: Final = EDIT_SCOPES + list(FULL_SCOPES_MAP.keys())

--- a/backend/handler/auth/constants.py
+++ b/backend/handler/auth/constants.py
@@ -2,8 +2,6 @@ import enum
 from datetime import timedelta
 from typing import Final
 
-from config import KIOSK_MODE
-
 ALGORITHM: Final = "HS256"
 DEFAULT_OAUTH_TOKEN_EXPIRY: Final = timedelta(minutes=15)
 
@@ -57,14 +55,7 @@ FULL_SCOPES_MAP: Final = {
     Scope.TASKS_RUN: "Run tasks",
 }
 
-DEFAULT_SCOPES: Final = (
-    list(READ_SCOPES_MAP.keys())
-    if KIOSK_MODE
-    else list(READ_SCOPES_MAP.keys()) + list(WRITE_SCOPES_MAP.keys())
-)
-EDIT_SCOPES: Final = (
-    list(READ_SCOPES_MAP.keys())
-    + list(WRITE_SCOPES_MAP.keys())
-    + list(EDIT_SCOPES_MAP.keys())
-)
+READ_SCOPES: Final = list(READ_SCOPES_MAP.keys())
+WRITE_SCOPES: Final = READ_SCOPES + list(WRITE_SCOPES_MAP.keys())
+EDIT_SCOPES: Final = WRITE_SCOPES + list(EDIT_SCOPES_MAP.keys())
 FULL_SCOPES: Final = EDIT_SCOPES + list(FULL_SCOPES_MAP.keys())

--- a/backend/handler/auth/hybrid_auth.py
+++ b/backend/handler/auth/hybrid_auth.py
@@ -1,8 +1,11 @@
+from config import KIOSK_MODE
 from fastapi.security.http import HTTPBasic
 from handler.auth import auth_handler, oauth_handler
 from models.user import User
 from starlette.authentication import AuthCredentials, AuthenticationBackend
 from starlette.requests import HTTPConnection
+
+from .constants import READ_SCOPES
 
 
 class HybridAuthBackend(AuthenticationBackend):
@@ -16,44 +19,47 @@ class HybridAuthBackend(AuthenticationBackend):
             return (AuthCredentials(user.oauth_scopes), user)
 
         # Check if Authorization header exists
-        if "Authorization" not in conn.headers:
-            return None
+        if "Authorization" in conn.headers:
+            scheme, token = conn.headers["Authorization"].split()
 
-        scheme, token = conn.headers["Authorization"].split()
+            # Check if basic auth header is valid
+            if scheme.lower() == "basic":
+                credentials = await HTTPBasic().__call__(conn)  # type: ignore[arg-type]
+                if not credentials:
+                    return None
 
-        # Check if basic auth header is valid
-        if scheme.lower() == "basic":
-            credentials = await HTTPBasic().__call__(conn)  # type: ignore[arg-type]
-            if not credentials:
-                return None
+                user = auth_handler.authenticate_user(
+                    credentials.username, credentials.password
+                )
+                if user is None:
+                    return None
 
-            user = auth_handler.authenticate_user(
-                credentials.username, credentials.password
-            )
-            if user is None:
-                return None
+                user.set_last_active()
+                return (AuthCredentials(user.oauth_scopes), user)
 
-            user.set_last_active()
-            return (AuthCredentials(user.oauth_scopes), user)
+            # Check if bearer auth header is valid
+            if scheme.lower() == "bearer":
+                (
+                    user,
+                    claims,
+                ) = await oauth_handler.get_current_active_user_from_bearer_token(token)
+                if user is None or claims is None:
+                    return None
 
-        # Check if bearer auth header is valid
-        if scheme.lower() == "bearer":
-            (
-                user,
-                claims,
-            ) = await oauth_handler.get_current_active_user_from_bearer_token(token)
-            if user is None or claims is None:
-                return None
+                # Only access tokens can request resources
+                if claims.get("type") != "access":
+                    return None
 
-            # Only access tokens can request resources
-            if claims.get("type") != "access":
-                return None
+                # Only grant access to resources with overlapping scopes
+                token_scopes = set(list(claims.get("scopes", "").split(" ")))
+                overlapping_scopes = list(token_scopes & set(user.oauth_scopes))
 
-            # Only grant access to resources with overlapping scopes
-            token_scopes = set(list(claims.get("scopes", "").split(" ")))
-            overlapping_scopes = list(token_scopes & set(user.oauth_scopes))
+                user.set_last_active()
+                return (AuthCredentials(overlapping_scopes), user)
 
-            user.set_last_active()
-            return (AuthCredentials(overlapping_scopes), user)
+        # Check if we're in KIOSK_MODE
+        if KIOSK_MODE:
+            user = User.kiosk_mode_user()
+            return (AuthCredentials(READ_SCOPES), user)
 
         return None

--- a/backend/handler/auth/tests/test_auth.py
+++ b/backend/handler/auth/tests/test_auth.py
@@ -3,7 +3,7 @@ from base64 import b64encode
 import pytest
 from fastapi.exceptions import HTTPException
 from handler.auth import auth_handler, oauth_handler
-from handler.auth.constants import WRITE_SCOPES
+from handler.auth.constants import EDIT_SCOPES
 from handler.auth.hybrid_auth import HybridAuthBackend
 from handler.database import db_user_handler
 from models.user import User
@@ -88,7 +88,7 @@ async def test_hybrid_auth_backend_session(editor_user: User):
     creds, user = result
     assert user.id == editor_user.id
     assert creds.scopes == editor_user.oauth_scopes
-    assert creds.scopes == WRITE_SCOPES
+    assert creds.scopes == EDIT_SCOPES
 
 
 async def test_hybrid_auth_backend_empty_session_and_headers(editor_user: User):
@@ -159,7 +159,7 @@ async def test_hybrid_auth_backend_basic_auth_header(editor_user: User):
 
     creds, user = result
     assert user.id == editor_user.id
-    assert creds.scopes == WRITE_SCOPES
+    assert creds.scopes == EDIT_SCOPES
     assert set(creds.scopes).issubset(editor_user.oauth_scopes)
 
 

--- a/backend/models/tests/test_user.py
+++ b/backend/models/tests/test_user.py
@@ -1,4 +1,4 @@
-from handler.auth.constants import DEFAULT_SCOPES, FULL_SCOPES, WRITE_SCOPES
+from handler.auth.constants import DEFAULT_SCOPES, EDIT_SCOPES, FULL_SCOPES
 from models.user import User
 
 
@@ -7,7 +7,7 @@ def test_admin(admin_user: User):
 
 
 def test_editor(editor_user: User):
-    assert editor_user.oauth_scopes == WRITE_SCOPES
+    assert editor_user.oauth_scopes == EDIT_SCOPES
 
 
 def test_user(viewer_user: User):

--- a/backend/models/tests/test_user.py
+++ b/backend/models/tests/test_user.py
@@ -1,4 +1,4 @@
-from handler.auth.constants import DEFAULT_SCOPES, EDIT_SCOPES, FULL_SCOPES
+from handler.auth.constants import EDIT_SCOPES, FULL_SCOPES, WRITE_SCOPES
 from models.user import User
 
 
@@ -11,4 +11,4 @@ def test_editor(editor_user: User):
 
 
 def test_user(viewer_user: User):
-    assert viewer_user.oauth_scopes == DEFAULT_SCOPES
+    assert viewer_user.oauth_scopes == WRITE_SCOPES

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -4,7 +4,7 @@ import enum
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from handler.auth.constants import DEFAULT_SCOPES, FULL_SCOPES, WRITE_SCOPES, Scope
+from handler.auth.constants import DEFAULT_SCOPES, EDIT_SCOPES, FULL_SCOPES, Scope
 from models.base import BaseModel
 from sqlalchemy import TIMESTAMP, Enum, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -51,7 +51,7 @@ class User(BaseModel, SimpleUser):
             return FULL_SCOPES
 
         if self.role == Role.EDITOR:
-            return WRITE_SCOPES
+            return EDIT_SCOPES
 
         return DEFAULT_SCOPES
 

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -4,7 +4,14 @@ import enum
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from handler.auth.constants import DEFAULT_SCOPES, EDIT_SCOPES, FULL_SCOPES, Scope
+from config import KIOSK_MODE
+from handler.auth.constants import (
+    EDIT_SCOPES,
+    FULL_SCOPES,
+    READ_SCOPES,
+    WRITE_SCOPES,
+    Scope,
+)
 from models.base import BaseModel
 from sqlalchemy import TIMESTAMP, Enum, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -45,6 +52,21 @@ class User(BaseModel, SimpleUser):
     rom_users: Mapped[list[RomUser]] = relationship(back_populates="user")
     collections: Mapped[list[Collection]] = relationship(back_populates="user")
 
+    @classmethod
+    def kiosk_mode_user(cls) -> User:
+        now = datetime.now(timezone.utc)
+        return cls(
+            id=-1,
+            username="kiosk",
+            role=Role.VIEWER,
+            enabled=True,
+            avatar_path="",
+            last_active=now,
+            last_login=now,
+            created_at=now,
+            updated_at=now,
+        )
+
     @property
     def oauth_scopes(self) -> list[Scope]:
         if self.role == Role.ADMIN:
@@ -53,7 +75,10 @@ class User(BaseModel, SimpleUser):
         if self.role == Role.EDITOR:
             return EDIT_SCOPES
 
-        return DEFAULT_SCOPES
+        if KIOSK_MODE:
+            return READ_SCOPES
+
+        return WRITE_SCOPES
 
     @property
     def fs_safe_folder_name(self):

--- a/env.template
+++ b/env.template
@@ -1,5 +1,6 @@
 ROMM_BASE_PATH=/path/to/romm_mock
 DEV_MODE=true
+KIOSK_MODE=false
 
 # Gunicorn (optional)
 GUNICORN_WORKERS=4 # (2 × CPU cores) + 1

--- a/frontend/src/components/Details/ActionBar.vue
+++ b/frontend/src/components/Details/ActionBar.vue
@@ -6,6 +6,7 @@ import storeDownload from "@/stores/download";
 import storeHeartbeat from "@/stores/heartbeat";
 import storeConfig from "@/stores/config";
 import type { DetailedRom } from "@/stores/roms";
+import storeAuth from "@/stores/auth";
 import type { Events } from "@/types/emitter";
 import {
   getDownloadLink,
@@ -26,6 +27,7 @@ const playInfoIcon = ref("mdi-play");
 const qrCodeIcon = ref("mdi-qrcode");
 const configStore = storeConfig();
 const { config } = storeToRefs(configStore);
+const auth = storeAuth();
 
 const platformSlug = computed(() =>
   props.rom.platform_slug in config.value.PLATFORMS_VERSIONS
@@ -128,7 +130,14 @@ async function copyDownloadLink(rom: DetailedRom) {
       >
         <v-icon :icon="qrCodeIcon" />
       </v-btn>
-      <v-menu location="bottom">
+      <v-menu
+        v-if="
+          auth.scopes.includes('roms.write') ||
+          auth.scopes.includes('roms.user.write') ||
+          auth.scopes.includes('collections.write')
+        "
+        location="bottom"
+      >
         <template #activator="{ props: menuProps }">
           <v-btn class="flex-grow-1" v-bind="menuProps">
             <v-icon icon="mdi-dots-vertical" size="large" />

--- a/frontend/src/components/Details/Info/GameInfo.vue
+++ b/frontend/src/components/Details/Info/GameInfo.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { type FilterType } from "@/stores/galleryFilter";
-import storeGalleryView from "@/stores/galleryView";
 import RAvatar from "@/components/common/Collection/RAvatar.vue";
 import type { DetailedRom } from "@/stores/roms";
-import { storeToRefs } from "pinia";
+import { ROUTES } from "@/plugins/router";
 import { ref } from "vue";
 import { useRouter } from "vue-router";
 import { useDisplay, useTheme } from "vuetify";
@@ -24,8 +23,6 @@ const filters = [
   { value: "collections", name: t("rom.collections") },
   { value: "companies", name: t("rom.companies") },
 ] as const;
-const galleryViewStore = storeGalleryView();
-const { defaultAspectRatioScreenshot } = storeToRefs(galleryViewStore);
 
 // Functions
 function onFilterClick(filter: FilterType, value: string) {
@@ -53,7 +50,7 @@ function onFilterClick(filter: FilterType, value: string) {
             <v-col cols="12" v-for="collection in rom.user_collections">
               <v-chip
                 :to="{
-                  name: 'collection',
+                  name: ROUTES.COLLECTION,
                   params: { collection: collection.id },
                 }"
                 size="large"

--- a/frontend/src/components/Details/Personal.vue
+++ b/frontend/src/components/Details/Personal.vue
@@ -9,6 +9,7 @@ import "md-editor-v3/lib/style.css";
 import { ref, watch } from "vue";
 import { useDisplay, useTheme } from "vuetify";
 import { useI18n } from "vue-i18n";
+import { storeToRefs } from "pinia";
 
 // Props
 const { t } = useI18n();
@@ -16,6 +17,7 @@ const props = defineProps<{ rom: DetailedRom }>();
 const auth = storeAuth();
 const theme = useTheme();
 const { mdAndUp, smAndDown } = useDisplay();
+const { scopes } = storeToRefs(auth);
 const editingNote = ref(false);
 const romUser = ref(props.rom.rom_user);
 const publicNotes =
@@ -75,7 +77,12 @@ watch(
         no-gutters
       >
         <v-col cols="12" md="5">
-          <v-checkbox v-model="romUser.backlogged" color="primary" hide-details>
+          <v-checkbox
+            :disabled="!scopes.includes('roms.user.write')"
+            v-model="romUser.backlogged"
+            color="primary"
+            hide-details
+          >
             <template #label
               ><span>{{ t("rom.backlogged") }}</span
               ><span class="ml-2">{{
@@ -84,6 +91,7 @@ watch(
             >
           </v-checkbox>
           <v-checkbox
+            :disabled="!scopes.includes('roms.user.write')"
             v-model="romUser.now_playing"
             color="primary"
             hide-details
@@ -95,7 +103,12 @@ watch(
               }}</span></template
             >
           </v-checkbox>
-          <v-checkbox v-model="romUser.hidden" color="primary" hide-details>
+          <v-checkbox
+            :disabled="!scopes.includes('roms.user.write')"
+            v-model="romUser.hidden"
+            color="primary"
+            hide-details
+          >
             <template #label
               ><span>{{ t("rom.hidden") }}</span
               ><span class="ml-2">{{
@@ -120,6 +133,7 @@ watch(
                 ripple
                 length="10"
                 size="26"
+                :disabled="!scopes.includes('roms.user.write')"
                 v-model="romUser.rating"
                 @update:model-value="
                   romUser.rating =
@@ -140,6 +154,7 @@ watch(
                 ripple
                 length="10"
                 size="26"
+                :disabled="!scopes.includes('roms.user.write')"
                 full-icon="mdi-chili-mild"
                 empty-icon="mdi-chili-mild-outline"
                 v-model="romUser.difficulty"
@@ -158,6 +173,7 @@ watch(
             <v-col cols="12" md="10">
               <v-slider
                 :class="{ 'ml-4': mdAndUp }"
+                :disabled="!scopes.includes('roms.user.write')"
                 v-model="romUser.completion"
                 min="1"
                 max="100"
@@ -174,6 +190,7 @@ watch(
           </v-row>
           <div class="d-flex align-center mt-4">
             <v-select
+              :disabled="!scopes.includes('roms.user.write')"
               v-model="romUser.status"
               :items="statusOptions"
               hide-details
@@ -218,6 +235,7 @@ watch(
               open-delay="500"
               ><template #activator="{ props: tooltipProps }">
                 <v-btn
+                  :disabled="!scopes.includes('roms.user.write')"
                   @click="romUser.note_is_public = !romUser.note_is_public"
                   v-bind="tooltipProps"
                   class="bg-toplayer"
@@ -236,6 +254,7 @@ watch(
               open-delay="500"
               ><template #activator="{ props: tooltipProps }">
                 <v-btn
+                  :disabled="!scopes.includes('roms.user.write')"
                   @click="editNote"
                   v-bind="tooltipProps"
                   class="bg-toplayer"
@@ -253,6 +272,7 @@ watch(
     <v-card-text class="pa-2">
       <MdEditor
         v-if="editingNote"
+        :disabled="!scopes.includes('roms.user.write')"
         v-model="romUser.note_raw_markdown"
         :theme="theme.name.value == 'dark' ? 'dark' : 'light'"
         language="en-US"

--- a/frontend/src/components/Details/Saves.vue
+++ b/frontend/src/components/Details/Saves.vue
@@ -9,10 +9,14 @@ import type { Emitter } from "mitt";
 import { inject, ref } from "vue";
 import { useDisplay } from "vuetify";
 import { useI18n } from "vue-i18n";
+import storeAuth from "@/stores/auth";
+import { storeToRefs } from "pinia";
 
 // Props
 const { t } = useI18n();
 const { mdAndUp } = useDisplay();
+const auth = storeAuth();
+const { scopes } = storeToRefs(auth);
 const props = defineProps<{ rom: DetailedRom }>();
 const selectedSaves = ref<SaveSchema[]>([]);
 const emitter = inject<Emitter<Events>>("emitter");
@@ -69,7 +73,11 @@ async function downloasSaves() {
   >
     <template #header.actions>
       <v-btn-group divided density="compact">
-        <v-btn size="small" @click="emitter?.emit('addSavesDialog', rom)">
+        <v-btn
+          v-if="scopes.includes('assets.write')"
+          size="small"
+          @click="emitter?.emit('addSavesDialog', rom)"
+        >
           <v-icon>mdi-upload</v-icon>
         </v-btn>
         <v-btn
@@ -84,7 +92,7 @@ async function downloasSaves() {
           :class="{
             'text-romm-red': selectedSaves.length,
           }"
-          :disabled="!selectedSaves.length"
+          :disabled="!selectedSaves.length || !scopes.includes('assets.write')"
           :variant="selectedSaves.length > 0 ? 'flat' : 'plain'"
           @click="
             emitter?.emit('showDeleteSavesDialog', {

--- a/frontend/src/components/Details/States.vue
+++ b/frontend/src/components/Details/States.vue
@@ -9,10 +9,14 @@ import type { Emitter } from "mitt";
 import { inject, ref } from "vue";
 import { useDisplay } from "vuetify";
 import { useI18n } from "vue-i18n";
+import storeAuth from "@/stores/auth";
+import { storeToRefs } from "pinia";
 
 // Props
 const { t } = useI18n();
 const { mdAndUp } = useDisplay();
+const auth = storeAuth();
+const { scopes } = storeToRefs(auth);
 const props = defineProps<{ rom: DetailedRom }>();
 const selectedStates = ref<StateSchema[]>([]);
 const emitter = inject<Emitter<Events>>("emitter");
@@ -70,6 +74,7 @@ async function downloasStates() {
     <template #header.actions>
       <v-btn-group divided density="compact">
         <v-btn
+          v-if="scopes.includes('assets.write')"
           drawer
           size="small"
           @click="emitter?.emit('addStatesDialog', rom)"
@@ -86,6 +91,7 @@ async function downloasStates() {
           <v-icon>mdi-download</v-icon>
         </v-btn>
         <v-btn
+          v-if="scopes.includes('assets.write')"
           drawer
           :class="{
             'text-romm-red': selectedStates.length,

--- a/frontend/src/components/Details/Title.vue
+++ b/frontend/src/components/Details/Title.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import FavBtn from "@/components/common/Game/FavBtn.vue";
 import PlatformIcon from "@/components/common/Platform/Icon.vue";
-import type { Platform } from "@/stores/platforms";
+import { ROUTES } from "@/plugins/router";
 import type { DetailedRom } from "@/stores/roms";
 import { languageToEmoji, regionToEmoji } from "@/utils";
 import { identity } from "lodash";
@@ -41,7 +41,7 @@ const hasReleaseDate = Number(props.rom.first_release_date) > 0;
     >
       <v-col>
         <v-chip
-          :to="{ name: 'platform', params: { platform: rom.platform_id } }"
+          :to="{ name: ROUTES.PLATFORM, params: { platform: rom.platform_id } }"
         >
           {{ rom.platform_display_name }}
           <platform-icon

--- a/frontend/src/components/common/Collection/Dialog/DeleteCollection.vue
+++ b/frontend/src/components/common/Collection/Dialog/DeleteCollection.vue
@@ -4,6 +4,7 @@ import RDialog from "@/components/common/RDialog.vue";
 import collectionApi from "@/services/api/collection";
 import storeCollections, { type Collection } from "@/stores/collections";
 import type { Events } from "@/types/emitter";
+import { ROUTES } from "@/plugins/router";
 import type { Emitter } from "mitt";
 import { inject, ref } from "vue";
 import { useRouter } from "vue-router";
@@ -51,7 +52,7 @@ async function deleteCollection() {
       return;
     });
 
-  await router.push({ name: "home" });
+  await router.push({ name: ROUTES.HOME });
 
   collectionsStore.remove(collection.value);
   emitter?.emit("refreshDrawer", null);

--- a/frontend/src/components/common/Game/Card/ActionBar.vue
+++ b/frontend/src/components/common/Game/Card/ActionBar.vue
@@ -5,6 +5,7 @@ import storeDownload from "@/stores/download";
 import storeHeartbeat from "@/stores/heartbeat";
 import storeConfig from "@/stores/config";
 import type { SimpleRom } from "@/stores/roms";
+import storeAuth from "@/stores/auth";
 import type { Events } from "@/types/emitter";
 import {
   isEJSEmulationSupported,
@@ -22,6 +23,7 @@ const heartbeatStore = storeHeartbeat();
 const emitter = inject<Emitter<Events>>("emitter");
 const configStore = storeConfig();
 const { config } = storeToRefs(configStore);
+const auth = storeAuth();
 
 const platformSlug = computed(() => {
   return props.rom.platform_slug in config.value.PLATFORMS_VERSIONS
@@ -101,7 +103,14 @@ const is3DSRom = computed(() => {
         rounded="0"
       />
     </v-col>
-    <v-col class="d-flex">
+    <v-col
+      v-if="
+        auth.scopes.includes('roms.write') ||
+        auth.scopes.includes('roms.user.write') ||
+        auth.scopes.includes('collections.write')
+      "
+      class="d-flex"
+    >
       <v-menu location="bottom">
         <template #activator="{ props }">
           <v-btn

--- a/frontend/src/components/common/Game/Card/ActionBar.vue
+++ b/frontend/src/components/common/Game/Card/ActionBar.vue
@@ -12,6 +12,7 @@ import {
   isRuffleEmulationSupported,
   is3DSCIARom,
 } from "@/utils";
+import { ROUTES } from "@/plugins/router";
 import type { Emitter } from "mitt";
 import { computed, inject } from "vue";
 import { storeToRefs } from "pinia";
@@ -68,7 +69,7 @@ const is3DSRom = computed(() => {
         size="x-small"
         @click="
           $router.push({
-            name: 'emulatorjs',
+            name: ROUTES.EMULATORJS,
             params: { rom: rom?.id },
           })
         "
@@ -83,7 +84,7 @@ const is3DSRom = computed(() => {
         size="x-small"
         @click="
           $router.push({
-            name: 'ruffle',
+            name: ROUTES.RUFFLE,
             params: { rom: rom?.id },
           })
         "

--- a/frontend/src/components/common/Game/Card/Base.vue
+++ b/frontend/src/components/common/Game/Card/Base.vue
@@ -9,7 +9,7 @@ import storeCollections from "@/stores/collections";
 import storeDownload from "@/stores/download";
 import storeGalleryView from "@/stores/galleryView";
 import storeRoms from "@/stores/roms";
-import { type SimpleRom } from "@/stores/roms.js";
+import { type SimpleRom } from "@/stores/roms";
 import { computed } from "vue";
 import { getMissingCoverImage, getUnmatchedCoverImage } from "@/utils/covers";
 

--- a/frontend/src/components/common/Game/Card/Flags.vue
+++ b/frontend/src/components/common/Game/Card/Flags.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { type SimpleRom } from "@/stores/roms.js";
+import { type SimpleRom } from "@/stores/roms";
 import {
   languageToEmoji,
   regionToEmoji,

--- a/frontend/src/components/common/Game/Dialog/DeleteRom.vue
+++ b/frontend/src/components/common/Game/Dialog/DeleteRom.vue
@@ -4,6 +4,7 @@ import RDialog from "@/components/common/RDialog.vue";
 import romApi from "@/services/api/rom";
 import storeRoms, { type SimpleRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
+import { ROUTES } from "@/plugins/router";
 import type { Emitter } from "mitt";
 import { inject, ref } from "vue";
 import { useRouter, useRoute } from "vue-router";
@@ -48,7 +49,7 @@ async function deleteRoms() {
       closeDialog();
       if (route.name == "rom") {
         router.push({
-          name: "platform",
+          name: ROUTES.PLATFORM,
           params: { platform: platformId.value },
         });
       }

--- a/frontend/src/components/common/Game/FavBtn.vue
+++ b/frontend/src/components/common/Game/FavBtn.vue
@@ -4,7 +4,8 @@ import collectionApi, {
 } from "@/services/api/collection";
 import storeCollections, { type Collection } from "@/stores/collections";
 import storeRoms from "@/stores/roms";
-import { type SimpleRom } from "@/stores/roms.js";
+import { type SimpleRom } from "@/stores/roms";
+import storeAuth from "@/stores/auth";
 import type { Events } from "@/types/emitter";
 import type { Emitter } from "mitt";
 import { storeToRefs } from "pinia";
@@ -15,6 +16,7 @@ const props = defineProps<{ rom: SimpleRom }>();
 const romsStore = storeRoms();
 const collectionsStore = storeCollections();
 const { favCollection } = storeToRefs(collectionsStore);
+const auth = storeAuth();
 const emitter = inject<Emitter<Events>>("emitter");
 
 // Functions
@@ -85,6 +87,7 @@ async function switchFromFavourites() {
 
 <template>
   <v-btn
+    v-if="auth.scopes.includes('roms.user.write')"
     @click.stop="switchFromFavourites"
     class="translucent text-shadow"
     rouded="0"

--- a/frontend/src/components/common/Game/Table.vue
+++ b/frontend/src/components/common/Game/Table.vue
@@ -6,6 +6,7 @@ import romApi from "@/services/api/rom";
 import storeConfig from "@/stores/config";
 import storeDownload from "@/stores/download";
 import storeHeartbeat from "@/stores/heartbeat";
+import storeAuth from "@/stores/auth";
 import storeRoms, { type SimpleRom } from "@/stores/roms";
 import {
   formatBytes,
@@ -30,6 +31,8 @@ const { filteredRoms, selectedRoms } = storeToRefs(romsStore);
 const heartbeatStore = storeHeartbeat();
 const configStore = storeConfig();
 const { config } = storeToRefs(configStore);
+const auth = storeAuth();
+
 const HEADERS = [
   {
     title: "Title",
@@ -288,7 +291,14 @@ function updateSelectedRom(rom: SimpleRom) {
         >
           <v-icon>mdi-play</v-icon>
         </v-btn>
-        <v-menu location="bottom">
+        <v-menu
+          v-if="
+            auth.scopes.includes('roms.write') ||
+            auth.scopes.includes('roms.user.write') ||
+            auth.scopes.includes('collections.write')
+          "
+          location="bottom"
+        >
           <template #activator="{ props }">
             <v-btn v-bind="props" size="small">
               <v-icon>mdi-dots-vertical</v-icon>

--- a/frontend/src/components/common/Game/Table.vue
+++ b/frontend/src/components/common/Game/Table.vue
@@ -15,6 +15,7 @@ import {
   languageToEmoji,
   regionToEmoji,
 } from "@/utils";
+import { ROUTES } from "@/plugins/router";
 import { isNull } from "lodash";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
@@ -88,7 +89,7 @@ const selectedRomIDs = computed(() => selectedRoms.value.map((rom) => rom.id));
 
 // Functions
 function rowClick(_: Event, row: { item: SimpleRom }) {
-  router.push({ name: "rom", params: { rom: row.item.id } });
+  router.push({ name: ROUTES.ROM, params: { rom: row.item.id } });
   romsStore.resetSelection();
 }
 
@@ -272,7 +273,7 @@ function updateSelectedRom(rom: SimpleRom) {
           size="small"
           @click.stop="
             $router.push({
-              name: 'emulatorjs',
+              name: ROUTES.EMULATORJS,
               params: { rom: item?.id },
             })
           "
@@ -284,7 +285,7 @@ function updateSelectedRom(rom: SimpleRom) {
           size="small"
           @click.stop="
             $router.push({
-              name: 'ruffle',
+              name: ROUTES.RUFFLE,
               params: { rom: item?.id },
             })
           "

--- a/frontend/src/components/common/Navigation/HomeBtn.vue
+++ b/frontend/src/components/common/Navigation/HomeBtn.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
-import { ref } from "vue";
 import RIsotipo from "@/components/common/RIsotipo.vue";
 import storeNavigation from "@/stores/navigation";
+import { ROUTES } from "@/plugins/router";
 
-const homeUrl = ref(`${location.protocol}//${location.host}`);
 const navigationStore = storeNavigation();
 </script>
 <template>
   <r-isotipo
-    :to="homeUrl"
+    :to="{ name: ROUTES.HOME }"
     @click="navigationStore.goHome"
     class="cursor-pointer"
     :size="40"

--- a/frontend/src/components/common/Navigation/SettingsDrawer.vue
+++ b/frontend/src/components/common/Navigation/SettingsDrawer.vue
@@ -88,7 +88,7 @@ async function logout() {
       <v-list-item
         class="mt-1"
         rounded
-        :to="{ name: 'userInterface' }"
+        :to="{ name: 'user-interface' }"
         append-icon="mdi-palette"
         >{{ t("common.user-interface") }}</v-list-item
       >
@@ -97,7 +97,7 @@ async function logout() {
         class="mt-1"
         rounded
         append-icon="mdi-table-cog"
-        :to="{ name: 'libraryManagement' }"
+        :to="{ name: 'library-management' }"
         >{{ t("common.library-management") }}
       </v-list-item>
       <v-list-item
@@ -108,7 +108,7 @@ async function logout() {
         append-icon="mdi-security"
         >{{ t("common.administration") }}
       </v-list-item>
-      <template v-if="smAndDown">
+      <template v-if="smAndDown && auth.user.id !== -1">
         <v-list-item
           @click="logout"
           append-icon="mdi-location-exit"
@@ -118,7 +118,7 @@ async function logout() {
         >
       </template>
     </v-list>
-    <template v-if="!smAndDown" #append>
+    <template v-if="!smAndDown && auth.user.id !== -1" #append>
       <v-list class="pa-0">
         <v-list-item
           @click="logout"

--- a/frontend/src/components/common/Navigation/SettingsDrawer.vue
+++ b/frontend/src/components/common/Navigation/SettingsDrawer.vue
@@ -6,6 +6,7 @@ import storeAuth from "@/stores/auth";
 import storeNavigation from "@/stores/navigation";
 import type { Events } from "@/types/emitter";
 import { defaultAvatarPath } from "@/utils";
+import { ROUTES } from "@/plugins/router";
 import type { Emitter } from "mitt";
 import { storeToRefs } from "pinia";
 import { inject } from "vue";
@@ -36,7 +37,7 @@ async function logout() {
     });
     navigationStore.switchActiveSettingsDrawer();
     auth.setUser(null);
-    await router.push({ name: "login" });
+    await router.push({ name: ROUTES.LOGIN });
   });
 }
 </script>
@@ -88,7 +89,7 @@ async function logout() {
       <v-list-item
         class="mt-1"
         rounded
-        :to="{ name: 'user-interface' }"
+        :to="{ name: ROUTES.USER_INTERFACE }"
         append-icon="mdi-palette"
         >{{ t("common.user-interface") }}</v-list-item
       >
@@ -97,14 +98,14 @@ async function logout() {
         class="mt-1"
         rounded
         append-icon="mdi-table-cog"
-        :to="{ name: 'library-management' }"
+        :to="{ name: ROUTES.LIBRARY_MANAGEMENT }"
         >{{ t("common.library-management") }}
       </v-list-item>
       <v-list-item
         v-if="scopes.includes('users.write')"
         class="mt-1"
         rounded
-        :to="{ name: 'administration' }"
+        :to="{ name: ROUTES.ADMINISTRATION }"
         append-icon="mdi-security"
         >{{ t("common.administration") }}
       </v-list-item>

--- a/frontend/src/components/common/Navigation/SettingsDrawer.vue
+++ b/frontend/src/components/common/Navigation/SettingsDrawer.vue
@@ -81,7 +81,7 @@ async function logout() {
       <v-list-item
         v-if="scopes.includes('me.write')"
         rounded
-        @click="emitter?.emit('showEditUserDialog', auth.user as UserSchema)"
+        @click="emitter?.emit('showEditUserDialog', user as UserSchema)"
         append-icon="mdi-account"
         >{{ t("common.profile") }}</v-list-item
       >
@@ -108,7 +108,7 @@ async function logout() {
         append-icon="mdi-security"
         >{{ t("common.administration") }}
       </v-list-item>
-      <template v-if="smAndDown && auth.user.id !== -1">
+      <template v-if="smAndDown && scopes.includes('me.write')" #append>
         <v-list-item
           @click="logout"
           append-icon="mdi-location-exit"
@@ -118,7 +118,7 @@ async function logout() {
         >
       </template>
     </v-list>
-    <template v-if="!smAndDown && auth.user.id !== -1" #append>
+    <template v-if="!smAndDown && scopes.includes('me.write')">
       <v-list class="pa-0">
         <v-list-item
           @click="logout"

--- a/frontend/src/components/common/Navigation/SettingsDrawer.vue
+++ b/frontend/src/components/common/Navigation/SettingsDrawer.vue
@@ -79,6 +79,7 @@ async function logout() {
     </v-list>
     <v-list class="py-1 px-0">
       <v-list-item
+        v-if="scopes.includes('me.write')"
         rounded
         @click="emitter?.emit('showEditUserDialog', auth.user as UserSchema)"
         append-icon="mdi-account"

--- a/frontend/src/components/common/Platform/Card.vue
+++ b/frontend/src/components/common/Platform/Card.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Platform } from "@/stores/platforms";
+import { ROUTES } from "@/plugins/router";
 import PlatformIcon from "@/components/common/Platform/Icon.vue";
 
 defineProps<{ platform: Platform }>();
@@ -12,7 +13,7 @@ defineProps<{ platform: Platform }>();
       class="bg-toplayer transform-scale"
       :class="{ 'on-hover': isHovering }"
       :elevation="isHovering ? 20 : 3"
-      :to="{ name: 'platform', params: { platform: platform.id } }"
+      :to="{ name: ROUTES.PLATFORM, params: { platform: platform.id } }"
     >
       <v-card-text>
         <v-row class="pa-1 justify-center bg-background">

--- a/frontend/src/components/common/Platform/Dialog/DeletePlatform.vue
+++ b/frontend/src/components/common/Platform/Dialog/DeletePlatform.vue
@@ -3,11 +3,12 @@ import RDialog from "@/components/common/RDialog.vue";
 import platformApi from "@/services/api/platform";
 import storePlatforms, { type Platform } from "@/stores/platforms";
 import type { Events } from "@/types/emitter";
+import { ROUTES } from "@/plugins/router";
+import PlatformIcon from "@/components/common/Platform/Icon.vue";
 import type { Emitter } from "mitt";
 import { inject, ref } from "vue";
 import { useRouter } from "vue-router";
 import { useDisplay } from "vuetify";
-import PlatformIcon from "@/components/common/Platform/Icon.vue";
 import { useI18n } from "vue-i18n";
 
 // Props
@@ -47,7 +48,7 @@ async function deletePlatform() {
       return;
     });
 
-  await router.push({ name: "home" });
+  await router.push({ name: ROUTES.HOME });
 
   platformsStore.remove(platform.value);
   emitter?.emit("refreshDrawer", null);

--- a/frontend/src/components/common/Platform/ListItem.vue
+++ b/frontend/src/components/common/Platform/ListItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import PlatformIcon from "@/components/common/Platform/Icon.vue";
+import { ROUTES } from "@/plugins/router";
 import type { Platform } from "@/stores/platforms";
 
 // Props
@@ -11,7 +12,7 @@ withDefaults(defineProps<{ platform: Platform; rail?: boolean }>(), {
 <template>
   <v-list-item
     :key="platform.slug"
-    :to="{ name: 'platform', params: { platform: platform.id } }"
+    :to="{ name: ROUTES.PLATFORM, params: { platform: platform.id } }"
     :value="platform.slug"
     rounded
     density="compact"

--- a/frontend/src/plugins/router.ts
+++ b/frontend/src/plugins/router.ts
@@ -3,75 +3,92 @@ import { createRouter, createWebHistory } from "vue-router";
 import storeHeartbeat from "@/stores/heartbeat";
 import storeAuth from "@/stores/auth";
 import { storeToRefs } from "pinia";
+import type { User } from "@/stores/users";
+
+export const ROUTES = {
+  SETUP: "setup",
+  LOGIN: "login",
+  MAIN: "main",
+  HOME: "home",
+  SEARCH: "search",
+  PLATFORM: "platform",
+  COLLECTION: "collection",
+  ROM: "rom",
+  EMULATORJS: "emulatorjs",
+  RUFFLE: "ruffle",
+  SCAN: "scan",
+  USER_INTERFACE: "user-interface",
+  LIBRARY_MANAGEMENT: "library-management",
+  ADMINISTRATION: "administration",
+  NOT_FOUND: "404",
+} as const;
 
 const routes = [
   {
     path: "/setup",
-    name: "setupView",
     component: () => import("@/layouts/Auth.vue"),
     children: [
       {
         path: "",
-        name: "setup",
+        name: ROUTES.SETUP,
         component: () => import("@/views/Auth/Setup.vue"),
       },
     ],
   },
   {
     path: "/login",
-    name: "loginView",
     component: () => import("@/layouts/Auth.vue"),
     children: [
       {
         path: "",
-        name: "login",
+        name: ROUTES.LOGIN,
         component: () => import("@/views/Auth/Login.vue"),
       },
     ],
   },
   {
     path: "/",
-    name: "main",
+    name: ROUTES.MAIN,
     component: () => import("@/layouts/Main.vue"),
     children: [
       {
         path: "",
-        name: "home",
+        name: ROUTES.HOME,
         component: () => import("@/views/Home.vue"),
       },
       {
         path: "search",
-        name: "search",
+        name: ROUTES.SEARCH,
         component: () => import("@/views/Gallery/Search.vue"),
       },
       {
         path: "platform/:platform",
-        name: "platform",
+        name: ROUTES.PLATFORM,
         component: () => import("@/views/Gallery/Platform.vue"),
       },
       {
         path: "collection/:collection",
-        name: "collection",
+        name: ROUTES.COLLECTION,
         component: () => import("@/views/Gallery/Collection.vue"),
       },
       {
         path: "rom/:rom",
-        name: "rom",
+        name: ROUTES.ROM,
         component: () => import("@/views/GameDetails.vue"),
       },
       {
         path: "rom/:rom/ejs",
-        name: "emulatorjs",
+        name: ROUTES.EMULATORJS,
         component: () => import("@/views/Player/EmulatorJS/Base.vue"),
       },
       {
         path: "rom/:rom/ruffle",
-        name: "ruffle",
+        name: ROUTES.RUFFLE,
         component: () => import("@/views/Player/RuffleRS/Base.vue"),
       },
       {
         path: "scan",
-        name: "scan",
+        name: ROUTES.SCAN,
         component: () => import("@/views/Scan.vue"),
       },
       {
@@ -80,7 +97,7 @@ const routes = [
         children: [
           {
             path: "",
-            name: "userInterface",
+            name: ROUTES.USER_INTERFACE,
             component: () => import("@/views/Settings/UserInterface.vue"),
           },
         ],
@@ -91,7 +108,7 @@ const routes = [
         children: [
           {
             path: "",
-            name: "libraryManagement",
+            name: ROUTES.LIBRARY_MANAGEMENT,
             component: () => import("@/views/Settings/LibraryManagement.vue"),
           },
         ],
@@ -102,57 +119,83 @@ const routes = [
         children: [
           {
             path: "",
-            name: "administration",
+            name: ROUTES.ADMINISTRATION,
             component: () => import("@/views/Settings/Administration.vue"),
           },
         ],
       },
       {
         path: ":pathMatch(.*)*",
-        name: "404",
+        name: ROUTES.NOT_FOUND,
         component: () => import("@/views/404.vue"),
       },
     ],
   },
 ];
 
+interface RoutePermissions {
+  path: string;
+  requiredScopes: string[];
+}
+
 const router = createRouter({
   history: createWebHistory(process.env.BASE_URL),
   routes,
 });
 
+const routePermissions: RoutePermissions[] = [
+  { path: ROUTES.SCAN, requiredScopes: ["platforms.write"] },
+  { path: ROUTES.LIBRARY_MANAGEMENT, requiredScopes: ["platforms.write"] },
+  { path: ROUTES.ADMINISTRATION, requiredScopes: ["users.write"] },
+];
+
+function checkRoutePermissions(route: string, user: User | null): boolean {
+  // No checks needed for login and setup pages
+  if (route === ROUTES.LOGIN || route === ROUTES.SETUP) return true;
+
+  // No user, no access
+  if (!user) return false;
+
+  // Check if route has permissions requirements
+  const routeConfig = routePermissions.find((config) => config.path === route);
+  if (!routeConfig) return true;
+
+  // Check if user has required scopes
+  return routeConfig.requiredScopes.every((scope) =>
+    user.oauth_scopes.includes(scope),
+  );
+}
+
 router.beforeEach(async (to, _from, next) => {
   const heartbeat = storeHeartbeat();
   const auth = storeAuth();
   const { user } = storeToRefs(auth);
+  const currentRoute = to.name?.toString();
 
-  if (
-    heartbeat.value.SYSTEM.SHOW_SETUP_WIZARD &&
-    to.name?.toString() !== "setup"
-  ) {
-    next({ name: "setup" });
-  } else if (!heartbeat.value.SYSTEM.SHOW_SETUP_WIZARD) {
-    if (
-      (to.name?.toString() === "login" || to.name?.toString() === "setup") &&
-      user.value
-    ) {
-      next({ name: "home" });
-    } else if (to.name?.toString() !== "login" && !user.value) {
-      next({ name: "login" });
-    } else if (
-      to.name &&
-      user.value &&
-      ((["scan", "management"].includes(to.name.toString()) &&
-        !user.value.oauth_scopes.includes("platforms.write")) ||
-        (["administration"].includes(to.name.toString()) &&
-          !user.value.oauth_scopes.includes("users.write")))
-    ) {
-      next({ name: "404" });
-    } else {
-      next();
+  try {
+    // Handle setup wizard
+    if (heartbeat.value.SYSTEM.SHOW_SETUP_WIZARD) {
+      return currentRoute !== "setup" ? next({ name: ROUTES.SETUP }) : next();
     }
-  } else {
+
+    // Handle authentication
+    if (!user.value && currentRoute !== ROUTES.LOGIN) {
+      return next({ name: ROUTES.LOGIN });
+    }
+
+    if (user.value && currentRoute == ROUTES.SETUP) {
+      return next({ name: ROUTES.HOME });
+    }
+
+    // Check permissions
+    if (currentRoute && !checkRoutePermissions(currentRoute, user.value)) {
+      return next({ name: ROUTES.NOT_FOUND });
+    }
+
     next();
+  } catch (error) {
+    console.error("Navigation guard error:", error);
+    next({ name: ROUTES.LOGIN });
   }
 });
 

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -1,4 +1,5 @@
 import router from "@/plugins/router";
+import { ROUTES } from "@/plugins/router";
 import axios from "axios";
 import { default as Cookies } from "js-cookie";
 import { debounce } from "lodash";
@@ -47,7 +48,7 @@ api.interceptors.response.use(
       const params = new URLSearchParams(window.location.search);
 
       router.push({
-        name: "login",
+        name: ROUTES.LOGIN,
         query: {
           next: params.get("next") ?? (pathname !== "/login" ? pathname : "/"),
         },

--- a/frontend/src/stores/navigation.ts
+++ b/frontend/src/stores/navigation.ts
@@ -1,4 +1,5 @@
 import { defineStore } from "pinia";
+import { ROUTES } from "@/plugins/router";
 
 export default defineStore("navigation", {
   state: () => ({
@@ -32,15 +33,15 @@ export default defineStore("navigation", {
     },
     goHome() {
       this.resetDrawers();
-      this.$router.push({ name: "home" });
+      this.$router.push({ name: ROUTES.HOME });
     },
     goScan() {
       this.resetDrawers();
-      this.$router.push({ name: "scan" });
+      this.$router.push({ name: ROUTES.SCAN });
     },
     goSearch() {
       this.resetDrawers();
-      this.$router.push({ name: "search" });
+      this.$router.push({ name: ROUTES.SEARCH });
     },
     resetDrawers() {
       this.activePlatformsDrawer = false;

--- a/frontend/src/views/Auth/Setup.vue
+++ b/frontend/src/views/Auth/Setup.vue
@@ -5,6 +5,7 @@ import userApi from "@/services/api/user";
 import api from "@/services/api/index";
 import storeHeartbeat from "@/stores/heartbeat";
 import type { Events } from "@/types/emitter";
+import { ROUTES } from "@/plugins/router";
 import type { Emitter } from "mitt";
 import { computed, inject, ref } from "vue";
 import { useDisplay } from "vuetify";
@@ -58,7 +59,7 @@ async function finishWizard() {
       await refetchCSRFToken();
       await api.get("/heartbeat").then(({ data: heartbeatData }) => {
         heartbeat.set(heartbeatData);
-        router.push({ name: "login" });
+        router.push({ name: ROUTES.LOGIN });
       });
     })
     .catch(({ response, message }) => {

--- a/frontend/src/views/Gallery/Collection.vue
+++ b/frontend/src/views/Gallery/Collection.vue
@@ -12,7 +12,8 @@ import storeGalleryFilter from "@/stores/galleryFilter";
 import storeGalleryView from "@/stores/galleryView";
 import storeRoms, { type SimpleRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
-import { normalizeString, views } from "@/utils";
+import { views } from "@/utils";
+import { ROUTES } from "@/plugins/router";
 import type { Emitter } from "mitt";
 import { storeToRefs } from "pinia";
 import { inject, onBeforeUnmount, onMounted, ref, watch } from "vue";
@@ -164,12 +165,12 @@ function onGameClick(emitData: { rom: SimpleRom; event: MouseEvent }) {
     }
   } else if (emitData.event.metaKey || emitData.event.ctrlKey) {
     const link = router.resolve({
-      name: "rom",
+      name: ROUTES.ROM,
       params: { rom: emitData.rom.id },
     });
     window.open(link.href, "_blank");
   } else {
-    router.push({ name: "rom", params: { rom: emitData.rom.id } });
+    router.push({ name: ROUTES.ROM, params: { rom: emitData.rom.id } });
   }
 }
 

--- a/frontend/src/views/Gallery/Platform.vue
+++ b/frontend/src/views/Gallery/Platform.vue
@@ -13,6 +13,7 @@ import storePlatforms from "@/stores/platforms";
 import storeRoms, { type SimpleRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import { views } from "@/utils";
+import { ROUTES } from "@/plugins/router";
 import type { Emitter } from "mitt";
 import { storeToRefs } from "pinia";
 import { inject, onBeforeUnmount, onMounted, ref, watch } from "vue";
@@ -157,12 +158,12 @@ function onGameClick(emitData: { rom: SimpleRom; event: MouseEvent }) {
     }
   } else if (emitData.event.metaKey || emitData.event.ctrlKey) {
     const link = router.resolve({
-      name: "rom",
+      name: ROUTES.ROM,
       params: { rom: emitData.rom.id },
     });
     window.open(link.href, "_blank");
   } else {
-    router.push({ name: "rom", params: { rom: emitData.rom.id } });
+    router.push({ name: ROUTES.ROM, params: { rom: emitData.rom.id } });
   }
 }
 

--- a/frontend/src/views/Gallery/Search.vue
+++ b/frontend/src/views/Gallery/Search.vue
@@ -12,6 +12,7 @@ import storeRoms, { type SimpleRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import type { Emitter } from "mitt";
 import { views } from "@/utils";
+import { ROUTES } from "@/plugins/router";
 import { storeToRefs } from "pinia";
 import { inject, onBeforeUnmount, onMounted, ref } from "vue";
 import { useRouter } from "vue-router";
@@ -119,12 +120,12 @@ function onGameClick(emitData: { rom: SimpleRom; event: MouseEvent }) {
     }
   } else if (emitData.event.metaKey || emitData.event.ctrlKey) {
     const link = router.resolve({
-      name: "rom",
+      name: ROUTES.ROM,
       params: { rom: emitData.rom.id },
     });
     window.open(link.href, "_blank");
   } else {
-    router.push({ name: "rom", params: { rom: emitData.rom.id } });
+    router.push({ name: ROUTES.ROM, params: { rom: emitData.rom.id } });
   }
 }
 

--- a/frontend/src/views/Player/EmulatorJS/Base.vue
+++ b/frontend/src/views/Player/EmulatorJS/Base.vue
@@ -6,6 +6,7 @@ import romApi from "@/services/api/rom";
 import storeGalleryView from "@/stores/galleryView";
 import type { DetailedRom } from "@/stores/roms";
 import { formatBytes, formatTimestamp, getSupportedEJSCores } from "@/utils";
+import { ROUTES } from "@/plugins/router";
 import Player from "@/views/Player/EmulatorJS/Player.vue";
 import { isNull } from "lodash";
 import { storeToRefs } from "pinia";
@@ -380,7 +381,7 @@ onMounted(async () => {
             prepend-icon="mdi-arrow-left"
             @click="
               $router.push({
-                name: 'rom',
+                name: ROUTES.ROM,
                 params: { rom: rom?.id },
               })
             "
@@ -394,7 +395,7 @@ onMounted(async () => {
             prepend-icon="mdi-arrow-left"
             @click="
               $router.push({
-                name: 'platform',
+                name: ROUTES.PLATFORM,
                 params: { platform: rom?.platform_id },
               })
             "

--- a/frontend/src/views/Player/RuffleRS/Base.vue
+++ b/frontend/src/views/Player/RuffleRS/Base.vue
@@ -3,12 +3,13 @@ import RomListItem from "@/components/common/Game/ListItem.vue";
 import romApi from "@/services/api/rom";
 import storeGalleryView from "@/stores/galleryView";
 import type { DetailedRom } from "@/stores/roms";
+import { getDownloadPath } from "@/utils";
+import { ROUTES } from "@/plugins/router";
 import { isNull } from "lodash";
 import { storeToRefs } from "pinia";
 import { nextTick, onMounted, ref } from "vue";
 import { useRoute } from "vue-router";
 import { useI18n } from "vue-i18n";
-import { getDownloadPath } from "@/utils";
 
 const RUFFLE_VERSION = "0.1.0-nightly.2024.12.28";
 
@@ -168,7 +169,7 @@ onMounted(async () => {
             prepend-icon="mdi-arrow-left"
             @click="
               $router.push({
-                name: 'rom',
+                name: ROUTES.ROM,
                 params: { rom: rom?.id },
               })
             "
@@ -182,7 +183,7 @@ onMounted(async () => {
             prepend-icon="mdi-arrow-left"
             @click="
               $router.push({
-                name: 'platform',
+                name: ROUTES.PLATFORM,
                 params: { platform: rom?.platform_id },
               })
             "

--- a/frontend/src/views/Scan.vue
+++ b/frontend/src/views/Scan.vue
@@ -270,7 +270,7 @@ async function stopScan() {
       rounded="4"
       height="40"
       class="ml-2"
-      :to="{ name: 'libraryManagement' }"
+      :to="{ name: 'library-management' }"
     >
       {{ t("scan.manage-library") }}
     </v-btn>

--- a/frontend/src/views/Scan.vue
+++ b/frontend/src/views/Scan.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import RAvatarRom from "@/components/common/Game/RAvatar.vue";
 import RomListItem from "@/components/common/Game/ListItem.vue";
 import PlatformIcon from "@/components/common/Platform/Icon.vue";
 import socket from "@/services/socket";
 import storeHeartbeat from "@/stores/heartbeat";
 import storePlatforms, { type Platform } from "@/stores/platforms";
 import storeScanning from "@/stores/scanning";
+import { ROUTES } from "@/plugins/router";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 import { useDisplay } from "vuetify";
@@ -270,7 +270,7 @@ async function stopScan() {
       rounded="4"
       height="40"
       class="ml-2"
-      :to="{ name: 'library-management' }"
+      :to="{ name: ROUTES.LIBRARY_MANAGEMENT }"
     >
       {{ t("scan.manage-library") }}
     </v-btn>


### PR DESCRIPTION
## Description

This PR add a new env var `KIOSK_MODE`, which when set to `true` will disable all editing for `VIEWER` roles. Options in the UI will be disabled/hidden, and the scopes on the backend are restricted to read-only ones. Login and setup screens will also be bypassed when accessing any authenticated page directly.

## Checklist

Please check all that apply.

- [x] I've tested the changes locally
- [x] I've updated the wiki accordingly
- [x] I've have updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
- [x] All existing tests are passing