### PR TITLE
fix: nginx configuration for library access when ROMM_BASE_PATH is set

### DIFF
--- a/docker/nginx/templates/default.conf.template
+++ b/docker/nginx/templates/default.conf.template
@@ -46,7 +46,7 @@ server {
     # Internally redirect download requests
     location /library/ {
         internal;
-        alias /romm/library/;
+        alias "${ROMM_BASE_PATH}/library/";
     }
 
     # This location, and the related server at port 8081, are used to serve files when
@@ -76,6 +76,6 @@ server {
     server_name localhost;
 
     location /library/ {
-        alias /romm/library/;
+        alias "${ROMM_BASE_PATH}/library/";
     }
 }


### PR DESCRIPTION
## Description

The nginx configuration was not updated to use the `ROMM_BASE_PATH` environment variable when serving the library files.

We no longer hardcode the base path to `/romm`, but instead use the provided path.

## Checklist

Please check all that apply.

- [x] I've tested the changes locally
- [ ] I've updated the wiki accordingly
- [ ] I've have updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
- [x] All existing tests are passing