### PR TITLE
fix: Custom covers for collections

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,12 +2,12 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.22.9
+  version: 1.22.10
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
     - id: trunk
-      ref: v1.6.6
+      ref: v1.6.7
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -18,25 +18,25 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - markdownlint@0.43.0
-    - eslint@9.18.0
+    - markdownlint@0.44.0
+    - eslint@9.20.1
     - actionlint@1.7.7
     - bandit@1.8.2
-    - black@24.10.0
-    - checkov@3.2.357
+    - black@25.1.0
+    - checkov@3.2.370
     - git-diff-check
-    - isort@5.13.2
-    - mypy@1.14.1
+    - isort@6.0.0
+    - mypy@1.15.0
     - osv-scanner@1.9.2
     - oxipng@9.1.3
-    - prettier@3.4.2
-    - ruff@0.9.3
+    - prettier@3.5.1
+    - ruff@0.9.6
     - shellcheck@0.10.0
     - shfmt@3.6.0
     - svgo@3.3.2
     - taplo@0.9.3
-    - trivy@0.58.2
-    - trufflehog@3.88.2
+    - trivy@0.59.1
+    - trufflehog@3.88.8
     - yamllint@1.35.1
   ignore:
     - linters: [ALL]

--- a/frontend/src/components/common/Collection/Card.vue
+++ b/frontend/src/components/common/Collection/Card.vue
@@ -23,7 +23,7 @@ const props = withDefaults(
     showRomCount: false,
     withLink: false,
     src: "",
-  }
+  },
 );
 
 const galleryViewStore = storeGalleryView();
@@ -37,7 +37,7 @@ const memoizedCovers = ref({
 const collectionCoverImage = computed(() =>
   props.collection.name?.toLowerCase() == "favourites"
     ? getFavoriteCoverImage(props.collection.name)
-    : getCollectionCoverImage(props.collection.name)
+    : getCollectionCoverImage(props.collection.name),
 );
 
 watchEffect(() => {
@@ -122,35 +122,40 @@ const secondSmallCover = computed(() => memoizedCovers.value.small[1]);
         class="image-container"
         :style="{ aspectRatio: galleryViewStore.defaultAspectRatioCollection }"
       >
-      <template v-if="collectionsStore.isVirtualCollection(collection) || !collection.path_cover_large">
-        <div class="split-image first-image">
+        <template
+          v-if="
+            collectionsStore.isVirtualCollection(collection) ||
+            !collection.path_cover_large
+          "
+        >
+          <div class="split-image first-image">
+            <v-img
+              cover
+              :src="firstCover"
+              :lazy-src="firstSmallCover"
+              :aspect-ratio="galleryViewStore.defaultAspectRatioCollection"
+            />
+          </div>
+          <div class="split-image second-image">
+            <v-img
+              cover
+              :src="secondCover"
+              :lazy-src="secondSmallCover"
+              :aspect-ratio="galleryViewStore.defaultAspectRatioCollection"
+            />
+          </div>
+        </template>
+        <template v-else>
           <v-img
             cover
-            :src="firstCover"
-            :lazy-src="firstSmallCover"
+            :src="collection.path_cover_large"
+            :lazy-src="collection.path_cover_small?.toString()"
             :aspect-ratio="galleryViewStore.defaultAspectRatioCollection"
           />
+        </template>
+        <div class="position-absolute append-inner">
+          <slot name="append-inner"></slot>
         </div>
-        <div class="split-image second-image">
-          <v-img
-            cover
-            :src="secondCover"
-            :lazy-src="secondSmallCover"
-            :aspect-ratio="galleryViewStore.defaultAspectRatioCollection"
-          />
-        </div>
-      </template>
-      <template v-else>
-        <v-img
-          cover
-          :src="collection.path_cover_large"
-          :lazy-src="collection.path_cover_small?.toString()"
-          :aspect-ratio="galleryViewStore.defaultAspectRatioCollection"
-        />
-      </template>
-      <div class="position-absolute append-inner">
-        <slot name="append-inner"></slot>
-      </div>
       </div>
       <v-chip
         v-if="showRomCount"

--- a/frontend/src/components/common/Collection/Card.vue
+++ b/frontend/src/components/common/Collection/Card.vue
@@ -23,7 +23,7 @@ const props = withDefaults(
     showRomCount: false,
     withLink: false,
     src: "",
-  },
+  }
 );
 
 const galleryViewStore = storeGalleryView();
@@ -37,7 +37,7 @@ const memoizedCovers = ref({
 const collectionCoverImage = computed(() =>
   props.collection.name?.toLowerCase() == "favourites"
     ? getFavoriteCoverImage(props.collection.name)
-    : getCollectionCoverImage(props.collection.name),
+    : getCollectionCoverImage(props.collection.name)
 );
 
 watchEffect(() => {
@@ -122,6 +122,7 @@ const secondSmallCover = computed(() => memoizedCovers.value.small[1]);
         class="image-container"
         :style="{ aspectRatio: galleryViewStore.defaultAspectRatioCollection }"
       >
+      <template v-if="collectionsStore.isVirtualCollection(collection) || !collection.path_cover_large">
         <div class="split-image first-image">
           <v-img
             cover
@@ -138,6 +139,18 @@ const secondSmallCover = computed(() => memoizedCovers.value.small[1]);
             :aspect-ratio="galleryViewStore.defaultAspectRatioCollection"
           />
         </div>
+      </template>
+      <template v-else>
+        <v-img
+          cover
+          :src="collection.path_cover_large"
+          :lazy-src="collection.path_cover_small?.toString()"
+          :aspect-ratio="galleryViewStore.defaultAspectRatioCollection"
+        />
+      </template>
+      <div class="position-absolute append-inner">
+        <slot name="append-inner"></slot>
+      </div>
       </div>
       <v-chip
         v-if="showRomCount"
@@ -169,5 +182,10 @@ const secondSmallCover = computed(() => memoizedCovers.value.small[1]);
 .first-image {
   clip-path: polygon(0 0, 100% 0, 0% 100%, 0 100%);
   z-index: 1;
+}
+
+.append-inner {
+  bottom: 0rem;
+  right: 0rem;
 }
 </style>

--- a/frontend/src/components/common/Collection/Card.vue
+++ b/frontend/src/components/common/Collection/Card.vue
@@ -2,6 +2,7 @@
 import type { Collection, VirtualCollection } from "@/stores/collections";
 import storeGalleryView from "@/stores/galleryView";
 import storeCollections from "@/stores/collections";
+import { ROUTES } from "@/plugins/router";
 import { computed, ref, watchEffect } from "vue";
 import { getCollectionCoverImage, getFavoriteCoverImage } from "@/utils/covers";
 
@@ -100,7 +101,10 @@ const secondSmallCover = computed(() => memoizedCovers.value.small[1]);
         ...hoverProps,
         ...(withLink && collection
           ? {
-              to: { name: 'collection', params: { collection: collection.id } },
+              to: {
+                name: ROUTES.COLLECTION,
+                params: { collection: collection.id },
+              },
             }
           : {}),
       }"

--- a/frontend/src/components/common/Collection/ListItem.vue
+++ b/frontend/src/components/common/Collection/ListItem.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Collection, VirtualCollection } from "@/stores/collections";
 import RAvatar from "@/components/common/Collection/RAvatar.vue";
+import { ROUTES } from "@/plugins/router";
 
 // Props
 withDefaults(
@@ -26,7 +27,10 @@ withDefaults(
     v-bind="{
       ...(withLink && collection
         ? {
-            to: { name: 'collection', params: { collection: collection.id } },
+            to: {
+              name: ROUTES.COLLECTION,
+              params: { collection: collection.id },
+            },
           }
         : {}),
     }"

--- a/frontend/src/components/common/Collection/RAvatar.vue
+++ b/frontend/src/components/common/Collection/RAvatar.vue
@@ -74,22 +74,32 @@ const secondSmallCover = computed(() => memoizedCovers.value.small[1]);
 <template>
   <v-avatar :rounded="0" :size="size">
     <div class="image-container" :style="{ aspectRatio: 1 / 1 }">
-      <div class="split-image first-image">
+      <template v-if="collectionsStore.isVirtualCollection(collection) || !collection.path_cover_large">
+        <div class="split-image first-image">
+          <v-img
+            cover
+            :src="firstCover"
+            :lazy-src="firstSmallCover"
+            :aspect-ratio="1 / 1"
+          />
+        </div>
+        <div class="split-image second-image">
+          <v-img
+            cover
+            :src="secondCover"
+            :lazy-src="secondSmallCover"
+            :aspect-ratio="1 / 1"
+          />
+        </div>
+      </template>
+      <template v-else>
         <v-img
           cover
-          :src="firstCover"
-          :lazy-src="firstSmallCover"
+          :src="collection.path_cover_large"
+          :lazy-src="collection.path_cover_small?.toString()"
           :aspect-ratio="1 / 1"
         />
-      </div>
-      <div class="split-image second-image">
-        <v-img
-          cover
-          :src="secondCover"
-          :lazy-src="secondSmallCover"
-          :aspect-ratio="1 / 1"
-        />
-      </div>
+      </template>
     </div>
   </v-avatar>
 </template>

--- a/frontend/src/components/common/Collection/RAvatar.vue
+++ b/frontend/src/components/common/Collection/RAvatar.vue
@@ -74,7 +74,12 @@ const secondSmallCover = computed(() => memoizedCovers.value.small[1]);
 <template>
   <v-avatar :rounded="0" :size="size">
     <div class="image-container" :style="{ aspectRatio: 1 / 1 }">
-      <template v-if="collectionsStore.isVirtualCollection(collection) || !collection.path_cover_large">
+      <template
+        v-if="
+          collectionsStore.isVirtualCollection(collection) ||
+          !collection.path_cover_large
+        "
+      >
         <div class="split-image first-image">
           <v-img
             cover

--- a/frontend/src/components/common/Game/Card/Base.vue
+++ b/frontend/src/components/common/Game/Card/Base.vue
@@ -8,6 +8,7 @@ import PlatformIcon from "@/components/common/Platform/Icon.vue";
 import storeCollections from "@/stores/collections";
 import storeDownload from "@/stores/download";
 import storeGalleryView from "@/stores/galleryView";
+import { ROUTES } from "@/plugins/router";
 import storeRoms from "@/stores/roms";
 import { type SimpleRom } from "@/stores/roms";
 import { computed } from "vue";
@@ -92,7 +93,7 @@ const fallbackCoverImage = computed(() =>
         ...hoverProps,
         ...(withLink && rom && romsStore.isSimpleRom(rom)
           ? {
-              to: { name: 'rom', params: { rom: rom.id } },
+              to: { name: ROUTES.ROM, params: { rom: rom.id } },
             }
           : {}),
       }"

--- a/frontend/src/components/common/Game/ListItem.vue
+++ b/frontend/src/components/common/Game/ListItem.vue
@@ -2,6 +2,7 @@
 import type { SimpleRom } from "@/stores/roms";
 import RAvatarRom from "@/components/common/Game/RAvatar.vue";
 import { formatBytes } from "@/utils";
+import { ROUTES } from "@/plugins/router";
 
 // Props
 withDefaults(
@@ -27,7 +28,7 @@ withDefaults(
     v-bind="{
       ...(withLink && rom
         ? {
-            to: { name: 'rom', params: { rom: rom.id } },
+            to: { name: ROUTES.ROM, params: { rom: rom.id } },
           }
         : {}),
     }"

--- a/frontend/src/components/common/Game/Table.vue
+++ b/frontend/src/components/common/Game/Table.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import PlatformIcon from "@/components/common/Platform/Icon.vue";
 import AdminMenu from "@/components/common/Game/AdminMenu.vue";
 import FavBtn from "@/components/common/Game/FavBtn.vue";
 import RAvatarRom from "@/components/common/Game/RAvatar.vue";
@@ -22,6 +23,14 @@ import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
 
 // Props
+withDefaults(
+  defineProps<{
+    showPlatformIcon?: boolean;
+  }>(),
+  {
+    showPlatformIcon: false,
+  },
+);
 const showSiblings = isNull(localStorage.getItem("settings.showSiblings"))
   ? true
   : localStorage.getItem("settings.showSiblings") === "true";
@@ -162,6 +171,12 @@ function updateSelectedRom(rom: SimpleRom) {
       <td>
         <v-list-item :min-width="400" class="px-0 py-2">
           <template #prepend>
+            <platform-icon
+              class="mr-4"
+              size="30"
+              v-if="showPlatformIcon"
+              :slug="item.platform_slug"
+            />
             <r-avatar-rom :rom="item" />
           </template>
           <v-row no-gutters>

--- a/frontend/src/components/common/Game/Table.vue
+++ b/frontend/src/components/common/Game/Table.vue
@@ -173,7 +173,7 @@ function updateSelectedRom(rom: SimpleRom) {
           <template #prepend>
             <platform-icon
               class="mr-4"
-              size="30"
+              :size="30"
               v-if="showPlatformIcon"
               :slug="item.platform_slug"
             />

--- a/frontend/src/components/common/Game/Table.vue
+++ b/frontend/src/components/common/Game/Table.vue
@@ -168,40 +168,40 @@ function updateSelectedRom(rom: SimpleRom) {
       />
     </template>
     <template #item.name="{ item }">
-      <td>
-        <v-list-item :min-width="400" class="px-0 py-2">
-          <template #prepend>
-            <platform-icon
-              class="mr-4"
-              :size="30"
-              v-if="showPlatformIcon"
-              :slug="item.platform_slug"
-            />
-            <r-avatar-rom :rom="item" />
-          </template>
-          <v-row no-gutters>
-            <v-col>{{ item.name }}</v-col>
-          </v-row>
-          <v-row no-gutters>
-            <v-col class="text-primary">
-              {{ item.fs_name }}
-            </v-col>
-          </v-row>
-          <template #append>
-            <v-chip
-              v-if="
-                item.sibling_roms &&
-                item.sibling_roms.length > 0 &&
-                showSiblings
-              "
-              class="translucent-dark ml-4"
-              size="x-small"
-            >
-              <span class="text-caption">+{{ item.sibling_roms.length }}</span>
-            </v-chip>
-          </template>
-        </v-list-item>
-      </td>
+      <v-list-item
+        :min-width="400"
+        class="px-0 py-2"
+        :to="{ name: ROUTES.ROM, params: { rom: item.id } }"
+      >
+        <template #prepend>
+          <platform-icon
+            class="mr-4"
+            :size="30"
+            v-if="showPlatformIcon"
+            :slug="item.platform_slug"
+          />
+          <r-avatar-rom :rom="item" />
+        </template>
+        <v-row no-gutters>
+          <v-col>{{ item.name }}</v-col>
+        </v-row>
+        <v-row no-gutters>
+          <v-col class="text-primary">
+            {{ item.fs_name }}
+          </v-col>
+        </v-row>
+        <template #append>
+          <v-chip
+            v-if="
+              item.sibling_roms && item.sibling_roms.length > 0 && showSiblings
+            "
+            class="translucent-dark ml-4"
+            size="x-small"
+          >
+            <span class="text-caption">+{{ item.sibling_roms.length }}</span>
+          </v-chip>
+        </template>
+      </v-list-item>
     </template>
     <template #item.fs_size_bytes="{ item }">
       <span class="text-no-wrap">{{ formatBytes(item.fs_size_bytes) }}</span>

--- a/frontend/src/stores/collections.ts
+++ b/frontend/src/stores/collections.ts
@@ -73,7 +73,13 @@ export default defineStore("collections", {
     isVirtualCollection(
       collection: Collection | VirtualCollection,
     ): collection is VirtualCollection {
-      return (collection as VirtualCollection).id !== undefined;
+      return (
+        collection &&
+        typeof collection === "object" &&
+        "id" in collection &&
+        "name" in collection &&
+        "virtual" in collection
+      );
     },
   },
 });

--- a/frontend/src/views/Gallery/Collection.vue
+++ b/frontend/src/views/Gallery/Collection.vue
@@ -392,7 +392,7 @@ onBeforeUnmount(() => {
         <!-- Gallery list view -->
         <v-row class="h-100" v-show="currentView == 2" no-gutters>
           <v-col class="h-100 pt-4 pb-2">
-            <game-data-table class="h-100 mx-2" />
+            <game-data-table show-platform-icon class="h-100 mx-2" />
           </v-col>
         </v-row>
         <fab-overlay />


### PR DESCRIPTION
## Description

Add again the ability to set custom covers for collections that were removed in #1562.
Also added the platform icon in the list view of a collection

## Checklist

Please check all that apply.

- [x] I've tested the changes locally
- [x] I've updated the wiki accordingly
- [x] I've have updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
- [x] All existing tests are passing

## Screenshots

![image](https://github.com/user-attachments/assets/2952a473-bc40-4619-9d22-fcdb01a924ff)

