### PR TITLE
feat: Allow configuring app port using ROMM_PORT environment variable

### DIFF
--- a/docker/init_scripts/docker-entrypoint.sh
+++ b/docker/init_scripts/docker-entrypoint.sh
@@ -33,6 +33,11 @@ for var_name in $(printenv | cut -d= -f1 | grep "_FILE$" || true); do
 	unset "${var_name}"
 done
 
+# Set default values for environment variables used by nginx templates.
+# Nginx uses `envsubst` to load environment variables into configuration files, but it does not
+# support the default value syntax `${VAR:-default}`.
+: "${ROMM_PORT:=8080}"
+
 # Replace environment variables used in nginx configuration templates.
 /docker-entrypoint.d/20-envsubst-on-templates.sh >/dev/null
 

--- a/docker/nginx/templates/default.conf.template
+++ b/docker/nginx/templates/default.conf.template
@@ -4,7 +4,7 @@
 
 server {
     root /var/www/html;
-    listen 8080;
+    listen ${ROMM_PORT};
     server_name localhost;
 
     proxy_set_header Host $http_host;


### PR DESCRIPTION
## Description

By using the `ROMM_PORT` environment variable, users can now configure the port on which the application listens, which defaults to `8080`.

## Related Issues

Closes #611.

## Checklist

Please check all that apply.

- [x] I've tested the changes locally
- [ ] I've updated the wiki accordingly
- [x] I've have updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
- [x] All existing tests are passing