### PR TITLE
misc: Do not warn when REDIS_HOST is set

### DIFF
--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -263,7 +263,7 @@ rm /tmp/*.pid -f
 if [[ -z ${REDIS_HOST} ]]; then
 	watchdog_process_pid valkey-server
 else
-	warn_log "REDIS_HOST is set, not starting internal valkey-server"
+	info_log "REDIS_HOST is set, not starting internal valkey-server"
 fi
 
 # Run needed database migrations once at startup


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Change log level to info when REDIS_HOST is set, as this is a valid and common configuration.

**Checklist**
- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes