### PR TITLE
Fix Retroachievements URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Here are a few projects that we think you might like:
 [screenscraper-api]: https://docs.romm.app/latest/Getting-Started/Generate-API-Keys/#screenscraper
 [mobygames-api]: https://docs.romm.app/latest/Getting-Started/Generate-API-Keys/#mobygames
 [steamgriddb-api]: https://docs.romm.app/latest/Getting-Started/Generate-API-Keys/#steamgriddb
-[retroachievements-api]: https://docs.romm.app/latest/Getting-Started/Generate-API-Keys/#retroachievements
+[retroachievements-api]: https://docs.romm.app/latest/Getting-Started/Metadata-Providers/#retroachievements
 [big-bear-casaos]: https://github.com/bigbeartechworld/big-bear-casaos
 [romm-comm-discord-bot]: https://github.com/idio-sync/romm-comm
 [deck-romm-sync]: https://github.com/PeriBluGaming/DeckRommSync-Standalone

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ Here are a few projects that we think you might like:
 
 <!-- External links -->
 
-[igdb-api]: https://docs.romm.app/latest/Getting-Started/Generate-API-Keys/#igdb
-[screenscraper-api]: https://docs.romm.app/latest/Getting-Started/Generate-API-Keys/#screenscraper
-[mobygames-api]: https://docs.romm.app/latest/Getting-Started/Generate-API-Keys/#mobygames
-[steamgriddb-api]: https://docs.romm.app/latest/Getting-Started/Generate-API-Keys/#steamgriddb
+[igdb-api]: https://docs.romm.app/latest/Getting-Started/Metadata-Providers/#igdb
+[screenscraper-api]: https://docs.romm.app/latest/Getting-Started/Metadata-Providers/#screenscraper
+[mobygames-api]: https://docs.romm.app/latest/Getting-Started/Metadata-Providers/#mobygames 
+[steamgriddb-api]: https://docs.romm.app/latest/Getting-Started/Metadata-Providers/#steamgriddb 
 [retroachievements-api]: https://docs.romm.app/latest/Getting-Started/Metadata-Providers/#retroachievements
 [big-bear-casaos]: https://github.com/bigbeartechworld/big-bear-casaos
 [romm-comm-discord-bot]: https://github.com/idio-sync/romm-comm


### PR DESCRIPTION
Nothing like a new user to break the docs :rofl:

Existing link is 404, I believe this is the correct link?