### PR TITLE
During a scan, if an image fails to be read, the scan is aborted

### DIFF
--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -74,7 +74,7 @@ class FSResourcesHandler(FSHandler):
             try:
                 with Image.open(cover_file) as img:
                     self.resize_cover_to_small(img, save_path=cover_file)
-            except UnidentifiedImageError as exc:                
+            except UnidentifiedImageError as exc:
                 log.error(f"Unable to identify image {cover_file}: {str(exc)}")
                 return None
 

--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -6,7 +6,7 @@ from config import RESOURCES_BASE_PATH
 from logger.logger import log
 from models.collection import Collection
 from models.rom import Rom
-from PIL import Image, ImageFile
+from PIL import Image, ImageFile, UnidentifiedImageError
 from utils.context import ctx_httpx_client
 
 from .base_handler import CoverSize, FSHandler
@@ -71,8 +71,12 @@ class FSResourcesHandler(FSHandler):
             return None
 
         if size == CoverSize.SMALL:
-            with Image.open(cover_file) as img:
-                self.resize_cover_to_small(img, save_path=cover_file)
+            try:
+                with Image.open(cover_file) as img:
+                    self.resize_cover_to_small(img, save_path=cover_file)
+            except UnidentifiedImageError as exc:                
+                log.error(f"Unable to identify image {cover_file}: {str(exc)}")
+                return None
 
     @staticmethod
     async def _get_cover_path(entity: Rom | Collection, size: CoverSize) -> str:


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
During a scan, if an image fails to be read, the scan is aborted and only one game is added to the library.
To work around this, you need to manually change the image and re-scan for every game that this affects.

I've validated that this works for me by changing my docker file directly. The scan completes fully.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
