### PR TITLE
[ROMM-2211] Only show missing platforms on lib manage page

### DIFF
--- a/frontend/src/components/Details/Title.vue
+++ b/frontend/src/components/Details/Title.vue
@@ -21,7 +21,7 @@ const releaseDate = new Date(
 });
 
 const platformsStore = storePlatforms();
-const { allPlatforms } = storeToRefs(platformsStore);
+const { filteredPlatforms } = storeToRefs(platformsStore);
 
 const hashMatches = computed(() => {
   return [
@@ -82,7 +82,7 @@ const hashMatches = computed(() => {
         >
           <missing-from-f-s-icon
             v-if="
-              allPlatforms.find((p) => p.id === rom.platform_id)
+              filteredPlatforms.find((p) => p.id === rom.platform_id)
                 ?.missing_from_fs
             "
             class="mr-2"

--- a/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
+++ b/frontend/src/components/Gallery/AppBar/common/FilterDrawer/Base.vue
@@ -73,7 +73,7 @@ const {
   filterLanguages,
 } = storeToRefs(galleryFilterStore);
 const { filteredRoms } = storeToRefs(romsStore);
-const { allPlatforms } = storeToRefs(platformsStore);
+const { filteredPlatforms } = storeToRefs(platformsStore);
 const emitter = inject<Emitter<Events>>("emitter");
 
 const onFilterChange = debounce(
@@ -301,7 +301,7 @@ onMounted(async () => {
   );
 
   watch(
-    () => allPlatforms.value,
+    () => filteredPlatforms.value,
     async () => setFilters(),
     { immediate: true }, // Ensure watcher is triggered immediately
   );

--- a/frontend/src/views/Gallery/Platform.vue
+++ b/frontend/src/views/Gallery/Platform.vue
@@ -26,7 +26,7 @@ const galleryViewStore = storeGalleryView();
 const galleryFilterStore = storeGalleryFilter();
 const { scrolledToTop, currentView } = storeToRefs(galleryViewStore);
 const platformsStore = storePlatforms();
-const { allPlatforms } = storeToRefs(platformsStore);
+const { filteredPlatforms } = storeToRefs(platformsStore);
 const romsStore = storeRoms();
 const {
   allRoms,
@@ -178,7 +178,7 @@ onMounted(async () => {
   currentCollection.value = null;
 
   watch(
-    () => allPlatforms.value,
+    () => filteredPlatforms.value,
     async (platforms) => {
       if (platforms.length > 0) {
         if (platforms.some((platform) => platform.id === routePlatformId)) {
@@ -215,7 +215,7 @@ onBeforeRouteUpdate(async (to, from) => {
   const routePlatformId = Number(to.params.platform);
 
   watch(
-    () => allPlatforms.value,
+    () => filteredPlatforms.value,
     async (platforms) => {
       if (platforms.length > 0) {
         const platform = platforms.find(
@@ -310,7 +310,7 @@ onBeforeUnmount(() => {
         <fab-overlay />
       </template>
       <template v-else>
-        <empty-game v-if="allPlatforms.length > 0 && !fetchingRoms" />
+        <empty-game v-if="filteredPlatforms.length > 0 && !fetchingRoms" />
       </template>
     </template>
   </template>

--- a/frontend/src/views/Scan.vue
+++ b/frontend/src/views/Scan.vue
@@ -124,7 +124,7 @@ async function stopScan() {
       <!-- TODO: add 'ALL' default option -->
       <v-select
         v-model="platformsToScan"
-        :items="platforms.allPlatforms"
+        :items="platforms.filteredPlatforms"
         :menu-props="{ maxHeight: 650 }"
         :label="t('common.platforms')"
         item-title="name"

--- a/frontend/src/views/Settings/LibraryManagement.vue
+++ b/frontend/src/views/Settings/LibraryManagement.vue
@@ -113,7 +113,16 @@ function cleanupAll() {
         loading: false,
         scrim: false,
       });
-      emitter?.emit("showDeleteRomDialog", romsStore.filteredRoms);
+      if (filteredRoms.value.length > 0) {
+        emitter?.emit("showDeleteRomDialog", filteredRoms.value);
+      } else {
+        emitter?.emit("snackbarShow", {
+          msg: "No missing ROMs to delete",
+          icon: "mdi-close-circle",
+          color: "red",
+          timeout: 4000,
+        });
+      }
     })
     .catch((error) => {
       console.error("Error fetching missing games:", error);


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Use `filteredPlatforms` for most uses of `allPlatforms`, which filters empty platforms (even on scan page).

Fixes #2211 

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
