### PR TITLE
fix: Remove critical log messages for 403 and 404 exceptions

### DIFF
--- a/backend/exceptions/endpoint_exceptions.py
+++ b/backend/exceptions/endpoint_exceptions.py
@@ -6,7 +6,6 @@ class PlatformNotFoundInDatabaseException(Exception):
     def __init__(self, id):
         self.message = f"Platform with id '{id}' not found"
         super().__init__(self.message)
-        log.critical(self.message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=self.message)
 
     def __repr__(self) -> str:
@@ -17,7 +16,6 @@ class RomNotFoundInDatabaseException(Exception):
     def __init__(self, id):
         self.message = f"Rom with id '{id}' not found"
         super().__init__(self.message)
-        log.critical(self.message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=self.message)
 
     def __repr__(self) -> str:
@@ -28,7 +26,6 @@ class CollectionNotFoundInDatabaseException(Exception):
     def __init__(self, id):
         self.message = f"Collection with id '{id}' not found"
         super().__init__(self.message)
-        log.critical(self.message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=self.message)
 
     def __repr__(self) -> str:
@@ -39,7 +36,6 @@ class CollectionPermissionError(Exception):
     def __init__(self, id):
         self.message = f"Permission denied for collection with id '{id}'"
         super().__init__(self.message)
-        log.critical(self.message)
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=self.message)
 
     def __repr__(self) -> str:
@@ -63,7 +59,6 @@ class RomNotFoundInRetroAchievementsException(Exception):
     def __init__(self, id):
         self.message = f"Rom with id '{id}' does not exist on RetroAchievements"
         super().__init__(self.message)
-        log.critical(self.message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=self.message)
 
 


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
These critical log messages are unnecessary and can clutter the logs, based on user requests. This is even more notorious when RomM is integrated to an error tracking system like Sentry.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes