### PR TITLE
misc: Remove support for deprecated GUNICORN_WORKERS variable

### DIFF
--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -83,12 +83,6 @@ start_bin_gunicorn() {
 	# commands to start our main application and store its PID to check for crashes
 	info_log "Starting backend"
 
-	# TODO: Remove support for GUNICORN_WORKERS in future version.
-	if [[ -n ${GUNICORN_WORKERS-} ]]; then
-		warn_log "GUNICORN_WORKERS variable is deprecated, use WEB_CONCURRENCY instead"
-		: "${WEB_CONCURRENCY:=${GUNICORN_WORKERS}}"
-	fi
-
 	gunicorn \
 		--bind=0.0.0.0:5000 \
 		--bind=unix:/tmp/gunicorn.sock \


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
The `GUNICORN_WORKERS` environment variable has been deprecated in favor of `WEB_CONCURRENCY`.

**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes