### PR TITLE
[ROMM-2155] Fix char bar jumping to wrong game

### DIFF
--- a/frontend/src/components/Gallery/AppBar/common/CharIndexBar.vue
+++ b/frontend/src/components/Gallery/AppBar/common/CharIndexBar.vue
@@ -30,7 +30,7 @@ async function fetchRoms() {
   });
 
   romsStore
-    .fetchRoms(galleryFilterStore, false)
+    .fetchRoms({ galleryFilter: galleryFilterStore, concat: false })
     .then(() => {
       emitter?.emit("showLoadingDialog", {
         loading: false,

--- a/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
+++ b/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
@@ -79,7 +79,7 @@ const emitter = inject<Emitter<Events>>("emitter");
 const onFilterChange = debounce(
   () => {
     romsStore.resetPagination();
-    romsStore.fetchRoms(galleryFilterStore, false);
+    romsStore.fetchRoms({ galleryFilter: galleryFilterStore });
 
     const url = new URL(window.location.href);
     // Update URL with filters

--- a/frontend/src/components/common/Game/Table.vue
+++ b/frontend/src/components/common/Game/Table.vue
@@ -147,7 +147,7 @@ function updateOptions({ sortBy }: { sortBy: SortBy }) {
   romsStore.resetPagination();
   romsStore.setOrderBy(key);
   romsStore.setOrderDir(order);
-  romsStore.fetchRoms(galleryFilterStore, false);
+  romsStore.fetchRoms({ galleryFilter: galleryFilterStore });
 }
 </script>
 

--- a/frontend/src/stores/roms.ts
+++ b/frontend/src/stores/roms.ts
@@ -116,11 +116,15 @@ export default defineStore("roms", {
         }
       }
     },
-    fetchRoms(
-      galleryFilter: GalleryFilterStore,
-      groupRoms?: boolean,
+    fetchRoms({
+      galleryFilter,
+      groupRoms,
       concat = true,
-    ) {
+    }: {
+      galleryFilter: GalleryFilterStore;
+      groupRoms?: boolean;
+      concat?: boolean;
+    }) {
       if (this.fetchingRoms) return Promise.resolve();
       this.fetchingRoms = true;
 

--- a/frontend/src/views/Gallery/Collection/BaseCollection.vue
+++ b/frontend/src/views/Gallery/Collection/BaseCollection.vue
@@ -60,7 +60,7 @@ async function fetchRoms() {
   });
 
   romsStore
-    .fetchRoms(galleryFilterStore)
+    .fetchRoms({ galleryFilter: galleryFilterStore })
     .then(() => {
       emitter?.emit("showLoadingDialog", {
         loading: false,

--- a/frontend/src/views/Gallery/Platform.vue
+++ b/frontend/src/views/Gallery/Platform.vue
@@ -60,7 +60,7 @@ async function fetchRoms() {
   });
 
   romsStore
-    .fetchRoms(galleryFilterStore)
+    .fetchRoms({ galleryFilter: galleryFilterStore })
     .then(() => {
       emitter?.emit("showLoadingDialog", {
         loading: false,

--- a/frontend/src/views/Gallery/Search.vue
+++ b/frontend/src/views/Gallery/Search.vue
@@ -115,7 +115,7 @@ function onGameTouchEnd() {
 
 function fetchRoms() {
   romsStore
-    .fetchRoms(galleryFilterStore)
+    .fetchRoms({ galleryFilter: galleryFilterStore })
     .catch((error) => {
       emitter?.emit("snackbarShow", {
         msg: `Couldn't fetch roms: ${error}`,

--- a/frontend/src/views/Settings/LibraryManagement.vue
+++ b/frontend/src/views/Settings/LibraryManagement.vue
@@ -46,7 +46,10 @@ const onFilterChange = debounce(
   () => {
     romsStore.resetPagination();
     galleryFilterStore.setFilterMissing(true);
-    romsStore.fetchRoms(galleryFilterStore, false);
+    romsStore.fetchRoms({
+      galleryFilter: galleryFilterStore,
+      groupRoms: false,
+    });
 
     const url = new URL(window.location.href);
     // Update URL with filters
@@ -79,7 +82,7 @@ async function fetchRoms() {
 
   galleryFilterStore.setFilterMissing(true);
   romsStore
-    .fetchRoms(galleryFilterStore, false)
+    .fetchRoms({ galleryFilter: galleryFilterStore, groupRoms: false })
     .then(() => {
       emitter?.emit("showLoadingDialog", {
         loading: false,
@@ -107,7 +110,7 @@ function cleanupAll() {
   romsStore.setLimit(MAX_FETCH_LIMIT);
   galleryFilterStore.setFilterMissing(true);
   romsStore
-    .fetchRoms(galleryFilterStore, false)
+    .fetchRoms({ galleryFilter: galleryFilterStore, groupRoms: false })
     .then(() => {
       emitter?.emit("showLoadingDialog", {
         loading: false,


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Refactored `fetchRoms` so it takes an object, which should prevent the issue (not setting `concat` to `false` on char bar fetch) from happening again.

Fixes #2155 

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
