### PR TITLE
feat: add Retroachievements filter to show only RA compatible games

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -148,6 +148,7 @@ def get_roms(
     favourites_only: bool = False,
     duplicates_only: bool = False,
     playables_only: bool = False,
+    ra_only: bool = False,
     group_by_meta_id: bool = False,
     selected_genre: str | None = None,
     selected_franchise: str | None = None,
@@ -173,6 +174,7 @@ def get_roms(
         favourites_only (bool, optional): Filter only favourite roms. Defaults to False.
         duplicates_only (bool, optional): Filter only duplicate roms. Defaults to False.
         playables_only (bool, optional): Filter only playable roms by emulatorjs. Defaults to False.
+        ra_only (bool, optional): Filter only roms with Retroachievements compatibility.
         group_by_meta_id (bool, optional): Group roms by igdb/moby/ssrf ID. Defaults to False.
         selected_genre (str, optional): Filter by genre. Defaults to None.
         selected_franchise (str, optional): Filter by franchise. Defaults to None.
@@ -207,6 +209,7 @@ def get_roms(
         favourites_only=favourites_only,
         duplicates_only=duplicates_only,
         playables_only=playables_only,
+        ra_only=ra_only,
         selected_genre=selected_genre,
         selected_franchise=selected_franchise,
         selected_collection=selected_collection,

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -224,6 +224,9 @@ class DBRomsHandler(DBBaseHandler):
             Platform.slug.in_(EJS_SUPPORTED_PLATFORMS)
         )
 
+    def filter_by_ra_only(self, query: Query):
+        return query.filter(Rom.ra_id.isnot(None))
+
     def filter_by_genre(self, query: Query, selected_genre: str):
         if ROMM_DB_DRIVER == "postgresql":
             return query.filter(
@@ -349,6 +352,7 @@ class DBRomsHandler(DBBaseHandler):
         favourites_only: bool = False,
         duplicates_only: bool = False,
         playables_only: bool = False,
+        ra_only: bool = False,
         group_by_meta_id: bool = False,
         selected_genre: str | None = None,
         selected_franchise: str | None = None,
@@ -389,6 +393,9 @@ class DBRomsHandler(DBBaseHandler):
 
         if playables_only:
             query = self.filter_by_playables_only(query)
+
+        if ra_only:
+            query = self.filter_by_ra_only(query)
 
         if group_by_meta_id:
 

--- a/frontend/src/components/Details/RetroAchievements.vue
+++ b/frontend/src/components/Details/RetroAchievements.vue
@@ -17,6 +17,7 @@ const achievemehtsPercentage = ref(0);
 const showEarned = ref(false);
 const filteredAchievements = ref<RAGameRomAchievement[]>([]);
 
+// Functions
 function toggleShowEarned() {
   showEarned.value = !showEarned.value;
   if (showEarned.value) {
@@ -31,6 +32,18 @@ function toggleShowEarned() {
       props.rom.merged_ra_metadata?.achievements ?? []
     ).sort((a, b) => (a.display_order ?? 0) - (b.display_order ?? 0));
   }
+}
+
+function isAchievementEarned(achievement: RAGameRomAchievement) {
+  return earnedAchievements.value.some(
+    (earned) => earned.id === (achievement.badge_id ?? ""),
+  );
+}
+
+function getAchievementEarnedDate(achievement: RAGameRomAchievement) {
+  return earnedAchievements.value.find(
+    (earned) => earned.id === (achievement.badge_id ?? ""),
+  )?.date;
 }
 
 onMounted(() => {
@@ -92,17 +105,9 @@ onMounted(() => {
       :title="achievement.title?.toString()"
       class="mb-2 py-4 rounded bg-toplayer"
       :class="{
-        earned: earnedAchievements.some(
-          (earned) => earned.id === (achievement.badge_id ?? ''),
-        ),
-        locked: !earnedAchievements.some(
-          (earned) => earned.id === (achievement.badge_id ?? ''),
-        ),
-        hidden:
-          showEarned &&
-          !earnedAchievements.some(
-            (earned) => earned.id === (achievement.badge_id ?? ''),
-          ),
+        earned: isAchievementEarned(achievement),
+        locked: !isAchievementEarned(achievement),
+        hidden: showEarned && !isAchievementEarned(achievement),
       }"
     >
       <template #prepend>
@@ -112,9 +117,7 @@ onMounted(() => {
         >
           <v-img
             :src="
-              earnedAchievements.some(
-                (earned) => earned.id === (achievement.badge_id ?? ''),
-              )
+              isAchievementEarned(achievement)
                 ? (achievement.badge_path ?? '')
                 : (achievement.badge_path_lock ?? '')
             "
@@ -126,36 +129,17 @@ onMounted(() => {
           achievement.description?.toString()
         }}</v-list-item-subtitle>
         <v-chip
-          v-if="
-            earnedAchievements.some(
-              (earned) => earned.id === (achievement.badge_id ?? ''),
-            ) && smAndDown
-          "
+          v-if="isAchievementEarned(achievement) && smAndDown"
           label
           size="x-small"
           class="mt-1"
         >
-          {{
-            earnedAchievements.find(
-              (earned) => earned.id === (achievement.badge_id ?? ""),
-            )?.date
-          }}
+          {{ getAchievementEarnedDate(achievement) }}
         </v-chip>
       </template>
-      <template
-        v-if="
-          earnedAchievements.some(
-            (earned) => earned.id === (achievement.badge_id ?? ''),
-          ) && !smAndDown
-        "
-        #append
-      >
+      <template v-if="isAchievementEarned(achievement) && !smAndDown" #append>
         <v-chip label size="small">
-          {{
-            earnedAchievements.find(
-              (earned) => earned.id === (achievement.badge_id ?? ""),
-            )?.date
-          }}
+          {{ getAchievementEarnedDate(achievement) }}
         </v-chip>
       </template>
     </v-list-item>

--- a/frontend/src/components/Details/RetroAchievements.vue
+++ b/frontend/src/components/Details/RetroAchievements.vue
@@ -4,8 +4,10 @@ import storeAuth from "@/stores/auth";
 import { ref, onMounted } from "vue";
 import type { RAGameRomAchievement } from "@/__generated__/models/RAGameRomAchievement";
 import { useI18n } from "vue-i18n";
+import { useDisplay } from "vuetify";
 
 // Props
+const { smAndDown } = useDisplay();
 const props = defineProps<{ rom: DetailedRom }>();
 const { t } = useI18n();
 const auth = storeAuth();
@@ -88,7 +90,6 @@ onMounted(() => {
     <v-list-item
       v-for="achievement in filteredAchievements"
       :title="achievement.title?.toString()"
-      :subtitle="achievement.description?.toString()"
       class="mb-2 py-4 rounded bg-toplayer"
       :class="{
         earned: earnedAchievements.some(
@@ -120,16 +121,36 @@ onMounted(() => {
           />
         </v-avatar>
       </template>
-      <template #append>
+      <template #subtitle>
+        <v-list-item-subtitle>{{
+          achievement.description?.toString()
+        }}</v-list-item-subtitle>
         <v-chip
-          label
-          size="small"
           v-if="
             earnedAchievements.some(
               (earned) => earned.id === (achievement.badge_id ?? ''),
-            )
+            ) && smAndDown
           "
+          label
+          size="x-small"
+          class="mt-1"
         >
+          {{
+            earnedAchievements.find(
+              (earned) => earned.id === (achievement.badge_id ?? ""),
+            )?.date
+          }}
+        </v-chip>
+      </template>
+      <template
+        v-if="
+          earnedAchievements.some(
+            (earned) => earned.id === (achievement.badge_id ?? ''),
+          ) && !smAndDown
+        "
+        #append
+      >
+        <v-chip label size="small">
           {{
             earnedAchievements.find(
               (earned) => earned.id === (achievement.badge_id ?? ""),

--- a/frontend/src/components/Details/RetroAchievements.vue
+++ b/frontend/src/components/Details/RetroAchievements.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { DetailedRom } from "@/stores/roms";
 import storeAuth from "@/stores/auth";
-import { ref, onMounted } from "vue";
+import { ref, onMounted, computed } from "vue";
 import type { RAGameRomAchievement } from "@/__generated__/models/RAGameRomAchievement";
 import { useI18n } from "vue-i18n";
 import { useDisplay } from "vuetify";
@@ -34,17 +34,21 @@ function toggleShowEarned() {
   }
 }
 
-function isAchievementEarned(achievement: RAGameRomAchievement) {
-  return earnedAchievements.value.some(
-    (earned) => earned.id === (achievement.badge_id ?? ""),
-  );
-}
+const isAchievementEarned = computed(
+  () => (achievement: RAGameRomAchievement) => {
+    return earnedAchievements.value.some(
+      (earned) => earned.id === (achievement.badge_id ?? ""),
+    );
+  },
+);
 
-function getAchievementEarnedDate(achievement: RAGameRomAchievement) {
-  return earnedAchievements.value.find(
-    (earned) => earned.id === (achievement.badge_id ?? ""),
-  )?.date;
-}
+const getAchievementEarnedDate = computed(
+  () => (achievement: RAGameRomAchievement) => {
+    return earnedAchievements.value.find(
+      (earned) => earned.id === (achievement.badge_id ?? ""),
+    )?.date;
+  },
+);
 
 onMounted(() => {
   filteredAchievements.value = (

--- a/frontend/src/components/Details/Title.vue
+++ b/frontend/src/components/Details/Title.vue
@@ -54,24 +54,15 @@ const hasReleaseDate = Number(props.rom.metadatum.first_release_date) > 0;
           />
         </v-chip>
         <v-chip
-          v-if="hasReleaseDate && !smAndDown"
-          class="ml-1 font-italic"
+          v-if="Number(rom.metadatum.first_release_date) > 0"
+          class="font-italic ma-1"
           size="small"
         >
           {{ releaseDate }}
         </v-chip>
-        <v-chip
-          v-if="Number(rom.metadatum.first_release_date) > 0 && smAndDown"
-          class="font-italic ml-1"
-          size="small"
-        >
-          {{ releaseDate }}
+        <v-chip v-if="!smAndDown && rom.revision" size="small" class="ma-1">
+          Revision {{ rom.revision }}
         </v-chip>
-        <template v-if="!smAndDown">
-          <v-chip v-if="rom.revision" size="small" class="ml-1">
-            Revision {{ rom.revision }}
-          </v-chip>
-        </template>
       </v-col>
     </v-row>
 

--- a/frontend/src/components/Details/Title.vue
+++ b/frontend/src/components/Details/Title.vue
@@ -43,15 +43,15 @@ const hasReleaseDate = Number(props.rom.metadatum.first_release_date) > 0;
         <v-chip
           :to="{ name: ROUTES.PLATFORM, params: { platform: rom.platform_id } }"
         >
-          {{ rom.platform_display_name }}
           <platform-icon
             :key="rom.platform_slug"
             :slug="rom.platform_slug"
             :name="rom.platform_name"
             :fs-slug="rom.platform_fs_slug"
             :size="30"
-            class="ml-2"
+            class="mr-2"
           />
+          {{ rom.platform_display_name }}
         </v-chip>
         <v-chip
           v-if="Number(rom.metadatum.first_release_date) > 0"

--- a/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
+++ b/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
@@ -5,6 +5,7 @@ import FilterMatchedBtn from "@/components/Gallery/AppBar/common/FilterDrawer/Fi
 import FilterFavouritesBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterFavouritesBtn.vue";
 import FilterDuplicatesBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterDuplicatesBtn.vue";
 import FilterPlayablesBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterPlayablesBtn.vue";
+import FilterRaBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterRaBtn.vue";
 import FilterTextField from "@/components/Gallery/AppBar/common/FilterTextField.vue";
 import storeGalleryFilter from "@/stores/galleryFilter";
 import storeRoms from "@/stores/roms";
@@ -210,6 +211,7 @@ onMounted(async () => {
           class="mt-2"
           :tabindex="activeFilterDrawer ? 0 : -1"
         />
+        <filter-ra-btn class="mt-2" :tabindex="activeFilterDrawer ? 0 : -1" />
       </v-list-item>
       <v-list-item
         v-if="showPlatformsFilter"

--- a/frontend/src/components/Gallery/AppBar/common/FilterDrawer/FilterRaBtn.vue
+++ b/frontend/src/components/Gallery/AppBar/common/FilterDrawer/FilterRaBtn.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import storeGalleryFilter from "@/stores/galleryFilter";
+import storeRoms from "@/stores/roms";
+import type { Events } from "@/types/emitter";
+import type { Emitter } from "mitt";
+import { storeToRefs } from "pinia";
+import { inject } from "vue";
+import { useI18n } from "vue-i18n";
+
+// Props
+const { t } = useI18n();
+const romsStore = storeRoms();
+const galleryFilterStore = storeGalleryFilter();
+const { fetchTotalRoms } = storeToRefs(romsStore);
+const { filterRA } = storeToRefs(galleryFilterStore);
+const emitter = inject<Emitter<Events>>("emitter");
+
+// Functions
+function setRA() {
+  galleryFilterStore.switchFilterRA();
+  emitter?.emit("filter", null);
+}
+</script>
+
+<template>
+  <v-btn
+    block
+    variant="tonal"
+    :color="filterRA ? 'primary' : ''"
+    @click="setRA()"
+    :disabled="fetchTotalRoms > 10000"
+  >
+    <v-icon :color="filterRA ? 'primary' : ''"> mdi-trophy </v-icon>
+    <span
+      class="ml-2"
+      :class="{
+        'text-primary': filterRA,
+      }"
+      >{{ t("platform.show-ra") }}
+    </span>
+  </v-btn>
+</template>

--- a/frontend/src/locales/de_DE/platform.json
+++ b/frontend/src/locales/de_DE/platform.json
@@ -29,6 +29,7 @@
   "show-matched": "Zeige zugewiesene",
   "show-playables": "Zeige spielbare",
   "show-unmatched": "Zeige unzugewiesene",
+  "show-ra": "Zeige Retroachievements",
   "status": "Status",
   "upload-roms": "Roms hochladen"
 }

--- a/frontend/src/locales/en_GB/platform.json
+++ b/frontend/src/locales/en_GB/platform.json
@@ -29,6 +29,7 @@
   "show-matched": "Show Matched",
   "show-unmatched": "Show unmatched",
   "show-playables": "Show playables",
+  "show-ra": "Show Retroachievements",
   "status": "Status",
   "upload-roms": "Upload Roms"
 }

--- a/frontend/src/locales/en_US/platform.json
+++ b/frontend/src/locales/en_US/platform.json
@@ -29,6 +29,7 @@
   "show-matched": "Show Matched",
   "show-unmatched": "Show unmatched",
   "show-playables": "Show playables",
+  "show-ra": "Show Retroachievements",
   "status": "Status",
   "upload-roms": "Upload Roms"
 }

--- a/frontend/src/locales/es_ES/platform.json
+++ b/frontend/src/locales/es_ES/platform.json
@@ -27,8 +27,9 @@
   "show-favourites": "Mostrar favoritos",
   "show-firmwares": "Mostrar firmwares/BIOS",
   "show-matched": "Mostrar identificados",
-  "show-playables": "Mostrar jugables",
   "show-unmatched": "Mostrar no identificados",
+  "show-playables": "Mostrar jugables",
+  "show-ra": "Mostrar Retroachievements",
   "status": "Estado",
   "upload-roms": "Subir Roms"
 }

--- a/frontend/src/locales/fr_FR/platform.json
+++ b/frontend/src/locales/fr_FR/platform.json
@@ -29,6 +29,7 @@
   "show-matched": "Jeux identifiés",
   "show-unmatched": "Jeux non identifiés",
   "show-playables": "Afficher les jouables",
+  "show-ra": "Afficher les Retroachievements",
   "status": "Statut",
   "upload-roms": "Télécharger des ROMs"
 }

--- a/frontend/src/locales/it_IT/platform.json
+++ b/frontend/src/locales/it_IT/platform.json
@@ -31,6 +31,7 @@
   "show-matched": "Mostra con corrispondenza",
   "show-unmatched": "Mostra senza corrispondenza",
   "show-playables": "Mostra giocabili",
+  "show-ra": "Mostra Retroachievements",
   "status": "Stato",
   "upload-roms": "Carica Rom"
 }

--- a/frontend/src/locales/ja_JP/platform.json
+++ b/frontend/src/locales/ja_JP/platform.json
@@ -29,6 +29,7 @@
   "show-matched": "該当を表示",
   "show-unmatched": "非該当を表示",
   "show-playables": "プレイ可能を表示",
+  "show-ra": "Retroachievementsを表示",
   "status": "ステータス",
   "upload-roms": "Romをアップロード"
 }

--- a/frontend/src/locales/ko_KR/platform.json
+++ b/frontend/src/locales/ko_KR/platform.json
@@ -29,6 +29,7 @@
   "show-matched": "DB 대응 됨",
   "show-unmatched": "DB 대응 안됨",
   "show-playables": "플레이 가능한 게임 보기",
+  "show-ra": "Retroachievements 보기",
   "status": "플레이 상태",
   "upload-roms": "롬 업로드"
 }

--- a/frontend/src/locales/pt_BR/platform.json
+++ b/frontend/src/locales/pt_BR/platform.json
@@ -29,6 +29,7 @@
   "show-matched": "Mostrar correspondentes",
   "show-unmatched": "Mostrar não correspondentes",
   "show-playables": "Mostrar jogáveis",
+  "show-ra": "Mostrar Retroachievements",
   "status": "Status",
   "upload-roms": "Carregar ROMs"
 }

--- a/frontend/src/locales/ro_RO/platform.json
+++ b/frontend/src/locales/ro_RO/platform.json
@@ -31,6 +31,7 @@
   "show-matched": "Jocuri identificate",
   "show-unmatched": "Jocuri neidentificate",
   "show-playables": "Afișează jocuri jucabile",
+  "show-ra": "Afișează Retroachievements",
   "status": "Stare",
   "upload-roms": "Încărcare ROM-uri"
 }

--- a/frontend/src/locales/ru_RU/platform.json
+++ b/frontend/src/locales/ru_RU/platform.json
@@ -29,6 +29,7 @@
   "show-matched": "Показать соответствующие",
   "show-unmatched": "Показать несоответствующие",
   "show-playables": "Показать доступные",
+  "show-ra": "Показать Retroachievements",
   "status": "Статус",
   "upload-roms": "Загрузить ромы"
 }

--- a/frontend/src/locales/zh_CN/platform.json
+++ b/frontend/src/locales/zh_CN/platform.json
@@ -29,6 +29,7 @@
   "show-matched": "显示匹配项",
   "show-unmatched": "显示不匹配项",
   "show-playables": "显示可玩",
+  "show-ra": "显示 Retroachievements",
   "status": "状态",
   "upload-roms": "上传 Roms"
 }

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -72,6 +72,7 @@ export interface GetRomsParams {
   filterFavourites?: boolean;
   filterDuplicates?: boolean;
   filterPlayables?: boolean;
+  filterRA?: boolean;
   groupByMetaId?: boolean;
   selectedGenre?: string | null;
   selectedFranchise?: string | null;
@@ -97,6 +98,7 @@ async function getRoms({
   filterFavourites = false,
   filterDuplicates = false,
   filterPlayables = false,
+  filterRA = false,
   groupByMetaId = false,
   selectedGenre = null,
   selectedFranchise = null,
@@ -122,6 +124,7 @@ async function getRoms({
       favourites_only: filterFavourites,
       duplicates_only: filterDuplicates,
       playables_only: filterPlayables,
+      ra_only: filterRA,
       group_by_meta_id: groupByMetaId,
       selected_genre: selectedGenre,
       selected_franchise: selectedFranchise,

--- a/frontend/src/stores/galleryFilter.ts
+++ b/frontend/src/stores/galleryFilter.ts
@@ -31,6 +31,7 @@ const defaultFilterState = {
   filterFavourites: false,
   filterDuplicates: false,
   filterPlayables: false,
+  filterRA: false,
   selectedPlatform: null as Platform | null,
   selectedGenre: null as string | null,
   selectedFranchise: null as string | null,
@@ -134,6 +135,12 @@ export default defineStore("galleryFilter", {
     disableFilterPlayables() {
       this.filterPlayables = false;
     },
+    switchFilterRA() {
+      this.filterRA = !this.filterRA;
+    },
+    disableFilterRA() {
+      this.filterRA = false;
+    },
     isFiltered() {
       return Boolean(
         this.filterUnmatched ||
@@ -141,6 +148,7 @@ export default defineStore("galleryFilter", {
           this.filterFavourites ||
           this.filterDuplicates ||
           this.filterPlayables ||
+          this.filterRA ||
           this.selectedPlatform ||
           this.selectedGenre ||
           this.selectedFranchise ||
@@ -168,6 +176,7 @@ export default defineStore("galleryFilter", {
       this.disableFilterFavourites();
       this.disableFilterDuplicates();
       this.disableFilterPlayables();
+      this.disableFilterRA();
     },
   },
 });


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
This PR add a new filter to show RA compatible roms only

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
