### PR TITLE
misc: Upgrade RALibretro to v1.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,13 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | b
 ENV PATH="$NVM_DIR/versions/node/v18.20.8/bin:$PATH"
 
 # Build and install RAHasher (optional for RA hashes)
-RUN git clone --recursive --branch 1.8.0 --depth 1 https://github.com/RetroAchievements/RALibretro.git /tmp/RALibretro
+RUN git clone --recursive --branch 1.8.1 --depth 1 https://github.com/RetroAchievements/RALibretro.git /tmp/RALibretro
 WORKDIR /tmp/RALibretro
 RUN sed -i '22a #include <ctime>' ./src/Util.h \
+    && sed -i '6a #include <unistd.h>' \
+      ./src/libchdr/deps/zlib-1.3.1/gzlib.c \
+      ./src/libchdr/deps/zlib-1.3.1/gzread.c \
+      ./src/libchdr/deps/zlib-1.3.1/gzwrite.c \
     && make HAVE_CHD=1 -f ./Makefile.RAHasher \
     && cp ./bin64/RAHasher /usr/bin/RAHasher
 RUN rm -rf /tmp/RALibretro

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,10 +58,7 @@ FROM backend-build AS backend-dev-build
 RUN poetry install --no-ansi --no-cache --all-extras
 
 
-# TODO: Upgrade Alpine to the same version as the other stages, when RAHasher is updated to workAdd commentMore actions
-#       with it (seems like Alpine 3.18's g++ v12 is the latest version that works with RAHasher,
-#       while g++ v13 fails to compile it).
-FROM alpine:3.18 AS rahasher-build
+FROM alpine:${ALPINE_VERSION} AS rahasher-build
 
 RUN apk add --no-cache \
     g++ \
@@ -70,12 +67,18 @@ RUN apk add --no-cache \
     make \
     zlib-dev
 
-ARG RALIBRETRO_VERSION=1.8.0
+ARG RALIBRETRO_VERSION=1.8.1
 
-# TODO: Remove `sed` command when RAHasher can be compiled without it.
+# TODO: Remove `sed` command adding "ctime", when RAHasher can be compiled without it.
+# TODO: Remove `sed` command adding "unistd.h", when RAHasher can be compiled without it.
+#       Related pull request: https://github.com/madler/zlib/pull/1022
 RUN git clone --recursive --branch "${RALIBRETRO_VERSION}" --depth 1 https://github.com/RetroAchievements/RALibretro.git && \
     cd ./RALibretro && \
     sed -i '22a #include <ctime>' ./src/Util.h && \
+    sed -i '6a #include <unistd.h>' \
+      ./src/libchdr/deps/zlib-1.3.1/gzlib.c \
+      ./src/libchdr/deps/zlib-1.3.1/gzread.c \
+      ./src/libchdr/deps/zlib-1.3.1/gzwrite.c && \
     make HAVE_CHD=1 -f ./Makefile.RAHasher
 
 


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
The previous attempt to upgrade RALibretro before a new tagged version was available (#1970) needed to be reverted, as the RAHasher tool failed with segmentation faults in some scenarios.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes