### PR TITLE
Fix for setting the correct forward proto when behind ssl proxy

### DIFF
--- a/docker/nginx/templates/default.conf.template
+++ b/docker/nginx/templates/default.conf.template
@@ -2,6 +2,12 @@
 # by using `envsubst` to replace the environment variables in the template with
 # their actual values.
 
+# Helper to get scheme regardless if we are behind a prox or not
+map $http_x_forwarded_proto $forwardscheme {
+    default $scheme;
+    https https;
+}
+
 server {
     root /var/www/html;
     listen ${ROMM_PORT};
@@ -10,7 +16,8 @@ server {
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $forwardscheme;
+
 
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Fixes #1737 

Feeds are generated using the "Forward protocol".
This was set to "http" by default in the nginx config, regardless if it is set or not.

This change will set it to `https`, if that's what it was set to already, or to `$scheme` if it's unset.


**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- ~[ ] I've added unit tests that cover the changes~ Not applicable in my opinion.