### PR TITLE
[ROMM-1846] Rename file from client input

### DIFF
--- a/backend/endpoints/tests/test_rom.py
+++ b/backend/endpoints/tests/test_rom.py
@@ -49,7 +49,6 @@ def test_update_rom(rename_fs_rom_mock, get_rom_by_id_mock, client, access_token
     response = client.put(
         f"/api/roms/{rom.id}",
         headers={"Authorization": f"Bearer {access_token}"},
-        params={"rename_as_source": True},
         data={
             "igdb_id": "236663",
             "name": "Metroid Prime Remastered",

--- a/frontend/src/components/common/Game/Dialog/EditRom.vue
+++ b/frontend/src/components/common/Game/Dialog/EditRom.vue
@@ -87,7 +87,6 @@ const noMetadataMatch = computed(() => {
 async function handleRomUpdate(
   options: {
     rom: UpdateRom;
-    renameAsSource?: boolean;
     removeCover?: boolean;
     unmatch?: boolean;
   },

--- a/frontend/src/components/common/Game/Dialog/MatchRom.vue
+++ b/frontend/src/components/common/Game/Dialog/MatchRom.vue
@@ -205,9 +205,10 @@ async function updateRom(
   // Set the properties from the selected rom
   rom.value = {
     ...rom.value,
-    fs_name: renameAsSource.value
-      ? `${selectedMatchRom.value.name}.${rom.value.fs_extension}`
-      : rom.value.fs_name,
+    fs_name:
+      renameAsSource.value && selectedMatchRom.value
+        ? `${selectedMatchRom.value.name}.${rom.value.fs_extension}`
+        : rom.value.fs_name,
     igdb_id: selectedRom.igdb_id || null,
     moby_id: selectedRom.moby_id || null,
     ss_id: selectedRom.ss_id || null,
@@ -502,7 +503,7 @@ onBeforeUnmount(() => {
               </v-col>
             </v-row>
           </v-col>
-          <v-col cols="12">
+          <v-col cols="12" v-if="selectedMatchRom">
             <v-row class="mt-4 text-center" no-gutters>
               <v-col>
                 <v-chip

--- a/frontend/src/components/common/Game/Dialog/MatchRom.vue
+++ b/frontend/src/components/common/Game/Dialog/MatchRom.vue
@@ -37,7 +37,7 @@ const matchedRoms = ref<SearchRomSchema[]>([]);
 const filteredMatchedRoms = ref<SearchRomSchema[]>();
 const emitter = inject<Emitter<Events>>("emitter");
 const showSelectSource = ref(false);
-const renameAsSource = ref(false);
+const renameFromSource = ref(false);
 const selectedMatchRom = ref<SearchRomSchema>();
 const selectedCover = ref<MatchedSource>();
 const sources = ref<MatchedSource[]>([]);
@@ -182,7 +182,7 @@ function confirm() {
 }
 
 function toggleRenameAsSource() {
-  renameAsSource.value = !renameAsSource.value;
+  renameFromSource.value = !renameFromSource.value;
 }
 
 function backToMatched() {
@@ -190,7 +190,7 @@ function backToMatched() {
   selectedCover.value = undefined;
   selectedMatchRom.value = undefined;
   sources.value = [];
-  renameAsSource.value = false;
+  renameFromSource.value = false;
 }
 
 async function updateRom(
@@ -206,7 +206,7 @@ async function updateRom(
   rom.value = {
     ...rom.value,
     fs_name:
-      renameAsSource.value && selectedMatchRom.value
+      renameFromSource.value && selectedMatchRom.value
         ? `${selectedMatchRom.value.name}.${rom.value.fs_extension}`
         : rom.value.fs_name,
     igdb_id: selectedRom.igdb_id || null,
@@ -260,7 +260,7 @@ function closeDialog() {
   showSelectSource.value = false;
   selectedCover.value = undefined;
   selectedMatchRom.value = undefined;
-  renameAsSource.value = false;
+  renameFromSource.value = false;
 }
 
 onBeforeUnmount(() => {
@@ -508,11 +508,11 @@ onBeforeUnmount(() => {
               <v-col>
                 <v-chip
                   @click="toggleRenameAsSource"
-                  :variant="renameAsSource ? 'flat' : 'outlined'"
-                  :color="renameAsSource ? 'primary' : ''"
+                  :variant="renameFromSource ? 'flat' : 'outlined'"
+                  :color="renameFromSource ? 'primary' : ''"
                   :disabled="selectedCover == undefined"
                   ><v-icon class="mr-1">{{
-                    selectedCover && renameAsSource
+                    selectedCover && renameFromSource
                       ? "mdi-checkbox-outline"
                       : "mdi-checkbox-blank-outline"
                   }}</v-icon
@@ -520,7 +520,7 @@ onBeforeUnmount(() => {
                     t("rom.rename-file-part1", { source: selectedCover?.name })
                   }}</v-chip
                 >
-                <v-list-item v-if="rom && renameAsSource" class="mt-2">
+                <v-list-item v-if="rom && renameFromSource" class="mt-2">
                   <span>{{ t("rom.rename-file-part2") }}</span>
                   <br />
                   <span>{{ t("rom.rename-file-part3") }}</span

--- a/frontend/src/components/common/Game/Dialog/MatchRom.vue
+++ b/frontend/src/components/common/Game/Dialog/MatchRom.vue
@@ -205,6 +205,9 @@ async function updateRom(
   // Set the properties from the selected rom
   rom.value = {
     ...rom.value,
+    fs_name: renameAsSource.value
+      ? `${selectedMatchRom.value.name}.${rom.value.fs_extension}`
+      : rom.value.fs_name,
     igdb_id: selectedRom.igdb_id || null,
     moby_id: selectedRom.moby_id || null,
     ss_id: selectedRom.ss_id || null,
@@ -225,7 +228,7 @@ async function updateRom(
   }
 
   await romApi
-    .updateRom({ rom: rom.value, renameAsSource: renameAsSource.value })
+    .updateRom({ rom: rom.value })
     .then(({ data }) => {
       emitter?.emit("snackbarShow", {
         msg: "Rom updated successfully!",
@@ -516,17 +519,15 @@ onBeforeUnmount(() => {
                     t("rom.rename-file-part1", { source: selectedCover?.name })
                   }}</v-chip
                 >
-                <v-list-item v-if="renameAsSource" class="mt-2">
+                <v-list-item v-if="rom && renameAsSource" class="mt-2">
                   <span>{{ t("rom.rename-file-part2") }}</span>
                   <br />
                   <span>{{ t("rom.rename-file-part3") }}</span
-                  ><span class="text-primary ml-1"
-                    >{{ rom?.fs_name_no_tags }}.{{ rom?.fs_extension }}</span
-                  >
+                  ><span class="text-primary ml-1">{{ rom.fs_name }}</span>
                   <br />
                   <span class="mx-1">{{ t("rom.rename-file-part4") }}</span
                   ><span class="text-secondary"
-                    >{{ selectedMatchRom?.name }}.{{ rom?.fs_extension }}</span
+                    >{{ selectedMatchRom.name }}.{{ rom.fs_extension }}</span
                   >
                   <br />
                   <span class="text-caption font-italic font-weight-bold"

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -192,12 +192,10 @@ export type UpdateRom = SimpleRom & {
 
 async function updateRom({
   rom,
-  renameAsSource = false,
   removeCover = false,
   unmatch = false,
 }: {
   rom: UpdateRom;
-  renameAsSource?: boolean;
   removeCover?: boolean;
   unmatch?: boolean;
 }): Promise<{ data: DetailedRom }> {
@@ -213,7 +211,6 @@ async function updateRom({
 
   return api.put(`/roms/${rom.id}`, formData, {
     params: {
-      rename_as_source: renameAsSource,
       remove_cover: removeCover,
       unmatch_metadata: unmatch,
     },


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

This PR simply passes the new filename to the endpoint, when updating the filesystam name of a game (file or folder). Also removes `rename_as_source` as a param on the update endpoint.

Fixes #1846 1846

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
