### PR TITLE
misc: Remove unused methods from Roms handler

### DIFF
--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -656,19 +656,6 @@ class DBRomsHandler(DBBaseHandler):
 
     @begin_session
     @with_details
-    def get_rom_by_fs_name(
-        self,
-        platform_id: int,
-        fs_name: str,
-        query: Query = None,
-        session: Session = None,
-    ) -> Rom | None:
-        return session.scalar(
-            query.filter_by(platform_id=platform_id, fs_name=fs_name).limit(1)
-        )
-
-    @begin_session
-    @with_details
     def get_roms_by_fs_name(
         self,
         platform_id: int,
@@ -687,20 +674,6 @@ class DBRomsHandler(DBBaseHandler):
             .all()
         )
         return {rom.fs_name: rom for rom in roms}
-
-    @begin_session
-    @with_details
-    def get_rom_by_fs_name_no_tags(
-        self, fs_name_no_tags: str, query: Query = None, session: Session = None
-    ) -> Rom | None:
-        return session.scalar(query.filter_by(fs_name_no_tags=fs_name_no_tags).limit(1))
-
-    @begin_session
-    @with_details
-    def get_rom_by_fs_name_no_ext(
-        self, fs_name_no_ext: str, query: Query = None, session: Session = None
-    ) -> Rom | None:
-        return session.scalar(query.filter_by(fs_name_no_ext=fs_name_no_ext).limit(1))
 
     @begin_session
     def update_rom(self, id: int, data: dict, session: Session = None) -> Rom:

--- a/backend/handler/tests/test_db_handler.py
+++ b/backend/handler/tests/test_db_handler.py
@@ -69,15 +69,6 @@ def test_roms(rom: Rom, platform: Platform):
     assert len(roms) == 1
 
 
-def test_utils(rom: Rom, platform: Platform):
-    roms = db_rom_handler.get_roms_scalar(platform_id=platform.id)
-    rom_1 = db_rom_handler.get_rom_by_fs_name(
-        platform_id=platform.id, fs_name=rom.fs_name
-    )
-    assert rom_1
-    assert rom_1.id == roms[0].id
-
-
 def test_users(admin_user):
     db_user_handler.add_user(
         User(


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
These methods are no longer used in the codebase and have been removed to clean up the code.

**Checklist**

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
