### PR TITLE
Display an icon on the card if game has notes

### DIFF
--- a/frontend/src/components/common/Game/Dialog/NoteDialog.vue
+++ b/frontend/src/components/common/Game/Dialog/NoteDialog.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { MdPreview } from "md-editor-v3";
+import "md-editor-v3/lib/style.css";
+import type { Events } from "@/types/emitter";
+import type { Emitter } from "mitt";
+import { inject, ref } from "vue";
+import type { SimpleRom } from "@/stores/roms";
+import { useTheme } from "vuetify";
+import { useI18n } from "vue-i18n";
+
+const theme = useTheme();
+const emitter = inject<Emitter<Events>>("emitter");
+const { t } = useI18n();
+
+const rom = ref<SimpleRom | null>(null);
+const show = ref(false);
+
+emitter?.on("showNoteDialog", (romToShow) => {
+  rom.value = romToShow;
+  show.value = true;
+});
+</script>
+
+<template>
+  <v-dialog v-model="show" max-width="600">
+    <v-card>
+      <v-card-title class="d-flex align-center">
+        <v-icon class="mr-2">mdi-notebook</v-icon>
+        {{ t("rom.my-notes") }} - {{ rom?.name }}
+        <v-spacer />
+        <v-btn icon @click="show = false">
+          <v-icon>mdi-close</v-icon>
+        </v-btn>
+      </v-card-title>
+      <v-card-text class="pa-4">
+        <div v-if="rom?.rom_user?.note_raw_markdown">
+          <MdPreview
+            :model-value="rom.rom_user.note_raw_markdown"
+            :theme="theme.name.value == 'dark' ? 'dark' : 'light'"
+            language="en-US"
+            preview-theme="vuepress"
+            code-theme="github"
+            class="py-2"
+          />
+        </div>
+        <div v-else class="text-center pa-4">
+          <v-icon size="48" color="grey">mdi-notebook-outline</v-icon>
+          <p class="text-grey mt-2">No notes available</p>
+        </div>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style scoped>
+/* Inherit markdown editor styles from the main application */
+:deep(.md-editor-dark) {
+  --md-bk-color: #161b22 !important;
+}
+
+:deep(.md-editor),
+:deep(.md-preview) {
+  line-height: 1.25 !important;
+}
+
+:deep(.md-editor-preview) {
+  word-break: break-word !important;
+
+  blockquote {
+    border-left-color: rgba(var(--v-theme-secondary));
+  }
+
+  .md-editor-code-flag {
+    visibility: hidden;
+  }
+
+  .md-editor-admonition {
+    border-color: rgba(var(--v-theme-secondary));
+    background-color: rgba(var(--v-theme-toplayer)) !important;
+  }
+
+  .md-editor-code summary,
+  .md-editor-code code {
+    background-color: rgba(var(--v-theme-toplayer)) !important;
+  }
+}
+
+:deep(.vuepress-theme pre code) {
+  background-color: #0d1117;
+}
+</style>

--- a/frontend/src/layouts/Main.vue
+++ b/frontend/src/layouts/Main.vue
@@ -17,6 +17,7 @@ import SelectSaveDialog from "@/components/common/Game/Dialog/Asset/SelectSave.v
 import SelectStateDialog from "@/components/common/Game/Dialog/Asset/SelectState.vue";
 import DeleteSavesDialog from "@/components/common/Game/Dialog/Asset/DeleteSaves.vue";
 import DeleteStatesDialog from "@/components/common/Game/Dialog/Asset/DeleteStates.vue";
+import NoteDialog from "@/components/common/Game/Dialog/NoteDialog.vue";
 import collectionApi from "@/services/api/collection";
 import platformApi from "@/services/api/platform";
 import storeCollections from "@/stores/collections";
@@ -108,6 +109,7 @@ onBeforeMount(async () => {
   <remove-roms-from-collection-dialog />
   <delete-rom-dialog />
   <edit-user-dialog />
+  <note-dialog />
   <show-q-r-code-dialog />
 
   <new-version-dialog />

--- a/frontend/src/types/emitter.d.ts
+++ b/frontend/src/types/emitter.d.ts
@@ -82,5 +82,6 @@ export type Events = {
   selectStateDialog: DetailedRom;
   saveSelected: SaveSchema;
   stateSelected: StateSchema;
-  showAboutDialog;
+  showAboutDialog: null;
+  showNoteDialog: SimpleRom;
 };

--- a/frontend/src/views/Gallery/Platform.vue
+++ b/frontend/src/views/Gallery/Platform.vue
@@ -13,7 +13,6 @@ import storePlatforms from "@/stores/platforms";
 import storeRoms, { type SimpleRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import { views } from "@/utils";
-import { ROUTES } from "@/plugins/router";
 import type { Emitter } from "mitt";
 import { isNull } from "lodash";
 import { storeToRefs } from "pinia";
@@ -128,14 +127,6 @@ function onGameClick(emitData: { rom: SimpleRom; event: MouseEvent }) {
     } else {
       romsStore.updateLastSelected(index);
     }
-  } else if (emitData.event.metaKey || emitData.event.ctrlKey) {
-    const link = router.resolve({
-      name: ROUTES.ROM,
-      params: { rom: emitData.rom.id },
-    });
-    window.open(link.href, "_blank");
-  } else {
-    router.push({ name: ROUTES.ROM, params: { rom: emitData.rom.id } });
   }
 }
 


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Clicking on the icon will display the note content in a window. This saves like 3 clicks, like a quick-view for notes.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots

<img width="307" height="388" alt="Screenshot 2025-08-06 at 6 35 03 PM" src="https://github.com/user-attachments/assets/08f5f460-f00c-43ce-b7c0-d3640f60d7da" />
<img width="789" height="459" alt="Screenshot 2025-08-06 at 6 35 09 PM" src="https://github.com/user-attachments/assets/b18cc01f-a9e6-46a0-ae04-8c8bac888196" />
<img width="616" height="802" alt="Screenshot 2025-08-06 at 6 40 43 PM" src="https://github.com/user-attachments/assets/11c1b3f9-3940-467b-b9c4-b381c5cd86e4" />
