### PR TITLE
fix: Support for assets when using custom ROMM_BASE_PATH

### DIFF
--- a/docker/init_scripts/docker-entrypoint.sh
+++ b/docker/init_scripts/docker-entrypoint.sh
@@ -36,9 +36,24 @@ done
 # Set default values for environment variables used by nginx templates.
 # Nginx uses `envsubst` to load environment variables into configuration files, but it does not
 # support the default value syntax `${VAR:-default}`.
-: "${ROMM_PORT:=8080}"
+export ROMM_BASE_PATH=${ROMM_BASE_PATH:-/romm}
+export ROMM_PORT=${ROMM_PORT:-8080}
 
 # Replace environment variables used in nginx configuration templates.
 /docker-entrypoint.d/20-envsubst-on-templates.sh >/dev/null
+
+# Fix symbolic links used by nginx for assets, if they do not point to the correct location,
+# set by the ROMM_BASE_PATH environment variable.
+for subfolder in assets resources; do
+	if [[ -L /var/www/html/assets/romm/${subfolder} ]]; then
+		target=$(readlink "/var/www/html/assets/romm/${subfolder}")
+
+		# If the target is not the same as ${ROMM_BASE_PATH}/${subfolder}, recreate the symbolic link.
+		if [[ ${target} != "${ROMM_BASE_PATH}/${subfolder}" ]]; then
+			rm "/var/www/html/assets/romm/${subfolder}"
+			ln -s "${ROMM_BASE_PATH}/${subfolder}" "/var/www/html/assets/romm/${subfolder}"
+		fi
+	fi
+done
 
 exec "$@"


### PR DESCRIPTION
## Description

When using a custom `ROMM_BASE_PATH`, the symbolic links used by nginx to serve assets were not being updated to point to the correct location, and always used the default `/romm` base path.

This change introduces a fix in the `docker-entrypoint.sh` script, so those symbolic links are updated to point to the correct location set by the `ROMM_BASE_PATH` environment variable.

## Related Issues

Fixes #1626.

## Checklist

Please check all that apply.

- [x] I've tested the changes locally
- [ ] I've updated the wiki accordingly
- [x] I've have updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
- [x] All existing tests are passing