### PR TITLE
fix: Nginx alias_traversal warning

### DIFF
--- a/docker/nginx/templates/default.conf.template
+++ b/docker/nginx/templates/default.conf.template
@@ -44,9 +44,9 @@ server {
     }
 
     # Internally redirect download requests
-    location /library {
+    location /library/ {
         internal;
-        alias /romm/library;
+        alias /romm/library/;
     }
 
     # This location, and the related server at port 8081, are used to serve files when
@@ -75,7 +75,7 @@ server {
     listen 8081;
     server_name localhost;
 
-    location /library {
-        alias /romm/library;
+    location /library/ {
+        alias /romm/library/;
     }
 }


### PR DESCRIPTION
## Description

Warning triggered by [gixy](https://github.com/yandex/gixy).

## Checklist

Please check all that apply.

- [x] I've tested the changes locally
- [ ] I've updated the wiki accordingly
- [ ] I've have updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
- [x] All existing tests are passing

## Additional Notes

Related documentation:
https://github.com/yandex/gixy/blob/master/docs/en/plugins/aliastraversal.md
