### PR TITLE
Add IPv6 support

### DIFF
--- a/docker/nginx/templates/default.conf.template
+++ b/docker/nginx/templates/default.conf.template
@@ -11,6 +11,7 @@ map $http_x_forwarded_proto $forwardscheme {
 server {
     root /var/www/html;
     listen ${ROMM_PORT};
+    listen [::]:${ROMM_PORT};
     server_name localhost;
 
     proxy_set_header Host $http_host;
@@ -80,6 +81,7 @@ server {
 
 server {
     listen 8081;
+    listen [::]:8081;
     server_name localhost;
 
     location /library/ {


### PR DESCRIPTION
Add IPv6 support

<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
This change adds IPv6 support to the nginx running in the docker container. This allows people to access RomM over IPv6 if they want.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
