### PR TITLE
feat: Use optional flags instead of booleans for Rom filtering

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from io import BytesIO
 from shutil import rmtree
 from stat import S_IFREG
-from typing import Any, TypeVar
+from typing import Annotated, Any, TypeVar
 from urllib.parse import quote
 from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile, ZipInfo
 
@@ -143,11 +143,17 @@ def get_roms(
     search_term: str | None = None,
     order_by: str = "name",
     order_dir: str = "asc",
-    unmatched_only: bool = False,
-    matched_only: bool = False,
-    favourites_only: bool = False,
-    duplicates_only: bool = False,
-    playables_only: bool = False,
+    matched: bool | None = None,
+    favourite: bool | None = None,
+    duplicate: bool | None = None,
+    playable: bool | None = None,
+    # TODO: Remove deprecated boolean parameters, in favor of their
+    #       optional counterparts.
+    unmatched_only: Annotated[bool, Query(deprecated=True)] = False,
+    matched_only: Annotated[bool, Query(deprecated=True)] = False,
+    favourites_only: Annotated[bool, Query(deprecated=True)] = False,
+    duplicates_only: Annotated[bool, Query(deprecated=True)] = False,
+    playables_only: Annotated[bool, Query(deprecated=True)] = False,
     ra_only: bool = False,
     group_by_meta_id: bool = False,
     selected_genre: str | None = None,
@@ -169,11 +175,15 @@ def get_roms(
         search_term (str, optional): Search term to filter roms. Defaults to None.
         order_by (str, optional): Field to order by. Defaults to "name".
         order_dir (str, optional): Order direction. Defaults to "asc".
-        unmatched_only (bool, optional): Filter only unmatched roms. Defaults to False.
-        matched_only (bool, optional): Filter only matched roms. Defaults to False.
-        favourites_only (bool, optional): Filter only favourite roms. Defaults to False.
-        duplicates_only (bool, optional): Filter only duplicate roms. Defaults to False.
-        playables_only (bool, optional): Filter only playable roms by emulatorjs. Defaults to False.
+        matched (bool, optional): Filter for matched or unmatched roms. Defaults to None.
+        favourite (bool, optional): Filter for favourite or non-favourite roms. Defaults to None.
+        duplicate (bool, optional): Filter for duplicate or non-duplicate roms. Defaults to None.
+        playable (bool, optional): Filter for playable or non-playable roms. Defaults to None.
+        unmatched_only (bool, optional): Filter only unmatched roms. Defaults to False. DEPRECATED: use `matched` instead.
+        matched_only (bool, optional): Filter only matched roms. Defaults to False. DEPRECATED: use `matched` instead.
+        favourites_only (bool, optional): Filter only favourite roms. Defaults to False. DEPRECATED: use `favourite` instead.
+        duplicates_only (bool, optional): Filter only duplicate roms. Defaults to False. DEPRECATED: use `duplicate` instead.
+        playables_only (bool, optional): Filter only playable roms by emulatorjs. Defaults to False. DEPRECATED: use `playable` instead.
         ra_only (bool, optional): Filter only roms with Retroachievements compatibility.
         group_by_meta_id (bool, optional): Group roms by igdb/moby/ssrf ID. Defaults to False.
         selected_genre (str, optional): Filter by genre. Defaults to None.
@@ -196,6 +206,22 @@ def get_roms(
         order_dir=order_dir.lower(),
     )
 
+    # Backwards compatibility for matched parameter.
+    if matched is None:
+        if unmatched_only:
+            matched = False
+        elif matched_only:
+            matched = True
+    # Backwards compatibility for favourite parameter.
+    if favourite is None and favourites_only:
+        favourite = True
+    # Backwards compatibility for duplicate parameter.
+    if duplicate is None and duplicates_only:
+        duplicate = True
+    # Backwards compatibility for playable parameter.
+    if playable is None and playables_only:
+        playable = True
+
     # Filter down the query
     query = db_rom_handler.filter_roms(
         query=query,
@@ -204,11 +230,10 @@ def get_roms(
         collection_id=collection_id,
         virtual_collection_id=virtual_collection_id,
         search_term=search_term,
-        unmatched_only=unmatched_only,
-        matched_only=matched_only,
-        favourites_only=favourites_only,
-        duplicates_only=duplicates_only,
-        playables_only=playables_only,
+        matched=matched,
+        favourite=favourite,
+        duplicate=duplicate,
+        playable=playable,
         ra_only=ra_only,
         selected_genre=selected_genre,
         selected_franchise=selected_franchise,

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -16,8 +16,10 @@ from sqlalchemy import (
     case,
     cast,
     delete,
+    false,
     func,
     literal,
+    not_,
     or_,
     select,
     text,
@@ -185,25 +187,21 @@ class DBRomsHandler(DBBaseHandler):
             )
         )
 
-    def filter_by_unmatched_only(self, query: Query):
-        return query.filter(
-            and_(
-                Rom.igdb_id.is_(None),
-                Rom.moby_id.is_(None),
-                Rom.ss_id.is_(None),
-            )
+    def filter_by_matched(self, query: Query, value: bool) -> Query:
+        """Filter based on whether the rom is matched to a metadata provider."""
+        predicate = or_(
+            Rom.igdb_id.isnot(None),
+            Rom.moby_id.isnot(None),
+            Rom.ss_id.isnot(None),
         )
+        if not value:
+            predicate = not_(predicate)
+        return query.filter(predicate)
 
-    def filter_by_matched_only(self, query: Query):
-        return query.filter(
-            or_(
-                Rom.igdb_id.isnot(None),
-                Rom.moby_id.isnot(None),
-                Rom.ss_id.isnot(None),
-            )
-        )
-
-    def filter_by_favourites_only(self, query: Query, session: Session, user_id: int):
+    def filter_by_favourite(
+        self, query: Query, session: Session, value: bool, user_id: int | None
+    ) -> Query:
+        """Filter based on whether the rom is in the user's Favourites collection."""
         favourites_collection = (
             session.query(Collection)
             .filter(Collection.name.ilike("favourites"))
@@ -212,17 +210,30 @@ class DBRomsHandler(DBBaseHandler):
         )
 
         if favourites_collection:
-            return query.filter(Rom.id.in_(favourites_collection.rom_ids))
+            predicate = Rom.id.in_(favourites_collection.rom_ids)
+            if not value:
+                predicate = not_(predicate)
+            return query.filter(predicate)
 
-        return query
+        # If no Favourites collection exists, return the original query if non-favourites
+        # were requested, or an empty query if favourites were requested.
+        if not value:
+            return query
+        return query.filter(false())
 
-    def filter_by_duplicates_only(self, query: Query):
-        return query.filter(Rom.sibling_roms.any())
+    def filter_by_duplicate(self, query: Query, value: bool) -> Query:
+        """Filter based on whether the rom has duplicates."""
+        predicate = Rom.sibling_roms.any()
+        if not value:
+            predicate = not_(predicate)
+        return query.filter(predicate)
 
-    def filter_by_playables_only(self, query: Query):
-        return query.join(Rom.platform).filter(
-            Platform.slug.in_(EJS_SUPPORTED_PLATFORMS)
-        )
+    def filter_by_playable(self, query: Query, value: bool) -> Query:
+        """Filter based on whether the rom is playable on supported platforms."""
+        predicate = Platform.slug.in_(EJS_SUPPORTED_PLATFORMS)
+        if not value:
+            predicate = not_(predicate)
+        return query.join(Rom.platform).filter(predicate)
 
     def filter_by_ra_only(self, query: Query):
         return query.filter(Rom.ra_id.isnot(None))
@@ -347,11 +358,10 @@ class DBRomsHandler(DBBaseHandler):
         collection_id: int | None = None,
         virtual_collection_id: str | None = None,
         search_term: str | None = None,
-        unmatched_only: bool = False,
-        matched_only: bool = False,
-        favourites_only: bool = False,
-        duplicates_only: bool = False,
-        playables_only: bool = False,
+        matched: bool | None = None,
+        favourite: bool | None = None,
+        duplicate: bool | None = None,
+        playable: bool | None = None,
         ra_only: bool = False,
         group_by_meta_id: bool = False,
         selected_genre: str | None = None,
@@ -379,20 +389,19 @@ class DBRomsHandler(DBBaseHandler):
         if search_term:
             query = self.filter_by_search_term(query, search_term)
 
-        if unmatched_only:
-            query = self.filter_by_unmatched_only(query)
+        if matched is not None:
+            query = self.filter_by_matched(query, value=matched)
 
-        if matched_only:
-            query = self.filter_by_matched_only(query)
+        if favourite is not None:
+            query = self.filter_by_favourite(
+                query, session=session, value=favourite, user_id=user_id
+            )
 
-        if favourites_only and user_id:
-            query = self.filter_by_favourites_only(query, session, user_id)
+        if duplicate is not None:
+            query = self.filter_by_duplicate(query, value=duplicate)
 
-        if duplicates_only:
-            query = self.filter_by_duplicates_only(query)
-
-        if playables_only:
-            query = self.filter_by_playables_only(query)
+        if playable is not None:
+            query = self.filter_by_playable(query, value=playable)
 
         if ra_only:
             query = self.filter_by_ra_only(query)
@@ -562,10 +571,10 @@ class DBRomsHandler(DBBaseHandler):
             collection_id=kwargs.pop("collection_id", None),
             virtual_collection_id=kwargs.pop("virtual_collection_id", None),
             search_term=kwargs.pop("search_term", None),
-            unmatched_only=kwargs.pop("unmatched_only", False),
-            matched_only=kwargs.pop("matched_only", False),
-            favourites_only=kwargs.pop("favourites_only", False),
-            duplicates_only=kwargs.pop("duplicates_only", False),
+            matched=kwargs.pop("matched", None),
+            favourite=kwargs.pop("favourite", None),
+            duplicate=kwargs.pop("duplicate", None),
+            playable=kwargs.pop("playable", None),
             selected_genre=kwargs.pop("selected_genre", None),
             selected_franchise=kwargs.pop("selected_franchise", None),
             selected_collection=kwargs.pop("selected_collection", None),

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -119,11 +119,6 @@ async function getRoms({
       offset: offset,
       order_by: orderBy,
       order_dir: orderDir,
-      unmatched_only: filterUnmatched,
-      matched_only: filterMatched,
-      favourites_only: filterFavourites,
-      duplicates_only: filterDuplicates,
-      playables_only: filterPlayables,
       ra_only: filterRA,
       group_by_meta_id: groupByMetaId,
       selected_genre: selectedGenre,
@@ -134,6 +129,11 @@ async function getRoms({
       selected_status: getStatusKeyForText(selectedStatus),
       selected_region: selectedRegion,
       selected_language: selectedLanguage,
+      ...(filterUnmatched ? { matched: false } : {}),
+      ...(filterMatched ? { matched: true } : {}),
+      ...(filterFavourites ? { favourite: true } : {}),
+      ...(filterDuplicates ? { duplicate: true } : {}),
+      ...(filterPlayables ? { playable: true } : {}),
     },
   });
 }


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
This change replaces boolean flags for filtering Roms with optional flags. This allows clients to specify whether they want to include or exclude certain types of Roms, such as matched, favourite, duplicate, or playable.

The boolean flags are still supported for backwards compatibility, but they are marked as deprecated. Clients should transition to using the new optional flags in future versions.

The main reason for this change is to allow the exclusion of certain results, without the need to add additional boolean flags, which are also confusing if both its `True` and `False` values are used within the same request.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes