### PR TITLE
fix: Run scheduler when only LaunchBox update is enabled

### DIFF
--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -250,7 +250,7 @@ while ! ((exited)); do
 	watchdog_process_pid python worker
 
 	# only start the scheduler if enabled
-	if [[ ${ENABLE_SCHEDULED_RESCAN} == "true" || ${ENABLE_SCHEDULED_UPDATE_SWITCH_TITLEDB} == "true" ]]; then
+	if [[ ${ENABLE_SCHEDULED_RESCAN} == "true" || ${ENABLE_SCHEDULED_UPDATE_SWITCH_TITLEDB} == "true" || ${ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA} == "true" ]]; then
 		watchdog_process_pid python scheduler
 	fi
 


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Include the check for `ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA` to decide whether to start the scheduler process.

**Checklist**
- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes