### PR TITLE
[ROMM-1726] Fix ruffle hidden in non-fs mode

### DIFF
--- a/frontend/src/views/Player/EmulatorJS/Base.vue
+++ b/frontend/src/views/Player/EmulatorJS/Base.vue
@@ -327,7 +327,7 @@ onMounted(async () => {
               cols="12"
               :sm="gameRunning ? 12 : 7"
               :xl="gameRunning ? 12 : 9"
-              class="ml-2"
+              :class="gameRunning ? 'mt-2' : 'ml-2'"
             >
               <v-btn
                 color="primary"

--- a/frontend/src/views/Player/RuffleRS/Base.vue
+++ b/frontend/src/views/Player/RuffleRS/Base.vue
@@ -80,7 +80,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <v-row v-if="rom" class="align-center justify-center scroll" no-gutters>
+  <v-row v-if="rom" class="align-center justify-center scroll h-100" no-gutters>
     <v-col
       v-if="gameRunning"
       cols="12"
@@ -134,6 +134,7 @@ onMounted(async () => {
               cols="12"
               :sm="gameRunning ? 12 : 7"
               :xl="gameRunning ? 12 : 9"
+              :class="gameRunning ? 'mt-2' : 'ml-2'"
             >
               <v-btn
                 color="primary"
@@ -196,6 +197,7 @@ onMounted(async () => {
 }
 
 #game {
+  height: 100%;
   --splash-screen-background: none;
 }
 


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

#### Description

<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The`<v-row>` needs to expand to its full height to display the game when not in fullscreen mode.

Fixes #1726 

#### Checklist

<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
