### PR TITLE
[POC] Server side cheat code

### DIFF
--- a/frontend/src/views/Player/EmulatorJS/Base.vue
+++ b/frontend/src/views/Player/EmulatorJS/Base.vue
@@ -21,6 +21,7 @@ import CacheDialog from "@/views/Player/EmulatorJS/CacheDialog.vue";
 import { getEmptyCoverImage } from "@/utils/covers";
 import { useDisplay } from "vuetify";
 import { storeToRefs } from "pinia";
+import { MdEditor, MdPreview } from "md-editor-v3";
 
 const EMULATORJS_VERSION = "4.2.3";
 
@@ -45,6 +46,8 @@ const supportedCores = ref<string[]>([]);
 const gameRunning = ref(false);
 const storedFSOP = localStorage.getItem("fullScreenOnPlay");
 const fullScreenOnPlay = ref(isNull(storedFSOP) ? true : storedFSOP === "true");
+const note_raw_markdown = ref<string | null>(null);
+const selectedCheat = ref<Array<Array<string>> | null>(null);
 
 // Functions
 function onPlay() {
@@ -190,6 +193,16 @@ onMounted(async () => {
   });
   rom.value = romResponse.data;
 
+  note_raw_markdown.value = rom.value.rom_user.note_raw_markdown;
+  var cheats = [];
+  for (const cheat of note_raw_markdown.value.split("\n")) {
+    const f = cheat.match(/- cheat:(.*):(.*)/);
+    if (f) {
+      cheats.push([f[1].trim(), f[2].trim()]);
+    }
+  }
+  selectedCheat.value = cheats;
+
   if (rom.value) {
     document.title = `${rom.value.name} | Play`;
   }
@@ -254,6 +267,7 @@ onBeforeUnmount(async () => {
         :bios="selectedFirmware"
         :core="selectedCore"
         :disc="selectedDisc"
+        :cheat="selectedCheat"
       />
     </v-col>
 
@@ -664,6 +678,15 @@ onBeforeUnmount(async () => {
           </v-expand-transition>
         </v-col>
       </v-row>
+
+      <MdPreview
+        :model-value="note_raw_markdown"
+        theme="dark"
+        language="en-US"
+        preview-theme="vuepress"
+        code-theme="github"
+        class="py-4 px-6"
+      />
 
       <!-- Action buttons -->
       <template v-if="!gameRunning">

--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -33,6 +33,7 @@ const props = defineProps<{
   bios: FirmwareSchema | null;
   core: string | null;
   disc: number | null;
+  cheat: Array<Array<string>> | null;
 }>();
 const romRef = ref<DetailedRom>(props.rom);
 const saveRef = ref<SaveSchema | null>(props.save);
@@ -40,6 +41,7 @@ const theme = useTheme();
 const emitter = inject<Emitter<Events>>("emitter");
 const playingStore = storePlaying();
 const { playing, fullScreen } = storeToRefs(playingStore);
+const cheatRef = ref<Array<Array<string>> | null>(props.cheat);
 
 // Declare global variables for EmulatorJS
 declare global {
@@ -56,7 +58,7 @@ declare global {
     EJS_backgroundColor: string;
     EJS_gameUrl: string;
     EJS_loadStateURL: string | null;
-    EJS_cheats: string;
+    EJS_cheats: Array<Array<string>> | null;
     EJS_gameParentUrl: string;
     EJS_gamePatchUrl: string;
     EJS_netplayServer: string;
@@ -112,6 +114,7 @@ window.EJS_defaultOptions = {
 window.EJS_gameName = romRef.value.fs_name_no_tags
   .replace(INVALID_CHARS_REGEX, "")
   .trim();
+window.EJS_cheats = cheatRef.value;
 
 onMounted(() => {
   window.scrollTo(0, 0);


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
If such a feature could be implemented, it would be very convenient for playing on different devices. Currently, cheat codes are stored in a note using a special format and are automatically loaded upon startup. It would be more suitable to use a database for this.
```
- cheat: Unlimited Health: 82020646+04FF
- cheat: Unlimited Super Bar: 8202064A+0400
```
**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
