### PR TITLE
misc: Remove deprecated boolean parameters from get_roms endpoint

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from io import BytesIO
 from shutil import rmtree
 from stat import S_IFREG
-from typing import Annotated, Any, TypeVar
+from typing import Any, TypeVar
 from urllib.parse import quote
 from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile, ZipInfo
 
@@ -160,15 +160,6 @@ def get_roms(
     missing: bool | None = None,
     has_ra: bool | None = None,
     verified: bool | None = None,
-    # TODO: Remove deprecated boolean parameters, in favor of their
-    #       optional counterparts.
-    unmatched_only: Annotated[bool, Query(deprecated=True)] = False,
-    matched_only: Annotated[bool, Query(deprecated=True)] = False,
-    favourites_only: Annotated[bool, Query(deprecated=True)] = False,
-    duplicates_only: Annotated[bool, Query(deprecated=True)] = False,
-    playables_only: Annotated[bool, Query(deprecated=True)] = False,
-    missing_only: Annotated[bool, Query(deprecated=True)] = False,
-    ra_only: Annotated[bool, Query(deprecated=True)] = False,
     group_by_meta_id: bool = False,
     selected_genre: str | None = None,
     selected_franchise: str | None = None,
@@ -195,13 +186,6 @@ def get_roms(
         playable (bool, optional): Filter for playable or non-playable roms. Defaults to None.
         missing (bool, optional): Filter only roms that are missing from the filesystem. Defaults to False.
         verified (bool, optional): Filter only roms that are verified by hasheous from the filesystem. Defaults to False.
-        unmatched_only (bool, optional): Filter only unmatched roms. Defaults to False. DEPRECATED: use `matched` instead.
-        matched_only (bool, optional): Filter only matched roms. Defaults to False. DEPRECATED: use `matched` instead.
-        favourites_only (bool, optional): Filter only favourite roms. Defaults to False. DEPRECATED: use `favourite` instead.
-        duplicates_only (bool, optional): Filter only duplicate roms. Defaults to False. DEPRECATED: use `duplicate` instead.
-        playables_only (bool, optional): Filter only playable roms by emulatorjs. Defaults to False. DEPRECATED: use `playable` instead.
-        ra_only (bool, optional): Filter only roms with Retroachievements compatibility. Defaults to False. DEPRECATED: use `has_ra` instead.
-        missing_only (bool, optional): Filter only roms that are missing from the filesystem. Defaults to False. DEPRECATED: use `missing` instead.
         group_by_meta_id (bool, optional): Group roms by igdb/moby/ssrf/launchbox ID. Defaults to False.
         selected_genre (str, optional): Filter by genre. Defaults to None.
         selected_franchise (str, optional): Filter by franchise. Defaults to None.
@@ -222,28 +206,6 @@ def get_roms(
         order_by=order_by.lower(),
         order_dir=order_dir.lower(),
     )
-
-    # Backwards compatibility for matched parameter.
-    if matched is None:
-        if unmatched_only:
-            matched = False
-        elif matched_only:
-            matched = True
-    # Backwards compatibility for favourite parameter.
-    if favourite is None and favourites_only:
-        favourite = True
-    # Backwards compatibility for duplicate parameter.
-    if duplicate is None and duplicates_only:
-        duplicate = True
-    # Backwards compatibility for playable parameter.
-    if playable is None and playables_only:
-        playable = True
-    # Backwards compatibility for has_ra parameter.
-    if has_ra is None and ra_only:
-        has_ra = True
-    # Backwards compatibility for missing parameter.
-    if missing is None and missing_only:
-        missing = True
 
     # Filter down the query
     query = db_rom_handler.filter_roms(

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -237,13 +237,16 @@ class DBRomsHandler(DBBaseHandler):
         return query.join(Rom.platform).filter(predicate)
 
     def filter_by_has_ra(self, query: Query, value: bool) -> Query:
-        predicate = query.filter(Rom.ra_id.isnot(None))
+        predicate = Rom.ra_id.isnot(None)
         if not value:
             predicate = not_(predicate)
         return query.filter(predicate)
 
-    def filter_by_missing_from_fs(self, query: Query):
-        return query.filter(Rom.missing_from_fs.isnot(False))
+    def filter_by_missing_from_fs(self, query: Query, value: bool) -> Query:
+        predicate = Rom.missing_from_fs.isnot(False)
+        if not value:
+            predicate = not_(predicate)
+        return query.filter(predicate)
 
     def filter_by_verified(self, query: Query):
         keys_to_check = [
@@ -391,9 +394,9 @@ class DBRomsHandler(DBBaseHandler):
         favourite: bool | None = None,
         duplicate: bool | None = None,
         playable: bool | None = None,
-        has_ra: bool | None = False,
-        missing: bool | None = False,
-        verified: bool | None = False,
+        has_ra: bool | None = None,
+        missing: bool | None = None,
+        verified: bool | None = None,
         group_by_meta_id: bool = False,
         selected_genre: str | None = None,
         selected_franchise: str | None = None,
@@ -437,9 +440,10 @@ class DBRomsHandler(DBBaseHandler):
         if has_ra is not None:
             query = self.filter_by_has_ra(query, value=has_ra)
 
-        if missing:
-            query = self.filter_by_missing_from_fs(query)
+        if missing is not None:
+            query = self.filter_by_missing_from_fs(query, value=missing)
 
+        # TODO: Correctly support true/false values.
         if verified:
             query = self.filter_by_verified(query)
 
@@ -615,6 +619,9 @@ class DBRomsHandler(DBBaseHandler):
             favourite=kwargs.pop("favourite", None),
             duplicate=kwargs.pop("duplicate", None),
             playable=kwargs.pop("playable", None),
+            has_ra=kwargs.pop("has_ra", None),
+            missing=kwargs.pop("missing", None),
+            verified=kwargs.pop("verified", None),
             selected_genre=kwargs.pop("selected_genre", None),
             selected_franchise=kwargs.pop("selected_franchise", None),
             selected_collection=kwargs.pop("selected_collection", None),

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -236,8 +236,11 @@ class DBRomsHandler(DBBaseHandler):
             predicate = not_(predicate)
         return query.join(Rom.platform).filter(predicate)
 
-    def filter_by_has_ra(self, query: Query):
-        return query.filter(Rom.ra_id.isnot(None))
+    def filter_by_has_ra(self, query: Query, value: bool) -> Query:
+        predicate = query.filter(Rom.ra_id.isnot(None))
+        if not value:
+            predicate = not_(predicate)
+        return query.filter(predicate)
 
     def filter_by_missing_from_fs(self, query: Query):
         return query.filter(Rom.missing_from_fs.isnot(False))
@@ -431,8 +434,8 @@ class DBRomsHandler(DBBaseHandler):
         if playable is not None:
             query = self.filter_by_playable(query, value=playable)
 
-        if has_ra:
-            query = self.filter_by_has_ra(query)
+        if has_ra is not None:
+            query = self.filter_by_has_ra(query, value=has_ra)
 
         if missing:
             query = self.filter_by_missing_from_fs(query)


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
These parameters were replaced by optional versions that allow for more flexibility. This change removes code already marked as deprecated.

**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes