### PR TITLE
[HOTFIX] Fix ramatcher on mult-file games

### DIFF
--- a/backend/adapters/services/rahasher.py
+++ b/backend/adapters/services/rahasher.py
@@ -6,7 +6,7 @@ from logger.formatter import LIGHTMAGENTA
 from logger.formatter import highlight as hl
 from logger.logger import log
 
-RAHASHER_VALID_HASH_REGEX = re.compile(r"^[0-9a-f]{32}$")
+RAHASHER_VALID_HASH_REGEX = re.compile(r"[0-9a-f]{32}")
 
 # TODO: Centralize standarized platform slugs using StrEnum.
 PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID: dict[str, int] = {
@@ -123,10 +123,12 @@ class RAHasherService:
         if not file_hash:
             log.error(f"RAHasher returned an empty hash. {platform_id=}, {file_path=}")
             return ""
-        if not RAHASHER_VALID_HASH_REGEX.match(file_hash):
+
+        match = RAHASHER_VALID_HASH_REGEX.search(file_hash)
+        if not match:
             log.error(
-                f"RAHasher returned an invalid hash: {file_hash=}, {platform_id=}, {file_path=}"
+                f"RAHasher returned an invalid hash: {file_hash}. Expected format: {RAHASHER_VALID_HASH_REGEX.pattern}"
             )
             return ""
 
-        return file_hash
+        return match.group(0)

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -418,7 +418,7 @@ class FSRomsHandler(FSHandler):
                 ra_hash=(
                     await RAHasherService().calculate_hash(
                         SLUG_TO_RA_ID[rom.platform.slug]["id"],
-                        f"{LIBRARY_BASE_PATH}/{rom.fs_path}/{rom.fs_name}{"/*" if rom.multi else ""}",
+                        f"{LIBRARY_BASE_PATH}/{rom.fs_path}/{rom.fs_name}{'/*' if rom.multi else ''}",
                     )
                     if rom.platform.slug in SLUG_TO_RA_ID.keys()
                     else ""

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -418,7 +418,7 @@ class FSRomsHandler(FSHandler):
                 ra_hash=(
                     await RAHasherService().calculate_hash(
                         SLUG_TO_RA_ID[rom.platform.slug]["id"],
-                        f"{LIBRARY_BASE_PATH}/{rom.fs_path}/{rom.fs_name}",
+                        f"{LIBRARY_BASE_PATH}/{rom.fs_path}/{rom.fs_name}/{"*" if rom.multi else ""}",
                     )
                     if rom.platform.slug in SLUG_TO_RA_ID.keys()
                     else ""

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -418,7 +418,7 @@ class FSRomsHandler(FSHandler):
                 ra_hash=(
                     await RAHasherService().calculate_hash(
                         SLUG_TO_RA_ID[rom.platform.slug]["id"],
-                        f"{LIBRARY_BASE_PATH}/{rom.fs_path}/{rom.fs_name}/{"*" if rom.multi else ""}",
+                        f"{LIBRARY_BASE_PATH}/{rom.fs_path}/{rom.fs_name}{"/*" if rom.multi else ""}",
                     )
                     if rom.platform.slug in SLUG_TO_RA_ID.keys()
                     else ""


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The core of this change is using the `folder/*` syntax when running the contents of a folder thought rahasher, plus searching all output lines for a matching hash. Parsing compressed files is still not supported.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
