### PR TITLE
fix: Docker build and init fixes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,10 @@ RUN uv sync --locked --no-cache
 
 FROM backend-build AS backend-dev-build
 
+# linux-headers is needed to install psutil
+RUN apk add --no-cache \
+    linux-headers
+
 RUN uv sync --locked --no-cache --all-extras
 
 

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -11,6 +11,7 @@ LOGLEVEL="${LOGLEVEL:="info"}"
 # make it possible to disable the inotify watcher process
 ENABLE_RESCAN_ON_FILESYSTEM_CHANGE="${ENABLE_RESCAN_ON_FILESYSTEM_CHANGE:="false"}"
 ENABLE_SCHEDULED_RESCAN="${ENABLE_SCHEDULED_RESCAN:="false"}"
+ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA="${ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA:="false"}"
 ENABLE_SCHEDULED_UPDATE_SWITCH_TITLEDB="${ENABLE_SCHEDULED_UPDATE_SWITCH_TITLEDB:="false"}"
 
 # if REDIS_HOST is set, we assume that an external redis is used
@@ -203,7 +204,7 @@ start_bin_watcher() {
 	info_log "Starting watcher"
 	watchfiles \
 		--target-type command \
-		'uv run python watcher.py' \
+		'python3 watcher.py' \
 		/romm/library &
 	WATCHER_PID=$!
 	echo "${WATCHER_PID}" >/tmp/watcher.pid


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
* Added `linux-headers` back, but only for development stage.
* Fixed initialization script, as `uv` is not included in the final Docker image.
* Initialize variable `ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA`.

**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes