### PR TITLE
misc: Strip environment variables related to third-party credentials

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -51,20 +51,20 @@ REDIS_URL: Final = yarl.URL.build(
 # IGDB
 IGDB_CLIENT_ID: Final = os.environ.get(
     "IGDB_CLIENT_ID", os.environ.get("CLIENT_ID", "")
-)
+).strip()
 IGDB_CLIENT_SECRET: Final = os.environ.get(
     "IGDB_CLIENT_SECRET", os.environ.get("CLIENT_SECRET", "")
-)
+).strip()
 
 # SCREENSCRAPER
 SCREENSCRAPER_USER: Final = os.environ.get("SCREENSCRAPER_USER", "")
 SCREENSCRAPER_PASSWORD: Final = os.environ.get("SCREENSCRAPER_PASSWORD", "")
 
 # STEAMGRIDDB
-STEAMGRIDDB_API_KEY: Final = os.environ.get("STEAMGRIDDB_API_KEY", "")
+STEAMGRIDDB_API_KEY: Final = os.environ.get("STEAMGRIDDB_API_KEY", "").strip()
 
 # MOBYGAMES
-MOBYGAMES_API_KEY: Final = os.environ.get("MOBYGAMES_API_KEY", "")
+MOBYGAMES_API_KEY: Final = os.environ.get("MOBYGAMES_API_KEY", "").strip()
 
 # AUTH
 ROMM_AUTH_SECRET_KEY: Final = os.environ.get(
@@ -81,8 +81,8 @@ DISABLE_USERPASS_LOGIN = str_to_bool(os.environ.get("DISABLE_USERPASS_LOGIN", "f
 # OIDC
 OIDC_ENABLED: Final = str_to_bool(os.environ.get("OIDC_ENABLED", "false"))
 OIDC_PROVIDER: Final = os.environ.get("OIDC_PROVIDER", "")
-OIDC_CLIENT_ID: Final = os.environ.get("OIDC_CLIENT_ID", "")
-OIDC_CLIENT_SECRET: Final = os.environ.get("OIDC_CLIENT_SECRET", "")
+OIDC_CLIENT_ID: Final = os.environ.get("OIDC_CLIENT_ID", "").strip()
+OIDC_CLIENT_SECRET: Final = os.environ.get("OIDC_CLIENT_SECRET", "").strip()
 OIDC_REDIRECT_URI: Final = os.environ.get("OIDC_REDIRECT_URI", "")
 OIDC_SERVER_APPLICATION_URL: Final = os.environ.get("OIDC_SERVER_APPLICATION_URL", "")
 OIDC_TLS_CACERTFILE: Final = os.environ.get("OIDC_TLS_CACERTFILE", None)

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -15,6 +15,7 @@ from config import (
     DISABLE_DOWNLOAD_ENDPOINT_AUTH,
     LIBRARY_BASE_PATH,
     RESOURCES_BASE_PATH,
+    str_to_bool,
 )
 from decorators.auth import protected_route
 from endpoints.responses import MessageResponse
@@ -320,7 +321,7 @@ async def get_rom_content(
         raise RomNotFoundInDatabaseException(id)
 
     # https://muos.dev/help/addcontent#what-about-multi-disc-content
-    hidden_folder = request.query_params.get("hidden_folder", "").lower() == "true"
+    hidden_folder = str_to_bool(request.query_params.get("hidden_folder", ""))
 
     file_ids = request.query_params.get("file_ids") or ""
     file_ids = [int(f) for f in file_ids.split(",") if f]


### PR DESCRIPTION
## Description

For client_id/client_secret combinations, and API keys, we are certain that they should not have leading/trailing whitespaces. We can strip them to avoid any potential issues for users who might have added them incorrectly in their Docker Compose configuration.

This change does NOT affect users/passwords, where leading/trailing whitespaces might be intentional and valid.

## Checklist

Please check all that apply.

- [x] I've tested the changes locally
- [ ] I've updated the wiki accordingly
- [ ] I've have updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
- [x] All existing tests are passing