### PR TITLE
feat: Mark missed files from filesystem as "missing"

### DIFF
--- a/backend/alembic/versions/0042_add_missing_from_fs.py
+++ b/backend/alembic/versions/0042_add_missing_from_fs.py
@@ -1,6 +1,6 @@
 """empty message
 
-Revision ID: 0042_add_missing_fields
+Revision ID: 0042_add_missing_from_fs
 Revises: 0041_assets_t_thumb_cleanup
 Create Date: 2025-06-11
 
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "0042_add_missing_fields"
+revision = "0042_add_missing_from_fs"
 down_revision = "0041_assets_t_thumb_cleanup"
 branch_labels = None
 depends_on = None
@@ -19,58 +19,72 @@ depends_on = None
 def upgrade():
     with op.batch_alter_table("platforms", schema=None) as batch_op:
         batch_op.add_column(
-            sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
+            sa.Column(
+                "missing_from_fs", sa.Boolean(), nullable=False, server_default="0"
+            )
         )
 
     with op.batch_alter_table("roms", schema=None) as batch_op:
         batch_op.add_column(
-            sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
+            sa.Column(
+                "missing_from_fs", sa.Boolean(), nullable=False, server_default="0"
+            )
         )
 
     with op.batch_alter_table("rom_files", schema=None) as batch_op:
         batch_op.add_column(
-            sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
+            sa.Column(
+                "missing_from_fs", sa.Boolean(), nullable=False, server_default="0"
+            )
         )
 
     with op.batch_alter_table("firmware", schema=None) as batch_op:
         batch_op.add_column(
-            sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
+            sa.Column(
+                "missing_from_fs", sa.Boolean(), nullable=False, server_default="0"
+            )
         )
 
     with op.batch_alter_table("saves", schema=None) as batch_op:
         batch_op.add_column(
-            sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
+            sa.Column(
+                "missing_from_fs", sa.Boolean(), nullable=False, server_default="0"
+            )
         )
 
     with op.batch_alter_table("states", schema=None) as batch_op:
         batch_op.add_column(
-            sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
+            sa.Column(
+                "missing_from_fs", sa.Boolean(), nullable=False, server_default="0"
+            )
         )
 
     with op.batch_alter_table("screenshots", schema=None) as batch_op:
         batch_op.add_column(
-            sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
+            sa.Column(
+                "missing_from_fs", sa.Boolean(), nullable=False, server_default="0"
+            )
         )
 
 
 def downgrade():
     with op.batch_alter_table("platforms", schema=None) as batch_op:
-        batch_op.drop_column("missing")
+        batch_op.drop_column("missing_from_fs")
 
     with op.batch_alter_table("roms", schema=None) as batch_op:
-        batch_op.drop_column("missing")
+        batch_op.drop_column("missing_from_fs")
 
     with op.batch_alter_table("rom_files", schema=None) as batch_op:
-        batch_op.drop_column("missing")
+        batch_op.drop_column("missing_from_fs")
 
     with op.batch_alter_table("firmware", schema=None) as batch_op:
-        batch_op.drop_column("missing")
+        batch_op.drop_column("missing_from_fs")
 
     with op.batch_alter_table("saves", schema=None) as batch_op:
-        batch_op.drop_column("missing")
+        batch_op.drop_column("missing_from_fs")
 
     with op.batch_alter_table("states", schema=None) as batch_op:
-        batch_op.drop_column("missing")
+        batch_op.drop_column("missing_from_fs")
 
     with op.batch_alter_table("screenshots", schema=None) as batch_op:
-        batch_op.drop_column("missing")
+        batch_op.drop_column("missing_from_fs")

--- a/backend/alembic/versions/0042_add_missing_rom_flag.py
+++ b/backend/alembic/versions/0042_add_missing_rom_flag.py
@@ -27,10 +27,50 @@ def upgrade():
             sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
         )
 
+    with op.batch_alter_table("rom_files", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
+        )
+
+    with op.batch_alter_table("firmware", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
+        )
+
+    with op.batch_alter_table("saves", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
+        )
+
+    with op.batch_alter_table("states", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
+        )
+
+    with op.batch_alter_table("screenshots", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
+        )
+
 
 def downgrade():
     with op.batch_alter_table("platforms", schema=None) as batch_op:
         batch_op.drop_column("missing")
 
     with op.batch_alter_table("roms", schema=None) as batch_op:
+        batch_op.drop_column("missing")
+
+    with op.batch_alter_table("rom_files", schema=None) as batch_op:
+        batch_op.drop_column("missing")
+
+    with op.batch_alter_table("firmware", schema=None) as batch_op:
+        batch_op.drop_column("missing")
+
+    with op.batch_alter_table("saves", schema=None) as batch_op:
+        batch_op.drop_column("missing")
+
+    with op.batch_alter_table("states", schema=None) as batch_op:
+        batch_op.drop_column("missing")
+
+    with op.batch_alter_table("screenshots", schema=None) as batch_op:
         batch_op.drop_column("missing")

--- a/backend/alembic/versions/0042_add_missing_rom_flag.py
+++ b/backend/alembic/versions/0042_add_missing_rom_flag.py
@@ -1,0 +1,36 @@
+"""empty message
+
+Revision ID: 0042_add_missing_fields
+Revises: 0041_assets_t_thumb_cleanup
+Create Date: 2025-06-11
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0042_add_missing_fields"
+down_revision = "0041_assets_t_thumb_cleanup"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("platforms", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
+        )
+
+    with op.batch_alter_table("roms", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("missing", sa.Boolean(), nullable=False, server_default="0")
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("platforms", schema=None) as batch_op:
+        batch_op.drop_column("missing")
+
+    with op.batch_alter_table("roms", schema=None) as batch_op:
+        batch_op.drop_column("missing")

--- a/backend/endpoints/platform.py
+++ b/backend/endpoints/platform.py
@@ -90,7 +90,7 @@ def get_supported_platforms(request: Request) -> list[PlatformSchema]:
             "created_at": now,
             "updated_at": now,
             "fs_size_bytes": 0,
-            "missing": False,
+            "missing_from_fs": False,
         }
 
         if platform["name"] in db_platforms_map:

--- a/backend/endpoints/platform.py
+++ b/backend/endpoints/platform.py
@@ -90,6 +90,7 @@ def get_supported_platforms(request: Request) -> list[PlatformSchema]:
             "created_at": now,
             "updated_at": now,
             "fs_size_bytes": 0,
+            "missing": False,
         }
 
         if platform["name"] in db_platforms_map:

--- a/backend/endpoints/responses/assets.py
+++ b/backend/endpoints/responses/assets.py
@@ -16,7 +16,7 @@ class BaseAsset(BaseModel):
     full_path: str
     download_path: str
 
-    missing: bool
+    missing_from_fs: bool
 
     created_at: datetime
     updated_at: datetime

--- a/backend/endpoints/responses/assets.py
+++ b/backend/endpoints/responses/assets.py
@@ -15,6 +15,9 @@ class BaseAsset(BaseModel):
     file_size_bytes: int
     full_path: str
     download_path: str
+
+    missing: bool
+
     created_at: datetime
     updated_at: datetime
 

--- a/backend/endpoints/responses/firmware.py
+++ b/backend/endpoints/responses/firmware.py
@@ -20,7 +20,7 @@ class FirmwareSchema(BaseModel):
     md5_hash: str
     sha1_hash: str
 
-    missing: bool
+    missing_from_fs: bool
 
     created_at: datetime
     updated_at: datetime

--- a/backend/endpoints/responses/firmware.py
+++ b/backend/endpoints/responses/firmware.py
@@ -6,20 +6,18 @@ from .base import BaseModel
 
 class FirmwareSchema(BaseModel):
     id: int
-
     file_name: str
     file_name_no_tags: str
     file_name_no_ext: str
     file_extension: str
     file_path: str
     file_size_bytes: int
-
     full_path: str
     is_verified: bool
     crc_hash: str
     md5_hash: str
     sha1_hash: str
-
+    missing: bool
     created_at: datetime
     updated_at: datetime
 

--- a/backend/endpoints/responses/firmware.py
+++ b/backend/endpoints/responses/firmware.py
@@ -6,18 +6,22 @@ from .base import BaseModel
 
 class FirmwareSchema(BaseModel):
     id: int
+
     file_name: str
     file_name_no_tags: str
     file_name_no_ext: str
     file_extension: str
     file_path: str
     file_size_bytes: int
+
     full_path: str
     is_verified: bool
     crc_hash: str
     md5_hash: str
     sha1_hash: str
+
     missing: bool
+
     created_at: datetime
     updated_at: datetime
 

--- a/backend/endpoints/responses/platform.py
+++ b/backend/endpoints/responses/platform.py
@@ -32,7 +32,7 @@ class PlatformSchema(BaseModel):
     updated_at: datetime
     fs_size_bytes: int
 
-    missing: bool
+    missing_from_fs: bool
 
     class Config:
         from_attributes = True

--- a/backend/endpoints/responses/platform.py
+++ b/backend/endpoints/responses/platform.py
@@ -32,6 +32,8 @@ class PlatformSchema(BaseModel):
     updated_at: datetime
     fs_size_bytes: int
 
+    missing: bool
+
     class Config:
         from_attributes = True
 

--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -225,7 +225,7 @@ class RomSchema(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    missing: bool
+    missing_from_fs: bool
 
     class Config:
         from_attributes = True

--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -225,6 +225,8 @@ class RomSchema(BaseModel):
     created_at: datetime
     updated_at: datetime
 
+    missing: bool
+
     class Config:
         from_attributes = True
 

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -159,6 +159,7 @@ def get_roms(
     favourites_only: Annotated[bool, Query(deprecated=True)] = False,
     duplicates_only: Annotated[bool, Query(deprecated=True)] = False,
     playables_only: Annotated[bool, Query(deprecated=True)] = False,
+    missing_only: Annotated[bool, Query(deprecated=True)] = False,
     ra_only: bool = False,
     group_by_meta_id: bool = False,
     selected_genre: str | None = None,
@@ -189,7 +190,8 @@ def get_roms(
         favourites_only (bool, optional): Filter only favourite roms. Defaults to False. DEPRECATED: use `favourite` instead.
         duplicates_only (bool, optional): Filter only duplicate roms. Defaults to False. DEPRECATED: use `duplicate` instead.
         playables_only (bool, optional): Filter only playable roms by emulatorjs. Defaults to False. DEPRECATED: use `playable` instead.
-        ra_only (bool, optional): Filter only roms with Retroachievements compatibility.
+        ra_only (bool, optional): Filter only roms with Retroachievements compatibility. Defaults to False.
+        missing_only (bool, optional): Filter only roms that are missing from the filesystem. Defaults to False.
         group_by_meta_id (bool, optional): Group roms by igdb/moby/ssrf ID. Defaults to False.
         selected_genre (str, optional): Filter by genre. Defaults to None.
         selected_franchise (str, optional): Filter by franchise. Defaults to None.
@@ -240,6 +242,7 @@ def get_roms(
         duplicate=duplicate,
         playable=playable,
         ra_only=ra_only,
+        missing_only=missing_only,
         selected_genre=selected_genre,
         selected_franchise=selected_franchise,
         selected_collection=selected_collection,

--- a/backend/endpoints/saves.py
+++ b/backend/endpoints/saves.py
@@ -58,7 +58,9 @@ async def add_save(
     if not rom:
         raise RomNotFoundInDatabaseException(rom_id)
 
-    log.info(f"Uploading save {hl(saveFile.filename)} for {hl(rom.name, color=BLUE)}")
+    log.info(
+        f"Uploading save {hl(saveFile.filename)} for {hl(str(rom.name), color=BLUE)}"
+    )
 
     saves_path = fs_asset_handler.build_saves_file_path(
         user=request.user,

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -210,9 +210,9 @@ async def scan_platforms(
         # This protects against accidental deletion of entries when
         # the folder structure is not correct or the drive is not mounted
         if len(fs_platforms) > 0:
-            purged_platforms = db_platform_handler.purge_platforms(fs_platforms)
+            purged_platforms = db_platform_handler.mark_missing_platforms(fs_platforms)
             if len(purged_platforms) > 0:
-                log.warning("Purging platforms not found in the filesystem:")
+                log.warning("Missing platforms not found in the filesystem:")
                 for p in purged_platforms:
                     log.warning(f" - {p.slug}")
 
@@ -330,12 +330,12 @@ async def _identify_platform(
     # This protects against accidental deletion of entries when
     # the folder structure is not correct or the drive is not mounted
     if len(fs_roms) > 0:
-        purged_roms = db_rom_handler.purge_roms(
+        missing_roms = db_rom_handler.mark_missing_roms(
             platform.id, [rom["fs_name"] for rom in fs_roms]
         )
-        if len(purged_roms) > 0:
-            log.warning("Purging roms not found in the filesystem:")
-            for r in purged_roms:
+        if len(missing_roms) > 0:
+            log.warning("Missing roms not found in the filesystem:")
+            for r in missing_roms:
                 log.warning(f" - {r.fs_name}")
 
     # Same protection for firmware

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -255,7 +255,7 @@ async def _identify_rom(
     _added_rom = db_rom_handler.add_rom(scanned_rom)
 
     # Delete the existing rom files in the DB
-    db_rom_handler.purge_rom_files(_added_rom.id)
+    db_rom_handler.missing_rom_files(_added_rom.id)
 
     # Create each file entry for the rom
     new_rom_files = [
@@ -467,12 +467,12 @@ async def _identify_platform(
 
     # Same protection for firmware
     if len(fs_firmware) > 0:
-        purged_firmware = db_firmware_handler.purge_firmware(
+        missing_firmware = db_firmware_handler.mark_missing_firmware(
             platform.id, [fw for fw in fs_firmware]
         )
-        if len(purged_firmware) > 0:
-            log.warning("Purging firmware not found in the filesystem:")
-            for f in purged_firmware:
+        if len(missing_firmware) > 0:
+            log.warning("Missing firmware not found in the filesystem:")
+            for f in missing_firmware:
                 log.warning(f" - {f}")
 
     return scan_stats
@@ -554,10 +554,10 @@ async def scan_platforms(
         # This protects against accidental deletion of entries when
         # the folder structure is not correct or the drive is not mounted
         if len(fs_platforms) > 0:
-            purged_platforms = db_platform_handler.mark_missing_platforms(fs_platforms)
-            if len(purged_platforms) > 0:
+            missed_platforms = db_platform_handler.mark_missing_platforms(fs_platforms)
+            if len(missed_platforms) > 0:
                 log.warning("Missing platforms not found in the filesystem:")
-                for p in purged_platforms:
+                for p in missed_platforms:
                     log.warning(f" - {p.slug}")
 
         log.info(emoji.emojize(":check_mark:  Scan completed "))

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -227,18 +227,14 @@ async def _identify_rom(
         return scan_stats
 
     if not _should_scan_rom(scan_type=scan_type, rom=rom, roms_ids=roms_ids):
-        log.debug(
-            f"Skipping {hl(fs_rom['fs_name'], color=BLUE)} for scan type {scan_type.name}"
-        )
-        if rom and rom.fs_name != fs_rom["fs_name"]:
-            # Just to update the filesystem data
-            rom.fs_name = fs_rom["fs_name"]
-            rom.missing = False
-            db_rom_handler.add_rom(rom)
+        if rom:
+            if rom.fs_name != fs_rom["fs_name"]:
+                # Just to update the filesystem data
+                rom.fs_name = fs_rom["fs_name"]
+                db_rom_handler.add_rom(rom)
 
-        elif rom and rom.missing:
-            rom.missing = False
-            db_rom_handler.add_rom(rom)
+            if rom.missing:
+                db_rom_handler.update_rom(rom.id, {"missing": False})
 
         return scan_stats
 
@@ -445,8 +441,6 @@ async def _identify_platform(
             platform_id=platform.id,
             fs_names={fs_rom["fs_name"] for fs_rom in fs_roms_batch},
         )
-
-        log.debug(rom_by_filename_map)
 
         for fs_rom in fs_roms_batch:
             scan_stats += await _identify_rom(

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -130,7 +130,7 @@ async def _identify_firmware(
     scan_stats.scanned_firmware += 1
     scan_stats.added_firmware += 1 if not firmware else 0
 
-    scanned_firmware.missing = False
+    scanned_firmware.missing_from_fs = False
     db_firmware_handler.add_firmware(scanned_firmware)
     return scan_stats
 
@@ -234,8 +234,8 @@ async def _identify_rom(
                 rom.fs_name = fs_rom["fs_name"]
                 db_rom_handler.add_rom(rom)
 
-            if rom.missing:
-                db_rom_handler.update_rom(rom.id, {"missing": False})
+            if rom.missing_from_fs:
+                db_rom_handler.update_rom(rom.id, {"missing_from_fs": False})
 
         return scan_stats
 

--- a/backend/handler/database/firmware_handler.py
+++ b/backend/handler/database/firmware_handler.py
@@ -65,10 +65,10 @@ class DBFirmwareHandler(DBBaseHandler):
         )
 
     @begin_session
-    def purge_firmware(
+    def mark_missing_firmware(
         self, platform_id: int, fs_firmwares_to_keep: list[str], session: Session = None
     ) -> Sequence[Firmware]:
-        purged_firmware = (
+        missing_firmware = (
             session.scalars(
                 select(Firmware)
                 .order_by(Firmware.file_name.asc())
@@ -83,13 +83,14 @@ class DBFirmwareHandler(DBBaseHandler):
             .all()
         )
         session.execute(
-            delete(Firmware)
+            update(Firmware)
             .where(
                 and_(
                     Firmware.platform_id == platform_id,
                     Firmware.file_name.not_in(fs_firmwares_to_keep),
                 )
             )
+            .values(**{"missing": True})
             .execution_options(synchronize_session="evaluate")
         )
-        return purged_firmware
+        return missing_firmware

--- a/backend/handler/database/firmware_handler.py
+++ b/backend/handler/database/firmware_handler.py
@@ -90,7 +90,7 @@ class DBFirmwareHandler(DBBaseHandler):
                     Firmware.file_name.not_in(fs_firmwares_to_keep),
                 )
             )
-            .values(**{"missing": True})
+            .values(**{"missing_from_fs": True})
             .execution_options(synchronize_session="evaluate")
         )
         return missing_firmware

--- a/backend/handler/database/platforms_handler.py
+++ b/backend/handler/database/platforms_handler.py
@@ -95,14 +95,14 @@ class DBPlatformsHandler(DBBaseHandler):
         session.execute(
             update(Platform)
             .where(or_(Platform.fs_slug.not_in(fs_platforms_to_keep), Platform.slug.is_(None)))  # type: ignore[attr-defined]
-            .values(**{"missing": True})
+            .values(**{"missing_from_fs": True})
             .execution_options(synchronize_session="fetch")
         )
 
         session.execute(
             update(Rom)
             .where(Rom.platform_id.in_([p.id for p in missing_platforms]))  # type: ignore[attr-defined]
-            .values(**{"missing": True})
+            .values(**{"missing_from_fs": True})
             .execution_options(synchronize_session="fetch")
         )
         return missing_platforms

--- a/backend/handler/database/platforms_handler.py
+++ b/backend/handler/database/platforms_handler.py
@@ -98,4 +98,11 @@ class DBPlatformsHandler(DBBaseHandler):
             .values(**{"missing": True})
             .execution_options(synchronize_session="fetch")
         )
+
+        session.execute(
+            update(Rom)
+            .where(Rom.platform_id.in_([p.id for p in missing_platforms]))  # type: ignore[attr-defined]
+            .values(**{"missing": True})
+            .execution_options(synchronize_session="fetch")
+        )
         return missing_platforms

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -238,6 +238,9 @@ class DBRomsHandler(DBBaseHandler):
     def filter_by_ra_only(self, query: Query):
         return query.filter(Rom.ra_id.isnot(None))
 
+    def filter_by_missing_only(self, query: Query):
+        return query.filter(Rom.missing.isnot(False))
+
     def filter_by_genre(self, query: Query, selected_genre: str):
         if ROMM_DB_DRIVER == "postgresql":
             return query.filter(
@@ -362,7 +365,8 @@ class DBRomsHandler(DBBaseHandler):
         favourite: bool | None = None,
         duplicate: bool | None = None,
         playable: bool | None = None,
-        ra_only: bool = False,
+        ra_only: bool | None = False,
+        missing_only: bool | None = False,
         group_by_meta_id: bool = False,
         selected_genre: str | None = None,
         selected_franchise: str | None = None,
@@ -405,6 +409,9 @@ class DBRomsHandler(DBBaseHandler):
 
         if ra_only:
             query = self.filter_by_ra_only(query)
+
+        if missing_only:
+            query = self.filter_by_missing_only(query)
 
         if group_by_meta_id:
 

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -238,8 +238,8 @@ class DBRomsHandler(DBBaseHandler):
     def filter_by_ra_only(self, query: Query):
         return query.filter(Rom.ra_id.isnot(None))
 
-    def filter_by_missing_only(self, query: Query):
-        return query.filter(Rom.missing.isnot(False))
+    def filter_by_missing_from_fs_only(self, query: Query):
+        return query.filter(Rom.missing_from_fs.isnot(False))
 
     def filter_by_genre(self, query: Query, selected_genre: str):
         if ROMM_DB_DRIVER == "postgresql":
@@ -411,7 +411,7 @@ class DBRomsHandler(DBBaseHandler):
             query = self.filter_by_ra_only(query)
 
         if missing_only:
-            query = self.filter_by_missing_only(query)
+            query = self.filter_by_missing_from_fs_only(query)
 
         if group_by_meta_id:
 
@@ -705,7 +705,7 @@ class DBRomsHandler(DBBaseHandler):
                     Rom.platform_id == platform_id, Rom.fs_name.not_in(fs_roms_to_keep)
                 )
             )
-            .values(**{"missing": True})
+            .values(**{"missing_from_fs": True})
             .execution_options(synchronize_session="evaluate")
         )
         return missing_roms
@@ -792,7 +792,7 @@ class DBRomsHandler(DBBaseHandler):
         session.execute(
             update(RomFile)
             .where(RomFile.rom_id == rom_id)
-            .values(**{"missing": True})
+            .values(**{"missing_from_fs": True})
             .execution_options(synchronize_session="evaluate")
         )
         return missing_rom_files

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -776,15 +776,16 @@ class DBRomsHandler(DBBaseHandler):
         return session.query(RomFile).filter_by(id=id).one()
 
     @begin_session
-    def purge_rom_files(
+    def missing_rom_files(
         self, rom_id: int, session: Session = None
     ) -> Sequence[RomFile]:
-        purged_rom_files = (
+        missing_rom_files = (
             session.scalars(select(RomFile).filter_by(rom_id=rom_id)).unique().all()
         )
         session.execute(
-            delete(RomFile)
+            update(RomFile)
             .where(RomFile.rom_id == rom_id)
+            .values(**{"missing": True})
             .execution_options(synchronize_session="evaluate")
         )
-        return purged_rom_files
+        return missing_rom_files

--- a/backend/handler/database/saves_handler.py
+++ b/backend/handler/database/saves_handler.py
@@ -64,14 +64,14 @@ class DBSavesHandler(DBBaseHandler):
         )
 
     @begin_session
-    def purge_saves(
+    def mark_missing_saves(
         self,
         rom_id: int,
         user_id: int,
         saves_to_keep: list[str],
         session: Session = None,
     ) -> Sequence[Save]:
-        purged_saves = session.scalars(
+        missing_saves = session.scalars(
             select(Save).filter(
                 and_(
                     Save.rom_id == rom_id,
@@ -82,7 +82,7 @@ class DBSavesHandler(DBBaseHandler):
         ).all()
 
         session.execute(
-            delete(Save)
+            update(Save)
             .where(
                 and_(
                     Save.rom_id == rom_id,
@@ -90,7 +90,8 @@ class DBSavesHandler(DBBaseHandler):
                     Save.file_name.not_in(saves_to_keep),
                 )
             )
+            .values(**{"missing": True})
             .execution_options(synchronize_session="evaluate")
         )
 
-        return purged_saves
+        return missing_saves

--- a/backend/handler/database/saves_handler.py
+++ b/backend/handler/database/saves_handler.py
@@ -90,7 +90,7 @@ class DBSavesHandler(DBBaseHandler):
                     Save.file_name.not_in(saves_to_keep),
                 )
             )
-            .values(**{"missing": True})
+            .values(**{"missing_from_fs": True})
             .execution_options(synchronize_session="evaluate")
         )
 

--- a/backend/handler/database/screenshots_handler.py
+++ b/backend/handler/database/screenshots_handler.py
@@ -50,14 +50,14 @@ class DBScreenshotsHandler(DBBaseHandler):
         )
 
     @begin_session
-    def purge_screenshots(
+    def mark_missing_screenshots(
         self,
         rom_id: int,
         user_id: int,
         screenshots_to_keep: list[str],
         session: Session = None,
     ) -> Sequence[Screenshot]:
-        purged_screenshots = session.scalars(
+        missing_screenshots = session.scalars(
             select(Screenshot).filter(
                 and_(
                     Screenshot.rom_id == rom_id,
@@ -68,7 +68,7 @@ class DBScreenshotsHandler(DBBaseHandler):
         ).all()
 
         session.execute(
-            delete(Screenshot)
+            update(Screenshot)
             .where(
                 and_(
                     Screenshot.rom_id == rom_id,
@@ -76,7 +76,8 @@ class DBScreenshotsHandler(DBBaseHandler):
                     Screenshot.file_name.not_in(screenshots_to_keep),
                 )
             )
+            .values(**{"missing": True})
             .execution_options(synchronize_session="evaluate")
         )
 
-        return purged_screenshots
+        return missing_screenshots

--- a/backend/handler/database/screenshots_handler.py
+++ b/backend/handler/database/screenshots_handler.py
@@ -76,7 +76,7 @@ class DBScreenshotsHandler(DBBaseHandler):
                     Screenshot.file_name.not_in(screenshots_to_keep),
                 )
             )
-            .values(**{"missing": True})
+            .values(**{"missing_from_fs": True})
             .execution_options(synchronize_session="evaluate")
         )
 

--- a/backend/handler/database/states_handler.py
+++ b/backend/handler/database/states_handler.py
@@ -90,7 +90,7 @@ class DBStatesHandler(DBBaseHandler):
                     State.file_name.not_in(states_to_keep),
                 )
             )
-            .values(**{"missing": True})
+            .values(**{"missing_from_fs": True})
             .execution_options(synchronize_session="evaluate")
         )
 

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -175,7 +175,7 @@ async def scan_platform(
             extra=LOGGER_MODULE_NAME,
         )
 
-    platform_attrs["missing"] = False
+    platform_attrs["missing_from_fs"] = False
     return Platform(**platform_attrs)
 
 
@@ -398,7 +398,7 @@ async def scan_rom(
                 extra=LOGGER_MODULE_NAME,
             )
 
-    rom_attrs["missing"] = False
+    rom_attrs["missing_from_fs"] = False
     return Rom(**rom_attrs)
 
 

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -175,6 +175,7 @@ async def scan_platform(
             extra=LOGGER_MODULE_NAME,
         )
 
+    platform_attrs["missing"] = False
     return Platform(**platform_attrs)
 
 
@@ -397,6 +398,7 @@ async def scan_rom(
                 extra=LOGGER_MODULE_NAME,
             )
 
+    romm_attrs["missing"] = False
     return Rom(**rom_attrs)
 
 

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -398,7 +398,7 @@ async def scan_rom(
                 extra=LOGGER_MODULE_NAME,
             )
 
-    romm_attrs["missing"] = False
+    rom_attrs["missing"] = False
     return Rom(**rom_attrs)
 
 

--- a/backend/handler/tests/test_db_handler.py
+++ b/backend/handler/tests/test_db_handler.py
@@ -27,7 +27,7 @@ def test_platforms():
     assert platform is not None
     assert platform.name == "test_platform"
 
-    db_platform_handler.purge_platforms([])
+    db_platform_handler.mark_missing_platforms([])
     platforms = db_platform_handler.get_platforms()
     assert len(platforms) == 0
 
@@ -63,7 +63,7 @@ def test_roms(rom: Rom, platform: Platform):
     roms = db_rom_handler.get_roms_scalar(platform_id=platform.id)
     assert len(roms) == 1
 
-    db_rom_handler.purge_roms(rom_2.platform_id, [])
+    db_rom_handler.mark_missing_roms(rom_2.platform_id, [])
 
     roms = db_rom_handler.get_roms_scalar(platform_id=platform.id)
     assert len(roms) == 0

--- a/backend/handler/tests/test_db_handler.py
+++ b/backend/handler/tests/test_db_handler.py
@@ -29,7 +29,7 @@ def test_platforms():
 
     db_platform_handler.mark_missing_platforms([])
     platforms = db_platform_handler.get_platforms()
-    assert len(platforms) == 0
+    assert len(platforms) == 1
 
 
 def test_roms(rom: Rom, platform: Platform):
@@ -66,7 +66,7 @@ def test_roms(rom: Rom, platform: Platform):
     db_rom_handler.mark_missing_roms(rom_2.platform_id, [])
 
     roms = db_rom_handler.get_roms_scalar(platform_id=platform.id)
-    assert len(roms) == 0
+    assert len(roms) == 1
 
 
 def test_utils(rom: Rom, platform: Platform):

--- a/backend/models/assets.py
+++ b/backend/models/assets.py
@@ -23,7 +23,7 @@ class BaseAsset(BaseModel):
     file_path: Mapped[str] = mapped_column(String(length=1000))
     file_size_bytes: Mapped[int] = mapped_column(BigInteger(), default=0)
 
-    missing: Mapped[bool] = mapped_column(default=False, nullable=False)
+    missing_from_fs: Mapped[bool] = mapped_column(default=False, nullable=False)
 
     @cached_property
     def full_path(self) -> str:

--- a/backend/models/assets.py
+++ b/backend/models/assets.py
@@ -23,6 +23,8 @@ class BaseAsset(BaseModel):
     file_path: Mapped[str] = mapped_column(String(length=1000))
     file_size_bytes: Mapped[int] = mapped_column(BigInteger(), default=0)
 
+    missing: Mapped[bool] = mapped_column(default=False, nullable=False)
+
     @cached_property
     def full_path(self) -> str:
         return f"{self.file_path}/{self.file_name}"

--- a/backend/models/firmware.py
+++ b/backend/models/firmware.py
@@ -41,7 +41,7 @@ class Firmware(BaseModel):
 
     platform: Mapped[Platform] = relationship(lazy="joined", back_populates="firmware")
 
-    missing: Mapped[bool] = mapped_column(default=False, nullable=False)
+    missing_from_fs: Mapped[bool] = mapped_column(default=False, nullable=False)
 
     @property
     def platform_slug(self) -> str:

--- a/backend/models/firmware.py
+++ b/backend/models/firmware.py
@@ -41,6 +41,8 @@ class Firmware(BaseModel):
 
     platform: Mapped[Platform] = relationship(lazy="joined", back_populates="firmware")
 
+    missing: Mapped[bool] = mapped_column(default=False, nullable=False)
+
     @property
     def platform_slug(self) -> str:
         return self.platform.slug

--- a/backend/models/platform.py
+++ b/backend/models/platform.py
@@ -50,7 +50,7 @@ class Platform(BaseModel):
         select(func.count(Rom.id)).where(Rom.platform_id == id).scalar_subquery()
     )
 
-    missing: Mapped[bool] = mapped_column(default=False, nullable=False)
+    missing_from_fs: Mapped[bool] = mapped_column(default=False, nullable=False)
 
     @cached_property
     def fs_size_bytes(self) -> int:

--- a/backend/models/platform.py
+++ b/backend/models/platform.py
@@ -50,11 +50,13 @@ class Platform(BaseModel):
         select(func.count(Rom.id)).where(Rom.platform_id == id).scalar_subquery()
     )
 
-    def __repr__(self) -> str:
-        return self.name
+    missing: Mapped[bool] = mapped_column(default=False, nullable=False)
 
     @cached_property
     def fs_size_bytes(self) -> int:
         from handler.database import db_stats_handler
 
         return db_stats_handler.get_platform_filesize(self.id)
+
+    def __repr__(self) -> str:
+        return self.name

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -59,6 +59,8 @@ class RomFile(BaseModel):
 
     rom: Mapped[Rom] = relationship(lazy="joined", back_populates="files")
 
+    missing: Mapped[bool] = mapped_column(default=False, nullable=False)
+
     @cached_property
     def full_path(self) -> str:
         return f"{self.file_path}/{self.file_name}"

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -203,6 +203,8 @@ class Rom(BaseModel):
         back_populates="roms",
     )
 
+    missing: Mapped[bool] = mapped_column(default=False, nullable=False)
+
     @property
     def platform_slug(self) -> str:
         return self.platform.slug

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -59,7 +59,7 @@ class RomFile(BaseModel):
 
     rom: Mapped[Rom] = relationship(lazy="joined", back_populates="files")
 
-    missing: Mapped[bool] = mapped_column(default=False, nullable=False)
+    missing_from_fs: Mapped[bool] = mapped_column(default=False, nullable=False)
 
     @cached_property
     def full_path(self) -> str:
@@ -205,7 +205,7 @@ class Rom(BaseModel):
         back_populates="roms",
     )
 
-    missing: Mapped[bool] = mapped_column(default=False, nullable=False)
+    missing_from_fs: Mapped[bool] = mapped_column(default=False, nullable=False)
 
     @property
     def platform_slug(self) -> str:

--- a/frontend/src/__generated__/models/DetailedRomSchema.ts
+++ b/frontend/src/__generated__/models/DetailedRomSchema.ts
@@ -62,6 +62,7 @@ export type DetailedRomSchema = {
     full_path: string;
     created_at: string;
     updated_at: string;
+    missing: boolean;
     merged_ra_metadata: (RomRAMetadata | null);
     merged_screenshots: Array<string>;
     siblings: Array<SiblingRomSchema>;

--- a/frontend/src/__generated__/models/DetailedRomSchema.ts
+++ b/frontend/src/__generated__/models/DetailedRomSchema.ts
@@ -62,7 +62,7 @@ export type DetailedRomSchema = {
     full_path: string;
     created_at: string;
     updated_at: string;
-    missing: boolean;
+    missing_from_fs: boolean;
     merged_ra_metadata: (RomRAMetadata | null);
     merged_screenshots: Array<string>;
     siblings: Array<SiblingRomSchema>;

--- a/frontend/src/__generated__/models/FirmwareSchema.ts
+++ b/frontend/src/__generated__/models/FirmwareSchema.ts
@@ -15,7 +15,7 @@ export type FirmwareSchema = {
     crc_hash: string;
     md5_hash: string;
     sha1_hash: string;
-    missing: boolean;
+    missing_from_fs: boolean;
     created_at: string;
     updated_at: string;
 };

--- a/frontend/src/__generated__/models/FirmwareSchema.ts
+++ b/frontend/src/__generated__/models/FirmwareSchema.ts
@@ -15,6 +15,7 @@ export type FirmwareSchema = {
     crc_hash: string;
     md5_hash: string;
     sha1_hash: string;
+    missing: boolean;
     created_at: string;
     updated_at: string;
 };

--- a/frontend/src/__generated__/models/PlatformSchema.ts
+++ b/frontend/src/__generated__/models/PlatformSchema.ts
@@ -27,6 +27,7 @@ export type PlatformSchema = {
     created_at: string;
     updated_at: string;
     fs_size_bytes: number;
+    missing: boolean;
     readonly display_name: string;
 };
 

--- a/frontend/src/__generated__/models/PlatformSchema.ts
+++ b/frontend/src/__generated__/models/PlatformSchema.ts
@@ -27,7 +27,7 @@ export type PlatformSchema = {
     created_at: string;
     updated_at: string;
     fs_size_bytes: number;
-    missing: boolean;
+    missing_from_fs: boolean;
     readonly display_name: string;
 };
 

--- a/frontend/src/__generated__/models/SaveSchema.ts
+++ b/frontend/src/__generated__/models/SaveSchema.ts
@@ -15,6 +15,7 @@ export type SaveSchema = {
     file_size_bytes: number;
     full_path: string;
     download_path: string;
+    missing: boolean;
     created_at: string;
     updated_at: string;
     emulator: (string | null);

--- a/frontend/src/__generated__/models/SaveSchema.ts
+++ b/frontend/src/__generated__/models/SaveSchema.ts
@@ -15,7 +15,7 @@ export type SaveSchema = {
     file_size_bytes: number;
     full_path: string;
     download_path: string;
-    missing: boolean;
+    missing_from_fs: boolean;
     created_at: string;
     updated_at: string;
     emulator: (string | null);

--- a/frontend/src/__generated__/models/ScreenshotSchema.ts
+++ b/frontend/src/__generated__/models/ScreenshotSchema.ts
@@ -14,6 +14,7 @@ export type ScreenshotSchema = {
     file_size_bytes: number;
     full_path: string;
     download_path: string;
+    missing: boolean;
     created_at: string;
     updated_at: string;
 };

--- a/frontend/src/__generated__/models/ScreenshotSchema.ts
+++ b/frontend/src/__generated__/models/ScreenshotSchema.ts
@@ -14,7 +14,7 @@ export type ScreenshotSchema = {
     file_size_bytes: number;
     full_path: string;
     download_path: string;
-    missing: boolean;
+    missing_from_fs: boolean;
     created_at: string;
     updated_at: string;
 };

--- a/frontend/src/__generated__/models/SimpleRomSchema.ts
+++ b/frontend/src/__generated__/models/SimpleRomSchema.ts
@@ -56,6 +56,7 @@ export type SimpleRomSchema = {
     full_path: string;
     created_at: string;
     updated_at: string;
+    missing: boolean;
     siblings: Array<SiblingRomSchema>;
     rom_user: RomUserSchema;
 };

--- a/frontend/src/__generated__/models/SimpleRomSchema.ts
+++ b/frontend/src/__generated__/models/SimpleRomSchema.ts
@@ -56,7 +56,7 @@ export type SimpleRomSchema = {
     full_path: string;
     created_at: string;
     updated_at: string;
-    missing: boolean;
+    missing_from_fs: boolean;
     siblings: Array<SiblingRomSchema>;
     rom_user: RomUserSchema;
 };

--- a/frontend/src/__generated__/models/StateSchema.ts
+++ b/frontend/src/__generated__/models/StateSchema.ts
@@ -15,6 +15,7 @@ export type StateSchema = {
     file_size_bytes: number;
     full_path: string;
     download_path: string;
+    missing: boolean;
     created_at: string;
     updated_at: string;
     emulator: (string | null);

--- a/frontend/src/__generated__/models/StateSchema.ts
+++ b/frontend/src/__generated__/models/StateSchema.ts
@@ -15,7 +15,7 @@ export type StateSchema = {
     file_size_bytes: number;
     full_path: string;
     download_path: string;
-    missing: boolean;
+    missing_from_fs: boolean;
     created_at: string;
     updated_at: string;
     emulator: (string | null);

--- a/frontend/src/components/Details/ActionBar.vue
+++ b/frontend/src/components/Details/ActionBar.vue
@@ -71,7 +71,7 @@ async function copyDownloadLink(rom: DetailedRom) {
   <div>
     <v-btn-group divided density="compact" rounded="0" class="d-flex flex-row">
       <v-btn
-        :disabled="downloadStore.value.includes(rom.id) || rom.missing"
+        :disabled="downloadStore.value.includes(rom.id) || rom.missing_from_fs"
         class="flex-grow-1"
         @click="
           romApi.downloadRom({
@@ -91,7 +91,7 @@ async function copyDownloadLink(rom: DetailedRom) {
         <v-icon icon="mdi-download" size="large" />
       </v-btn>
       <v-btn
-        :disabled="rom.missing"
+        :disabled="rom.missing_from_fs"
         :aria-label="`Copy download link ${rom.name}`"
         class="flex-grow-1"
         @click="copyDownloadLink(rom)"
@@ -107,7 +107,7 @@ async function copyDownloadLink(rom: DetailedRom) {
       </v-btn>
       <v-btn
         v-if="ejsEmulationSupported"
-        :disabled="rom.missing"
+        :disabled="rom.missing_from_fs"
         class="flex-grow-1"
         @click="
           $router.push({
@@ -121,7 +121,7 @@ async function copyDownloadLink(rom: DetailedRom) {
       </v-btn>
       <v-btn
         v-if="ruffleEmulationSupported"
-        :disabled="rom.missing"
+        :disabled="rom.missing_from_fs"
         class="flex-grow-1"
         @click="
           $router.push({
@@ -135,7 +135,7 @@ async function copyDownloadLink(rom: DetailedRom) {
       </v-btn>
       <v-btn
         v-if="is3DSRom"
-        :disabled="rom.missing"
+        :disabled="rom.missing_from_fs"
         class="flex-grow-1"
         @click="emitter?.emit('showQRCodeDialog', rom)"
         :aria-label="`Show ${rom.name} QR code`"

--- a/frontend/src/components/Details/ActionBar.vue
+++ b/frontend/src/components/Details/ActionBar.vue
@@ -71,8 +71,8 @@ async function copyDownloadLink(rom: DetailedRom) {
   <div>
     <v-btn-group divided density="compact" rounded="0" class="d-flex flex-row">
       <v-btn
+        :disabled="downloadStore.value.includes(rom.id) || rom.missing"
         class="flex-grow-1"
-        :disabled="downloadStore.value.includes(rom.id)"
         @click="
           romApi.downloadRom({
             rom,
@@ -91,6 +91,7 @@ async function copyDownloadLink(rom: DetailedRom) {
         <v-icon icon="mdi-download" size="large" />
       </v-btn>
       <v-btn
+        :disabled="rom.missing"
         :aria-label="`Copy download link ${rom.name}`"
         class="flex-grow-1"
         @click="copyDownloadLink(rom)"
@@ -106,6 +107,7 @@ async function copyDownloadLink(rom: DetailedRom) {
       </v-btn>
       <v-btn
         v-if="ejsEmulationSupported"
+        :disabled="rom.missing"
         class="flex-grow-1"
         @click="
           $router.push({
@@ -119,6 +121,7 @@ async function copyDownloadLink(rom: DetailedRom) {
       </v-btn>
       <v-btn
         v-if="ruffleEmulationSupported"
+        :disabled="rom.missing"
         class="flex-grow-1"
         @click="
           $router.push({
@@ -132,6 +135,7 @@ async function copyDownloadLink(rom: DetailedRom) {
       </v-btn>
       <v-btn
         v-if="is3DSRom"
+        :disabled="rom.missing"
         class="flex-grow-1"
         @click="emitter?.emit('showQRCodeDialog', rom)"
         :aria-label="`Show ${rom.name} QR code`"

--- a/frontend/src/components/Details/Info/FileInfo.vue
+++ b/frontend/src/components/Details/Info/FileInfo.vue
@@ -78,7 +78,6 @@ watch(
                 :label="rom.fs_name"
                 :items="rom.files"
                 :itemProps="itemProps"
-                rounded="0"
                 density="compact"
                 variant="outlined"
                 return-object

--- a/frontend/src/components/Details/Info/FileInfo.vue
+++ b/frontend/src/components/Details/Info/FileInfo.vue
@@ -53,7 +53,7 @@ watch(
         </v-col>
         <v-col>
           <missing-from-f-s-icon
-            v-if="rom.missing"
+            v-if="rom.missing_from_fs"
             :text="`Missing game from filesystem: ${rom.fs_path}/${rom.fs_name}`"
             class="mr-2"
           /><span class="text-body-1">{{ rom.fs_name }}</span>
@@ -65,7 +65,7 @@ watch(
         </v-col>
         <v-col>
           <v-row class="align-center" no-gutters>
-            <v-col v-if="rom.missing" cols="auto" class="pr-2">
+            <v-col v-if="rom.missing_from_fs" cols="auto" class="pr-2">
               <missing-from-f-s-icon
                 :text="`Missing game from filesystem: ${rom.fs_path}/${rom.fs_name}`"
                 :size="25"

--- a/frontend/src/components/Details/Info/FileInfo.vue
+++ b/frontend/src/components/Details/Info/FileInfo.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { RomFileSchema } from "@/__generated__";
 import VersionSwitcher from "@/components/Details/VersionSwitcher.vue";
+import MissingFromFSIcon from "@/components/common/MissingFromFSIcon.vue";
 import romApi from "@/services/api/rom";
 import storeAuth from "@/stores/auth";
 import storeDownload from "@/stores/download";
@@ -51,7 +52,11 @@ watch(
           <span>{{ t("rom.file") }}</span>
         </v-col>
         <v-col>
-          <span class="text-body-1">{{ rom.fs_name }}</span>
+          <missing-from-f-s-icon
+            v-if="rom.missing"
+            :text="`Missing game from filesystem: ${rom.fs_path}/${rom.fs_name}`"
+            class="mr-2"
+          /><span class="text-body-1">{{ rom.fs_name }}</span>
         </v-col>
       </v-row>
       <v-row v-if="rom.multi" class="align-center my-3" no-gutters>
@@ -59,44 +64,55 @@ watch(
           <span>{{ t("rom.files") }}</span>
         </v-col>
         <v-col>
-          <v-select
-            v-model="downloadStore.filesToDownload"
-            :label="rom.fs_name"
-            :items="rom.files"
-            :itemProps="itemProps"
-            rounded="0"
-            density="compact"
-            variant="outlined"
-            return-object
-            multiple
-            hide-details
-            clearable
-            chips
-          >
-            <template #item="{ item, props }">
-              <v-list-item v-bind="props">
-                <template v-slot:prepend="{ isSelected }">
-                  <v-checkbox-btn
-                    :model-value="isSelected"
-                    density="compact"
-                    class="mr-2"
-                  />
+          <v-row class="align-center" no-gutters>
+            <v-col cols="auto" class="pr-2">
+              <missing-from-f-s-icon
+                v-if="rom.missing"
+                :text="`Missing game from filesystem: ${rom.fs_path}/${rom.fs_name}`"
+                :size="25"
+              />
+            </v-col>
+            <v-col>
+              <v-select
+                v-model="downloadStore.filesToDownload"
+                :label="rom.fs_name"
+                :items="rom.files"
+                :itemProps="itemProps"
+                rounded="0"
+                density="compact"
+                variant="outlined"
+                return-object
+                multiple
+                hide-details
+                clearable
+                chips
+              >
+                <template #item="{ item, props }">
+                  <v-list-item v-bind="props">
+                    <template v-slot:prepend="{ isSelected }">
+                      <v-checkbox-btn
+                        :model-value="isSelected"
+                        density="compact"
+                        class="mr-2"
+                      />
+                    </template>
+                    <v-list-item-subtitle class="mt-1">
+                      <v-chip
+                        color="primary"
+                        size="x-small"
+                        class="mr-1"
+                        v-if="item.raw.category"
+                        >{{ item.raw.category.toLocaleUpperCase() }}</v-chip
+                      >
+                      <v-chip size="x-small">{{
+                        formatBytes(item.raw.file_size_bytes)
+                      }}</v-chip>
+                    </v-list-item-subtitle>
+                  </v-list-item>
                 </template>
-                <v-list-item-subtitle class="mt-1">
-                  <v-chip
-                    color="primary"
-                    size="x-small"
-                    class="mr-1"
-                    v-if="item.raw.category"
-                    >{{ item.raw.category.toLocaleUpperCase() }}</v-chip
-                  >
-                  <v-chip size="x-small">{{
-                    formatBytes(item.raw.file_size_bytes)
-                  }}</v-chip>
-                </v-list-item-subtitle>
-              </v-list-item>
-            </template>
-          </v-select>
+              </v-select>
+            </v-col>
+          </v-row>
         </v-col>
       </v-row>
       <v-row no-gutters class="align-center my-3">

--- a/frontend/src/components/Details/Info/FileInfo.vue
+++ b/frontend/src/components/Details/Info/FileInfo.vue
@@ -65,9 +65,8 @@ watch(
         </v-col>
         <v-col>
           <v-row class="align-center" no-gutters>
-            <v-col cols="auto" class="pr-2">
+            <v-col v-if="rom.missing" cols="auto" class="pr-2">
               <missing-from-f-s-icon
-                v-if="rom.missing"
                 :text="`Missing game from filesystem: ${rom.fs_path}/${rom.fs_name}`"
                 :size="25"
               />

--- a/frontend/src/components/Details/Title.vue
+++ b/frontend/src/components/Details/Title.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import FavBtn from "@/components/common/Game/FavBtn.vue";
 import PlatformIcon from "@/components/common/Platform/Icon.vue";
+import MissingFromFSIcon from "@/components/common/MissingFromFSIcon.vue";
 import { ROUTES } from "@/plugins/router";
 import type { DetailedRom } from "@/stores/roms";
-import { languageToEmoji, regionToEmoji } from "@/utils";
-import { identity } from "lodash";
+import storePlatforms from "@/stores/platforms";
+import { storeToRefs } from "pinia";
 import { useDisplay } from "vuetify";
 
 // Props
@@ -17,7 +18,9 @@ const releaseDate = new Date(
   month: "short",
   year: "numeric",
 });
-const hasReleaseDate = Number(props.rom.metadatum.first_release_date) > 0;
+
+const platformsStore = storePlatforms();
+const { allPlatforms } = storeToRefs(platformsStore);
 </script>
 <template>
   <div>
@@ -43,6 +46,11 @@ const hasReleaseDate = Number(props.rom.metadatum.first_release_date) > 0;
         <v-chip
           :to="{ name: ROUTES.PLATFORM, params: { platform: rom.platform_id } }"
         >
+          <missing-from-f-s-icon
+            v-if="allPlatforms.find((p) => p.id === rom.platform_id)?.missing"
+            class="mr-2"
+            text="Missing platform from filesystem"
+          />
           <platform-icon
             :key="rom.platform_slug"
             :slug="rom.platform_slug"

--- a/frontend/src/components/Details/Title.vue
+++ b/frontend/src/components/Details/Title.vue
@@ -47,7 +47,10 @@ const { allPlatforms } = storeToRefs(platformsStore);
           :to="{ name: ROUTES.PLATFORM, params: { platform: rom.platform_id } }"
         >
           <missing-from-f-s-icon
-            v-if="allPlatforms.find((p) => p.id === rom.platform_id)?.missing"
+            v-if="
+              allPlatforms.find((p) => p.id === rom.platform_id)
+                ?.missing_from_fs
+            "
             class="mr-2"
             text="Missing platform from filesystem"
           />

--- a/frontend/src/components/Gallery/AppBar/Platform/Base.vue
+++ b/frontend/src/components/Gallery/AppBar/Platform/Base.vue
@@ -20,7 +20,7 @@ const { activePlatformInfoDrawer } = storeToRefs(navigationStore);
   <base-gallery-app-bar :show-playables-filter="false" show-filter-bar>
     <template #prepend>
       <missing-from-f-s-icon
-        v-if="currentPlatform && currentPlatform.missing"
+        v-if="currentPlatform && currentPlatform.missing_from_fs"
         text="Missing platform from filesystem"
         class="mx-2"
         :size="18"

--- a/frontend/src/components/Gallery/AppBar/Platform/Base.vue
+++ b/frontend/src/components/Gallery/AppBar/Platform/Base.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import BaseGalleryAppBar from "@/components/Gallery/AppBar/Base.vue";
 import PlatformIcon from "@/components/common/Platform/Icon.vue";
+import MissingFromFSIcon from "@/components/common/MissingFromFSIcon.vue";
 import FirmwareBtn from "@/components/Gallery/AppBar/Platform/FirmwareBtn.vue";
 import FirmwareDrawer from "@/components/Gallery/AppBar/Platform/FirmwareDrawer.vue";
 import PlatformInfoDrawer from "@/components/Gallery/AppBar/Platform/PlatformInfoDrawer.vue";
@@ -18,6 +19,12 @@ const { activePlatformInfoDrawer } = storeToRefs(navigationStore);
 <template>
   <base-gallery-app-bar :show-playables-filter="false" show-filter-bar>
     <template #prepend>
+      <missing-from-f-s-icon
+        v-if="currentPlatform && currentPlatform.missing"
+        text="Missing platform from filesystem"
+        class="mx-2"
+        :size="18"
+      />
       <v-btn
         v-if="currentPlatform"
         variant="text"

--- a/frontend/src/components/Gallery/AppBar/Platform/FirmwareDrawer.vue
+++ b/frontend/src/components/Gallery/AppBar/Platform/FirmwareDrawer.vue
@@ -116,7 +116,7 @@ function deleteSelectedFirmware() {
           <v-row no-gutters>
             <v-col>
               <missing-from-f-s-icon
-                v-if="item.missing"
+                v-if="item.missing_from_fs"
                 class="mr-1"
                 text="Missing firmware from filesystem"
               />

--- a/frontend/src/components/Gallery/AppBar/Platform/FirmwareDrawer.vue
+++ b/frontend/src/components/Gallery/AppBar/Platform/FirmwareDrawer.vue
@@ -2,6 +2,7 @@
 import type { FirmwareSchema } from "@/__generated__";
 import DeleteFirmwareDialog from "@/components/common/Platform/Dialog/DeleteFirmware.vue";
 import UploadFirmwareDialog from "@/components/common/Platform/Dialog/UploadFirmware.vue";
+import MissingFromFSIcon from "@/components/common/MissingFromFSIcon.vue";
 import storeAuth from "@/stores/auth";
 import storeGalleryView from "@/stores/galleryView";
 import storeRoms from "@/stores/roms";
@@ -114,6 +115,11 @@ function deleteSelectedFirmware() {
         <v-list-item :tabindex="tabIndex" role="listitem" class="px-0">
           <v-row no-gutters>
             <v-col>
+              <missing-from-f-s-icon
+                v-if="item.missing"
+                class="mr-1"
+                text="Missing firmware from filesystem"
+              />
               <span>{{ item.file_name }}</span>
             </v-col>
           </v-row>
@@ -144,7 +150,6 @@ function deleteSelectedFirmware() {
               </v-chip>
             </v-col>
           </v-row>
-          <template> </template>
           <template #append>
             <template v-if="mdAndUp">
               <v-chip size="x-small" tabindex="-1" label>{{

--- a/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
+++ b/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
@@ -2,6 +2,7 @@
 import PlatformIcon from "@/components/common/Platform/Icon.vue";
 import FilterUnmatchedBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterUnmatchedBtn.vue";
 import FilterMatchedBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterMatchedBtn.vue";
+import FilterMissingBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterMissingBtn.vue";
 import FilterFavouritesBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterFavouritesBtn.vue";
 import FilterDuplicatesBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterDuplicatesBtn.vue";
 import FilterPlayablesBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterPlayablesBtn.vue";
@@ -212,6 +213,10 @@ onMounted(async () => {
           :tabindex="activeFilterDrawer ? 0 : -1"
         />
         <filter-ra-btn class="mt-2" :tabindex="activeFilterDrawer ? 0 : -1" />
+        <filter-missing-btn
+          class="mt-2"
+          :tabindex="activeFilterDrawer ? 0 : -1"
+        />
       </v-list-item>
       <v-list-item
         v-if="showPlatformsFilter"

--- a/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
+++ b/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
@@ -253,7 +253,7 @@ onMounted(async () => {
               </template>
               <template #append>
                 <missing-from-f-s-icon
-                  v-if="item.raw.missing"
+                  v-if="item.raw.missing_from_fs"
                   text="Missing platform from filesystem"
                   chip
                   chip-label

--- a/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
+++ b/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
@@ -8,6 +8,7 @@ import FilterDuplicatesBtn from "@/components/Gallery/AppBar/common/FilterDrawer
 import FilterPlayablesBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterPlayablesBtn.vue";
 import FilterRaBtn from "@/components/Gallery/AppBar/common/FilterDrawer/FilterRaBtn.vue";
 import FilterTextField from "@/components/Gallery/AppBar/common/FilterTextField.vue";
+import MissingFromFSIcon from "@/components/common/MissingFromFSIcon.vue";
 import storeGalleryFilter from "@/stores/galleryFilter";
 import storeRoms from "@/stores/roms";
 import storePlatforms from "@/stores/platforms";
@@ -251,6 +252,14 @@ onMounted(async () => {
                 />
               </template>
               <template #append>
+                <missing-from-f-s-icon
+                  v-if="item.raw.missing"
+                  text="Missing platform from filesystem"
+                  chip
+                  chip-label
+                  chipDensity="compact"
+                  class="ml-2"
+                />
                 <v-chip class="ml-2" size="x-small" label>
                   {{ item.raw.rom_count }}
                 </v-chip>

--- a/frontend/src/components/Gallery/AppBar/common/FilterDrawer/FilterMissingBtn.vue
+++ b/frontend/src/components/Gallery/AppBar/common/FilterDrawer/FilterMissingBtn.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import storeGalleryFilter from "@/stores/galleryFilter";
+import type { Events } from "@/types/emitter";
+import type { Emitter } from "mitt";
+import { storeToRefs } from "pinia";
+import { inject } from "vue";
+import { useI18n } from "vue-i18n";
+
+// Props
+const { t } = useI18n();
+const galleryFilterStore = storeGalleryFilter();
+const { filterMissing } = storeToRefs(galleryFilterStore);
+const emitter = inject<Emitter<Events>>("emitter");
+function setMissing() {
+  galleryFilterStore.switchFilterMissing();
+  emitter?.emit("filter", null);
+}
+</script>
+
+<template>
+  <v-btn
+    block
+    variant="tonal"
+    :color="filterMissing ? 'primary' : ''"
+    @click="setMissing"
+  >
+    <v-icon :color="filterMissing ? 'primary' : ''">mdi-alert-circle</v-icon
+    ><span
+      class="ml-2"
+      :class="{
+        'text-primary': filterMissing,
+      }"
+      >{{ t("platform.show-missing") }}</span
+    ></v-btn
+  >
+</template>

--- a/frontend/src/components/Home/ContinuePlaying.vue
+++ b/frontend/src/components/Home/ContinuePlaying.vue
@@ -94,6 +94,7 @@ function onClosedMenu() {
             transformScale
             showActionBar
             showPlatformIcon
+            show-missing-flag
             :enable3DTilt="enable3DEffect"
             @hover="onHover"
             @openedmenu="onOpenedMenu"

--- a/frontend/src/components/Home/RecentAdded.vue
+++ b/frontend/src/components/Home/RecentAdded.vue
@@ -99,6 +99,7 @@ function onClosedMenu() {
             transformScale
             showActionBar
             showPlatformIcon
+            show-missing-flag
             :enable3DTilt="enable3DEffect"
             @hover="onHover"
             @openedmenu="onOpenedMenu"

--- a/frontend/src/components/common/Game/Card/ActionBar.vue
+++ b/frontend/src/components/common/Game/Card/ActionBar.vue
@@ -62,7 +62,7 @@ watch(menuOpen, (val) => {
       <v-btn
         class="action-bar-btn-small flex-grow-1"
         :size="computedSize"
-        :disabled="downloadStore.value.includes(rom.id)"
+        :disabled="downloadStore.value.includes(rom.id) || rom.missing"
         icon="mdi-download"
         variant="text"
         rounded="0"
@@ -76,6 +76,7 @@ watch(menuOpen, (val) => {
     >
       <v-btn
         v-if="ejsEmulationSupported"
+        :disabled="rom.missing"
         @click.prevent
         class="action-bar-btn-small flex-grow-1"
         :size="computedSize"
@@ -92,6 +93,7 @@ watch(menuOpen, (val) => {
       />
       <v-btn
         v-if="ruffleEmulationSupported"
+        :disabled="rom.missing"
         @click.prevent
         class="action-bar-btn-small flex-grow-1"
         :size="computedSize"
@@ -110,6 +112,7 @@ watch(menuOpen, (val) => {
     <v-col v-if="is3DSRom" class="d-flex">
       <v-btn
         @click.prevent
+        :disabled="rom.missing"
         class="action-bar-btn-small flex-grow-1"
         :size="computedSize"
         @click="emitter?.emit('showQRCodeDialog', rom)"

--- a/frontend/src/components/common/Game/Card/ActionBar.vue
+++ b/frontend/src/components/common/Game/Card/ActionBar.vue
@@ -62,7 +62,7 @@ watch(menuOpen, (val) => {
       <v-btn
         class="action-bar-btn-small flex-grow-1"
         :size="computedSize"
-        :disabled="downloadStore.value.includes(rom.id) || rom.missing"
+        :disabled="downloadStore.value.includes(rom.id) || rom.missing_from_fs"
         icon="mdi-download"
         variant="text"
         rounded="0"
@@ -76,7 +76,7 @@ watch(menuOpen, (val) => {
     >
       <v-btn
         v-if="ejsEmulationSupported"
-        :disabled="rom.missing"
+        :disabled="rom.missing_from_fs"
         @click.prevent
         class="action-bar-btn-small flex-grow-1"
         :size="computedSize"
@@ -93,7 +93,7 @@ watch(menuOpen, (val) => {
       />
       <v-btn
         v-if="ruffleEmulationSupported"
-        :disabled="rom.missing"
+        :disabled="rom.missing_from_fs"
         @click.prevent
         class="action-bar-btn-small flex-grow-1"
         :size="computedSize"
@@ -112,7 +112,7 @@ watch(menuOpen, (val) => {
     <v-col v-if="is3DSRom" class="d-flex">
       <v-btn
         @click.prevent
-        :disabled="rom.missing"
+        :disabled="rom.missing_from_fs"
         class="action-bar-btn-small flex-grow-1"
         :size="computedSize"
         @click="emitter?.emit('showQRCodeDialog', rom)"

--- a/frontend/src/components/common/Game/Card/Base.vue
+++ b/frontend/src/components/common/Game/Card/Base.vue
@@ -244,7 +244,7 @@ onBeforeUnmount(() => {
                   <missing-from-f-s-icon
                     v-if="
                       romsStore.isSimpleRom(rom) &&
-                      rom.missing &&
+                      rom.missing_from_fs &&
                       showMissingFlag
                     "
                     :text="`Missing game from filesystem: ${rom.fs_path}/${rom.fs_name}`"

--- a/frontend/src/components/common/Game/Card/Base.vue
+++ b/frontend/src/components/common/Game/Card/Base.vue
@@ -238,6 +238,26 @@ onBeforeUnmount(() => {
                 </template>
                 <sources v-if="!romsStore.isSimpleRom(rom)" :rom="rom" />
                 <v-row no-gutters class="text-white px-1">
+                  <v-tooltip
+                    v-if="romsStore.isSimpleRom(rom) && rom.missing"
+                    location="top"
+                    class="tooltip"
+                    transition="fade-transition"
+                    :text="`Missing game from filesystem: ${rom.fs_path}/${rom.fs_name}`"
+                    open-delay="500"
+                    ><template #activator="{ props }">
+                      <v-chip
+                        v-bind="props"
+                        class="translucent-dark mr-1 mt-1 px-1"
+                        color="accent"
+                        density="compact"
+                      >
+                        <span class="text-caption"
+                          ><v-icon>mdi-alert-circle</v-icon></span
+                        >
+                      </v-chip>
+                    </template>
+                  </v-tooltip>
                   <game-card-flags
                     v-if="romsStore.isSimpleRom(rom) && showFlags"
                     :rom="rom"

--- a/frontend/src/components/common/Game/Card/Base.vue
+++ b/frontend/src/components/common/Game/Card/Base.vue
@@ -5,6 +5,7 @@ import GameCardFlags from "@/components/common/Game/Card/Flags.vue";
 import Sources from "@/components/common/Game/Card/Sources.vue";
 import storePlatforms from "@/stores/platforms";
 import PlatformIcon from "@/components/common/Platform/Icon.vue";
+import MissingFromFSIcon from "@/components/common/MissingFromFSIcon.vue";
 import storeCollections from "@/stores/collections";
 import storeGalleryView from "@/stores/galleryView";
 import { ROUTES } from "@/plugins/router";
@@ -31,6 +32,7 @@ const props = withDefaults(
     showActionBar?: boolean;
     sizeActionBar?: number;
     showPlatformIcon?: boolean;
+    showMissingFlag?: boolean;
     showFav?: boolean;
     withBorderPrimary?: boolean;
     withLink?: boolean;
@@ -50,6 +52,7 @@ const props = withDefaults(
     showActionBar: false,
     sizeActionBar: 0,
     showPlatformIcon: false,
+    showMissingFlag: false,
     showFav: false,
     withBorderPrimary: false,
     disableViewTransition: false,
@@ -238,26 +241,17 @@ onBeforeUnmount(() => {
                 </template>
                 <sources v-if="!romsStore.isSimpleRom(rom)" :rom="rom" />
                 <v-row no-gutters class="text-white px-1">
-                  <v-tooltip
-                    v-if="romsStore.isSimpleRom(rom) && rom.missing"
-                    location="top"
-                    class="tooltip"
-                    transition="fade-transition"
+                  <missing-from-f-s-icon
+                    v-if="
+                      romsStore.isSimpleRom(rom) &&
+                      rom.missing &&
+                      showMissingFlag
+                    "
                     :text="`Missing game from filesystem: ${rom.fs_path}/${rom.fs_name}`"
-                    open-delay="500"
-                    ><template #activator="{ props }">
-                      <v-chip
-                        v-bind="props"
-                        class="translucent-dark mr-1 mt-1 px-1"
-                        color="accent"
-                        density="compact"
-                      >
-                        <span class="text-caption"
-                          ><v-icon>mdi-alert-circle</v-icon></span
-                        >
-                      </v-chip>
-                    </template>
-                  </v-tooltip>
+                    class="mr-1 mt-1 px-1"
+                    chip
+                    chipDensity="compact"
+                  />
                   <game-card-flags
                     v-if="romsStore.isSimpleRom(rom) && showFlags"
                     :rom="rom"

--- a/frontend/src/components/common/Game/Table.vue
+++ b/frontend/src/components/common/Game/Table.vue
@@ -313,7 +313,7 @@ function updateOptions({ sortBy }: { sortBy: SortBy }) {
       <v-btn-group density="compact">
         <fav-btn :rom="item" />
         <v-btn
-          :disabled="downloadStore.value.includes(item.id)"
+          :disabled="downloadStore.value.includes(item.id) || item.missing"
           download
           variant="text"
           size="small"
@@ -323,6 +323,7 @@ function updateOptions({ sortBy }: { sortBy: SortBy }) {
         </v-btn>
         <v-btn
           v-if="checkIfEJSEmulationSupported(item.platform_slug)"
+          :disabled="item.missing"
           variant="text"
           size="small"
           @click.stop="
@@ -336,6 +337,7 @@ function updateOptions({ sortBy }: { sortBy: SortBy }) {
         </v-btn>
         <v-btn
           v-if="checkIfRuffleEmulationSupported(item.platform_slug)"
+          :disabled="item.missing"
           variant="text"
           size="small"
           @click.stop="

--- a/frontend/src/components/common/Game/Table.vue
+++ b/frontend/src/components/common/Game/Table.vue
@@ -3,6 +3,7 @@ import PlatformIcon from "@/components/common/Platform/Icon.vue";
 import AdminMenu from "@/components/common/Game/AdminMenu.vue";
 import FavBtn from "@/components/common/Game/FavBtn.vue";
 import RAvatarRom from "@/components/common/Game/RAvatar.vue";
+import MissingFromFSIcon from "@/components/common/MissingFromFSIcon.vue";
 import romApi from "@/services/api/rom";
 import storeConfig from "@/stores/config";
 import storeDownload from "@/stores/download";
@@ -207,26 +208,12 @@ function updateOptions({ sortBy }: { sortBy: SortBy }) {
           </v-col>
         </v-row>
         <template #append>
-          <v-tooltip
+          <missing-from-f-s-icon
             v-if="item.missing"
-            location="top"
-            class="tooltip"
-            transition="fade-transition"
             :text="`Missing game from filesystem: ${item.fs_path}/${item.fs_name}`"
-            open-delay="500"
-            ><template #activator="{ props }">
-              <v-chip
-                v-bind="props"
-                class="translucent-dark ml-4"
-                color="accent"
-                size="x-small"
-              >
-                <span class="text-caption"
-                  ><v-icon>mdi-alert-circle</v-icon></span
-                >
-              </v-chip>
-            </template>
-          </v-tooltip>
+            chip
+            chip-size="small"
+          />
           <v-chip
             v-if="item.siblings.length > 0 && showSiblings"
             class="translucent-dark ml-2"

--- a/frontend/src/components/common/Game/Table.vue
+++ b/frontend/src/components/common/Game/Table.vue
@@ -207,9 +207,29 @@ function updateOptions({ sortBy }: { sortBy: SortBy }) {
           </v-col>
         </v-row>
         <template #append>
+          <v-tooltip
+            v-if="item.missing"
+            location="top"
+            class="tooltip"
+            transition="fade-transition"
+            :text="`Missing game from filesystem: ${item.fs_path}/${item.fs_name}`"
+            open-delay="500"
+            ><template #activator="{ props }">
+              <v-chip
+                v-bind="props"
+                class="translucent-dark ml-4"
+                color="accent"
+                size="x-small"
+              >
+                <span class="text-caption"
+                  ><v-icon>mdi-alert-circle</v-icon></span
+                >
+              </v-chip>
+            </template>
+          </v-tooltip>
           <v-chip
             v-if="item.siblings.length > 0 && showSiblings"
-            class="translucent-dark ml-4"
+            class="translucent-dark ml-2"
             size="x-small"
           >
             <span class="text-caption">+{{ item.siblings.length }}</span>

--- a/frontend/src/components/common/Game/Table.vue
+++ b/frontend/src/components/common/Game/Table.vue
@@ -209,7 +209,7 @@ function updateOptions({ sortBy }: { sortBy: SortBy }) {
         </v-row>
         <template #append>
           <missing-from-f-s-icon
-            v-if="item.missing"
+            v-if="item.missing_from_fs"
             :text="`Missing game from filesystem: ${item.fs_path}/${item.fs_name}`"
             chip
             chip-size="small"
@@ -300,7 +300,9 @@ function updateOptions({ sortBy }: { sortBy: SortBy }) {
       <v-btn-group density="compact">
         <fav-btn :rom="item" />
         <v-btn
-          :disabled="downloadStore.value.includes(item.id) || item.missing"
+          :disabled="
+            downloadStore.value.includes(item.id) || item.missing_from_fs
+          "
           download
           variant="text"
           size="small"
@@ -310,7 +312,7 @@ function updateOptions({ sortBy }: { sortBy: SortBy }) {
         </v-btn>
         <v-btn
           v-if="checkIfEJSEmulationSupported(item.platform_slug)"
-          :disabled="item.missing"
+          :disabled="item.missing_from_fs"
           variant="text"
           size="small"
           @click.stop="
@@ -324,7 +326,7 @@ function updateOptions({ sortBy }: { sortBy: SortBy }) {
         </v-btn>
         <v-btn
           v-if="checkIfRuffleEmulationSupported(item.platform_slug)"
-          :disabled="item.missing"
+          :disabled="item.missing_from_fs"
           variant="text"
           size="small"
           @click.stop="

--- a/frontend/src/components/common/MissingFromFSIcon.vue
+++ b/frontend/src/components/common/MissingFromFSIcon.vue
@@ -1,0 +1,56 @@
+<script lang="ts" setup>
+withDefaults(
+  defineProps<{
+    text: string;
+    size?: number;
+    chip?: boolean;
+    chipLabel?: boolean;
+    chipSize?: "x-small" | "small" | "default" | "large";
+    chipDensity?: "compact" | "comfortable";
+  }>(),
+  {
+    size: 20,
+    text: "",
+    chip: false,
+    chipLabel: false,
+    chipSize: "default",
+    chipDensity: "comfortable",
+  },
+);
+</script>
+<template>
+  <v-chip
+    v-if="chip"
+    class="translucent-dark"
+    :density="chipDensity"
+    color="accent"
+    :label="chipLabel"
+    :size="chipSize"
+  >
+    <v-tooltip
+      location="top"
+      class="tooltip"
+      transition="fade-transition"
+      :text="text"
+      open-delay="500"
+      activator="parent"
+    />
+    <v-icon>mdi-alert-circle</v-icon>
+  </v-chip>
+  <span v-else>
+    <v-tooltip
+      location="top"
+      class="tooltip"
+      transition="fade-transition"
+      :text="text"
+      open-delay="500"
+      activator="parent"
+    />
+    <v-icon color="accent" :size="size"> mdi-alert-circle </v-icon>
+  </span>
+</template>
+<style scoped>
+.v-icon {
+  opacity: 1 !important;
+}
+</style>

--- a/frontend/src/components/common/Platform/Card.vue
+++ b/frontend/src/components/common/Platform/Card.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, onBeforeUnmount } from "vue";
 import type { Platform } from "@/stores/platforms";
 import { ROUTES } from "@/plugins/router";
 import PlatformIcon from "@/components/common/Platform/Icon.vue";
+import MissingFromFSIcon from "@/components/common/MissingFromFSIcon.vue";
 import VanillaTilt from "vanilla-tilt";
 import { useDisplay } from "vuetify";
 
@@ -62,7 +63,12 @@ onBeforeUnmount(() => {
         "
       >
         <v-card-text>
-          <v-row class="pa-1 justify-center bg-background">
+          <v-row class="pa-1 justify-center align-center bg-background">
+            <missing-from-f-s-icon
+              v-if="platform.missing"
+              text="Missing platform from filesystem"
+              :size="15"
+            />
             <div
               :title="platform.display_name"
               class="px-2 text-truncate text-caption"

--- a/frontend/src/components/common/Platform/Card.vue
+++ b/frontend/src/components/common/Platform/Card.vue
@@ -65,7 +65,7 @@ onBeforeUnmount(() => {
         <v-card-text>
           <v-row class="pa-1 justify-center align-center bg-background">
             <missing-from-f-s-icon
-              v-if="platform.missing"
+              v-if="platform.missing_from_fs"
               text="Missing platform from filesystem"
               :size="15"
             />

--- a/frontend/src/components/common/Platform/ListItem.vue
+++ b/frontend/src/components/common/Platform/ListItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import PlatformIcon from "@/components/common/Platform/Icon.vue";
+import MissingFromFSIcon from "@/components/common/MissingFromFSIcon.vue";
 import { ROUTES } from "@/plugins/router";
 import type { Platform } from "@/stores/platforms";
 
@@ -50,25 +51,14 @@ withDefaults(
       </v-col>
     </v-row>
     <template v-if="showRomCount" #append>
-      <v-tooltip
+      <missing-from-f-s-icon
         v-if="platform.missing"
-        location="top"
-        class="tooltip"
-        transition="fade-transition"
         text="Missing platform from filesystem"
-        open-delay="500"
-        ><template #activator="{ props }">
-          <v-chip
-            v-bind="props"
-            class="ml-2"
-            size="x-small"
-            color="accent"
-            label
-          >
-            <v-icon>mdi-alert-circle</v-icon>
-          </v-chip>
-        </template>
-      </v-tooltip>
+        chip
+        chip-label
+        chipDensity="compact"
+        class="ml-2"
+      />
       <v-chip class="ml-2" size="x-small" label>
         {{ platform.rom_count }}
       </v-chip>

--- a/frontend/src/components/common/Platform/ListItem.vue
+++ b/frontend/src/components/common/Platform/ListItem.vue
@@ -52,7 +52,7 @@ withDefaults(
     </v-row>
     <template v-if="showRomCount" #append>
       <missing-from-f-s-icon
-        v-if="platform.missing"
+        v-if="platform.missing_from_fs"
         text="Missing platform from filesystem"
         chip
         chip-label

--- a/frontend/src/components/common/Platform/ListItem.vue
+++ b/frontend/src/components/common/Platform/ListItem.vue
@@ -37,24 +37,7 @@ withDefaults(
         :name="platform.name"
         :fs-slug="platform.fs_slug"
         :size="40"
-      >
-        <v-tooltip
-          location="bottom"
-          class="tooltip"
-          transition="fade-transition"
-          text="Not found"
-          open-delay="500"
-          ><template #activator="{ props }">
-            <div
-              v-if="!platform.igdb_id && !platform.moby_id && !platform.ss_id"
-              v-bind="props"
-              class="not-found-icon"
-            >
-              ⚠️
-            </div>
-          </template>
-        </v-tooltip></platform-icon
-      >
+      />
     </template>
     <v-row no-gutters
       ><v-col
@@ -67,17 +50,28 @@ withDefaults(
       </v-col>
     </v-row>
     <template v-if="showRomCount" #append>
+      <v-tooltip
+        v-if="platform.missing"
+        location="top"
+        class="tooltip"
+        transition="fade-transition"
+        text="Missing platform from filesystem"
+        open-delay="500"
+        ><template #activator="{ props }">
+          <v-chip
+            v-bind="props"
+            class="ml-2"
+            size="x-small"
+            color="accent"
+            label
+          >
+            <v-icon>mdi-alert-circle</v-icon>
+          </v-chip>
+        </template>
+      </v-tooltip>
       <v-chip class="ml-2" size="x-small" label>
         {{ platform.rom_count }}
       </v-chip>
     </template>
   </v-list-item>
 </template>
-
-<style scoped>
-.not-found-icon {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-}
-</style>

--- a/frontend/src/locales/de_DE/platform.json
+++ b/frontend/src/locales/de_DE/platform.json
@@ -30,6 +30,7 @@
   "show-playables": "Zeige spielbare",
   "show-unmatched": "Zeige unzugewiesene",
   "show-ra": "Zeige Retroachievements",
+  "show-missing": "Zeige fehlende",
   "status": "Status",
   "upload-roms": "Roms hochladen"
 }

--- a/frontend/src/locales/en_GB/platform.json
+++ b/frontend/src/locales/en_GB/platform.json
@@ -30,6 +30,7 @@
   "show-unmatched": "Show unmatched",
   "show-playables": "Show playables",
   "show-ra": "Show Retroachievements",
+  "show-missing": "Show missing",
   "status": "Status",
   "upload-roms": "Upload Roms"
 }

--- a/frontend/src/locales/en_US/platform.json
+++ b/frontend/src/locales/en_US/platform.json
@@ -30,6 +30,7 @@
   "show-unmatched": "Show unmatched",
   "show-playables": "Show playables",
   "show-ra": "Show Retroachievements",
+  "show-missing": "Show missing",
   "status": "Status",
   "upload-roms": "Upload Roms"
 }

--- a/frontend/src/locales/es_ES/platform.json
+++ b/frontend/src/locales/es_ES/platform.json
@@ -30,6 +30,7 @@
   "show-unmatched": "Mostrar no identificados",
   "show-playables": "Mostrar jugables",
   "show-ra": "Mostrar Retroachievements",
+  "show-missing": "Mostrar perdidos",
   "status": "Estado",
   "upload-roms": "Subir Roms"
 }

--- a/frontend/src/locales/fr_FR/platform.json
+++ b/frontend/src/locales/fr_FR/platform.json
@@ -30,6 +30,7 @@
   "show-unmatched": "Jeux non identifiés",
   "show-playables": "Afficher les jouables",
   "show-ra": "Afficher les Retroachievements",
+  "show-missing": "Afficher les manquants",
   "status": "Statut",
   "upload-roms": "Télécharger des ROMs"
 }

--- a/frontend/src/locales/it_IT/platform.json
+++ b/frontend/src/locales/it_IT/platform.json
@@ -32,6 +32,7 @@
   "show-unmatched": "Mostra senza corrispondenza",
   "show-playables": "Mostra giocabili",
   "show-ra": "Mostra Retroachievements",
+  "show-missing": "Mostra mancanti",
   "status": "Stato",
   "upload-roms": "Carica Rom"
 }

--- a/frontend/src/locales/ja_JP/platform.json
+++ b/frontend/src/locales/ja_JP/platform.json
@@ -30,6 +30,7 @@
   "show-unmatched": "非該当を表示",
   "show-playables": "プレイ可能を表示",
   "show-ra": "Retroachievementsを表示",
+  "show-missing": "欠落を表示",
   "status": "ステータス",
   "upload-roms": "Romをアップロード"
 }

--- a/frontend/src/locales/ko_KR/platform.json
+++ b/frontend/src/locales/ko_KR/platform.json
@@ -30,6 +30,7 @@
   "show-unmatched": "DB 대응 안됨",
   "show-playables": "플레이 가능한 게임 보기",
   "show-ra": "Retroachievements 보기",
+  "show-missing": "누락된 항목 보기",
   "status": "플레이 상태",
   "upload-roms": "롬 업로드"
 }

--- a/frontend/src/locales/pt_BR/platform.json
+++ b/frontend/src/locales/pt_BR/platform.json
@@ -30,6 +30,7 @@
   "show-unmatched": "Mostrar não correspondentes",
   "show-playables": "Mostrar jogáveis",
   "show-ra": "Mostrar Retroachievements",
+  "show-missing": "Mostrar faltantes",
   "status": "Status",
   "upload-roms": "Carregar ROMs"
 }

--- a/frontend/src/locales/ro_RO/platform.json
+++ b/frontend/src/locales/ro_RO/platform.json
@@ -32,6 +32,7 @@
   "show-unmatched": "Jocuri neidentificate",
   "show-playables": "Afișează jocuri jucabile",
   "show-ra": "Afișează Retroachievements",
+  "show-missing": "Afișează lipsurile",
   "status": "Stare",
   "upload-roms": "Încărcare ROM-uri"
 }

--- a/frontend/src/locales/ru_RU/platform.json
+++ b/frontend/src/locales/ru_RU/platform.json
@@ -30,6 +30,7 @@
   "show-unmatched": "Показать несоответствующие",
   "show-playables": "Показать доступные",
   "show-ra": "Показать Retroachievements",
+  "show-missing": "Показать отсутствующие",
   "status": "Статус",
   "upload-roms": "Загрузить ромы"
 }

--- a/frontend/src/locales/zh_CN/platform.json
+++ b/frontend/src/locales/zh_CN/platform.json
@@ -30,6 +30,7 @@
   "show-unmatched": "显示不匹配项",
   "show-playables": "显示可玩",
   "show-ra": "显示 Retroachievements",
+  "show-missing": "显示缺失",
   "status": "状态",
   "upload-roms": "上传 Roms"
 }

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -73,6 +73,7 @@ export interface GetRomsParams {
   filterDuplicates?: boolean;
   filterPlayables?: boolean;
   filterRA?: boolean;
+  filterMissing?: boolean;
   groupByMetaId?: boolean;
   selectedGenre?: string | null;
   selectedFranchise?: string | null;
@@ -99,6 +100,7 @@ async function getRoms({
   filterDuplicates = false,
   filterPlayables = false,
   filterRA = false,
+  filterMissing = false,
   groupByMetaId = false,
   selectedGenre = null,
   selectedFranchise = null,
@@ -134,6 +136,7 @@ async function getRoms({
       ...(filterFavourites ? { favourite: true } : {}),
       ...(filterDuplicates ? { duplicate: true } : {}),
       ...(filterPlayables ? { playable: true } : {}),
+      ...(filterMissing ? { missing_only: true } : {}),
     },
   });
 }

--- a/frontend/src/stores/galleryFilter.ts
+++ b/frontend/src/stores/galleryFilter.ts
@@ -32,6 +32,7 @@ const defaultFilterState = {
   filterDuplicates: false,
   filterPlayables: false,
   filterRA: false,
+  filterMissing: false,
   selectedPlatform: null as Platform | null,
   selectedGenre: null as string | null,
   selectedFranchise: null as string | null,
@@ -141,6 +142,12 @@ export default defineStore("galleryFilter", {
     disableFilterRA() {
       this.filterRA = false;
     },
+    switchFilterMissing() {
+      this.filterMissing = !this.filterMissing;
+    },
+    disableFilterMissing() {
+      this.filterMissing = false;
+    },
     isFiltered() {
       return Boolean(
         this.filterUnmatched ||
@@ -149,6 +156,7 @@ export default defineStore("galleryFilter", {
           this.filterDuplicates ||
           this.filterPlayables ||
           this.filterRA ||
+          this.filterMissing ||
           this.selectedPlatform ||
           this.selectedGenre ||
           this.selectedFranchise ||
@@ -177,6 +185,7 @@ export default defineStore("galleryFilter", {
       this.disableFilterDuplicates();
       this.disableFilterPlayables();
       this.disableFilterRA();
+      this.disableFilterMissing();
     },
   },
 });

--- a/frontend/src/styles/scrollbar.css
+++ b/frontend/src/styles/scrollbar.css
@@ -1,17 +1,20 @@
 ::-webkit-scrollbar {
-  width: 4px;
-  height: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 12px; /* More rounded */
 }
 ::-webkit-scrollbar-track {
   background: transparent;
+  border-radius: 12px; /* More rounded */
 }
 ::-webkit-scrollbar-thumb {
-  background-color: rgba(164, 82, 254, 0.35);
-  border-radius: 1px;
+  background-color: #a452fe59 transparent;
+  border-radius: 12px; /* More rounded */
   border: transparent;
 }
 
-/* * {
+/* For Firefox */
+* {
   scrollbar-width: thin;
-  scrollbar-color: #202832 rgba(0, 0, 0, 0);
-} */
+  scrollbar-color: #a452fe59 transparent;
+}

--- a/frontend/src/views/Gallery/Collection.vue
+++ b/frontend/src/views/Gallery/Collection.vue
@@ -339,6 +339,7 @@ onBeforeUnmount(() => {
               transform-scale
               show-action-bar
               show-platform-icon
+              show-missing-flag
               :with-border-primary="
                 romsStore.isSimpleRom(rom) && selectedRoms?.includes(rom)
               "

--- a/frontend/src/views/Gallery/Platform.vue
+++ b/frontend/src/views/Gallery/Platform.vue
@@ -285,6 +285,7 @@ onBeforeUnmount(() => {
               showFav
               transformScale
               showActionBar
+              show-missing-flag
               :withBorderPrimary="
                 romsStore.isSimpleRom(rom) && selectedRoms?.includes(rom)
               "

--- a/frontend/src/views/Gallery/Search.vue
+++ b/frontend/src/views/Gallery/Search.vue
@@ -202,6 +202,7 @@ onBeforeUnmount(() => {
             transformScale
             showActionBar
             showPlatformIcon
+            show-missing-flag
             :withBorderPrimary="
               romsStore.isSimpleRom(rom) && selectedRoms?.includes(rom)
             "

--- a/frontend/src/views/Scan.vue
+++ b/frontend/src/views/Scan.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import RomListItem from "@/components/common/Game/ListItem.vue";
 import PlatformIcon from "@/components/common/Platform/Icon.vue";
+import MissingFromFSIcon from "@/components/common/MissingFromFSIcon.vue";
 import socket from "@/services/socket";
 import storeHeartbeat from "@/stores/heartbeat";
 import storePlatforms, { type Platform } from "@/stores/platforms";
@@ -160,6 +161,14 @@ async function stopScan() {
               />
             </template>
             <template #append>
+              <missing-from-f-s-icon
+                v-if="item.raw.missing"
+                text="Missing platform from filesystem"
+                chip
+                chip-label
+                chipDensity="compact"
+                class="ml-2"
+              />
               <v-chip class="ml-2" size="x-small" label>
                 {{ item.raw.rom_count }}
               </v-chip>

--- a/frontend/src/views/Scan.vue
+++ b/frontend/src/views/Scan.vue
@@ -162,7 +162,7 @@ async function stopScan() {
             </template>
             <template #append>
               <missing-from-f-s-icon
-                v-if="item.raw.missing"
+                v-if="item.raw.missing_from_fs"
                 text="Missing platform from filesystem"
                 chip
                 chip-label


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
This PR changes the scanner behaviour when any entity (rom, platform or firmware) is missing from the filesystem. Now instead of purging it from the database, will be marked as ``missing`` avoiding user data loss. If the file is restored (same path, same filename) and a scan is performed, will be unmarked as ``missing`` again.

**Checklist**

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots

![image](https://github.com/user-attachments/assets/7d7ebe5c-7603-446c-baaf-4f10ac37629a)

![image](https://github.com/user-attachments/assets/fa85ec05-7734-4226-926c-a1af5434eab6)

Closes #1784
