### PR TITLE
Fix spelling error: 'arwork' to 'artwork' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ RomM (ROM Manager) allows you to scan, enrich, browse and play your game collect
 ## Features
 
 - Scans and enhance your game library with metadata from [IGDB][igdb-api], [Screenscraper][screenscraper-api] and [MobyGames][mobygames-api]
-- Fetch custom arwork from [SteamGridDB][steamgriddb-api]
+- Fetch custom artwork from [SteamGridDB][steamgriddb-api]
 - Display your achievements from [Retroachievements][retroachievements-api]
 - Metadata available for [400+ platforms][docs-supported-platforms]
 - Play games directly from the browser using [EmulatorJS][docs-emulatorjs] and [RuffleRS][docs-rufflers]


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Fixed a spelling error in the README where "arwork" was misspelled as "artwork" in the SteamGridDB feature description.

**Location**: README.md, SteamGridDB feature bullet point

**Checklist**

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
N/A - Text-only documentation change. The fix changes "arwork" to "artwork" in the README.

## Additional Context
This is a minor documentation improvement that enhances the professional appearance of the project README. The misspelling was found during a documentation review.
