### PR TITLE
fix: Iterate through user completion progress in RetroAchievements

### DIFF
--- a/backend/adapters/services/retroachievements_types.py
+++ b/backend/adapters/services/retroachievements_types.py
@@ -1,5 +1,12 @@
 import enum
+from collections.abc import Mapping
 from typing import NotRequired, TypedDict
+
+
+class PaginatedResponse[T: Mapping](TypedDict):
+    Count: int
+    Total: int
+    Results: list[T]
 
 
 # https://github.com/RetroAchievements/RAWeb/blob/master/app/Platform/Enums/AchievementType.php
@@ -88,10 +95,7 @@ class RAUserCompletionProgressResult(TypedDict):
 
 
 # https://api-docs.retroachievements.org/v1/get-user-completion-progress.html#response
-class RAUserCompletionProgress(TypedDict):
-    Count: int
-    Total: int
-    Results: list[RAUserCompletionProgressResult]
+RAUserCompletionProgress = PaginatedResponse[RAUserCompletionProgressResult]
 
 
 # https://api-docs.retroachievements.org/v1/get-game-info-and-user-progress.html#response


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Iterate through all pages of user completion progress in the RetroAchievements service, instead of limiting the data retrieval to the first 500 results.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes