### PR TITLE
[ROMM-1770] Stop squashing old metadata props when manually matching

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -543,7 +543,7 @@ async def update_rom(
         and int(cleaned_data.get("moby_id", "")) != rom.moby_id
     ):
         moby_rom = await meta_moby_handler.get_rom_by_id(
-            int(cleaned_data.get("ss_id", ""))
+            int(cleaned_data.get("moby_id", ""))
         )
         cleaned_data.update(moby_rom)
         path_screenshots = await fs_resource_handler.get_rom_screenshots(

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -538,9 +538,13 @@ async def update_rom(
         "ss_id": data.get("ss_id", rom.ss_id),
     }
 
-    moby_id = cleaned_data["moby_id"]
-    if moby_id and int(moby_id) != rom.moby_id:
-        moby_rom = await meta_moby_handler.get_rom_by_id(int(moby_id))
+    if (
+        cleaned_data.get("moby_id", "")
+        and int(cleaned_data.get("moby_id", "")) != rom.moby_id
+    ):
+        moby_rom = await meta_moby_handler.get_rom_by_id(
+            int(cleaned_data.get("ss_id", ""))
+        )
         cleaned_data.update(moby_rom)
         path_screenshots = await fs_resource_handler.get_rom_screenshots(
             rom=rom,

--- a/backend/handler/metadata/moby_handler.py
+++ b/backend/handler/metadata/moby_handler.py
@@ -52,7 +52,6 @@ class MobyMetadata(TypedDict):
 
 class MobyGamesRom(TypedDict):
     moby_id: int | None
-    slug: NotRequired[str]
     name: NotRequired[str]
     summary: NotRequired[str]
     url_cover: NotRequired[str]
@@ -280,7 +279,6 @@ class MobyGamesHandler(MetadataHandler):
         rom = {
             "moby_id": res["game_id"],
             "name": res["title"],
-            "slug": res["moby_url"].split("/")[-1],
             "summary": res.get("description", ""),
             "url_cover": pydash.get(res, "sample_cover.image", ""),
             "url_screenshots": [s["image"] for s in res.get("sample_screenshots", [])],
@@ -303,7 +301,6 @@ class MobyGamesHandler(MetadataHandler):
         rom = {
             "moby_id": res["game_id"],
             "name": res["title"],
-            "slug": res["moby_url"].split("/")[-1],
             "summary": res.get("description", None),
             "url_cover": pydash.get(res, "sample_cover.image", None),
             "url_screenshots": [s["image"] for s in res.get("sample_screenshots", [])],
@@ -341,7 +338,6 @@ class MobyGamesHandler(MetadataHandler):
                     for k, v in {
                         "moby_id": rom["game_id"],
                         "name": rom["title"],
-                        "slug": rom["moby_url"].split("/")[-1],
                         "summary": rom.get("description", ""),
                         "url_cover": pydash.get(rom, "sample_cover.image", ""),
                         "url_screenshots": [

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -129,7 +129,6 @@ class SSMetadata(TypedDict):
 
 class SSRom(TypedDict):
     ss_id: int | None
-    slug: NotRequired[str]
     name: NotRequired[str]
     summary: NotRequired[str]
     url_cover: NotRequired[str]
@@ -438,13 +437,6 @@ class SSHandler(MetadataHandler):
             .head()
             .value()
         )
-        res_slug = (
-            pydash.chain(res.get("noms", []))
-            .filter({"region": "ss"})
-            .map("text")
-            .head()
-            .value()
-        )
         res_summary = (
             pydash.chain(res.get("synopsis", []))
             .filter({"langue": "en"})
@@ -486,7 +478,6 @@ class SSHandler(MetadataHandler):
         rom = {
             "ss_id": ss_id,
             "name": res_name,
-            "slug": res_slug,
             "summary": res_summary,
             "url_cover": res_url_cover,
             "url_manual": res_url_manual,
@@ -507,13 +498,6 @@ class SSHandler(MetadataHandler):
             return SSRom(ss_id=None)
 
         res_name = (
-            pydash.chain(res.get("noms", []))
-            .filter({"region": "ss"})
-            .map("text")
-            .head()
-            .value()
-        )
-        res_slug = (
             pydash.chain(res.get("noms", []))
             .filter({"region": "ss"})
             .map("text")
@@ -561,7 +545,6 @@ class SSHandler(MetadataHandler):
         rom = {
             "ss_id": res.get("id"),
             "name": res_name,
-            "slug": res_slug,
             "summary": res_summary,
             "url_cover": res_url_cover,
             "url_manual": res_url_manual,
@@ -579,7 +562,7 @@ class SSHandler(MetadataHandler):
         return rom if rom.get("ss_id", "") else None
 
     async def get_matched_roms_by_name(
-        self, search_term: str, platform_ss_id: int
+        self, search_term: str, platform_ss_id: int | None
     ) -> list[SSRom]:
         if not SS_API_ENABLED:
             return []
@@ -597,15 +580,6 @@ class SSHandler(MetadataHandler):
         matched_roms = [] if len(roms) == 1 and not roms[0] else roms
 
         def _get_name(rom: dict) -> str | None:
-            return (
-                pydash.chain(rom.get("noms", []))
-                .filter({"region": "ss"})
-                .map("text")
-                .head()
-                .value()
-            )
-
-        def _get_slug(rom: dict) -> str | None:
             return (
                 pydash.chain(rom.get("noms", []))
                 .filter({"region": "ss"})
@@ -683,7 +657,6 @@ class SSHandler(MetadataHandler):
                     for k, v in {
                         "ss_id": rom.get("id"),
                         "name": _get_name(rom),
-                        "slug": _get_slug(rom),
                         "summary": _get_summary(rom),
                         "url_cover": _get_url_cover(rom),
                         "url_manual": _get_url_manual(rom),

--- a/frontend/src/components/common/Game/Dialog/MatchRom.vue
+++ b/frontend/src/components/common/Game/Dialog/MatchRom.vue
@@ -212,13 +212,13 @@ async function updateRom(
     igdb_id: selectedRom.igdb_id || null,
     moby_id: selectedRom.moby_id || null,
     ss_id: selectedRom.ss_id || null,
-    name: selectedRom.name,
-    slug: selectedRom.slug,
-    summary: selectedRom.summary,
+    name: selectedRom.name || null,
+    slug: selectedRom.slug || null,
+    summary: selectedRom.summary || null,
     url_cover:
       urlCover ||
-      selectedRom.ss_url_cover ||
       selectedRom.igdb_url_cover ||
+      selectedRom.ss_url_cover ||
       selectedRom.moby_url_cover ||
       null,
   };


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

This PR removes `slug` from the return value of an `SSRom` and `MobyRom`, since the value is a) useless and b) can override the value we use to link to the game in IGDB.

Fixes #1770 

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
