### PR TITLE
fix: Download for single-file games in folder

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -238,18 +238,6 @@ async def head_rom_content(
 
     # Serve the file directly in development mode for emulatorjs
     if DEV_MODE:
-        if not rom.multi:
-            rom_path = f"{LIBRARY_BASE_PATH}/{rom.full_path}"
-            return FileResponse(
-                path=rom_path,
-                filename=rom.fs_name,
-                headers={
-                    "Content-Disposition": f'attachment; filename="{quote(rom.fs_name)}"',
-                    "Content-Type": "application/octet-stream",
-                    "Content-Length": str(rom.fs_size_bytes),
-                },
-            )
-
         if len(files) == 1:
             file = files[0]
             rom_path = f"{LIBRARY_BASE_PATH}/{file.full_path}"
@@ -271,12 +259,6 @@ async def head_rom_content(
         )
 
     # Otherwise proxy through nginx
-    if not rom.multi:
-        return FileRedirectResponse(
-            download_path=Path(f"/library/{rom.full_path}"),
-            filename=rom.fs_name,
-        )
-
     if len(files) == 1:
         return FileRedirectResponse(
             download_path=Path(f"/library/{files[0].full_path}"),
@@ -332,18 +314,6 @@ async def get_rom_content(
 
     # Serve the file directly in development mode for emulatorjs
     if DEV_MODE:
-        if not rom.multi:
-            rom_path = f"{LIBRARY_BASE_PATH}/{rom.full_path}"
-            return FileResponse(
-                path=rom_path,
-                filename=rom.fs_name,
-                headers={
-                    "Content-Disposition": f'attachment; filename="{quote(rom.fs_name)}"',
-                    "Content-Type": "application/octet-stream",
-                    "Content-Length": str(rom.fs_size_bytes),
-                },
-            )
-
         if len(files) == 1:
             file = files[0]
             rom_path = f"{LIBRARY_BASE_PATH}/{file.full_path}"
@@ -422,12 +392,6 @@ async def get_rom_content(
         )
 
     # Otherwise proxy through nginx
-    if not rom.multi:
-        return FileRedirectResponse(
-            download_path=Path(f"/library/{rom.full_path}"),
-            filename=rom.fs_name,
-        )
-
     if len(files) == 1:
         return FileRedirectResponse(
             download_path=Path(f"/library/{files[0].full_path}"),


### PR DESCRIPTION
## Description

When trying to download a game that is contained in a folder, but is single-file (what we consider "non-multi" game), the download would fail, trying to make nginx proxy the folder instead of that single file.

This commit removes custom logic related to `multi` games, so the logic ends up executing the `if len(files) == 1` block, which is the correct one for single-file games.

A simple way to reproduce this issue is to create a game folder with a single file inside it, and try to download or run EmulatorJS with that game. Both `DEV_MODE=true` and `DEV_MODE=false` were failing in this scenario.

## Related Issues

Fixes #1644.

## Checklist

Please check all that apply.

- [x] I've tested the changes locally
- [ ] I've updated the wiki accordingly
- [x] I've have updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
- [x] All existing tests are passing