### PR TITLE
Hide save slot settings from menu

### DIFF
--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -51,6 +51,7 @@ declare global {
     EJS_threads: boolean;
     EJS_controlScheme: string | null;
     EJS_emulator: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    EJS_Buttons: Record<string, boolean>;
     EJS_onGameStart: () => void;
     EJS_onSaveState: (args: { screenshot: File; state: File }) => void;
     EJS_onLoadState: () => void;
@@ -79,13 +80,20 @@ window.EJS_color = "#A453FF";
 window.EJS_alignStartButton = "center";
 window.EJS_startOnLoaded = true;
 window.EJS_backgroundImage = "/assets/emulatorjs/loading_black.png";
+// Force saving saves and states to the browser
 window.EJS_defaultOptions = {
   "save-state-location": "browser",
   rewindEnabled: "enabled",
 };
+// Set a valid game name
 window.EJS_gameName = romRef.value.fs_name_no_tags
   .replace(INVALID_CHARS_REGEX, "")
   .trim();
+// Disable quick save and quick load
+window.EJS_Buttons = {
+  quickSave: false,
+  quickLoad: false,
+};
 
 onBeforeUnmount(() => {
   window.location.reload();
@@ -343,6 +351,14 @@ window.EJS_onGameStart = async () => {
 <style>
 #game .ejs_cheat_code {
   background-color: white;
+}
+
+#game .ejs_settings_transition {
+  height: fit-content;
+}
+
+#game .ejs_setting_menu .ejs_settings_main_bar:nth-child(3) {
+  display: none;
 }
 </style>
 


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

#### Description
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

This PR disables the quick save/load buttons, and the ability to switch quick save/load slots. These options can't be synced to the server and don't persist after reload (check demo.emulatorjs.org for default behavior), and their presence is confusing users.

#### Checklist
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots

<img width="962" alt="Screenshot 2025-03-17 at 2 35 52 PM" src="https://github.com/user-attachments/assets/61c64e8b-9fa7-423f-b61e-3bce683a61ed" />