### PR TITLE
feat: Added custom session max age

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -79,6 +79,9 @@ MOBYGAMES_API_KEY: Final = os.environ.get("MOBYGAMES_API_KEY", "").strip()
 ROMM_AUTH_SECRET_KEY: Final = os.environ.get(
     "ROMM_AUTH_SECRET_KEY", secrets.token_hex(32)
 )
+SESSION_MAX_AGE_SECONDS: Final = int(
+    os.environ.get("SESSION_MAX_AGE_SECONDS", 14 * 24 * 60 * 60)
+)  # 14 days, in seconds
 DISABLE_CSRF_PROTECTION = str_to_bool(
     os.environ.get("DISABLE_CSRF_PROTECTION", "false")
 )

--- a/backend/handler/auth/middleware.py
+++ b/backend/handler/auth/middleware.py
@@ -1,6 +1,7 @@
 import time
 from collections import namedtuple
 
+from config import SESSION_MAX_AGE_SECONDS
 from joserfc import jwt
 from joserfc.errors import BadSignatureError
 from joserfc.jwk import OctKey
@@ -37,7 +38,7 @@ class SessionMiddleware:
         app: ASGIApp,
         secret_key: str | Secret | SecretKey,
         session_cookie: str = "session",
-        max_age: int = 14 * 24 * 60 * 60,  # 14 days, in seconds
+        max_age: int = SESSION_MAX_AGE_SECONDS,
         same_site: str = "lax",
         https_only: bool = False,
         jwt_alg: str = "HS256",


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
This PR adds a new variable `SESSION_MAX_AGE_SECONDS` to manage the max age of the session cookies

**Checklist**
- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

Closes #1974 
