### PR TITLE
[HOTFIX] Update content-disposition headers

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -244,7 +244,7 @@ async def head_rom_content(
                 path=rom_path,
                 filename=file.file_name,
                 headers={
-                    "Content-Disposition": f'attachment; filename="{quote(file.file_name)}"',
+                    "Content-Disposition": f"attachment; filename*=UTF-8''{quote(file.file_name)}; filename=\"{quote(file.file_name)}\"",
                     "Content-Type": "application/octet-stream",
                     "Content-Length": str(file.file_size_bytes),
                 },
@@ -253,7 +253,7 @@ async def head_rom_content(
         return Response(
             headers={
                 "Content-Type": "application/zip",
-                "Content-Disposition": f'attachment; filename="{quote(file_name)}.zip"',
+                "Content-Disposition": f"attachment; filename*=UTF-8''{quote(file_name)}.zip; filename=\"{quote(file_name)}.zip\"",
             },
         )
 
@@ -266,7 +266,7 @@ async def head_rom_content(
     return Response(
         media_type="application/zip",
         headers={
-            "Content-Disposition": f'attachment; filename="{quote(file_name)}.zip"',
+            "Content-Disposition": f"attachment; filename*=UTF-8''{quote(file_name)}.zip; filename=\"{quote(file_name)}.zip\"",
         },
     )
 
@@ -324,7 +324,7 @@ async def get_rom_content(
                 path=rom_path,
                 filename=file.file_name,
                 headers={
-                    "Content-Disposition": f'attachment; filename="{quote(file.file_name)}"',
+                    "Content-Disposition": f"attachment; filename*=UTF-8''{quote(file.file_name)}; filename=\"{quote(file.file_name)}\"",
                     "Content-Type": "application/octet-stream",
                     "Content-Length": str(file.file_size_bytes),
                 },
@@ -382,7 +382,7 @@ async def get_rom_content(
             content=zip_data,
             media_type="application/zip",
             headers={
-                "Content-Disposition": f'attachment; filename="{quote(file_name)}.zip"',
+                "Content-Disposition": f"attachment; filename*=UTF-8''{quote(file_name)}.zip; filename=\"{quote(file_name)}.zip\"",
             },
         )
 
@@ -850,7 +850,7 @@ async def get_romfile_content(
             path=rom_path,
             filename=file_name,
             headers={
-                "Content-Disposition": f'attachment; filename="{quote(file_name)}"',
+                "Content-Disposition": f"attachment; filename*=UTF-8''{quote(file_name)}; filename=\"{quote(file_name)}\"",
                 "Content-Type": "application/octet-stream",
                 "Content-Length": str(file.file_size_bytes),
             },

--- a/backend/utils/nginx.py
+++ b/backend/utils/nginx.py
@@ -43,7 +43,7 @@ class ZipResponse(Response):
         kwargs["content"] = "\n".join(str(line) for line in content_lines)
         kwargs.setdefault("headers", {}).update(
             {
-                "Content-Disposition": f'attachment; filename="{filename}"',
+                "Content-Disposition": f"attachment; filename*=UTF-8''{filename}; filename=\"{filename}\"",
                 "X-Archive-Files": "zip",
             }
         )
@@ -67,7 +67,7 @@ class FileRedirectResponse(Response):
         filename = filename or download_path.name
         kwargs.setdefault("headers", {}).update(
             {
-                "Content-Disposition": f'attachment; filename="{quote(filename)}"',
+                "Content-Disposition": f"attachment; filename*=UTF-8''{quote(filename)}; filename=\"{quote(filename)}\"",
                 "X-Accel-Redirect": quote(str(download_path)),
             }
         )


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

#### Description

<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Update Content-Disposition headers to allow for proper filenames when downloading via Safari on Mac & iPhone

@DebugDax

Fixes #1810 

#### Checklist

<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
