### PR TITLE
[ROMM-1849] Fix excluding files in multi-file ROM

### DIFF
--- a/backend/handler/filesystem/base_handler.py
+++ b/backend/handler/filesystem/base_handler.py
@@ -101,11 +101,11 @@ class FSHandler:
         file_name_no_extension = self.get_file_name_with_no_extension(file_name)
         return TAG_REGEX.split(file_name_no_extension)[0].strip()
 
-    def parse_file_extension(self, file_name) -> str:
+    def parse_file_extension(self, file_name: str) -> str:
         match = EXTENSION_REGEX.search(file_name)
         return match.group(1) if match else ""
 
-    def _exclude_single_files(self, files) -> list[str]:
+    def exclude_single_files(self, files: list[str]) -> list[str]:
         excluded_extensions = cm.get_config().EXCLUDED_SINGLE_EXT
         excluded_names = cm.get_config().EXCLUDED_SINGLE_FILES
         excluded_files: list = []
@@ -119,10 +119,9 @@ class FSHandler:
                 excluded_files.append(file_name)
 
             # Additionally, check if the file name mathes a pattern in the excluded list.
-            if len(excluded_names) > 0:
-                for name in excluded_names:
-                    if file_name == name or fnmatch.fnmatch(file_name, name):
-                        excluded_files.append(file_name)
+            for name in excluded_names:
+                if file_name == name or fnmatch.fnmatch(file_name, name):
+                    excluded_files.append(file_name)
 
         # Return files that are not in the filtered list.
         return [f for f in files if f not in excluded_files]

--- a/backend/handler/filesystem/base_handler.py
+++ b/backend/handler/filesystem/base_handler.py
@@ -105,10 +105,9 @@ class FSHandler:
         match = EXTENSION_REGEX.search(file_name)
         return match.group(1) if match else ""
 
-    def _exclude_files(self, files, filetype) -> list[str]:
-        cnfg = cm.get_config()
-        excluded_extensions = getattr(cnfg, f"EXCLUDED_{filetype.upper()}_EXT")
-        excluded_names = getattr(cnfg, f"EXCLUDED_{filetype.upper()}_FILES")
+    def _exclude_single_files(self, files) -> list[str]:
+        excluded_extensions = cm.get_config().EXCLUDED_SINGLE_EXT
+        excluded_names = cm.get_config().EXCLUDED_SINGLE_FILES
         excluded_files: list = []
 
         for file_name in files:

--- a/backend/handler/filesystem/firmware_handler.py
+++ b/backend/handler/filesystem/firmware_handler.py
@@ -43,7 +43,7 @@ class FSFirmwareHandler(FSHandler):
         except IndexError as exc:
             raise FirmwareNotFoundException(platform_fs_slug) from exc
 
-        return [f for f in self._exclude_files(fs_firmware_files, "single")]
+        return [f for f in self._exclude_single_files(fs_firmware_files)]
 
     def get_firmware_file_size(self, firmware_path: str, file_name: str):
         files = [f"{LIBRARY_BASE_PATH}/{firmware_path}/{file_name}"]

--- a/backend/handler/filesystem/firmware_handler.py
+++ b/backend/handler/filesystem/firmware_handler.py
@@ -43,7 +43,7 @@ class FSFirmwareHandler(FSHandler):
         except IndexError as exc:
             raise FirmwareNotFoundException(platform_fs_slug) from exc
 
-        return [f for f in self._exclude_single_files(fs_firmware_files)]
+        return [f for f in self.exclude_single_files(fs_firmware_files)]
 
     def get_firmware_file_size(self, firmware_path: str, file_name: str):
         files = [f"{LIBRARY_BASE_PATH}/{firmware_path}/{file_name}"]

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -289,11 +289,7 @@ class FSRomsHandler(FSHandler):
                     self._build_rom_file(f_path.relative_to(LIBRARY_BASE_PATH), file)
                 )
         else:
-            # Check if file is excluded
-            if rom not in excluded_file_names and not any(
-                rom.endswith(ext) for ext in excluded_file_exts
-            ):
-                rom_files.append(self._build_rom_file(Path(roms_path), rom))
+            rom_files.append(self._build_rom_file(Path(roms_path), rom))
 
         return rom_files
 
@@ -437,7 +433,7 @@ class FSRomsHandler(FSHandler):
 
         fs_roms: list[dict] = [
             {"multi": False, "fs_name": rom}
-            for rom in self._exclude_files(fs_single_roms, "single")
+            for rom in self._exclude_single_files(fs_single_roms)
         ] + [
             {"multi": True, "fs_name": rom}
             for rom in self._exclude_multi_roms(fs_multi_roms)

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -273,14 +273,27 @@ class FSRomsHandler(FSHandler):
         abs_fs_path = f"{LIBRARY_BASE_PATH}/{roms_path}"  # Absolute path to roms
         rom_files: list[RomFile] = []
 
+        excluded_file_names = cm.get_config().EXCLUDED_MULTI_PARTS_FILES
+        excluded_file_exts = cm.get_config().EXCLUDED_MULTI_PARTS_EXT
+
         # Check if rom is a multi-part rom
         if os.path.isdir(f"{abs_fs_path}/{rom}"):
             for f_path, file in iter_files(f"{abs_fs_path}/{rom}", recursive=True):
+                # Check if file is excluded
+                if file in excluded_file_names:
+                    continue
+                if any(file.endswith(ext) for ext in excluded_file_exts):
+                    continue
+
                 rom_files.append(
                     self._build_rom_file(f_path.relative_to(LIBRARY_BASE_PATH), file)
                 )
         else:
-            rom_files.append(self._build_rom_file(Path(roms_path), rom))
+            # Check if file is excluded
+            if rom not in excluded_file_names and not any(
+                rom.endswith(ext) for ext in excluded_file_exts
+            ):
+                rom_files.append(self._build_rom_file(Path(roms_path), rom))
 
         return rom_files
 

--- a/backend/handler/filesystem/tests/test_fs.py
+++ b/backend/handler/filesystem/tests/test_fs.py
@@ -39,7 +39,7 @@ def test_get_roms():
     assert roms[1]["multi"]
 
 
-def test_exclude_files():
+def test_exclude_single_files():
     from config.config_manager import ConfigManager
 
     empty_config_file = os.path.join(
@@ -52,50 +52,46 @@ def test_exclude_files():
 
     cm.add_exclusion("EXCLUDED_SINGLE_FILES", "Super Mario 64 (J) (Rev A) [Part 1].z64")
 
-    filtered_files = fs_rom_handler._exclude_files(
+    filtered_files = fs_rom_handler._exclude_single_files(
         files=[
             "Super Mario 64 (J) (Rev A) [Part 1].z64",
             "Super Mario 64 (J) (Rev A) [Part 2].z64",
         ],
-        filetype="single",
     )
 
     assert len(filtered_files) == 1
 
     cm.add_exclusion("EXCLUDED_SINGLE_EXT", "z64")
 
-    filtered_files = fs_rom_handler._exclude_files(
+    filtered_files = fs_rom_handler._exclude_single_files(
         files=[
             "Super Mario 64 (J) (Rev A) [Part 1].z64",
             "Super Mario 64 (J) (Rev A) [Part 2].z64",
         ],
-        filetype="single",
     )
 
     assert len(filtered_files) == 0
 
     cm.add_exclusion("EXCLUDED_SINGLE_FILES", "*.z64")
 
-    filtered_files = fs_rom_handler._exclude_files(
+    filtered_files = fs_rom_handler._exclude_single_files(
         files=[
             "Super Mario 64 (J) (Rev A) [Part 1].z64",
             "Super Mario 64 (J) (Rev A) [Part 2].z64",
         ],
-        filetype="single",
     )
 
     assert len(filtered_files) == 0
 
     cm.add_exclusion("EXCLUDED_SINGLE_FILES", "_.*")
 
-    filtered_files = fs_rom_handler._exclude_files(
+    filtered_files = fs_rom_handler._exclude_single_files(
         files=[
             "Links Awakening.nsp",
             "_.Links Awakening.nsp",
             "Kirby's Adventure.nsp",
             "_.Kirby's Adventure.nsp",
         ],
-        filetype="single",
     )
 
     assert len(filtered_files) == 2

--- a/backend/handler/filesystem/tests/test_fs.py
+++ b/backend/handler/filesystem/tests/test_fs.py
@@ -39,7 +39,7 @@ def test_get_roms():
     assert roms[1]["multi"]
 
 
-def test_exclude_single_files():
+def testexclude_single_files():
     from config.config_manager import ConfigManager
 
     empty_config_file = os.path.join(
@@ -52,7 +52,7 @@ def test_exclude_single_files():
 
     cm.add_exclusion("EXCLUDED_SINGLE_FILES", "Super Mario 64 (J) (Rev A) [Part 1].z64")
 
-    filtered_files = fs_rom_handler._exclude_single_files(
+    filtered_files = fs_rom_handler.exclude_single_files(
         files=[
             "Super Mario 64 (J) (Rev A) [Part 1].z64",
             "Super Mario 64 (J) (Rev A) [Part 2].z64",
@@ -63,7 +63,7 @@ def test_exclude_single_files():
 
     cm.add_exclusion("EXCLUDED_SINGLE_EXT", "z64")
 
-    filtered_files = fs_rom_handler._exclude_single_files(
+    filtered_files = fs_rom_handler.exclude_single_files(
         files=[
             "Super Mario 64 (J) (Rev A) [Part 1].z64",
             "Super Mario 64 (J) (Rev A) [Part 2].z64",
@@ -74,7 +74,7 @@ def test_exclude_single_files():
 
     cm.add_exclusion("EXCLUDED_SINGLE_FILES", "*.z64")
 
-    filtered_files = fs_rom_handler._exclude_single_files(
+    filtered_files = fs_rom_handler.exclude_single_files(
         files=[
             "Super Mario 64 (J) (Rev A) [Part 1].z64",
             "Super Mario 64 (J) (Rev A) [Part 2].z64",
@@ -85,7 +85,7 @@ def test_exclude_single_files():
 
     cm.add_exclusion("EXCLUDED_SINGLE_FILES", "_.*")
 
-    filtered_files = fs_rom_handler._exclude_single_files(
+    filtered_files = fs_rom_handler.exclude_single_files(
         files=[
             "Links Awakening.nsp",
             "_.Links Awakening.nsp",


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

This PR finally puts `EXCLUDED_MULTI_PARTS_FILES` and `EXCLUDED_MULTI_PARTS_EXT` by skipping matched file names and extensions.

Fixes #1849 

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
