### PR TITLE
[ROMM-1616] Support custom icons for platform versions

### DIFF
--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -258,7 +258,7 @@ async def _identify_platform(
     await socket_manager.emit(
         "scan:scanning_platform",
         PlatformSchema.model_validate(platform).model_dump(
-            include={"id", "name", "slug"}
+            include={"id", "name", "slug", "fs_slug"}
         ),
     )
     await socket_manager.emit("", None)
@@ -512,6 +512,7 @@ async def _identify_rom(
         {
             "platform_name": platform.name,
             "platform_slug": platform.slug,
+            "platform_fs_slug": platform.fs_slug,
             **SimpleRomSchema.from_orm_with_factory(_added_rom).model_dump(
                 exclude={"created_at", "updated_at", "rom_user"}
             ),

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -71,6 +71,7 @@ async def scan_platform(
 
     cnfg = cm.get_config()
     swapped_platform_bindings = {v: k for k, v in cnfg.PLATFORMS_BINDING.items()}
+    swapped_platform_versions = {v: k for k, v in cnfg.PLATFORMS_VERSIONS.items()}
 
     # Sometimes users change the name of the folder, so we try to match it with the config
     if fs_slug not in fs_platforms:
@@ -81,10 +82,16 @@ async def scan_platform(
             platform = db_platform_handler.get_platform_by_fs_slug(fs_slug)
             if platform:
                 platform_attrs["fs_slug"] = swapped_platform_bindings[platform.slug]
+        elif fs_slug in swapped_platform_versions.keys():
+            platform = db_platform_handler.get_platform_by_fs_slug(fs_slug)
+            if platform:
+                platform_attrs["fs_slug"] = swapped_platform_versions[platform.slug]
 
     try:
         if fs_slug in cnfg.PLATFORMS_BINDING.keys():
             platform_attrs["slug"] = cnfg.PLATFORMS_BINDING[fs_slug]
+        elif fs_slug in cnfg.PLATFORMS_VERSIONS.keys():
+            platform_attrs["slug"] = cnfg.PLATFORMS_VERSIONS[fs_slug]
         else:
             platform_attrs["slug"] = fs_slug
     except (KeyError, TypeError, AttributeError):

--- a/frontend/src/components/Details/Title.vue
+++ b/frontend/src/components/Details/Title.vue
@@ -48,6 +48,7 @@ const hasReleaseDate = Number(props.rom.first_release_date) > 0;
             :key="rom.platform_slug"
             :slug="rom.platform_slug"
             :name="rom.platform_name"
+            :fs-slug="rom.platform_fs_slug"
             :size="30"
             class="ml-2"
           />

--- a/frontend/src/components/Gallery/AppBar/Platform/Base.vue
+++ b/frontend/src/components/Gallery/AppBar/Platform/Base.vue
@@ -36,6 +36,7 @@ const { activePlatformInfoDrawer } = storeToRefs(navigationStore);
       v-if="currentPlatform"
       :slug="currentPlatform.slug"
       :name="currentPlatform.name"
+      :fs-slug="currentPlatform.fs_slug"
       :size="36"
       class="mx-3 cursor-pointer platform-icon"
       :class="{ active: activePlatformInfoDrawer }"

--- a/frontend/src/components/Gallery/AppBar/Platform/PlatformInfoDrawer.vue
+++ b/frontend/src/components/Gallery/AppBar/Platform/PlatformInfoDrawer.vue
@@ -222,6 +222,7 @@ watch(
           <platform-icon
             :slug="currentPlatform.slug"
             :name="currentPlatform.name"
+            :fs-slug="currentPlatform.fs_slug"
             class="platform-icon"
             :size="160"
           />

--- a/frontend/src/components/Gallery/AppBar/Search/PlatformSelector.vue
+++ b/frontend/src/components/Gallery/AppBar/Search/PlatformSelector.vue
@@ -109,6 +109,7 @@ function clearFilter() {
             :key="item.raw.slug"
             :slug="item.raw.slug"
             :name="item.raw.display_name"
+            :fs-slug="item.raw.fs_slug"
           />
         </template>
       </v-list-item>
@@ -121,6 +122,7 @@ function clearFilter() {
             :key="item.raw.slug"
             :slug="item.raw.slug"
             :name="item.raw.display_name"
+            :fs-slug="item.raw.fs_slug"
           />
         </template>
       </v-list-item>

--- a/frontend/src/components/Settings/LibraryManagement/Dialog/CreatePlatformBinding.vue
+++ b/frontend/src/components/Settings/LibraryManagement/Dialog/CreatePlatformBinding.vue
@@ -138,6 +138,7 @@ function closeDialog() {
                     :size="35"
                     :slug="item.raw.slug"
                     :name="item.raw.name"
+                    :fs-slug="item.raw.fs_slug"
                   />
                 </template>
               </v-list-item>
@@ -150,6 +151,7 @@ function closeDialog() {
                     :key="item.raw.slug"
                     :slug="item.raw.slug"
                     :name="item.raw.name"
+                    :fs-slug="item.raw.fs_slug"
                   />
                 </template>
               </v-list-item>

--- a/frontend/src/components/Settings/LibraryManagement/Dialog/CreatePlatformVersion.vue
+++ b/frontend/src/components/Settings/LibraryManagement/Dialog/CreatePlatformVersion.vue
@@ -139,6 +139,7 @@ function closeDialog() {
                     :size="35"
                     :slug="item.raw.slug"
                     :name="item.raw.name"
+                    :fs-slug="item.raw.fs_slug"
                   />
                 </template>
               </v-list-item>
@@ -151,6 +152,7 @@ function closeDialog() {
                     :key="item.raw.slug"
                     :slug="item.raw.slug"
                     :name="item.raw.name"
+                    :fs-slug="item.raw.fs_slug"
                   />
                 </template>
               </v-list-item>

--- a/frontend/src/components/Settings/LibraryManagement/Dialog/DeletePlatformBinding.vue
+++ b/frontend/src/components/Settings/LibraryManagement/Dialog/DeletePlatformBinding.vue
@@ -56,6 +56,7 @@ function closeDialog() {
           class="mx-2"
           :key="platformBindingSlugToDelete"
           :slug="platformBindingSlugToDelete"
+          :fs-slug="platformBindingFSSlugToDelete"
         />
         <span>[</span>
         <span class="text-primary ml-1">

--- a/frontend/src/components/Settings/LibraryManagement/Dialog/DeletePlatformVersion.vue
+++ b/frontend/src/components/Settings/LibraryManagement/Dialog/DeletePlatformVersion.vue
@@ -53,7 +53,12 @@ function closeDialog() {
     <template #content>
       <v-row class="justify-center pa-2 align-center" no-gutters>
         <span class="mr-1">Deleting platform binding</span>
-        <platform-icon class="mx-2" :key="slugToDelete" :slug="slugToDelete" />
+        <platform-icon
+          class="mx-2"
+          :key="slugToDelete"
+          :slug="slugToDelete"
+          :fs-slug="fsSlugToDelete"
+        />
         <span>[</span>
         <span class="text-primary ml-1"> {{ fsSlugToDelete }}</span>
         <span class="mx-1">:</span>

--- a/frontend/src/components/Settings/LibraryManagement/PlatformBindCard.vue
+++ b/frontend/src/components/Settings/LibraryManagement/PlatformBindCard.vue
@@ -18,7 +18,12 @@ defineProps<{
     <v-card-text class="pa-1">
       <v-list-item class="bg-toplayer pa-1 text-truncate">
         <template #prepend>
-          <platform-icon class="mx-2" :key="slug" :slug="slug" />
+          <platform-icon
+            class="mx-2"
+            :key="slug"
+            :slug="slug"
+            :fs-slug="fsSlug"
+          />
         </template>
         <v-list-item class="bg-background pr-2 pl-2">
           <span>{{ fsSlug }}</span>

--- a/frontend/src/components/common/Game/Card/Base.vue
+++ b/frontend/src/components/common/Game/Card/Base.vue
@@ -173,6 +173,7 @@ const fallbackCoverImage = computed(() =>
                 :key="rom.platform_slug"
                 :slug="rom.platform_slug"
                 :name="rom.platform_name"
+                :fs-slug="rom.platform_slug"
                 class="label-platform"
               />
             </div>

--- a/frontend/src/components/common/Game/Dialog/UploadRom.vue
+++ b/frontend/src/components/common/Game/Dialog/UploadRom.vue
@@ -190,10 +190,11 @@ function closeDialog() {
               >
                 <template #prepend>
                   <platform-icon
-                    :key="item.raw.slug"
                     :size="35"
-                    :slug="item.raw.slug"
+                    :key="item.raw.slug"
                     :name="item.raw.name"
+                    :slug="item.raw.slug"
+                    :fs-slug="item.raw.fs_slug"
                   />
                 </template>
               </v-list-item>
@@ -206,6 +207,7 @@ function closeDialog() {
                     :key="item.raw.slug"
                     :slug="item.raw.slug"
                     :name="item.raw.name"
+                    :fs-slug="item.raw.fs_slug"
                   />
                 </template>
               </v-list-item>

--- a/frontend/src/components/common/Navigation/ScanBtn.vue
+++ b/frontend/src/components/common/Navigation/ScanBtn.vue
@@ -33,12 +33,22 @@ if (!socket.connected) socket.connect();
 
 socket.on(
   "scan:scanning_platform",
-  ({ name, slug, id }: { name: string; slug: string; id: number }) => {
+  ({
+    name,
+    slug,
+    id,
+    fs_slug,
+  }: {
+    name: string;
+    slug: string;
+    id: number;
+    fs_slug: string;
+  }) => {
     scanningStore.set(true);
     scanningPlatforms.value = scanningPlatforms.value.filter(
       (platform) => platform.name !== name,
     );
-    scanningPlatforms.value.push({ name, slug, id, roms: [] });
+    scanningPlatforms.value.push({ name, slug, id, fs_slug, roms: [] });
   },
 );
 
@@ -63,6 +73,7 @@ socket.on("scan:scanning_rom", (rom: SimpleRom) => {
       name: rom.platform_name,
       slug: rom.platform_slug,
       id: rom.platform_id,
+      fs_slug: rom.platform_fs_slug,
       roms: [],
     });
     scannedPlatform = scanningPlatforms.value[0];

--- a/frontend/src/components/common/Navigation/SettingsDrawer.vue
+++ b/frontend/src/components/common/Navigation/SettingsDrawer.vue
@@ -115,7 +115,7 @@ async function logout() {
         append-icon="mdi-security"
         >{{ t("common.administration") }}
       </v-list-item>
-      <template v-if="smAndDown && scopes.includes('me.write')" #append>
+      <template v-if="smAndDown && scopes.includes('me.write')">
         <v-list-item
           @click="logout"
           append-icon="mdi-location-exit"
@@ -125,7 +125,7 @@ async function logout() {
         >
       </template>
     </v-list>
-    <template v-if="!smAndDown && scopes.includes('me.write')">
+    <template v-if="!smAndDown && scopes.includes('me.write')" #append>
       <v-list class="pa-0">
         <v-list-item
           @click="logout"

--- a/frontend/src/components/common/Platform/Card.vue
+++ b/frontend/src/components/common/Platform/Card.vue
@@ -29,6 +29,7 @@ defineProps<{ platform: Platform }>();
             :key="platform.slug"
             :slug="platform.slug"
             :name="platform.name"
+            :fs-slug="platform.fs_slug"
             :size="105"
             class="mt-2"
           />

--- a/frontend/src/components/common/Platform/Dialog/DeletePlatform.vue
+++ b/frontend/src/components/common/Platform/Dialog/DeletePlatform.vue
@@ -71,7 +71,11 @@ function closeDialog() {
     <template #content>
       <v-row class="justify-center align-center pa-2" no-gutters>
         <span class="mr-1">{{ t("platform.removing-platform-1") }}</span>
-        <platform-icon :slug="platform.slug" :name="platform.name" />
+        <platform-icon
+          :slug="platform.slug"
+          :name="platform.name"
+          :fs-slug="platform.fs_slug"
+        />
         <span class="ml-1"
           >{{ platform.name }} - [<span class="text-primary">{{
             platform.fs_slug

--- a/frontend/src/components/common/Platform/Icon.vue
+++ b/frontend/src/components/common/Platform/Icon.vue
@@ -1,28 +1,22 @@
 <script setup lang="ts">
-import storeConfig from "@/stores/config";
-import { storeToRefs } from "pinia";
-
 const props = withDefaults(
   defineProps<{
     slug: string;
     name?: string;
     size?: number;
     rounded?: number;
+    fsSlug?: string;
   }>(),
   { size: 40, rounded: 0 },
 );
-const configStore = storeConfig();
-const { config } = storeToRefs(configStore);
+
+console.log(props);
 </script>
 
 <template>
   <v-avatar :size="size" :rounded="rounded" :title="name || slug">
     <v-img
-      :src="
-        config.PLATFORMS_VERSIONS?.[props.slug]?.toLowerCase()
-          ? `/assets/platforms/${config.PLATFORMS_VERSIONS?.[props.slug]?.toLowerCase()}.ico`
-          : `/assets/platforms/${props.slug.toLowerCase()}.ico`
-      "
+      :src="`/assets/platforms/${(props.fsSlug || props.slug).toLowerCase()}.ico`"
     >
       <template #error>
         <v-img :src="`/assets/platforms/${props.slug.toLowerCase()}.ico`">

--- a/frontend/src/components/common/Platform/Icon.vue
+++ b/frontend/src/components/common/Platform/Icon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const props = withDefaults(
+withDefaults(
   defineProps<{
     slug: string;
     name?: string;
@@ -9,17 +9,13 @@ const props = withDefaults(
   }>(),
   { size: 40, rounded: 0 },
 );
-
-console.log(props);
 </script>
 
 <template>
   <v-avatar :size="size" :rounded="rounded" :title="name || slug">
-    <v-img
-      :src="`/assets/platforms/${(props.fsSlug || props.slug).toLowerCase()}.ico`"
-    >
+    <v-img :src="`/assets/platforms/${(fsSlug || slug).toLowerCase()}.ico`">
       <template #error>
-        <v-img :src="`/assets/platforms/${props.slug.toLowerCase()}.ico`">
+        <v-img :src="`/assets/platforms/${slug.toLowerCase()}.ico`">
           <template #error>
             <v-img src="/assets/platforms/default.ico"></v-img>
           </template>

--- a/frontend/src/components/common/Platform/ListItem.vue
+++ b/frontend/src/components/common/Platform/ListItem.vue
@@ -23,6 +23,7 @@ withDefaults(defineProps<{ platform: Platform; rail?: boolean }>(), {
         :key="platform.slug"
         :slug="platform.slug"
         :name="platform.name"
+        :fs-slug="platform.fs_slug"
         :size="40"
       >
         <v-tooltip

--- a/frontend/src/stores/scanning.ts
+++ b/frontend/src/stores/scanning.ts
@@ -4,6 +4,7 @@ import type { SimpleRom } from "@/stores/roms";
 interface ScanningPlatforms {
   name: string;
   slug: string;
+  fs_slug: string;
   id: number;
   roms: SimpleRom[];
 }

--- a/frontend/src/views/Scan.vue
+++ b/frontend/src/views/Scan.vue
@@ -140,6 +140,7 @@ async function stopScan() {
                 :size="35"
                 :slug="item.raw.slug"
                 :name="item.raw.name"
+                :fs-slug="item.raw.fs_slug"
               />
             </template>
             <template #append>
@@ -155,6 +156,7 @@ async function stopScan() {
               :key="item.raw.slug"
               :slug="item.raw.slug"
               :name="item.raw.name"
+              :fs-slug="item.raw.fs_slug"
               :size="20"
               class="mr-2"
             />
@@ -309,6 +311,7 @@ async function stopScan() {
                     :key="platform.slug"
                     :slug="platform.slug"
                     :name="platform.name"
+                    :fs-slug="platform.fs_slug"
                   />
                 </v-avatar>
               </template>


### PR DESCRIPTION
# Pull request template

## Description

When using PLATFORM_VERSIONS, this PR sets the `platform.slug` to the "real" metadata slug, instead of the `fs_slug`. It also updates the `platform-icon` component to try and load the `fs_slug` first, then fallback to the `slug`, then finally the default icon. All of this allows us to display the custom `.ico` for bindings and versions, while allowing users to play the system with emulatorjs. Also fixes the logout button visibility on mobile.

## Screenshots

<img width="241" alt="Screenshot 2025-02-16 at 11 53 20 AM" src="https://github.com/user-attachments/assets/4bf53a96-f29d-4114-84f3-43fa15077270" />
