### PR TITLE
[ROMM-1868] Fix grouping by metadata rows

### DIFF
--- a/backend/alembic/versions/0048_sibling_roms_more_ids.py
+++ b/backend/alembic/versions/0048_sibling_roms_more_ids.py
@@ -1,0 +1,107 @@
+"""Add additional metadata IDs to sibling_roms view
+
+Revision ID: 0048_sibling_roms_more_ids
+Revises: 0047_smart_collections
+Create Date: 2025-01-27 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from utils.database import is_postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0048_sibling_roms_more_ids"
+down_revision = "0047_smart_collections"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    null_safe_equal_operator = (
+        "IS NOT DISTINCT FROM" if is_postgresql(connection) else "<=>"
+    )
+
+    connection.execute(
+        sa.text(
+            f"""
+            CREATE OR REPLACE VIEW sibling_roms AS
+            SELECT
+                r1.id AS rom_id,
+                r2.id AS sibling_rom_id,
+                r1.platform_id AS platform_id,
+                NOW() AS created_at,
+                NOW() AS updated_at,
+                CASE WHEN r1.igdb_id {null_safe_equal_operator} r2.igdb_id THEN r1.igdb_id END AS igdb_id,
+                CASE WHEN r1.moby_id {null_safe_equal_operator} r2.moby_id THEN r1.moby_id END AS moby_id,
+                CASE WHEN r1.ss_id {null_safe_equal_operator} r2.ss_id THEN r1.ss_id END AS ss_id,
+                CASE WHEN r1.launchbox_id {null_safe_equal_operator} r2.launchbox_id THEN r1.launchbox_id END AS launchbox_id,
+                CASE WHEN r1.ra_id {null_safe_equal_operator} r2.ra_id THEN r1.ra_id END AS ra_id,
+                CASE WHEN r1.hasheous_id {null_safe_equal_operator} r2.hasheous_id THEN r1.hasheous_id END AS hasheous_id,
+                CASE WHEN r1.tgdb_id {null_safe_equal_operator} r2.tgdb_id THEN r1.tgdb_id END AS tgdb_id
+            FROM
+                roms r1
+            JOIN
+                roms r2
+            ON
+                r1.platform_id = r2.platform_id
+                AND r1.id != r2.id
+                AND (
+                    (r1.igdb_id = r2.igdb_id AND r1.igdb_id IS NOT NULL)
+                    OR
+                    (r1.moby_id = r2.moby_id AND r1.moby_id IS NOT NULL)
+                    OR
+                    (r1.ss_id = r2.ss_id AND r1.ss_id IS NOT NULL)
+                    OR
+                    (r1.launchbox_id = r2.launchbox_id AND r1.launchbox_id IS NOT NULL)
+                    OR
+                    (r1.ra_id = r2.ra_id AND r1.ra_id IS NOT NULL)
+                    OR
+                    (r1.hasheous_id = r2.hasheous_id AND r1.hasheous_id IS NOT NULL)
+                    OR
+                    (r1.tgdb_id = r2.tgdb_id AND r1.tgdb_id IS NOT NULL)
+                );
+            """  # nosec B608
+        ),
+    )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    null_safe_equal_operator = (
+        "IS NOT DISTINCT FROM" if is_postgresql(connection) else "<=>"
+    )
+
+    connection.execute(sa.text("DROP VIEW IF EXISTS sibling_roms;"))
+
+    connection.execute(
+        sa.text(
+            f"""
+            CREATE VIEW sibling_roms AS
+            SELECT
+                r1.id AS rom_id,
+                r2.id AS sibling_rom_id,
+                r1.platform_id AS platform_id,
+                NOW() AS created_at,
+                NOW() AS updated_at,
+                CASE WHEN r1.igdb_id {null_safe_equal_operator} r2.igdb_id THEN r1.igdb_id END AS igdb_id,
+                CASE WHEN r1.moby_id {null_safe_equal_operator} r2.moby_id THEN r1.moby_id END AS moby_id,
+                CASE WHEN r1.ss_id {null_safe_equal_operator} r2.ss_id THEN r1.ss_id END AS ss_id
+            FROM
+                roms r1
+            JOIN
+                roms r2
+            ON
+                r1.platform_id = r2.platform_id
+                AND r1.id != r2.id
+                AND (
+                    (r1.igdb_id = r2.igdb_id AND r1.igdb_id IS NOT NULL)
+                    OR
+                    (r1.moby_id = r2.moby_id AND r1.moby_id IS NOT NULL)
+                    OR
+                    (r1.ss_id = r2.ss_id AND r1.ss_id IS NOT NULL)
+                );
+            """  # nosec B608
+        ),
+    )

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -445,7 +445,7 @@ class DBRomsHandler(DBBaseHandler):
         if group_by_meta_id:
 
             def build_func(provider: str, column: InstrumentedAttribute):
-                return func.concat(provider, "-", Rom.platform_id, "-", column)
+                return func.concat(provider, "-", column)
 
             # Create a group ID based on metadata IDs, prioritizing in order: igdb, moby, ss, launchbox, sgdb, ra, hasheous, tgdb
             # If no metadata ID exists, use the ROM ID to ensure each ROM is in its own group

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -447,19 +447,19 @@ class DBRomsHandler(DBBaseHandler):
             def build_func(provider: str, column: InstrumentedAttribute):
                 return func.concat(provider, "-", column)
 
-            # Create a group ID based on metadata IDs, prioritizing in order: igdb, moby, ss, launchbox, sgdb, ra, hasheous, tgdb
+            # Create a group ID based on metadata IDs, prioritizing in order
             # If no metadata ID exists, use the ROM ID to ensure each ROM is in its own group
             group_id = case(
                 {
                     Rom.igdb_id.isnot(None): build_func("igdb", Rom.igdb_id),
-                    Rom.moby_id.isnot(None): build_func("moby", Rom.moby_id),
                     Rom.ss_id.isnot(None): build_func("ss", Rom.ss_id),
-                    Rom.launchbox_id.isnot(None): build_func(
-                        "launchbox", Rom.launchbox_id
-                    ),
+                    Rom.moby_id.isnot(None): build_func("moby", Rom.moby_id),
                     Rom.ra_id.isnot(None): build_func("ra", Rom.ra_id),
                     Rom.hasheous_id.isnot(None): build_func(
                         "hasheous", Rom.hasheous_id
+                    ),
+                    Rom.launchbox_id.isnot(None): build_func(
+                        "launchbox", Rom.launchbox_id
                     ),
                     Rom.tgdb_id.isnot(None): build_func("tgdb", Rom.tgdb_id),
                 },

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -445,11 +445,10 @@ class DBRomsHandler(DBBaseHandler):
         if group_by_meta_id:
 
             def build_func(provider: str, column: InstrumentedAttribute):
-                if platform_id:
-                    return func.concat(provider, "-", Rom.platform_id, "-", column)
-
                 return func.concat(provider, "-", Rom.platform_id, "-", column)
 
+            # Create a group ID based on metadata IDs, prioritizing in order: igdb, moby, ss, launchbox, sgdb, ra, hasheous, tgdb
+            # If no metadata ID exists, use the ROM ID to ensure each ROM is in its own group
             group_id = case(
                 {
                     Rom.igdb_id.isnot(None): build_func("igdb", Rom.igdb_id),
@@ -458,6 +457,11 @@ class DBRomsHandler(DBBaseHandler):
                     Rom.launchbox_id.isnot(None): build_func(
                         "launchbox", Rom.launchbox_id
                     ),
+                    Rom.ra_id.isnot(None): build_func("ra", Rom.ra_id),
+                    Rom.hasheous_id.isnot(None): build_func(
+                        "hasheous", Rom.hasheous_id
+                    ),
+                    Rom.tgdb_id.isnot(None): build_func("tgdb", Rom.tgdb_id),
                 },
                 else_=build_func("romm", Rom.id),
             )
@@ -469,7 +473,8 @@ class DBRomsHandler(DBBaseHandler):
                 else literal(1)
             )
 
-            # Create a subquery that identifies the first ROM in each group
+            # Create a subquery that identifies the primary ROM in each group
+            # Priority order: is_main_sibling (desc), then by fs_name_no_ext (asc)
             group_subquery = (
                 session.query(Rom.id)
                 .outerjoin(
@@ -480,14 +485,14 @@ class DBRomsHandler(DBBaseHandler):
                     func.row_number()
                     .over(
                         partition_by=group_id,
-                        order_by=[is_main_sibling_order, Rom.fs_name_no_ext],
+                        order_by=[is_main_sibling_order, Rom.fs_name_no_ext.asc()],
                     )
                     .label("row_num"),
                 )
                 .subquery()
             )
 
-            # Add a filter to the original query to only include the first ROM from each group
+            # Add a filter to the original query to only include the primary ROM from each group
             query = query.filter(
                 Rom.id.in_(
                     session.query(group_subquery.c.id).filter(


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

This PR adds more metadata providers to sibling ROM grouping, and fixes(?) missing ROMs from collections (somehow...).

Fixes #1868 

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
