### PR TITLE
Cleanup lingeting t_thumb in cover and screenshto art

### DIFF
--- a/backend/alembic/versions/0041_assets_t_thumb_cleanup.py
+++ b/backend/alembic/versions/0041_assets_t_thumb_cleanup.py
@@ -1,0 +1,69 @@
+"""empty message
+
+Revision ID: 0041_assets_t_thumb_cleanup
+Revises: 0040_migrate_assets_paths
+Create Date: 2025-06-06 16:22:08.361524
+
+"""
+
+from alembic import op
+from sqlalchemy.sql import text
+from utils.database import is_postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0041_assets_t_thumb_cleanup"
+down_revision = "0040_migrate_assets_paths"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(
+        text(
+            """
+            UPDATE roms 
+            SET url_cover = replace(url_cover, 't_thumb', 't_1080p')
+            WHERE url_cover LIKE '%t_thumb%'
+            """
+        )
+    )
+
+    if is_postgresql(conn):
+        conn.execute(
+            text(
+                """
+                UPDATE roms 
+                SET url_screenshots = (
+                    SELECT jsonb_agg(
+                        to_jsonb(replace(value, 't_thumb', 't_720p'))
+                    )
+                    FROM jsonb_array_elements_text(url_screenshots) AS value
+                )
+                WHERE url_screenshots::text LIKE '%t_thumb%';
+                """
+            )
+        )
+    else:
+        conn.execute(
+            text(
+                """
+                UPDATE roms 
+                SET url_screenshots = (
+                    SELECT JSON_ARRAYAGG(
+                        REPLACE(JSON_UNQUOTE(value), 't_thumb', 't_720p')
+                    )
+                    FROM JSON_TABLE(
+                        roms.url_screenshots, 
+                        '$[*]' COLUMNS (value JSON PATH '$')
+                    ) AS jt
+                )
+                WHERE JSON_SEARCH(url_screenshots, 'one', '%t_thumb%') IS NOT NULL;
+                """
+            )
+        )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -502,26 +502,22 @@ async def _identify_rom(
                     rom_id=_added_rom.id,
                     hash=ra_hash,
                 )
-                _added_rom.ra_id = ra_handler_rom.get("ra_id", "")
-                _added_rom.ra_metadata = ra_handler_rom.get("ra_metadata", {})
-                for a in _added_rom.ra_metadata.get("achievements", {}):
-                    # Store both normal and locked version
-                    badge_url_lock = a.get("badge_url_lock", None)
-                    badge_path_lock = a.get("badge_path_lock", None)
-                    if badge_url_lock and badge_path_lock:
-                        await fs_resource_handler.store_badge(
-                            badge_url_lock, badge_path_lock
-                        )
-                    badge_url = a.get("badge_url", None)
-                    badge_path = a.get("badge_path", None)
-                    if badge_url and badge_path:
-                        await fs_resource_handler.store_badge(badge_url, badge_path)
-                # Uncomment this to run scan in a background process
-                # low_prio_queue.enqueue(
-                #     _set_rom_hashes,
-                #     _added_rom.id,
-                #     job_timeout=60 * 15,  # Timeout (15 minutes)
-                # )
+                _added_rom.ra_id = ra_handler_rom["ra_id"]
+                ra_metadata = ra_handler_rom.get("ra_metadata", None)
+                if ra_metadata:
+                    _added_rom.ra_metadata = dict(ra_metadata)
+                    for a in ra_metadata.get("achievements", {}):
+                        # Store both normal and locked version
+                        badge_url_lock = a.get("badge_url_lock", None)
+                        badge_path_lock = a.get("badge_path_lock", None)
+                        if badge_url_lock and badge_path_lock:
+                            await fs_resource_handler.store_badge(
+                                badge_url_lock, badge_path_lock
+                            )
+                        badge_url = a.get("badge_url", None)
+                        badge_path = a.get("badge_path", None)
+                        if badge_url and badge_path:
+                            await fs_resource_handler.store_badge(badge_url, badge_path)
 
     # Return early if we're only scanning for hashes
     if scan_type == ScanType.HASHES:

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -502,7 +502,7 @@ async def _identify_rom(
                     rom_id=_added_rom.id,
                     hash=ra_hash,
                 )
-                _added_rom.ra_id = ra_handler_rom["ra_id"]
+                _added_rom.ra_id = ra_handler_rom.get("ra_id", None)
                 ra_metadata = ra_handler_rom.get("ra_metadata", None)
                 if ra_metadata:
                     _added_rom.ra_metadata = dict(ra_metadata)

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -50,7 +50,6 @@ async def fetch_ra_info(
     rom_id: int,
     hash: str,
 ) -> RAGameRom:
-
     return await meta_ra_handler.get_rom(
         platform=platform,
         rom_id=rom_id,
@@ -373,7 +372,7 @@ async def scan_rom(
         # Reversed to prioritize IGDB
         rom_attrs.update({**moby_handler_rom, **ss_handler_rom, **igdb_handler_rom})
 
-    # If not found in IGDB, MobyGames and Screenscraper
+    # If not found in IGDB, MobyGames or Screenscraper
     if (
         not igdb_handler_rom.get("igdb_id")
         and not moby_handler_rom.get("moby_id")


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Lingering `t_thumb` values in `url_cover` and `url_screenshots` will cause romm to overrite cover and screenshot art with thumbnails on partial scans. This replaces all uses of `t_thumb` in those fields with `t_1080p` for covers and `t_720p` for screenshots. Tested on both mariadb and postgres locally.

Some `cover_url` fields in `igdb_metadata` might still use `t_thumb` and would still be affected, but there's no easy way top clean those up through SQL.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
