### PR TITLE
fix: Correctly evaluate enabled metadata sources in scheduled library scan

### DIFF
--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -1,5 +1,5 @@
 import asyncio
-from enum import Enum
+import enum
 from typing import Any
 
 import emoji
@@ -38,7 +38,8 @@ from models.user import User
 LOGGER_MODULE_NAME = {"module_name": "scan"}
 
 
-class ScanType(Enum):
+@enum.unique
+class ScanType(enum.StrEnum):
     NEW_PLATFORMS = "new_platforms"
     QUICK = "quick"
     UNIDENTIFIED = "unidentified"
@@ -47,7 +48,8 @@ class ScanType(Enum):
     HASHES = "hashes"
 
 
-class MetadataSource:
+@enum.unique
+class MetadataSource(enum.StrEnum):
     IGDB = "igdb"  # IGDB
     MOBY = "moby"  # MobyGames
     SS = "ss"  # Screenscraper

--- a/backend/tasks/scheduled/scan_library.py
+++ b/backend/tasks/scheduled/scan_library.py
@@ -32,17 +32,17 @@ class ScanLibraryTask(PeriodicTask):
             self.unschedule()
             return
 
-        source_mapping = {
-            IGDB_API_ENABLED: MetadataSource.IGDB,
-            SS_API_ENABLED: MetadataSource.SS,
-            MOBY_API_ENABLED: MetadataSource.MOBY,
-            RA_API_ENABLED: MetadataSource.RA,
-            LAUNCHBOX_API_ENABLED: MetadataSource.LB,
-            HASHEOUS_API_ENABLED: MetadataSource.HASHEOUS,
-            STEAMGRIDDB_API_ENABLED: MetadataSource.SGDB,
+        source_mapping: dict[str, bool] = {
+            MetadataSource.IGDB: IGDB_API_ENABLED,
+            MetadataSource.SS: SS_API_ENABLED,
+            MetadataSource.MOBY: MOBY_API_ENABLED,
+            MetadataSource.RA: RA_API_ENABLED,
+            MetadataSource.LB: LAUNCHBOX_API_ENABLED,
+            MetadataSource.HASHEOUS: HASHEOUS_API_ENABLED,
+            MetadataSource.SGDB: STEAMGRIDDB_API_ENABLED,
         }
 
-        metadata_sources = [source for flag, source in source_mapping.items() if flag]
+        metadata_sources = [source for source, flag in source_mapping.items() if flag]
         if not metadata_sources:
             log.warning("No metadata sources enabled, unscheduling library scan")
             self.unschedule()

--- a/backend/tasks/tests/test_scan_library.py
+++ b/backend/tasks/tests/test_scan_library.py
@@ -19,7 +19,7 @@ class TestScanLibraryTask:
     @patch("tasks.scheduled.scan_library.IGDB_API_ENABLED", False)
     @patch("tasks.scheduled.scan_library.SS_API_ENABLED", False)
     @patch("tasks.scheduled.scan_library.MOBY_API_ENABLED", False)
-    @patch("tasks.scheduled.scan_library.RA_API_ENABLED", False)
+    @patch("tasks.scheduled.scan_library.RA_API_ENABLED", True)
     @patch("tasks.scheduled.scan_library.LAUNCHBOX_API_ENABLED", True)
     @patch("tasks.scheduled.scan_library.HASHEOUS_API_ENABLED", False)
     @patch("tasks.scheduled.scan_library.STEAMGRIDDB_API_ENABLED", False)
@@ -33,7 +33,9 @@ class TestScanLibraryTask:
 
         mock_log.info.assert_any_call("Scheduled library scan started...")
         mock_scan_platforms.assert_called_once_with(
-            [], scan_type=ScanType.UNIDENTIFIED, metadata_sources=[MetadataSource.LB]
+            [],
+            scan_type=ScanType.UNIDENTIFIED,
+            metadata_sources=[MetadataSource.RA, MetadataSource.LB],
         )
         mock_log.info.assert_any_call("Scheduled library scan done")
 


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
The existing code incorrectly maps boolean flags to metadata sources, leading to colliding `True` keys in the dictionary. This caused only one metadata source to be recognized during scheduled scans, even when multiple sources were enabled.

**Checklist**
- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes