### PR TITLE
[FIX] Improved handing of search inputs on mobile

### DIFF
--- a/frontend/src/components/Gallery/AppBar/Base.vue
+++ b/frontend/src/components/Gallery/AppBar/Base.vue
@@ -39,10 +39,9 @@ const { calculatedWidth } = calculateMainLayoutWidth();
       <filter-btn />
     </template>
     <filter-text-field v-if="!xs && showFilterBar" />
-    <search-text-field v-if="!xs && showSearchBar" />
+    <search-text-field v-if="showSearchBar" />
     <slot name="content" />
     <template #append>
-      <search-btn v-if="!xs && showSearchBar" />
       <slot name="append" />
       <selecting-btn />
       <gallery-view-btn />
@@ -52,7 +51,6 @@ const { calculatedWidth } = calculateMainLayoutWidth();
   <filter-drawer
     :show-platforms-filter="showPlatformsFilter"
     :show-filter-bar="showFilterBar"
-    :show-search-bar="showSearchBar"
   />
   <char-index-bar />
 </template>

--- a/frontend/src/components/Gallery/AppBar/common/CharIndexBar.vue
+++ b/frontend/src/components/Gallery/AppBar/common/CharIndexBar.vue
@@ -89,7 +89,7 @@ watch(
     density="compact"
     rounded
     height="100%"
-    class="position-fixed bg-surface mt-4 char-index-toolbar"
+    class="position-fixed bg-surface mt-5 char-index-toolbar"
     :style="{
       'max-height': calculatedHeight,
     }"

--- a/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
+++ b/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
@@ -5,15 +5,13 @@ import FilterMatchedBtn from "@/components/Gallery/AppBar/common/FilterDrawer/Fi
 import FilterFavouritesBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterFavouritesBtn.vue";
 import FilterDuplicatesBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterDuplicatesBtn.vue";
 import FilterTextField from "@/components/Gallery/AppBar/common/FilterTextField.vue";
-import SearchTextField from "@/components/Gallery/AppBar/Search/SearchTextField.vue";
-import SearchBtn from "@/components/Gallery/AppBar/Search/SearchBtn.vue";
 import storeGalleryFilter from "@/stores/galleryFilter";
 import storeRoms from "@/stores/roms";
 import storePlatforms from "@/stores/platforms";
 import type { Events } from "@/types/emitter";
 import type { Emitter } from "mitt";
 import { storeToRefs } from "pinia";
-import { inject, nextTick, onMounted, ref, watch } from "vue";
+import { inject, nextTick, onMounted, watch } from "vue";
 import { useDisplay } from "vuetify";
 import { useI18n } from "vue-i18n";
 
@@ -22,18 +20,15 @@ withDefaults(
   defineProps<{
     showPlatformsFilter?: boolean;
     showFilterBar?: boolean;
-    showSearchBar?: boolean;
   }>(),
   {
     showPlatformsFilter: false,
     showFilterBar: false,
-    showSearchBar: false,
   },
 );
 
 const { t } = useI18n();
 const { xs, smAndDown } = useDisplay();
-const viewportWidth = ref(window.innerWidth);
 const galleryFilterStore = storeGalleryFilter();
 const romsStore = storeRoms();
 const platformsStore = storePlatforms();
@@ -193,18 +188,6 @@ onMounted(async () => {
           <filter-text-field />
         </v-list-item>
       </template>
-      <template v-if="showSearchBar && xs">
-        <v-list-item>
-          <v-row no-gutters>
-            <v-col>
-              <search-text-field />
-            </v-col>
-            <v-col cols="auto">
-              <search-btn />
-            </v-col>
-          </v-row>
-        </v-list-item>
-      </template>
       <v-list-item>
         <filter-unmatched-btn />
         <filter-matched-btn class="mt-2" />
@@ -220,7 +203,6 @@ onMounted(async () => {
           :label="t('common.platform')"
           variant="outlined"
           density="comfortable"
-          class="my-2"
           :items="filterPlatforms"
           @update:model-value="nextTick(() => emitter?.emit('filter', null))"
         >

--- a/frontend/src/components/Gallery/AppBar/common/FilterTextField.vue
+++ b/frontend/src/components/Gallery/AppBar/common/FilterTextField.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import storeGalleryFilter from "@/stores/galleryFilter";
+import storeRoms from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import { debounce } from "lodash";
 import type { Emitter } from "mitt";
@@ -7,12 +8,16 @@ import { storeToRefs } from "pinia";
 import { inject, nextTick, onMounted, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
+import { useDisplay } from "vuetify";
 
 // Props
 const { t } = useI18n();
+const { xs } = useDisplay();
 const router = useRouter();
 const galleryFilterStore = storeGalleryFilter();
+const romsStore = storeRoms();
 const { searchTerm } = storeToRefs(galleryFilterStore);
+const { fetchingRoms } = storeToRefs(romsStore);
 const emitter = inject<Emitter<Events>>("emitter");
 
 const filterRoms = debounce(() => {
@@ -21,7 +26,7 @@ const filterRoms = debounce(() => {
   emitter?.emit("filter", null);
 }, 500);
 
-function clear() {
+function clearInput() {
   searchTerm.value = null;
 }
 
@@ -47,13 +52,17 @@ watch(
 
 <template>
   <v-text-field
-    v-model="searchTerm"
-    prepend-inner-icon="mdi-filter-outline"
-    :label="t('common.filter')"
+    :density="xs ? 'comfortable' : 'default'"
+    clearable
+    autofocus
     hide-details
     rounded="0"
-    clearable
-    @click:clear="clear"
+    :label="t('common.filter')"
+    v-model="searchTerm"
+    :disabled="fetchingRoms"
+    @keyup.enter="filterRoms"
+    prepend-inner-icon="mdi-filter-outline"
+    @click:clear="clearInput"
     @update:model-value="nextTick(filterRoms)"
   />
 </template>

--- a/frontend/src/components/Gallery/Skeleton.vue
+++ b/frontend/src/components/Gallery/Skeleton.vue
@@ -11,7 +11,7 @@ const { currentView } = storeToRefs(galleryViewStore);
 <template>
   <v-row no-gutters>
     <v-col>
-      <v-row v-if="currentView != 2" no-gutters class="mx-1 mt-3 mr-14">
+      <v-row v-if="currentView != 2" no-gutters class="mx-1 mt-4 mr-14">
         <v-col
           v-for="_ in 60"
           class="pa-1 align-self-end"

--- a/frontend/src/views/Gallery/Collection.vue
+++ b/frontend/src/views/Gallery/Collection.vue
@@ -280,7 +280,7 @@ onBeforeUnmount(() => {
     </template>
     <template v-else>
       <template v-if="filteredRoms.length > 0">
-        <v-row v-if="currentView != 2" class="mx-1 mt-3 mr-14" no-gutters>
+        <v-row v-if="currentView != 2" class="mx-1 mt-4 mr-14" no-gutters>
           <!-- Gallery cards view -->
           <!-- v-show instead of v-if to avoid recalculate on view change -->
           <v-col

--- a/frontend/src/views/Gallery/Platform.vue
+++ b/frontend/src/views/Gallery/Platform.vue
@@ -229,7 +229,7 @@ onBeforeUnmount(() => {
     </template>
     <template v-else>
       <template v-if="filteredRoms.length > 0">
-        <v-row v-if="currentView != 2" class="mx-1 mt-3 mr-14" no-gutters>
+        <v-row v-if="currentView != 2" class="mx-1 mt-4 mr-14" no-gutters>
           <!-- Gallery cards view -->
           <v-col
             v-for="rom in filteredRoms"

--- a/frontend/src/views/Gallery/Search.vue
+++ b/frontend/src/views/Gallery/Search.vue
@@ -149,7 +149,7 @@ onBeforeUnmount(() => {
   </template>
   <template v-else>
     <template v-if="filteredRoms.length > 0">
-      <v-row v-if="currentView != 2" class="mx-1 mt-3 mr-14" no-gutters>
+      <v-row v-if="currentView != 2" class="mx-1 mt-4 mr-14" no-gutters>
         <!-- Gallery cards view -->
         <v-col
           v-for="rom in filteredRoms"


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Search input will always be visible, but filter input will move to sidebar when on mobile. Also removed the search button, now any change in the input will trigger a search/filter, with 500ms debounce.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots

|<img width="423" alt="Screenshot 2025-04-10 at 9 26 03 AM" src="https://github.com/user-attachments/assets/bdde4a74-cbfb-4e69-8632-11304a10175d" />|<img width="421" alt="Screenshot 2025-04-10 at 9 26 10 AM" src="https://github.com/user-attachments/assets/730e99f6-9351-4d65-80e6-a4933cedbf86" />|
|---|---|

