### PR TITLE
fix: correct user creation logic in OpenIDHandler

### DIFF
--- a/backend/handler/auth/base_handler.py
+++ b/backend/handler/auth/base_handler.py
@@ -149,14 +149,14 @@ class OpenIDHandler:
         user = db_user_handler.get_user_by_email(email)
         if user is None:
             log.info("User with email '%s' not found, creating new user", email)
-            user = User(
+            new_user = User(
                 username=preferred_username,
                 hashed_password=str(uuid.uuid4()),
                 email=email,
                 enabled=True,
                 role=Role.VIEWER,
             )
-            db_user_handler.add_user(user)
+            user = db_user_handler.add_user(new_user)
 
         if not user.enabled:
             raise UserDisabledException


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Fix for OIDC new user logins getting a "Internal Server Error" message on first login.  This handles the new user database object properly, so that further updates to it (like when updating the last login and last active times) successfully happen.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

Not sure who to add as reviewers as I am new here.
Partially/fully fixes #1502 
