### PR TITLE
[HOTFIX] Fix dowbnloading multi-files in windows

### DIFF
--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -62,6 +62,12 @@ class RomFile(BaseModel):
     def full_path(self) -> str:
         return f"{self.file_path}/{self.file_name}"
 
+    def file_name_for_download(self, rom: Rom, hidden_folder: bool = False) -> str:
+        # This needs a trailing slash in the path to work!
+        return self.full_path.replace(
+            f"{rom.full_path}/", ".hidden/" if hidden_folder else ""
+        )
+
 
 class Rom(BaseModel):
     __tablename__ = "roms"


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

#### Description

<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

This PR centralized the login for generating multi-file-download-filenames under `RomFile.file_name_for_download`, and fixes a bug that makes the folder invisible when downloaded on Windows (also tested on macOS).

#### Checklist

<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots
