### PR TITLE
feat: Display achievements earned in hardcore mode

### DIFF
--- a/backend/handler/metadata/ra_handler.py
+++ b/backend/handler/metadata/ra_handler.py
@@ -60,6 +60,7 @@ class RAGameRom(TypedDict):
 class EarnedAchievement(TypedDict):
     id: str
     date: str
+    date_hardcore: NotRequired[str]
 
 
 class RAUserGameProgression(TypedDict):
@@ -281,14 +282,18 @@ class RAHandler(MetadataHandler):
                     username=username,
                     game_id=rom_game_id,
                 )
-                earned_achievements = [
-                    {
-                        "id": achievement["BadgeName"],
-                        "date": achievement["DateEarned"],
-                    }
-                    for achievement in result.get("Achievements", {}).values()
-                    if achievement.get("DateEarned") and achievement.get("BadgeName")
-                ]
+                for achievement in result.get("Achievements", {}).values():
+                    badge_name = achievement.get("BadgeName")
+                    date_earned = achievement.get("DateEarned")
+                    date_earned_hardcore = achievement.get("DateEarnedHardcore")
+                    if badge_name and date_earned:
+                        earned_achievement = EarnedAchievement(
+                            id=badge_name,
+                            date=date_earned,
+                        )
+                        if date_earned_hardcore:
+                            earned_achievement["date_hardcore"] = date_earned_hardcore
+                        earned_achievements.append(earned_achievement)
 
             game_progressions.append(
                 RAUserGameProgression(

--- a/frontend/src/__generated__/models/EarnedAchievement.ts
+++ b/frontend/src/__generated__/models/EarnedAchievement.ts
@@ -5,5 +5,6 @@
 export type EarnedAchievement = {
     id: string;
     date: string;
+    date_hardcore?: string;
 };
 

--- a/frontend/src/__generated__/models/RAProgression.ts
+++ b/frontend/src/__generated__/models/RAProgression.ts
@@ -4,7 +4,6 @@
 /* eslint-disable */
 import type { RAUserGameProgression } from './RAUserGameProgression';
 export type RAProgression = {
-    count?: number;
     total?: number;
     results?: Array<RAUserGameProgression>;
 };

--- a/frontend/src/components/Details/RetroAchievements.vue
+++ b/frontend/src/components/Details/RetroAchievements.vue
@@ -12,8 +12,11 @@ const props = defineProps<{ rom: DetailedRom }>();
 const { t } = useI18n();
 const auth = storeAuth();
 const targetRom = ref();
-const earnedAchievements = ref<{ id: string; date: string }[]>([]);
-const achievemehtsPercentage = ref(0);
+const earnedAchievements = ref<
+  { id: string; date: string; hardcore: boolean }[]
+>([]);
+const achievementsPercentage = ref(0);
+const achievementsPercentageHardcore = ref(0);
 const showEarned = ref(false);
 const filteredAchievements = ref<RAGameRomAchievement[]>([]);
 
@@ -42,6 +45,16 @@ const isAchievementEarned = computed(
   },
 );
 
+const isAchievementEarnedHarcore = computed(
+  () => (achievement: RAGameRomAchievement) => {
+    return (
+      earnedAchievements.value.find(
+        (earned) => earned.id === (achievement.badge_id ?? ""),
+      )?.hardcore ?? false
+    );
+  },
+);
+
 const getAchievementEarnedDate = computed(
   () => (achievement: RAGameRomAchievement) => {
     return earnedAchievements.value.find(
@@ -60,14 +73,27 @@ onMounted(() => {
     );
     if (targetRom.value) {
       earnedAchievements.value = targetRom.value.earned_achievements.map(
-        (achievement: { id: string; date: string }) => ({
+        (achievement: {
+          id: string;
+          date: string;
+          date_hardcore?: string | null;
+        }) => ({
           id: achievement.id,
-          date: achievement.date,
+          date: achievement.date_hardcore || achievement.date,
+          hardcore: !!achievement.date_hardcore,
         }),
       );
       if (props.rom.merged_ra_metadata?.achievements) {
-        achievemehtsPercentage.value = Math.round(
+        achievementsPercentage.value = Math.round(
           (targetRom.value.earned_achievements.length /
+            props.rom.merged_ra_metadata?.achievements.length) *
+            100,
+        );
+        achievementsPercentageHardcore.value = Math.round(
+          (targetRom.value.earned_achievements.filter(
+            (achievement: { date_hardcore?: string }) =>
+              achievement.date_hardcore,
+          ).length /
             props.rom.merged_ra_metadata?.achievements.length) *
             100,
         );
@@ -86,10 +112,14 @@ onMounted(() => {
       >
     </template>
     <v-progress-linear
-      color="accent"
-      :model-value="achievemehtsPercentage"
+      bg-color="secondary"
+      color="romm-gold"
+      :model-value="achievementsPercentageHardcore"
+      buffer-color="primary"
+      buffer-opacity="0.6"
+      :buffer-value="achievementsPercentage"
       height="32"
-      ><p>{{ Math.ceil(achievemehtsPercentage) }}%</p></v-progress-linear
+      ><p>{{ Math.ceil(achievementsPercentage) }}%</p></v-progress-linear
     >
   </v-list-item>
   <v-chip
@@ -109,7 +139,10 @@ onMounted(() => {
       :title="achievement.title?.toString()"
       class="mb-2 py-4 rounded bg-toplayer"
       :class="{
-        earned: isAchievementEarned(achievement),
+        earned:
+          isAchievementEarned(achievement) &&
+          !isAchievementEarnedHarcore(achievement),
+        'earned-hardcore': isAchievementEarnedHarcore(achievement),
         locked: !isAchievementEarned(achievement),
         hidden: showEarned && !isAchievementEarned(achievement),
       }"
@@ -162,6 +195,9 @@ onMounted(() => {
 }
 .earned {
   border-left: solid rgba(var(--v-theme-primary)) 4px;
+}
+.earned-hardcore {
+  border-left: solid rgba(var(--v-theme-romm-gold)) 4px;
 }
 .hidden {
   display: none;

--- a/frontend/src/styles/themes.ts
+++ b/frontend/src/styles/themes.ts
@@ -5,6 +5,7 @@ const commonColors = {
   "romm-white": "#FEFDFE",
   "romm-gray": "#5D5D5D",
   "romm-black": "#000000",
+  "romm-gold": "#FFD700",
 };
 
 export const dark = {


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Differentiate between achievements earned in softcore and hardcore modes, by using the characteristic gold color for hardcore ones.

Also, update the progress bar to show both softcore and hardcore completion percentages.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots

![image](https://github.com/user-attachments/assets/eff26aa9-1d84-4b2f-b322-548ee652f262)
