### PR TITLE
fix: Partial metadata scan

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -645,12 +645,12 @@ async def update_rom(
         await fs_resource_handler.manual_exists(rom)
     ):
         cleaned_data.update({"url_manual": data.get("url_manual", rom.url_manual)})
-        url_manual = await fs_resource_handler.get_manual(
+        path_manual = await fs_resource_handler.get_manual(
             rom=rom,
             overwrite=True,
             url_manual=str(data.get("url_manual") or ""),
         )
-        cleaned_data.update({"url_manual": url_manual})
+        cleaned_data.update({"path_manual": path_manual})
 
     log.debug(
         f"Updating {hl(cleaned_data.get('name', ''))} [{id}] with data {cleaned_data}"

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -125,14 +125,8 @@ def _should_scan_rom(scan_type: ScanType, rom: Rom | None, roms_ids: list[str]) 
         or (
             rom
             and (
-                (
-                    scan_type == ScanType.UNIDENTIFIED
-                    and not (rom.igdb_id or rom.moby_id)
-                )
-                or (
-                    scan_type == ScanType.PARTIAL
-                    and (not rom.igdb_id or not rom.moby_id)
-                )
+                (scan_type == ScanType.UNIDENTIFIED and rom.is_unidentified)
+                or (scan_type == ScanType.PARTIAL and rom.is_partially_identified)
                 or (rom.id in roms_ids)
             )
         )

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -287,6 +287,16 @@ async def scan_rom(
             return await meta_igdb_handler.get_rom(
                 rom_attrs["fs_name"], main_platform_igdb_id or platform.igdb_id
             )
+        elif rom and scan_type == ScanType.PARTIAL and rom.igdb_id:
+            return IGDBRom(
+                igdb_id=rom.igdb_id,
+                slug=rom.slug,
+                name=rom.name,
+                summary=rom.summary,
+                url_cover=rom.url_cover,
+                url_screenshots=rom.url_screenshots,
+                igdb_metadata=rom.igdb_metadata,
+            )
 
         return IGDBRom(igdb_id=None)
 
@@ -304,6 +314,16 @@ async def scan_rom(
             return await meta_moby_handler.get_rom(
                 rom_attrs["fs_name"], platform_moby_id=platform.moby_id
             )
+        elif rom and scan_type == ScanType.PARTIAL and rom.moby_id:
+            return MobyGamesRom(
+                moby_id=rom.moby_id,
+                slug=rom.slug,
+                name=rom.name,
+                summary=rom.summary,
+                url_cover=rom.url_cover,
+                url_screenshots=rom.url_screenshots,
+                moby_metadata=rom.moby_metadata,
+            )
 
         return MobyGamesRom(moby_id=None)
 
@@ -320,6 +340,17 @@ async def scan_rom(
         ):
             return await meta_ss_handler.get_rom(
                 rom_attrs["fs_name"], platform_ss_id=platform.ss_id
+            )
+        elif rom and scan_type == ScanType.PARTIAL and rom.ss_id:
+            return SSRom(
+                ss_id=rom.ss_id,
+                slug=rom.slug,
+                name=rom.name,
+                summary=rom.summary,
+                url_cover=rom.url_cover,
+                url_manual=rom.url_manual,
+                url_screenshots=rom.url_screenshots,
+                ss_metadata=rom.ss_metadata,
             )
 
         return SSRom(ss_id=None)

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -211,10 +211,6 @@ class Rom(BaseModel):
             else ""
         )
 
-    @property
-    def is_unidentified(self) -> bool:
-        return not self.igdb_id and not self.moby_id
-
     # Metadata fields
     @property
     def youtube_video_id(self) -> str:
@@ -306,6 +302,18 @@ class Rom(BaseModel):
         if self.igdb_metadata:
             return [r["rating"] for r in self.igdb_metadata.get("age_ratings", [])]
         return []
+
+    @property
+    def is_unidentified(self) -> bool:
+        return not self.igdb_id and not self.moby_id and not self.ss_id
+
+    @property
+    def is_partially_identified(self) -> bool:
+        return not self.is_unidentified and not self.is_fully_identified
+
+    @property
+    def is_fully_identified(self) -> bool:
+        return self.igdb_id and self.moby_id and self.ss_id
 
     def __repr__(self) -> str:
         return self.fs_name

--- a/frontend/src/components/Gallery/FabOverlay.vue
+++ b/frontend/src/components/Gallery/FabOverlay.vue
@@ -52,7 +52,7 @@ async function onScan() {
   socket.emit("scan", {
     platforms: [Number(route.params.platform)],
     roms_ids: romsStore.selectedRoms.map((r) => r.id),
-    type: "quick", // Quick scan so we can filter by selected roms
+    type: "partial", // Quick scan so we can filter by selected roms
     apis: heartbeat.getMetadataOptions().map((s) => s.value),
   });
 }
@@ -180,7 +180,7 @@ function onDownload() {
         <v-icon color="romm-red"> mdi-delete </v-icon>
       </v-btn>
       <v-btn
-        title="Scan roms"
+        title="Refresh metadata"
         key="2"
         v-if="auth.scopes.includes('roms.write')"
         color="toplayer"

--- a/frontend/src/components/common/Game/AdminMenu.vue
+++ b/frontend/src/components/common/Game/AdminMenu.vue
@@ -131,7 +131,7 @@ async function onScan() {
   socket.emit("scan", {
     platforms: [props.rom.platform_id],
     roms_ids: [props.rom.id],
-    type: "quick", // Quick scan so we can filter by selected roms
+    type: "partial", // Quick scan so we can filter by selected roms
     apis: heartbeat.getMetadataOptions().map((s) => s.value),
   });
 }


### PR DESCRIPTION
## Description

This PR fixes the partial metadata scan. If any of the sources already have metadata it will remain in the database.

Also, the ``refresh metadata`` option (in rom admin menu and fab menu) is considered as ``partial-metadata`` scan to refres metadata from any source that doesn't have metadata

## Checklist

Please check all that apply.

- [x] I've tested the changes locally
- [x] I've updated the wiki accordingly
- [x] I've have updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
- [x] All existing tests are passing
