### PR TITLE
Fire off search if URL state prepopulated

### DIFF
--- a/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
+++ b/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
@@ -116,7 +116,7 @@ const onFilterChange = debounce(
   500,
   // If leading and trailing options are true, this is invoked on the trailing edge of
   // the timeout only if the the function is invoked more than once during the wait
-  { leading: true, trailing: true },
+  { leading: false, trailing: true },
 );
 
 emitter?.on("filterRoms", onFilterChange);
@@ -234,12 +234,6 @@ onMounted(async () => {
     status: urlStatus,
   } = router.currentRoute.value.query;
 
-  // Check if search term is set in the URL (empty string is ok)
-  if (urlSearch !== undefined && urlSearch !== searchTerm.value) {
-    searchTerm.value = urlSearch as string;
-    romsStore.resetPagination();
-  }
-
   // Check for query params to set filters
   if (urlFilteredMatch !== undefined) {
     galleryFilterStore.setFilterMatched(true);
@@ -292,6 +286,18 @@ onMounted(async () => {
   }
   if (urlStatus !== undefined) {
     galleryFilterStore.setSelectedFilterStatus(urlStatus as string);
+  }
+
+  // Check if search term is set in the URL (empty string is ok)
+  const freshSearch = urlSearch !== undefined && urlSearch !== searchTerm.value;
+  if (freshSearch) {
+    searchTerm.value = urlSearch as string;
+    romsStore.resetPagination();
+  }
+
+  // Fire off search if URL state prepopulated
+  if (freshSearch || galleryFilterStore.isFiltered()) {
+    emitter?.emit("filterRoms", null);
   }
 
   watch(

--- a/frontend/src/views/Gallery/Search.vue
+++ b/frontend/src/views/Gallery/Search.vue
@@ -144,7 +144,6 @@ function onScroll() {
 }
 
 onMounted(async () => {
-  emitter?.emit("filterRoms", null);
   scrolledToTop.value = true;
   window.addEventListener("scroll", onScroll);
 });

--- a/frontend/src/views/Settings/LibraryManagement.vue
+++ b/frontend/src/views/Settings/LibraryManagement.vue
@@ -66,7 +66,7 @@ const onFilterChange = debounce(
   500,
   // If leading and trailing options are true, this is invoked on the trailing edge of
   // the timeout only if the the function is invoked more than once during the wait
-  { leading: true, trailing: true },
+  { leading: false, trailing: true },
 );
 
 async function fetchRoms() {


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Small improvements to search where the filter drawer fires a fetch event on mount of any of the filters are present in the URL.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
