### PR TITLE
misc: Optimized covers storing them as webp format

### DIFF
--- a/backend/alembic/versions/0041_convert_resources_to_webp.py
+++ b/backend/alembic/versions/0041_convert_resources_to_webp.py
@@ -1,0 +1,140 @@
+"""convert resource paths to webp and update db
+
+Revision ID: 0041_convert_resources_to_webp
+Revises: 0040_migrate_assets_paths
+Create Date: 2025-05-29 00:00:00.000000
+"""
+
+import json
+import os
+
+from alembic import op
+from config import RESOURCES_BASE_PATH
+from logger.logger import log
+from sqlalchemy.sql import text
+
+revision = "0041_convert_resources_to_webp"
+down_revision = "0040_migrate_assets_paths"
+branch_labels = None
+depends_on = None
+
+
+def convert_to_webp(abs_path):
+    from PIL import Image, UnidentifiedImageError
+
+    base, ext = os.path.splitext(abs_path)
+    if ext.lower() == ".webp":
+        return abs_path  # Already webp
+
+    webp_path = base + ".webp"
+    if os.path.exists(webp_path):
+        return webp_path  # Already converted
+
+    try:
+        with Image.open(abs_path) as img:
+            img.save(webp_path, format="WEBP", quality=90, method=6)
+        os.remove(abs_path)
+        log.info(f"Converted {abs_path} to {webp_path}")
+        return webp_path
+    except UnidentifiedImageError:
+        log.warning(f"Not an image: {abs_path}")
+        return abs_path
+    except Exception as exc:
+        log.error(f"Failed to convert {abs_path}: {exc}")
+        return abs_path
+
+
+def rel_to_webp(rel_path):
+    base, ext = os.path.splitext(rel_path)
+    if ext.lower() == ".webp":
+        return rel_path
+    return base + ".webp"
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # --- ROMS TABLE ---
+    results = conn.execute(
+        text("SELECT id, path_cover_s, path_cover_l, path_screenshots FROM roms")
+    ).fetchall()
+
+    for row in results:
+        updates = {}
+        # Cover small
+        if row.path_cover_s:
+            abs_path = os.path.join(RESOURCES_BASE_PATH, row.path_cover_s)
+            new_abs = convert_to_webp(abs_path)
+            new_rel = rel_to_webp(row.path_cover_s)
+            if new_abs != abs_path:
+                updates["path_cover_s"] = new_rel
+
+        # Cover large
+        if row.path_cover_l:
+            abs_path = os.path.join(RESOURCES_BASE_PATH, row.path_cover_l)
+            new_abs = convert_to_webp(abs_path)
+            new_rel = rel_to_webp(row.path_cover_l)
+            if new_abs != abs_path:
+                updates["path_cover_l"] = new_rel
+
+        # Screenshots (JSON string)
+        if row.path_screenshots:
+            try:
+                screenshots = json.loads(row.path_screenshots)
+            except Exception:
+                log.error(f"Invalid JSON in path_screenshots for rom id {row.id}")
+                screenshots = []
+            new_screens = []
+            changed = False
+            for s in screenshots:
+                abs_path = os.path.join(RESOURCES_BASE_PATH, s)
+                new_abs = convert_to_webp(abs_path)
+                new_rel = rel_to_webp(s)
+                new_screens.append(new_rel)
+                if new_abs != abs_path:
+                    changed = True
+            if changed:
+                updates["path_screenshots"] = json.dumps(new_screens)
+
+        # Update DB if needed
+        if updates:
+            set_clause = ", ".join([f"{k} = :{k}" for k in updates])
+            params = {**updates, "id": row.id}
+            conn.execute(
+                text(f"UPDATE roms SET {set_clause} WHERE id = :id"),
+                params,
+            )
+            log.info(f"Updated rom id {row.id}: {updates}")
+
+    # --- COLLECTIONS TABLE ---
+    results = conn.execute(
+        text("SELECT id, path_cover_s, path_cover_l FROM collections")
+    ).fetchall()
+
+    for row in results:
+        updates = {}
+        if row.path_cover_s:
+            abs_path = os.path.join(RESOURCES_BASE_PATH, row.path_cover_s)
+            new_abs = convert_to_webp(abs_path)
+            new_rel = rel_to_webp(row.path_cover_s)
+            if new_abs != abs_path:
+                updates["path_cover_s"] = new_rel
+        if row.path_cover_l:
+            abs_path = os.path.join(RESOURCES_BASE_PATH, row.path_cover_l)
+            new_abs = convert_to_webp(abs_path)
+            new_rel = rel_to_webp(row.path_cover_l)
+            if new_abs != abs_path:
+                updates["path_cover_l"] = new_rel
+        if updates:
+            set_clause = ", ".join([f"{k} = :{k}" for k in updates])
+            params = {**updates, "id": row.id}
+            conn.execute(
+                text(f"UPDATE collections SET {set_clause} WHERE id = :id"),
+                params,
+            )
+            log.info(f"Updated collection id {row.id}: {updates}")
+
+
+def downgrade():
+    # Not implemented
+    pass

--- a/backend/endpoints/collections.py
+++ b/backend/endpoints/collections.py
@@ -1,8 +1,6 @@
 import json
-from io import BytesIO
 from shutil import rmtree
 
-from anyio import Path
 from config import RESOURCES_BASE_PATH
 from decorators.auth import protected_route
 from endpoints.responses import MessageResponse
@@ -21,7 +19,6 @@ from logger.formatter import BLUE
 from logger.formatter import highlight as hl
 from logger.logger import log
 from models.collection import Collection
-from PIL import Image
 from sqlalchemy.inspection import inspect
 from utils.router import APIRouter
 
@@ -63,21 +60,11 @@ async def add_collection(
     _added_collection = db_collection_handler.add_collection(Collection(**cleaned_data))
 
     if artwork is not None and artwork.filename is not None:
-        file_ext = artwork.filename.split(".")[-1]
-        (
-            path_cover_l,
-            path_cover_s,
-            artwork_path,
-        ) = await fs_resource_handler.build_artwork_path(_added_collection, file_ext)
-
-        artwork_content = BytesIO(await artwork.read())
-        file_location_small = Path(f"{artwork_path}/small.{file_ext}")
-        file_location_large = Path(f"{artwork_path}/big.{file_ext}")
-        with Image.open(artwork_content) as img:
-            img.save(file_location_large)
-            fs_resource_handler.resize_cover_to_small(
-                img, save_path=file_location_small
-            )
+        cover_data = await fs_resource_handler.save_uploaded_cover(
+            _added_collection, artwork
+        )
+        path_cover_s = cover_data["path_cover_s"]
+        path_cover_l = cover_data["path_cover_l"]
     else:
         path_cover_s, path_cover_l = await fs_resource_handler.get_cover(
             entity=_added_collection,
@@ -221,26 +208,10 @@ async def update_collection(
         cleaned_data.update({"url_cover": ""})
     else:
         if artwork is not None and artwork.filename is not None:
-            file_ext = artwork.filename.split(".")[-1]
-            (
-                path_cover_l,
-                path_cover_s,
-                artwork_path,
-            ) = await fs_resource_handler.build_artwork_path(collection, file_ext)
-
-            cleaned_data["path_cover_l"] = path_cover_l
-            cleaned_data["path_cover_s"] = path_cover_s
-
-            artwork_content = BytesIO(await artwork.read())
-            file_location_small = Path(f"{artwork_path}/small.{file_ext}")
-            file_location_large = Path(f"{artwork_path}/big.{file_ext}")
-            with Image.open(artwork_content) as img:
-                img.save(file_location_large)
-                fs_resource_handler.resize_cover_to_small(
-                    img, save_path=file_location_small
-                )
-
-            cleaned_data.update({"url_cover": ""})
+            cover_data = await fs_resource_handler.save_uploaded_cover(
+                collection, artwork
+            )
+            cleaned_data.update(cover_data)
         else:
             if data.get("url_cover", "") != collection.url_cover or not (
                 await fs_resource_handler.cover_exists(collection, CoverSize.BIG)

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -611,7 +611,6 @@ async def update_rom(
         cleaned_data.update({"url_cover": ""})
     else:
         if artwork is not None and artwork.filename is not None:
-            # Use the resource handler to save and process the cover artwork
             cover_data = await fs_resource_handler.save_uploaded_cover(rom, artwork)
             cleaned_data.update(cover_data)
         else:


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Now any kind of new artowrk (uploaded or fetched) will be converted to `.webp` format to improve performance

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
