### PR TITLE
Reset stores on logout + move hash calc out of background on scan

### DIFF
--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -24,7 +24,7 @@ from handler.filesystem import (
     fs_rom_handler,
 )
 from handler.filesystem.roms_handler import FSRom
-from handler.redis_handler import high_prio_queue, low_prio_queue, redis_client
+from handler.redis_handler import high_prio_queue, redis_client
 from handler.scan_handler import ScanType, scan_firmware, scan_platform, scan_rom
 from handler.socket_handler import socket_handler
 from logger.formatter import LIGHTYELLOW, RED
@@ -471,14 +471,14 @@ async def _identify_rom(
     if not rom or scan_type == ScanType.COMPLETE or scan_type == ScanType.HASHES:
         # Skip hashing games for platforms that don't have a hash database
         if platform.slug not in NON_HASHABLE_PLATFORMS:
-            # Uncomment this to run scan in the current process
-            # _set_rom_hashes(_added_rom.id)
+            _set_rom_hashes(_added_rom.id)
 
-            low_prio_queue.enqueue(
-                _set_rom_hashes,
-                _added_rom.id,
-                job_timeout=60 * 15,  # Timeout (15 minutes)
-            )
+            # Uncomment this to run scan in a background process
+            # low_prio_queue.enqueue(
+            #     _set_rom_hashes,
+            #     _added_rom.id,
+            #     job_timeout=60 * 15,  # Timeout (15 minutes)
+            # )
 
     # Return early if we're only scanning for hashes
     if scan_type == ScanType.HASHES:

--- a/frontend/src/components/common/Game/Dialog/UploadRom.vue
+++ b/frontend/src/components/common/Game/Dialog/UploadRom.vue
@@ -101,7 +101,7 @@ async function uploadRoms() {
       const failedUploads = responses.filter((d) => d.status == "rejected");
 
       if (failedUploads.length == 0) {
-        uploadStore.clearAll();
+        uploadStore.reset();
       }
 
       if (successfulUploads.length == 0) {

--- a/frontend/src/components/common/Navigation/SettingsDrawer.vue
+++ b/frontend/src/components/common/Navigation/SettingsDrawer.vue
@@ -8,7 +8,7 @@ import type { Events } from "@/types/emitter";
 import { defaultAvatarPath } from "@/utils";
 import { ROUTES } from "@/plugins/router";
 import type { Emitter } from "mitt";
-import { storeToRefs } from "pinia";
+import { storeToRefs, getActivePinia, type StateTree } from "pinia";
 import { inject } from "vue";
 import { useRouter } from "vue-router";
 import { useDisplay } from "vuetify";
@@ -35,8 +35,14 @@ async function logout() {
       icon: "mdi-check-bold",
       color: "green",
     });
-    navigationStore.switchActiveSettingsDrawer();
-    auth.setUser(null);
+
+    // Clear all pinia stores
+    // @ts-expect-error(2339)
+    getActivePinia()?._s.forEach((store: StateTree) => {
+      store.reset?.();
+    });
+
+    // Redirect to login page
     await router.push({ name: ROUTES.LOGIN });
   });
 }

--- a/frontend/src/layouts/Main.vue
+++ b/frontend/src/layouts/Main.vue
@@ -79,7 +79,7 @@ onBeforeMount(async () => {
       });
   }
 
-  navigationStore.resetDrawers();
+  navigationStore.reset();
 });
 </script>
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -18,5 +18,9 @@ export default defineStore("auth", {
     setUser(user: User | null) {
       this.user = user;
     },
+    reset() {
+      this.user = null;
+      this.oauth_scopes = [];
+    },
   },
 });

--- a/frontend/src/stores/collections.ts
+++ b/frontend/src/stores/collections.ts
@@ -10,14 +10,12 @@ export type Collection = CollectionSchema;
 export type VirtualCollection = VirtualCollectionSchema;
 
 export default defineStore("collections", {
-  state: () => {
-    return {
-      allCollections: [] as Collection[],
-      virtualCollections: [] as VirtualCollection[],
-      favCollection: {} as Collection | undefined,
-      searchText: "" as string,
-    };
-  },
+  state: () => ({
+    allCollections: [] as Collection[],
+    virtualCollections: [] as VirtualCollection[],
+    favCollection: {} as Collection | undefined,
+    searchText: "" as string,
+  }),
   getters: {
     filteredCollections: ({ allCollections, searchText }) =>
       allCollections.filter((p) =>
@@ -74,6 +72,12 @@ export default defineStore("collections", {
       collection: Collection | VirtualCollection,
     ): collection is VirtualCollection {
       return (collection as VirtualCollection).id !== undefined;
+    },
+    reset() {
+      this.allCollections = [];
+      this.virtualCollections = [];
+      this.favCollection = undefined;
+      this.searchText = "";
     },
   },
 });

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -10,21 +10,21 @@ type ExclusionTypes =
   | "EXCLUDED_MULTI_PARTS_EXT"
   | "EXCLUDED_MULTI_PARTS_FILES";
 
+const defaultConfig = {
+  EXCLUDED_PLATFORMS: [],
+  EXCLUDED_SINGLE_EXT: [],
+  EXCLUDED_SINGLE_FILES: [],
+  EXCLUDED_MULTI_FILES: [],
+  EXCLUDED_MULTI_PARTS_EXT: [],
+  EXCLUDED_MULTI_PARTS_FILES: [],
+  PLATFORMS_BINDING: {},
+  PLATFORMS_VERSIONS: {},
+} as ConfigResponse;
+
 export default defineStore("config", {
-  state: () => {
-    return {
-      config: {
-        EXCLUDED_PLATFORMS: [] as string[],
-        EXCLUDED_SINGLE_EXT: [] as string[],
-        EXCLUDED_SINGLE_FILES: [] as string[],
-        EXCLUDED_MULTI_FILES: [] as string[],
-        EXCLUDED_MULTI_PARTS_EXT: [] as string[],
-        EXCLUDED_MULTI_PARTS_FILES: [] as string[],
-        PLATFORMS_BINDING: {} as Record<string, string>,
-        PLATFORMS_VERSIONS: {} as Record<string, string>,
-      } as ConfigResponse,
-    };
-  },
+  state: () => ({
+    config: defaultConfig,
+  }),
 
   actions: {
     set(data: ConfigResponse) {
@@ -57,6 +57,9 @@ export default defineStore("config", {
     },
     isExclusionType(type: string): type is ExclusionTypes {
       return Object.keys(this.config).includes(type);
+    },
+    reset() {
+      this.config = defaultConfig;
     },
   },
 });

--- a/frontend/src/stores/download.ts
+++ b/frontend/src/stores/download.ts
@@ -18,7 +18,7 @@ export default defineStore("download", {
     remove(id: number) {
       this.value.splice(this.value.indexOf(id), 1);
     },
-    clear() {
+    reset() {
       this.value = [] as number[];
       this.filesToDownload = [] as RomFileSchema[];
     },

--- a/frontend/src/stores/galleryFilter.ts
+++ b/frontend/src/stores/galleryFilter.ts
@@ -17,30 +17,32 @@ const statusFilters = Object.values(romStatusMap).map((status) => status.text);
 
 export type FilterType = (typeof filters)[number];
 
+const defaultFilterState = {
+  activeFilterDrawer: false,
+  searchText: "",
+  filterPlatforms: [] as Platform[],
+  filterText: "",
+  filters: filters,
+  filterGenres: [] as string[],
+  filterFranchises: [] as string[],
+  filterCollections: [] as string[],
+  filterCompanies: [] as string[],
+  filterAgeRatings: [] as string[],
+  filterStatuses: statusFilters,
+  filterUnmatched: false,
+  filterMatched: false,
+  filterFavourites: false,
+  filterDuplicates: false,
+  selectedGenre: null as string | null,
+  selectedFranchise: null as string | null,
+  selectedCollection: null as string | null,
+  selectedCompany: null as string | null,
+  selectedAgeRating: null as string | null,
+  selectedStatus: null as string | null,
+};
+
 export default defineStore("galleryFilter", {
-  state: () => ({
-    activeFilterDrawer: false,
-    searchText: "",
-    filterPlatforms: [] as Platform[],
-    filterText: "",
-    filters: filters,
-    filterGenres: [] as string[],
-    filterFranchises: [] as string[],
-    filterCollections: [] as string[],
-    filterCompanies: [] as string[],
-    filterAgeRatings: [] as string[],
-    filterStatuses: statusFilters,
-    filterUnmatched: false,
-    filterMatched: false,
-    filterFavourites: false,
-    filterDuplicates: false,
-    selectedGenre: null as string | null,
-    selectedFranchise: null as string | null,
-    selectedCollection: null as string | null,
-    selectedCompany: null as string | null,
-    selectedAgeRating: null as string | null,
-    selectedStatus: null as string | null,
-  }),
+  state: () => defaultFilterState,
 
   actions: {
     switchActiveFilterDrawer() {
@@ -124,16 +126,7 @@ export default defineStore("galleryFilter", {
       );
     },
     reset() {
-      this.filterGenres = [];
-      this.filterFranchises = [];
-      this.filterCollections = [];
-      this.filterCompanies = [];
-      this.selectedGenre = null;
-      this.selectedFranchise = null;
-      this.selectedCollection = null;
-      this.selectedCompany = null;
-      this.selectedAgeRating = null;
-      this.selectedStatus = null;
+      Object.assign(this, defaultFilterState);
     },
   },
 });

--- a/frontend/src/stores/galleryView.ts
+++ b/frontend/src/stores/galleryView.ts
@@ -1,17 +1,17 @@
 import { defineStore } from "pinia";
 
+const defaultGalleryState = {
+  currentView: JSON.parse(localStorage.getItem("currentView") ?? "0") as number,
+  defaultAspectRatioCover: 2 / 3,
+  defaultAspectRatioCollection: 2 / 3,
+  defaultAspectRatioScreenshot: 16 / 9,
+  activeFirmwareDrawer: false,
+  scrolledToTop: false,
+  scroll: 0,
+};
+
 export default defineStore("galleryView", {
-  state: () => ({
-    currentView: JSON.parse(
-      localStorage.getItem("currentView") ?? "0",
-    ) as number,
-    defaultAspectRatioCover: 2 / 3,
-    defaultAspectRatioCollection: 2 / 3,
-    defaultAspectRatioScreenshot: 16 / 9,
-    activeFirmwareDrawer: false,
-    scrolledToTop: false,
-    scroll: 0,
-  }),
+  state: () => defaultGalleryState,
 
   actions: {
     setView(view: number) {
@@ -27,6 +27,9 @@ export default defineStore("galleryView", {
       } else {
         this.setView(this.currentView + 1);
       }
+    },
+    reset() {
+      Object.assign(this, defaultGalleryState);
     },
   },
 });

--- a/frontend/src/stores/heartbeat.ts
+++ b/frontend/src/stores/heartbeat.ts
@@ -5,9 +5,9 @@ import { computed } from "vue";
 export type Heartbeat = HeartbeatResponse;
 
 export default defineStore("heartbeat", {
-  state: () => {
-    return { value: {} as HeartbeatResponse };
-  },
+  state: () => ({
+    value: {} as HeartbeatResponse,
+  }),
 
   actions: {
     set(data: HeartbeatResponse) {
@@ -26,6 +26,9 @@ export default defineStore("heartbeat", {
           disabled: !this.value.METADATA_SOURCES?.MOBY_API_ENABLED,
         },
       ]).value.filter((s) => !s.disabled);
+    },
+    reset() {
+      this.value = {} as HeartbeatResponse;
     },
   },
 });

--- a/frontend/src/stores/language.ts
+++ b/frontend/src/stores/language.ts
@@ -1,25 +1,30 @@
 import { defineStore } from "pinia";
 
+const defaultLanguageState = {
+  defaultLanguage: { value: "en_US", name: "English (USA)" },
+  selectedLanguage: { value: "en_US", name: "English (USA)" },
+  languages: [
+    { value: "en_US", name: "English (USA)" },
+    { value: "en_GB", name: "English (United Kingdom)" },
+    { value: "fr_FR", name: "Français" },
+    { value: "de_DE", name: "Deutsch" },
+    { value: "ru_RU", name: "Русский" },
+    { value: "pt_BR", name: "Português (Brasil)" },
+    { value: "es_ES", name: "Español (España)" },
+    { value: "zh_CN", name: "简体中文 (中国)" },
+    { value: "ko_KR", name: "한국어 (대한민국)" },
+  ].sort((a, b) => a.name.localeCompare(b.name)),
+};
+
 export default defineStore("language", {
-  state: () => ({
-    defaultLanguage: { value: "en_US", name: "English (USA)" },
-    selectedLanguage: { value: "en_US", name: "English (USA)" },
-    languages: [
-      { value: "en_US", name: "English (USA)" },
-      { value: "en_GB", name: "English (United Kingdom)" },
-      { value: "fr_FR", name: "Français" },
-      { value: "de_DE", name: "Deutsch" },
-      { value: "ru_RU", name: "Русский" },
-      { value: "pt_BR", name: "Português (Brasil)" },
-      { value: "es_ES", name: "Español (España)" },
-      { value: "zh_CN", name: "简体中文 (中国)" },
-      { value: "ko_KR", name: "한국어 (대한민국)" },
-    ].sort((a, b) => a.name.localeCompare(b.name)),
-  }),
+  state: () => defaultLanguageState,
 
   actions: {
     setLanguage(lang: { value: string; name: string }) {
       this.selectedLanguage = lang;
+    },
+    reset() {
+      Object.assign(this, defaultLanguageState);
     },
   },
 });

--- a/frontend/src/stores/navigation.ts
+++ b/frontend/src/stores/navigation.ts
@@ -1,14 +1,16 @@
 import { defineStore } from "pinia";
 import { ROUTES } from "@/plugins/router";
 
+const defaultNavigationState = {
+  activePlatformsDrawer: false,
+  activeCollectionsDrawer: false,
+  activeSettingsDrawer: false,
+  activePlatformInfoDrawer: false,
+  activeCollectionInfoDrawer: false,
+};
+
 export default defineStore("navigation", {
-  state: () => ({
-    activePlatformsDrawer: false,
-    activeCollectionsDrawer: false,
-    activeSettingsDrawer: false,
-    activePlatformInfoDrawer: false,
-    activeCollectionInfoDrawer: false,
-  }),
+  state: () => defaultNavigationState,
 
   actions: {
     switchActivePlatformsDrawer() {
@@ -32,23 +34,19 @@ export default defineStore("navigation", {
       this.activeCollectionInfoDrawer = !this.activeCollectionInfoDrawer;
     },
     goHome() {
-      this.resetDrawers();
+      this.reset();
       this.$router.push({ name: ROUTES.HOME });
     },
     goScan() {
-      this.resetDrawers();
+      this.reset();
       this.$router.push({ name: ROUTES.SCAN });
     },
     goSearch() {
-      this.resetDrawers();
+      this.reset();
       this.$router.push({ name: ROUTES.SEARCH });
     },
-    resetDrawers() {
-      this.activePlatformsDrawer = false;
-      this.activeCollectionsDrawer = false;
-      this.activeSettingsDrawer = false;
-      this.activePlatformInfoDrawer = false;
-      this.activeCollectionInfoDrawer = false;
+    reset() {
+      Object.assign(this, defaultNavigationState);
     },
     resetDrawersExcept(drawer: string) {
       this.activePlatformsDrawer =

--- a/frontend/src/stores/notifications.ts
+++ b/frontend/src/stores/notifications.ts
@@ -15,7 +15,7 @@ export default defineStore("notifications", {
         (notification) => notification.id !== id,
       );
     },
-    clear() {
+    reset() {
       this.notifications = [] as SnackbarStatus[];
     },
   },

--- a/frontend/src/stores/platforms.ts
+++ b/frontend/src/stores/platforms.ts
@@ -5,12 +5,11 @@ import { defineStore } from "pinia";
 export type Platform = PlatformSchema;
 
 export default defineStore("platforms", {
-  state: () => {
-    return {
-      allPlatforms: [] as Platform[],
-      searchText: "" as string,
-    };
-  },
+  state: () => ({
+    allPlatforms: [] as Platform[],
+    searchText: "" as string,
+  }),
+
   getters: {
     totalGames: ({ allPlatforms: value }) =>
       value.reduce((count, p) => count + p.rom_count, 0),
@@ -60,6 +59,10 @@ export default defineStore("platforms", {
       return platform && platform.aspect_ratio
         ? parseFloat(eval(platform.aspect_ratio as string))
         : 2 / 3;
+    },
+    reset() {
+      this.allPlatforms = [] as Platform[];
+      this.searchText = "";
     },
   },
 });

--- a/frontend/src/stores/roms.ts
+++ b/frontend/src/stores/roms.ts
@@ -17,23 +17,25 @@ type GalleryFilterStore = ExtractPiniaStoreType<typeof storeGalleryFilter>;
 export type SimpleRom = SimpleRomSchema;
 export type DetailedRom = DetailedRomSchema;
 
+const defaultRomsState = {
+  currentPlatform: null as Platform | null,
+  currentCollection: null as Collection | null,
+  currentVirtualCollection: null as VirtualCollection | null,
+  currentRom: null as DetailedRom | null,
+  allRoms: [] as SimpleRom[],
+  _grouped: [] as SimpleRom[],
+  _filteredIDs: new Set<number>(),
+  _selectedIDs: new Set<number>(),
+  recentRoms: [] as SimpleRom[],
+  continuePlayingRoms: [] as SimpleRom[],
+  lastSelectedIndex: -1,
+  selecting: false,
+  itemsPerBatch: 72,
+  gettingRoms: false,
+};
+
 export default defineStore("roms", {
-  state: () => ({
-    currentPlatform: null as Platform | null,
-    currentCollection: null as Collection | null,
-    currentVirtualCollection: null as VirtualCollection | null,
-    currentRom: null as DetailedRom | null,
-    allRoms: [] as SimpleRom[],
-    _grouped: [] as SimpleRom[],
-    _filteredIDs: new Set<number>(),
-    _selectedIDs: new Set<number>(),
-    recentRoms: [] as SimpleRom[],
-    continuePlayingRoms: [] as SimpleRom[],
-    lastSelectedIndex: -1,
-    selecting: false,
-    itemsPerBatch: 72,
-    gettingRoms: false,
-  }),
+  state: () => defaultRomsState,
 
   getters: {
     filteredRoms: (state) =>
@@ -150,11 +152,7 @@ export default defineStore("roms", {
       roms.forEach((rom) => this._filteredIDs.delete(rom.id));
     },
     reset() {
-      this.allRoms = [];
-      this._grouped = [];
-      this._filteredIDs = new Set<number>();
-      this._selectedIDs = new Set<number>();
-      this.lastSelectedIndex = -1;
+      Object.assign(this, defaultRomsState);
     },
     // Filter roms by gallery filter store state
     setFiltered(roms: SimpleRom[], galleryFilter: GalleryFilterStore) {

--- a/frontend/src/stores/runningTasks.ts
+++ b/frontend/src/stores/runningTasks.ts
@@ -7,5 +7,8 @@ export default defineStore("runningTasks", {
     set(runningTasks: boolean) {
       this.value = runningTasks;
     },
+    reset() {
+      this.value = false;
+    },
   },
 });

--- a/frontend/src/stores/scanning.ts
+++ b/frontend/src/stores/scanning.ts
@@ -1,15 +1,17 @@
 import { defineStore } from "pinia";
 import type { SimpleRom } from "@/stores/roms";
 
+interface ScanningPlatforms {
+  name: string;
+  slug: string;
+  id: number;
+  roms: SimpleRom[];
+}
+
 export default defineStore("scanning", {
   state: () => ({
     scanning: false,
-    scanningPlatforms: [] as {
-      name: string;
-      slug: string;
-      id: number;
-      roms: SimpleRom[];
-    }[],
+    scanningPlatforms: [] as ScanningPlatforms[],
     scanStats: {
       scanned_platforms: 0,
       added_platforms: 0,
@@ -23,6 +25,18 @@ export default defineStore("scanning", {
   actions: {
     set(scanning: boolean) {
       this.scanning = scanning;
+    },
+    reset() {
+      this.scanning = false;
+      this.scanningPlatforms = [] as ScanningPlatforms[];
+      this.scanStats = {
+        scanned_platforms: 0,
+        added_platforms: 0,
+        metadata_platforms: 0,
+        scanned_roms: 0,
+        added_roms: 0,
+        metadata_roms: 0,
+      };
     },
   },
 });

--- a/frontend/src/stores/upload.ts
+++ b/frontend/src/stores/upload.ts
@@ -53,8 +53,8 @@ export default defineStore("upload", {
     clearFinished() {
       this.files = this.files.filter((f) => !f.finished && !f.failed);
     },
-    clearAll() {
-      this.files = [];
+    reset() {
+      this.files = [] as UploadingFile[];
     },
   },
 });

--- a/frontend/src/stores/users.ts
+++ b/frontend/src/stores/users.ts
@@ -33,7 +33,7 @@ export default defineStore("users", {
       });
     },
     reset() {
-      this.allUsers = [];
+      this.allUsers = [] as User[];
     },
   },
 });

--- a/frontend/src/views/GameDetails.vue
+++ b/frontend/src/views/GameDetails.vue
@@ -69,7 +69,7 @@ onBeforeMount(async () => {
   }
 
   const downloadStore = storeDownload();
-  downloadStore.clear();
+  downloadStore.reset();
 });
 
 watch(


### PR DESCRIPTION
## Description

* Unity clearing pinia caches under `reset` command and run on logout
* Run hash calculations in the same background process
  * Rational: it's ok if scans take longer since they calculate hashes, and better to have them available on scan when we start integrating hasheous