### PR TITLE
misc: Add support for WEB_CONCURRENCY environment variable

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -16,7 +16,6 @@ def str_to_bool(value: str) -> bool:
 DEV_MODE: Final = str_to_bool(os.environ.get("DEV_MODE", "false"))
 DEV_HOST: Final = os.environ.get("DEV_HOST", "127.0.0.1")
 DEV_PORT: Final = int(os.environ.get("DEV_PORT", "5000"))
-GUNICORN_WORKERS: Final = int(os.environ.get("GUNICORN_WORKERS", 2))
 
 # PATHS
 ROMM_BASE_PATH: Final = os.environ.get("ROMM_BASE_PATH", "/romm")

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -19,12 +19,14 @@ debug_log() {
 	fi
 }
 
-# print debug log output if enabled
 info_log() {
 	echo "INFO:     [init][$(date +"%Y-%m-%d %T")]" "${@}" || true
 }
 
-# print error log output if enabled
+warn_log() {
+	echo "WARNING:  [init][$(date +"%Y-%m-%d %T")]" "${@}" || true
+}
+
 error_log() {
 	echo "ERROR:    [init][$(date +"%Y-%m-%d %T")]" "${@}" || true
 	exit 1
@@ -45,6 +47,13 @@ start_bin_gunicorn() {
 
 	# commands to start our main application and store its PID to check for crashes
 	info_log "starting gunicorn"
+
+	# TODO: Remove support for GUNICORN_WORKERS in future version.
+	if [[ -n ${GUNICORN_WORKERS-} ]]; then
+		warn_log "GUNICORN_WORKERS variable is deprecated, use WEB_CONCURRENCY instead"
+		: "${WEB_CONCURRENCY:=${GUNICORN_WORKERS}}"
+	fi
+
 	gunicorn \
 		--access-logfile - \
 		--error-logfile - \
@@ -53,7 +62,7 @@ start_bin_gunicorn() {
 		--bind=unix:/tmp/gunicorn.sock \
 		--pid=/tmp/gunicorn.pid \
 		--forwarded-allow-ips="*" \
-		--workers "${GUNICORN_WORKERS:=2}" \
+		--workers "${WEB_CONCURRENCY:-2}" \
 		main:app &
 }
 

--- a/env.template
+++ b/env.template
@@ -4,7 +4,7 @@ KIOSK_MODE=false
 
 # Gunicorn (optional)
 # Workers -> (2 × CPU cores) + 1
-GUNICORN_WORKERS=4
+WEB_CONCURRENCY=4
 
 # IGDB credentials
 IGDB_CLIENT_ID=


### PR DESCRIPTION
## Description

The `WEB_CONCURRENCY` environment variable is a more common way to configure the number of workers for Gunicorn [1] or other web servers.

This change maintains `GUNICORN_WORKERS` compatibility, while notifying users that it is deprecated and should be replaced with `WEB_CONCURRENCY`.

It would also allow us to replace Gunicorn with another web server in the future without changing the variable name.

[1] https://docs.gunicorn.org/en/stable/settings.html#workers

## Checklist

Please check all that apply.

- [x] I've tested the changes locally
- [x] I've updated the wiki accordingly
- [x] I've have updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
- [x] All existing tests are passing