### PR TITLE
misc: Specify English language for all Markdown blocks

### DIFF
--- a/frontend/src/components/Details/Info/GameInfo.vue
+++ b/frontend/src/components/Details/Info/GameInfo.vue
@@ -132,6 +132,7 @@ function onFilterClick(filter: FilterType, value: string) {
               class="py-4 px-6"
               :model-value="rom.summary ?? ''"
               :theme="theme.name.value == 'dark' ? 'dark' : 'light'"
+              language="en-US"
               preview-theme="vuepress"
               code-theme="github"
               :readonly="true"

--- a/frontend/src/components/Details/Personal.vue
+++ b/frontend/src/components/Details/Personal.vue
@@ -325,6 +325,7 @@ watch(
                 v-else
                 :model-value="romUser.note_raw_markdown"
                 :theme="theme.name.value == 'dark' ? 'dark' : 'light'"
+                language="en-US"
                 preview-theme="vuepress"
                 code-theme="github"
                 class="py-4 px-6"
@@ -350,6 +351,7 @@ watch(
                     <MdPreview
                       :model-value="note.note_raw_markdown"
                       :theme="theme.name.value == 'dark' ? 'dark' : 'light'"
+                      language="en-US"
                       preview-theme="vuepress"
                       code-theme="github"
                       class="py-4 px-6"


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
`md-editor-v3` defaults to Simplified Chinese for `MdEditor` and `MdPreview` components. This change explicitly sets the language to English (`en-US`) for all instances of these components.

Ideally, this should take the user's language preference into account, and a common component can be created to avoid forgetting to set common settings on new instances.

**Checklist**

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes