### PR TITLE
feat: Add platform grouping options

### DIFF
--- a/frontend/src/components/Home/VirtualCollections.vue
+++ b/frontend/src/components/Home/VirtualCollections.vue
@@ -10,11 +10,24 @@ import { useI18n } from "vue-i18n";
 // Props
 const { t } = useI18n();
 const collections = storeCollections();
-const gridCollections = isNull(localStorage.getItem("settings.gridCollections"))
-  ? true
-  : localStorage.getItem("settings.gridCollections") === "true";
+const storedVirtualCollections = localStorage.getItem(
+  "settings.gridVirtualCollections",
+);
+const gridVirtualCollections = ref(
+  isNull(storedVirtualCollections)
+    ? false
+    : storedVirtualCollections === "true",
+);
+function toggleGridVirtualCollections() {
+  gridVirtualCollections.value = !gridVirtualCollections.value;
+  localStorage.setItem(
+    "settings.gridVirtualCollections",
+    gridVirtualCollections.value.toString(),
+  );
+}
 const visibleCollections = ref(72);
 
+// Functions
 function onScroll() {
   if (
     window.innerHeight + window.scrollY >= document.body.offsetHeight - 60 &&
@@ -37,10 +50,17 @@ onBeforeUnmount(() => {
     icon="mdi-bookmark-box-multiple"
     :title="t('common.virtual-collections')"
   >
+    <template #toolbar-append>
+      <v-btn icon rounded="0" @click="toggleGridVirtualCollections"
+        ><v-icon>{{
+          gridVirtualCollections ? "mdi-view-comfy" : "mdi-view-column"
+        }}</v-icon>
+      </v-btn>
+    </template>
     <template #content>
       <v-row
         :class="{
-          'flex-nowrap overflow-x-auto': !gridCollections,
+          'flex-nowrap overflow-x-auto': !gridVirtualCollections,
         }"
         class="pa-1"
         no-gutters

--- a/frontend/src/components/Settings/UserInterface/Interface.vue
+++ b/frontend/src/components/Settings/UserInterface/Interface.vue
@@ -282,7 +282,7 @@ const toggleStatus = (value: boolean) => {
             :items="[
               { title: 'Family (manufacturer)', value: 'family_name' },
               { title: 'Generation', value: 'generation' },
-              { title: 'Category', value: 'category' },
+              { title: 'Category (console type)', value: 'category' },
               { title: 'None', value: null },
             ]"
             :label="t('settings.platforms-drawer-group-by')"

--- a/frontend/src/components/Settings/UserInterface/Interface.vue
+++ b/frontend/src/components/Settings/UserInterface/Interface.vue
@@ -14,10 +14,12 @@ const { smAndDown } = useDisplay();
 const collectionsStore = storeCollections();
 
 // Initializing refs from localStorage
+// Home
 const storedShowRecentRoms = localStorage.getItem("settings.showRecentRoms");
 const showRecentRomsRef = ref(
   isNull(storedShowRecentRoms) ? true : storedShowRecentRoms === "true",
 );
+
 const storedShowContinuePlaying = localStorage.getItem(
   "settings.showContinuePlaying",
 );
@@ -34,6 +36,8 @@ const storedShowCollections = localStorage.getItem("settings.showCollections");
 const showCollectionsRef = ref(
   isNull(storedShowCollections) ? true : storedShowCollections === "true",
 );
+
+// Virtual collections
 const storedShowVirtualCollections = localStorage.getItem(
   "settings.showVirtualCollections",
 );
@@ -51,6 +55,15 @@ const virtualCollectionTypeRef = ref(
     : storedVirtualCollectionType,
 );
 
+// Platforms drawer
+const storedPlatformsGroupBy = localStorage.getItem(
+  "settings.platformsGroupBy",
+);
+const platformsGroupByRef = ref(
+  isNull(storedPlatformsGroupBy) ? null : storedPlatformsGroupBy,
+);
+
+// Gallery
 const storedGroupRoms = localStorage.getItem("settings.groupRoms");
 const groupRomsRef = ref(
   isNull(storedGroupRoms) ? true : storedGroupRoms === "true",
@@ -103,6 +116,17 @@ const homeOptions = computed(() => [
   },
 ]);
 
+const platformsDrawerOptions = computed(() => [
+  {
+    title: t("settings.group-platforms-by"),
+    description: t("settings.group-platforms-by-desc"),
+    iconEnabled: "mdi-controller",
+    iconDisabled: "mdi-controller",
+    model: platformsGroupByRef,
+    modelTrigger: setPlatformDrawerGroupBy,
+  },
+]);
+
 const galleryOptions = computed(() => [
   {
     title: t("settings.group-roms"),
@@ -118,7 +142,7 @@ const galleryOptions = computed(() => [
     iconEnabled: "mdi-account-group-outline",
     iconDisabled: "mdi-account-outline",
     model: siblingsRef,
-    disabled: !groupRomsRef.value,
+    disabled: !groupRomsRef,
     modelTrigger: toggleSiblings,
   },
   {
@@ -148,9 +172,9 @@ const galleryOptions = computed(() => [
 ]);
 
 // Functions to update localStorage
-const toggleShowRecentRoms = (value: boolean) => {
-  showRecentRomsRef.value = value;
-  localStorage.setItem("settings.showRecentRoms", value.toString());
+const setPlatformDrawerGroupBy = (value: string) => {
+  platformsGroupByRef.value = value;
+  localStorage.setItem("settings.platformsGroupBy", value);
 };
 const toggleShowContinuePlaying = (value: boolean) => {
   showContinuePlayingRef.value = value;
@@ -177,6 +201,11 @@ const setVirtualCollectionType = async (value: string) => {
     .then(({ data: virtualCollections }) => {
       collectionsStore.setVirtual(virtualCollections);
     });
+};
+
+const toggleShowRecentRoms = (value: boolean) => {
+  showRecentRomsRef.value = value;
+  localStorage.setItem("settings.showRecentRoms", value.toString());
 };
 
 const toggleGroupRoms = (value: boolean) => {
@@ -231,6 +260,37 @@ const toggleStatus = (value: boolean) => {
             "
             v-model="option.model.value"
             @update:model-value="option.modelTrigger"
+          />
+        </v-col>
+      </v-row>
+      <v-chip
+        label
+        variant="text"
+        prepend-icon="mdi-controller"
+        class="ml-2 mt-1"
+        >{{ t("settings.platforms-drawer") }}</v-chip
+      >
+      <v-divider class="border-opacity-25 ma-1 mb-2" />
+      <v-row class="py-2 align-center" no-gutters>
+        <v-col
+          cols="12"
+          v-for="option in platformsDrawerOptions"
+          :key="option.title"
+        >
+          <v-select
+            v-model="platformsGroupByRef"
+            :items="[
+              { title: 'Family (manufacturer)', value: 'family_name' },
+              { title: 'Generation', value: 'generation' },
+              { title: 'Category', value: 'category' },
+              { title: 'None', value: null },
+            ]"
+            :label="t('settings.platforms-drawer-group-by')"
+            class="mx-2"
+            :class="{ 'mt-4': smAndDown }"
+            variant="outlined"
+            hide-details
+            @update:model-value="setPlatformDrawerGroupBy"
           />
         </v-col>
       </v-row>

--- a/frontend/src/components/common/Navigation/PlatformsDrawer.vue
+++ b/frontend/src/components/common/Navigation/PlatformsDrawer.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
+import type { Platform } from "@/stores/platforms";
 import PlatformListItem from "@/components/common/Platform/ListItem.vue";
 import storeNavigation from "@/stores/navigation";
 import storePlatforms from "@/stores/platforms";
 import { storeToRefs } from "pinia";
 import { useDisplay } from "vuetify";
 import { useI18n } from "vue-i18n";
+import { computed, ref } from "vue";
+import { isNull } from "lodash";
 
 // Props
 const { t } = useI18n();
@@ -13,6 +16,33 @@ const { mdAndUp, smAndDown } = useDisplay();
 const platformsStore = storePlatforms();
 const { filteredPlatforms, filterText } = storeToRefs(platformsStore);
 const { activePlatformsDrawer } = storeToRefs(navigationStore);
+const storedPlatformsGroupBy = localStorage.getItem(
+  "settings.platformsGroupBy",
+);
+const virtualCollectionTypeRef = ref(
+  isNull(storedPlatformsGroupBy) ? null : storedPlatformsGroupBy,
+);
+const allowedGroupBy = ["family_name", "generation", "category"];
+const groupBy = ref<"family_name" | "generation" | "category" | null>(
+  allowedGroupBy.includes(virtualCollectionTypeRef.value as string)
+    ? (virtualCollectionTypeRef.value as
+        | "family_name"
+        | "generation"
+        | "category")
+    : null,
+);
+
+// Functions
+const groupedPlatforms = computed(() => {
+  if (!groupBy.value) return null;
+  const groups: Record<string, Platform[]> = {};
+  for (const platform of filteredPlatforms.value) {
+    const key = platform[groupBy.value] ?? "Other";
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(platform);
+  }
+  return groups;
+});
 
 function clear() {
   filterText.value = "";
@@ -50,12 +80,37 @@ function clear() {
         density="compact"
       ></v-text-field>
     </template>
-    <v-list lines="two" class="py-1 px-0">
-      <platform-list-item
-        v-for="platform in filteredPlatforms"
-        :key="platform.slug"
-        :platform="platform"
-      />
-    </v-list>
+    <template v-if="groupedPlatforms">
+      <v-expansion-panels class="mt-2" multiple flat variant="accordion">
+        <v-expansion-panel
+          v-for="[group, platforms] in Object.entries(groupedPlatforms).sort(
+            (a, b) => a[0].localeCompare(b[0]),
+          )"
+          :key="group"
+        >
+          <v-expansion-panel-title color="toplayer" static>
+            {{ group }}
+          </v-expansion-panel-title>
+          <v-expansion-panel-text>
+            <v-list lines="two" class="py-1 px-0">
+              <platform-list-item
+                v-for="platform in platforms"
+                :key="platform.slug"
+                :platform="platform"
+              />
+            </v-list>
+          </v-expansion-panel-text>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </template>
+    <template v-else>
+      <v-list lines="two" class="py-1 px-0">
+        <platform-list-item
+          v-for="platform in filteredPlatforms"
+          :key="platform.slug"
+          :platform="platform"
+        />
+      </v-list>
+    </template>
   </v-navigation-drawer>
 </template>

--- a/frontend/src/locales/de_DE/settings.json
+++ b/frontend/src/locales/de_DE/settings.json
@@ -17,6 +17,8 @@
   "language": "Sprache",
   "main-platform": "Haupt-Plattform",
   "password": "Passwort",
+  "platforms-drawer": "Plattformen-Menü",
+  "platforms-drawer-group-by": "Gruppieren nach",
   "platform-version": "Plattform-Version",
   "platforms-bindings": "Platform-Zuweisung",
   "platforms-versions": "Platform-Versionen",

--- a/frontend/src/locales/en_GB/settings.json
+++ b/frontend/src/locales/en_GB/settings.json
@@ -17,6 +17,8 @@
   "language": "Language",
   "main-platform": "Main platform",
   "password": "Password",
+  "platforms-drawer": "Platforms menu",
+  "platforms-drawer-group-by": "Group by",
   "platform-version": "Platform version",
   "platforms-bindings": "Platforms bindings",
   "platforms-versions": "Platforms versions",

--- a/frontend/src/locales/en_US/settings.json
+++ b/frontend/src/locales/en_US/settings.json
@@ -17,6 +17,8 @@
   "language": "Language",
   "main-platform": "Main platform",
   "password": "Password",
+  "platforms-drawer": "Platforms menu",
+  "platforms-drawer-group-by": "Group by",
   "platform-version": "Platform version",
   "platforms-bindings": "Platforms bindings",
   "platforms-versions": "Platforms versions",

--- a/frontend/src/locales/es_ES/settings.json
+++ b/frontend/src/locales/es_ES/settings.json
@@ -17,6 +17,8 @@
   "language": "Idioma",
   "main-platform": "Plataforma principal",
   "password": "Contraseña",
+  "platforms-drawer": "Menú de plataformas",
+  "platforms-drawer-group-by": "Agrupar por",
   "platform-version": "Version de la plataforma",
   "platforms-bindings": "Asociaciones de plataformas",
   "platforms-versions": "Versiones de plataformas",

--- a/frontend/src/locales/fr_FR/settings.json
+++ b/frontend/src/locales/fr_FR/settings.json
@@ -17,6 +17,8 @@
   "language": "Langue",
   "main-platform": "Plateforme principale",
   "password": "Mot de passe",
+  "platforms-drawer": "Menu des plateformes",
+  "platforms-drawer-group-by": "Grouper par",
   "platform-version": "Version de la plateforme",
   "platforms-bindings": "Liaisons des plateformes",
   "platforms-versions": "Versions des plateformes",

--- a/frontend/src/locales/it_IT/settings.json
+++ b/frontend/src/locales/it_IT/settings.json
@@ -18,6 +18,8 @@
   "language": "Lingua",
   "main-platform": "Piattaforma principale",
   "password": "Password",
+  "platforms-drawer": "Menu piattaforme",
+  "platforms-drawer-group-by": "Raggruppa per",
   "platform-version": "Versione piattaforma",
   "platforms-bindings": "Associazioni piattaforme",
   "platforms-versions": "Versioni piattaforme",

--- a/frontend/src/locales/ja_JP/settings.json
+++ b/frontend/src/locales/ja_JP/settings.json
@@ -17,6 +17,8 @@
   "language": "言語",
   "main-platform": "メインプラットフォーム",
   "password": "パスワード",
+  "platforms-drawer": "プラットフォームメニュー",
+  "platforms-drawer-group-by": "グループ化",
   "platform-version": "プラットフォームバージョン",
   "platforms-bindings": "プラットフォーム割当",
   "platforms-versions": "プラットフォームバージョン",

--- a/frontend/src/locales/ko_KR/settings.json
+++ b/frontend/src/locales/ko_KR/settings.json
@@ -17,6 +17,8 @@
   "language": "언어",
   "main-platform": "메인 플랫폼",
   "password": "패스워드",
+  "platforms-drawer": "플랫폼 메뉴",
+  "platforms-drawer-group-by": "그룹화",
   "platform-version": "플랫폼 버전",
   "platforms-bindings": "플랫폼 연결",
   "platforms-versions": "플랫폼 버전",

--- a/frontend/src/locales/pt_BR/settings.json
+++ b/frontend/src/locales/pt_BR/settings.json
@@ -17,6 +17,8 @@
   "language": "Idioma",
   "main-platform": "Plataforma principal",
   "password": "Senha",
+  "platforms-drawer": "Menu de plataformas",
+  "platforms-drawer-group-by": "Agrupar por",
   "platform-version": "Versão da plataforma",
   "platforms-bindings": "Vinculações de plataformas",
   "platforms-versions": "Versões de plataformas",

--- a/frontend/src/locales/ro_RO/settings.json
+++ b/frontend/src/locales/ro_RO/settings.json
@@ -18,6 +18,8 @@
   "language": "Limbă",
   "main-platform": "Platformă principală",
   "password": "Parolă",
+  "platforms-drawer": "Meniu platforme",
+  "platforms-drawer-group-by": "Grupare după",
   "platform-version": "Versiune platformă",
   "platforms-bindings": "Asocieri platforme",
   "platforms-versions": "Versiuni platforme",

--- a/frontend/src/locales/ru_RU/settings.json
+++ b/frontend/src/locales/ru_RU/settings.json
@@ -17,6 +17,8 @@
   "language": "Язык",
   "main-platform": "Основная платформа",
   "password": "Пароль",
+  "platforms-drawer": "Меню платформ",
+  "platforms-drawer-group-by": "Группировать по",
   "platform-version": "Версия платформы",
   "platforms-bindings": "Связи платформ",
   "platforms-versions": "Версии платформ",

--- a/frontend/src/locales/zh_CN/settings.json
+++ b/frontend/src/locales/zh_CN/settings.json
@@ -17,6 +17,8 @@
   "language": "语言",
   "main-platform": "主平台",
   "password": "密码",
+  "platforms-drawer": "平台菜单",
+  "platforms-drawer-group-by": "分组方式",
   "platform-version": "平台版本",
   "platforms-bindings": "平台绑定",
   "platforms-versions": "平台版本",

--- a/frontend/src/views/Scan.vue
+++ b/frontend/src/views/Scan.vue
@@ -328,7 +328,7 @@ async function stopScan() {
               v-for="platform in scanningPlatforms"
               :key="platform.id"
             >
-              <v-expansion-panel-title>
+              <v-expansion-panel-title static>
                 <v-list-item class="pa-0">
                   <template #prepend>
                     <v-avatar rounded="0" size="40">


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
This PR adds a new option to group platforms by ``family (manufacturer)``, ``generation`` or ``category (console type)``

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots

![image](https://github.com/user-attachments/assets/c1daaa04-198f-4058-a347-09a52385cb92)

Closes #358 
