### PR TITLE
misc: Add RetroAchievements links to game and achievement badges

### DIFF
--- a/frontend/src/components/Details/RetroAchievements.vue
+++ b/frontend/src/components/Details/RetroAchievements.vue
@@ -119,13 +119,19 @@ onMounted(() => {
           v-if="achievement.badge_path_lock || achievement.badge_path"
           rounded="0"
         >
-          <v-img
-            :src="
-              isAchievementEarned(achievement)
-                ? (achievement.badge_path ?? '')
-                : (achievement.badge_path_lock ?? '')
-            "
-          />
+          <a
+            :href="`https://retroachievements.org/achievement/${achievement.ra_id}`"
+            target="_blank"
+            style="height: 100%; width: 100%"
+          >
+            <v-img
+              :src="
+                isAchievementEarned(achievement)
+                  ? (achievement.badge_path ?? '')
+                  : (achievement.badge_path_lock ?? '')
+              "
+            />
+          </a>
         </v-avatar>
       </template>
       <template #subtitle>

--- a/frontend/src/components/Details/Title.vue
+++ b/frontend/src/components/Details/Title.vue
@@ -138,12 +138,13 @@ const hasReleaseDate = Number(props.rom.metadatum.first_release_date) > 0;
         <a
           v-if="rom.ra_id"
           style="text-decoration: none; color: inherit"
+          :href="`https://retroachievements.org/game/${rom.ra_id}`"
           target="_blank"
           :class="{ 'ml-1': rom.igdb_id || rom.ss_id || rom.moby_id }"
         >
           <v-chip class="pl-0 mt-1" size="small" @click.stop>
             <v-avatar class="mr-2" size="30" rounded="1">
-              <v-img src="/assets/scrappers/ra.png" />
+              <v-img src="/assets/scrappers/ra.png" :cover="false" />
             </v-avatar>
             <span>{{ rom.ra_id }}</span>
           </v-chip>


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

* Add a link to the game page in the RetroAchievements chip in the title.
* Add links to the achievement pages in the achievement badges.
* Fix the RetroAchievements chip to correctly display the RA logo.

**Checklist**

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
