### PR TITLE
[ROMM-1742] Fix updating cover when manual matching

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -443,7 +443,7 @@ async def update_rom(
         request (Request): Fastapi Request object
         id (Rom): Rom internal id
         rename_as_source (bool, optional): Flag to rename rom file as matched IGDB game. Defaults to False.
-        artwork (UploadFile, optional): Custom artork to set as cover. Defaults to File(None).
+        artwork (UploadFile, optional): Custom artwork to set as cover. Defaults to File(None).
         unmatch_metadata: Remove the metadata matches for this game. Defaults to False.
 
     Raises:

--- a/frontend/src/components/common/Game/Dialog/MatchRom.vue
+++ b/frontend/src/components/common/Game/Dialog/MatchRom.vue
@@ -177,11 +177,7 @@ function selectCover(source: MatchedSource) {
 
 function confirm() {
   if (!selectedMatchRom.value || !selectedCover.value) return;
-  updateRom(
-    Object.assign(selectedMatchRom.value, {
-      url_cover: selectedCover.value.url_cover,
-    }),
-  );
+  updateRom(selectedMatchRom.value, selectedCover.value.url_cover);
   closeDialog();
 }
 
@@ -197,7 +193,10 @@ function backToMatched() {
   renameAsSource.value = false;
 }
 
-async function updateRom(selectedRom: SearchRomSchema) {
+async function updateRom(
+  selectedRom: SearchRomSchema,
+  urlCover: string | undefined,
+) {
   if (!rom.value) return;
 
   show.value = false;
@@ -213,9 +212,10 @@ async function updateRom(selectedRom: SearchRomSchema) {
     slug: selectedRom.slug,
     summary: selectedRom.summary,
     url_cover:
-      selectedRom.moby_url_cover ||
-      selectedRom.igdb_url_cover ||
+      urlCover ||
       selectedRom.ss_url_cover ||
+      selectedRom.igdb_url_cover ||
+      selectedRom.moby_url_cover ||
       null,
   };
 


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

#### Description

<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

We should be passing in the `urlCover` in all cases and fallback to the metadata values.

Fixes #1742 

#### Checklist

<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots
