### PR TITLE
[HOTFIX] Remove single forward-slash endpoints

### DIFF
--- a/backend/endpoints/collections.py
+++ b/backend/endpoints/collections.py
@@ -29,7 +29,7 @@ router = APIRouter(
 )
 
 
-@protected_route(router.post, "/", [Scope.COLLECTIONS_WRITE])
+@protected_route(router.post, "", [Scope.COLLECTIONS_WRITE])
 async def add_collection(
     request: Request,
     artwork: UploadFile | None = None,
@@ -98,7 +98,7 @@ async def add_collection(
     return CollectionSchema.model_validate(created_collection)
 
 
-@protected_route(router.get, "/", [Scope.COLLECTIONS_READ])
+@protected_route(router.get, "", [Scope.COLLECTIONS_READ])
 def get_collections(request: Request) -> list[CollectionSchema]:
     """Get collections endpoint
 

--- a/backend/endpoints/configs.py
+++ b/backend/endpoints/configs.py
@@ -17,7 +17,7 @@ router = APIRouter(
 )
 
 
-@router.get("/")
+@router.get("")
 def get_config() -> ConfigResponse:
     """Get config endpoint
 

--- a/backend/endpoints/firmware.py
+++ b/backend/endpoints/firmware.py
@@ -17,7 +17,7 @@ router = APIRouter(
 )
 
 
-@protected_route(router.post, "/", [Scope.FIRMWARE_WRITE])
+@protected_route(router.post, "", [Scope.FIRMWARE_WRITE])
 def add_firmware(
     request: Request,
     platform_id: int,
@@ -84,7 +84,7 @@ def add_firmware(
     }
 
 
-@protected_route(router.get, "/", [Scope.FIRMWARE_READ])
+@protected_route(router.get, "", [Scope.FIRMWARE_READ])
 def get_platform_firmware(
     request: Request,
     platform_id: int | None = None,

--- a/backend/endpoints/platform.py
+++ b/backend/endpoints/platform.py
@@ -20,7 +20,7 @@ router = APIRouter(
 )
 
 
-@protected_route(router.post, "/", [Scope.PLATFORMS_WRITE])
+@protected_route(router.post, "", [Scope.PLATFORMS_WRITE])
 async def add_platforms(request: Request) -> PlatformSchema:
     """Create platform endpoint
 
@@ -43,7 +43,7 @@ async def add_platforms(request: Request) -> PlatformSchema:
     )
 
 
-@protected_route(router.get, "/", [Scope.PLATFORMS_READ])
+@protected_route(router.get, "", [Scope.PLATFORMS_READ])
 def get_platforms(request: Request) -> list[PlatformSchema]:
     """Get platforms endpoint
 

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -48,7 +48,7 @@ router = APIRouter(
 )
 
 
-@protected_route(router.post, "/", [Scope.ROMS_WRITE])
+@protected_route(router.post, "", [Scope.ROMS_WRITE])
 async def add_rom(request: Request):
     """Upload single rom endpoint
 
@@ -110,7 +110,7 @@ async def add_rom(request: Request):
     return Response(status_code=status.HTTP_201_CREATED)
 
 
-@protected_route(router.get, "/", [Scope.ROMS_READ])
+@protected_route(router.get, "", [Scope.ROMS_READ])
 def get_roms(
     request: Request,
     platform_id: int | None = None,

--- a/backend/endpoints/saves.py
+++ b/backend/endpoints/saves.py
@@ -18,7 +18,7 @@ router = APIRouter(
 )
 
 
-@protected_route(router.post, "/", [Scope.ASSETS_WRITE])
+@protected_route(router.post, "", [Scope.ASSETS_WRITE])
 def add_saves(
     request: Request,
     rom_id: int,
@@ -87,7 +87,7 @@ def add_saves(
     }
 
 
-# @protected_route(router.get, "/", [Scope.ASSETS_READ])
+# @protected_route(router.get, "", [Scope.ASSETS_READ])
 # def get_saves(request: Request) -> MessageResponse:
 #     pass
 

--- a/backend/endpoints/screenshots.py
+++ b/backend/endpoints/screenshots.py
@@ -15,7 +15,7 @@ router = APIRouter(
 )
 
 
-@protected_route(router.post, "/", [Scope.ASSETS_WRITE])
+@protected_route(router.post, "", [Scope.ASSETS_WRITE])
 def add_screenshots(
     request: Request,
     rom_id: int,

--- a/backend/endpoints/states.py
+++ b/backend/endpoints/states.py
@@ -18,7 +18,7 @@ router = APIRouter(
 )
 
 
-@protected_route(router.post, "/", [Scope.ASSETS_WRITE])
+@protected_route(router.post, "", [Scope.ASSETS_WRITE])
 def add_states(
     request: Request,
     rom_id: int,
@@ -86,7 +86,7 @@ def add_states(
     }
 
 
-# @protected_route(router.get, "/", [Scope.ASSETS_READ])
+# @protected_route(router.get, "", [Scope.ASSETS_READ])
 # def get_states(request: Request) -> MessageResponse:
 #     pass
 

--- a/backend/endpoints/stats.py
+++ b/backend/endpoints/stats.py
@@ -8,7 +8,7 @@ router = APIRouter(
 )
 
 
-@router.get("/")
+@router.get("")
 def stats() -> StatsReturn:
     """Endpoint to return the current RomM stats
 

--- a/backend/endpoints/user.py
+++ b/backend/endpoints/user.py
@@ -24,7 +24,7 @@ router = APIRouter(
 
 @protected_route(
     router.post,
-    "/",
+    "",
     [],
     status_code=status.HTTP_201_CREATED,
 )
@@ -80,7 +80,7 @@ def add_user(
     return UserSchema.model_validate(db_user_handler.add_user(user))
 
 
-@protected_route(router.get, "/", [Scope.USERS_READ])
+@protected_route(router.get, "", [Scope.USERS_READ])
 def get_users(request: Request) -> list[UserSchema]:
     """Get all users endpoint
 


### PR DESCRIPTION
The addition of prefixes in API routes broke any forward-slash-only endpoint `"/"`, so this PR removed all them them. The changes in `APIRouter` should cover an weird edge cases.