### PR TITLE
Update config.batocera-retrobat.yml

### DIFF
--- a/examples/config.batocera-retrobat.yml
+++ b/examples/config.batocera-retrobat.yml
@@ -110,6 +110,7 @@ system:
     prboom: doom
     ps2: ps2
     ps3: ps3
+    ps4: ps4--1
     psp: psp
     psvita: psvita
     psx: ps
@@ -119,7 +120,7 @@ system:
     saturn: saturn
     scummvm: scummvm
     scv: epoch-super-cassette-vision
-    sega32x: sega-32x
+    sega32x: sega32
     segacd: segacd
     sg1000: sg1000
     sgb: gbc


### PR DESCRIPTION
1. added PS4
2. changed sega32x to match ROMM correctly

# Pull request template

## Description

Fixing sega 32x mapping - controller shows up. And just added PS4 mapping.

## Related Issues

32X showing black controller. Now shows correct sega controller.

## Checklist

Please check all that apply.

- [X] I've tested the changes locally
- [ ] I've updated the wiki accordingly
- [ ] I've have updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
- [ ] All existing tests are passing

## Additional Notes

Add any additional information or context about the pull request here.
