### PR TITLE
fix: Load platform icon image source to prefer SVG over ICO format

### DIFF
--- a/frontend/src/components/common/Platform/Icon.vue
+++ b/frontend/src/components/common/Platform/Icon.vue
@@ -13,11 +13,19 @@ withDefaults(
 
 <template>
   <v-avatar :size="size" :rounded="rounded" :title="name || slug">
-    <v-img :src="`/assets/platforms/${(fsSlug || slug).toLowerCase()}.ico`">
+    <v-img :src="`/assets/platforms/${(fsSlug || slug).toLowerCase()}.svg`">
       <template #error>
-        <v-img :src="`/assets/platforms/${slug.toLowerCase()}.ico`">
+        <v-img :src="`/assets/platforms/${(fsSlug || slug).toLowerCase()}.ico`">
           <template #error>
-            <v-img src="/assets/platforms/default.ico"></v-img>
+            <v-img :src="`/assets/platforms/${slug.toLowerCase()}.svg`">
+              <template #error>
+                <v-img :src="`/assets/platforms/${slug.toLowerCase()}.ico`">
+                  <template #error>
+                    <v-img src="/assets/platforms/default.ico"></v-img>
+                  </template>
+                </v-img>
+              </template>
+            </v-img>
           </template>
         </v-img>
       </template>


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Load platform icon image source to prefer SVG over ICO format

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
