### PR TITLE
fix: Make nginx configuration files writable by everyone

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -158,8 +158,13 @@ COPY ./docker/nginx/templates/ /etc/nginx/templates/
 COPY ./docker/nginx/default.conf /etc/nginx/nginx.conf
 
 # User permissions
+# - Create default user `romm` (1000) and group `romm` (1000).
+# - Create base directories and make default user/group the owner.
+# - Make nginx configuration files writable by everyone, for `envsubst` to work
+#     when a custom UID/GID is used.
 RUN addgroup -g 1000 -S romm && adduser -u 1000 -D -S -G romm romm && \
-    mkdir /romm /redis-data && chown romm:romm /romm /redis-data
+    mkdir /romm /redis-data && chown romm:romm /romm /redis-data && \
+    chmod -R a+w /etc/nginx/conf.d
 
 
 FROM scratch AS slim-image


### PR DESCRIPTION
## Description

As the container entrypoint runs `envsubst` to replace environment variables in the nginx configuration files, the `/etc/nginx/conf.d` and its contents must be writable by everyone.

This is needed because a user can set a custom UID/GID to run the container, and the `envsubst` command will run as that user.

## Checklist

Please check all that apply.

- [x] I've tested the changes locally
- [ ] I've updated the wiki accordingly
- [x] I've have updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
- [x] All existing tests are passing