### PR TITLE
Easy way to clear emulatorjs cache via the UI

### DIFF
--- a/frontend/src/locales/de_DE/play.json
+++ b/frontend/src/locales/de_DE/play.json
@@ -3,5 +3,9 @@
   "play": "Spielen",
   "reset-session": "Session zurücksetzen",
   "back-to-game-details": "Zurück zu den Spieldetails",
-  "back-to-gallery": "Zurück zur Plattformübersicht"
+  "back-to-gallery": "Zurück zur Plattformübersicht",
+  "clear-cache": "EmulatorJS-Cache löschen",
+  "clear-cache-title": "Möchtest du den EmulatorJS-Cache wirklich löschen?",
+  "clear-cache-warning": "Dadurch werden alle im Browser gespeicherten Spielstände und Speicherungen entfernt.",
+  "clear-cache-description": "Es hat keine Auswirkungen auf Spielstände und Speicherungen, die auf dem Server gespeichert sind."
 }

--- a/frontend/src/locales/en_GB/play.json
+++ b/frontend/src/locales/en_GB/play.json
@@ -3,5 +3,9 @@
   "play": "Play",
   "reset-session": "Reset Session",
   "back-to-game-details": "Back to game details",
-  "back-to-gallery": "Back to gallery"
+  "back-to-gallery": "Back to gallery",
+  "clear-cache": "Clear EmulatorJS Cache",
+  "clear-cache-title": "Are you sure you want to clear the EmulatorJS cache?",
+  "clear-cache-warning": "This will remove all saves and states stored in the browser.",
+  "clear-cache-description": "Any saves or states stored on the server will not be affected."
 }

--- a/frontend/src/locales/en_US/play.json
+++ b/frontend/src/locales/en_US/play.json
@@ -3,5 +3,9 @@
   "play": "Play",
   "reset-session": "Reset Session",
   "back-to-game-details": "Back to game details",
-  "back-to-gallery": "Back to gallery"
+  "back-to-gallery": "Back to gallery",
+  "clear-cache": "Clear EmulatorJS Cache",
+  "clear-cache-title": "Are you sure you want to clear the EmulatorJS cache?",
+  "clear-cache-warning": "This will remove all saves and states stored in the browser.",
+  "clear-cache-description": "Any saves or states stored on the server will not be affected."
 }

--- a/frontend/src/locales/es_ES/play.json
+++ b/frontend/src/locales/es_ES/play.json
@@ -3,5 +3,9 @@
   "play": "Jugar",
   "reset-session": "Restablecer sesión",
   "back-to-game-details": "Volver a detalles",
-  "back-to-gallery": "Volver a galería"
+  "back-to-gallery": "Volver a galería",
+  "clear-cache": "Limpiar caché de EmulatorJS",
+  "clear-cache-title": "¿Estás seguro de que quieres limpiar la caché de EmulatorJS?",
+  "clear-cache-warning": "Esto eliminará todas las partidas y estados almacenados en el navegador.",
+  "clear-cache-description": "No afectará a las partidas o estados almacenados en el servidor."
 }

--- a/frontend/src/locales/fr_FR/play.json
+++ b/frontend/src/locales/fr_FR/play.json
@@ -3,5 +3,9 @@
   "play": "Jouer",
   "reset-session": "Réinitialiser la session",
   "back-to-game-details": "Retour aux détails du jeu",
-  "back-to-gallery": "Retour à la galerie"
+  "back-to-gallery": "Retour à la galerie",
+  "clear-cache": "Effacer le cache EmulatorJS",
+  "clear-cache-title": "Êtes-vous sûr de vouloir effacer le cache EmulatorJS ?",
+  "clear-cache-warning": "Cela supprimera toutes les sauvegardes et les états stockés dans le navigateur.",
+  "clear-cache-description": "Les sauvegardes ou les états stockés sur le serveur ne seront pas affectés."
 }

--- a/frontend/src/locales/ja_JP/play.json
+++ b/frontend/src/locales/ja_JP/play.json
@@ -3,5 +3,9 @@
   "play": "プレイ",
   "reset-session": "セッションをリセット",
   "back-to-game-details": "ゲーム詳細へ戻る",
-  "back-to-gallery": "ギャラリーへ戻る"
+  "back-to-gallery": "ギャラリーへ戻る",
+  "clear-cache": "EmulatorJS キャッシュをクリア",
+  "clear-cache-title": "EmulatorJS キャッシュをクリアしてもよろしいですか？",
+  "clear-cache-warning": "これにより、ブラウザに保存されているすべてのセーブデータとステートが削除されます。",
+  "clear-cache-description": "サーバーに保存されているセーブデータやステートには影響しません。"
 }

--- a/frontend/src/locales/ko_KR/play.json
+++ b/frontend/src/locales/ko_KR/play.json
@@ -3,5 +3,9 @@
   "play": "실행",
   "reset-session": "세션 초기화",
   "back-to-game-details": "게임 설명으로 가기",
-  "back-to-gallery": "갤러리로 가기"
+  "back-to-gallery": "갤러리로 가기",
+  "clear-cache": "EmulatorJS 캐시 지우기",
+  "clear-cache-title": "EmulatorJS 캐시를 지우시겠습니까?",
+  "clear-cache-warning": "이로 인해 브라우저에 저장된 모든 세이브 및 상태가 제거됩니다.",
+  "clear-cache-description": "서버에 저장된 세이브 및 상태에는 영향을 주지 않습니다."
 }

--- a/frontend/src/locales/pt_BR/play.json
+++ b/frontend/src/locales/pt_BR/play.json
@@ -3,5 +3,9 @@
   "play": "Jogar",
   "reset-session": "Redefinir sessão",
   "back-to-game-details": "Voltar aos detalhes do jogo",
-  "back-to-gallery": "Voltar à galeria"
+  "back-to-gallery": "Voltar à galeria",
+  "clear-cache": "Limpar cache do EmulatorJS",
+  "clear-cache-title": "Tem certeza de que deseja limpar o cache do EmulatorJS?",
+  "clear-cache-warning": "Isso removerá todos os saves e estados armazenados no navegador.",
+  "clear-cache-description": "Não afetará nenhum save ou estado armazenado no servidor."
 }

--- a/frontend/src/locales/ro_RO/play.json
+++ b/frontend/src/locales/ro_RO/play.json
@@ -3,5 +3,9 @@
   "play": "Joacă",
   "reset-session": "Resetează sesiunea",
   "back-to-game-details": "Înapoi la detaliile jocului",
-  "back-to-gallery": "Înapoi la galerie"
+  "back-to-gallery": "Înapoi la galerie",
+  "clear-cache": "Șterge cache-ul EmulatorJS",
+  "clear-cache-title": "Ești sigur că vrei să ștergi cache-ul EmulatorJS?",
+  "clear-cache-warning": "Acest lucru va elimina toate salvările și stările stocate în browser.",
+  "clear-cache-description": "Nu va afecta nicio salvare sau stare stocată pe server."
 }

--- a/frontend/src/locales/ru_RU/play.json
+++ b/frontend/src/locales/ru_RU/play.json
@@ -1,7 +1,11 @@
 {
-  "full-screen": "Full Screen",
-  "play": "Play",
-  "reset-session": "Reset Session",
-  "back-to-game-details": "Back to game details",
-  "back-to-gallery": "Back to gallery"
+  "full-screen": "Полный экран",
+  "play": "Играть",
+  "reset-session": "Сбросить сессию",
+  "back-to-game-details": "Вернуться к деталям игры",
+  "back-to-gallery": "Вернуться в галерею",
+  "clear-cache": "Очистить кэш EmulatorJS",
+  "clear-cache-title": "Вы уверены, что хотите очистить кэш EmulatorJS?",
+  "clear-cache-warning": "Это удалит все сохранения и состояния, хранящиеся в браузере.",
+  "clear-cache-description": "Любые сохранения или состояния, хранящиеся на сервере, не будут затронуты."
 }

--- a/frontend/src/locales/zh_CN/play.json
+++ b/frontend/src/locales/zh_CN/play.json
@@ -3,5 +3,9 @@
   "play": "游玩",
   "reset-session": "重置会话",
   "back-to-game-details": "返回游戏详情",
-  "back-to-gallery": "返回游戏库"
+  "back-to-gallery": "返回游戏库",
+  "clear-cache": "清除 EmulatorJS 缓存",
+  "clear-cache-title": "您确定要清除 EmulatorJS 缓存吗？",
+  "clear-cache-warning": "这将删除浏览器中存储的所有保存和状态。",
+  "clear-cache-description": "这不会影响服务器上存储的任何保存或状态。"
 }

--- a/frontend/src/views/Player/EmulatorJS/Base.vue
+++ b/frontend/src/views/Player/EmulatorJS/Base.vue
@@ -12,6 +12,7 @@ import { isNull } from "lodash";
 import { onMounted, ref } from "vue";
 import { useRoute } from "vue-router";
 import { useI18n } from "vue-i18n";
+import CacheDialog from "./CacheDialog.vue";
 
 const EMULATORJS_VERSION = "4.2.1";
 
@@ -378,6 +379,7 @@ onMounted(async () => {
             "
             >{{ t("play.back-to-gallery") }}
           </v-btn>
+          <cache-dialog v-if="!gameRunning" />
         </v-col>
       </v-row>
     </v-col>

--- a/frontend/src/views/Player/EmulatorJS/CacheDialog.vue
+++ b/frontend/src/views/Player/EmulatorJS/CacheDialog.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { useI18n } from "vue-i18n";
+import RDialog from "@/components/common/RDialog.vue";
+
+const { t } = useI18n();
+const show = ref(false);
+
+function clearIndexDB() {
+  window.indexedDB.deleteDatabase("/data/saves");
+  window.indexedDB.deleteDatabase("EmulatorJS-roms");
+  window.indexedDB.deleteDatabase("EmulatorJS-core");
+  window.indexedDB.deleteDatabase("EmulatorJS-states");
+
+  closeDialog();
+}
+
+function closeDialog() {
+  show.value = false;
+}
+</script>
+
+<template>
+  <v-btn
+    class="mt-12 text-romm-red"
+    block
+    variant="outlined"
+    size="large"
+    prepend-icon="mdi-database-remove"
+    @click="show = true"
+    >{{ t("play.clear-cache") }}
+  </v-btn>
+  <r-dialog v-model="show" @close="closeDialog" icon="mdi-database-remove">
+    <template #header>
+      <v-row class="ml-2">
+        {{ t("play.clear-cache") }}
+      </v-row>
+    </template>
+    <template #content>
+      <div class="text-h6 pa-4">{{ t("play.clear-cache-title") }}</div>
+      <div class="text-body-1 px-4 pb-4">
+        <strong>{{ t("play.clear-cache-warning") }}</strong>
+        <br />
+        {{ t("play.clear-cache-description") }}
+      </div>
+    </template>
+    <template #append>
+      <v-row class="justify-center pa-2" no-gutters>
+        <v-btn-group divided density="compact">
+          <v-btn class="bg-toplayer" @click="closeDialog">
+            {{ t("common.cancel") }}
+          </v-btn>
+          <v-btn class="bg-toplayer text-romm-red" @click="clearIndexDB">
+            {{ t("common.confirm") }}
+          </v-btn>
+        </v-btn-group>
+      </v-row>
+    </template>
+  </r-dialog>
+</template>


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

#### Description

<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Our emulatorjs changes sometimes require users to clear IndexDB, so we add a simple button and warning dialog that does just that.

#### Checklist

<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots

<img width="1289" alt="Screenshot 2025-03-25 at 7 19 14 PM" src="https://github.com/user-attachments/assets/531c458e-c607-4aeb-9210-6acda92cb557" />