### PR TITLE
feat: Add support for database query string using DB_QUERY_JSON variable

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -29,12 +29,15 @@ ASSETS_BASE_PATH: Final = f"{ROMM_BASE_PATH}/assets"
 FRONTEND_RESOURCES_PATH: Final = "/assets/romm/resources"
 
 # DATABASE
-DB_HOST: Final = os.environ.get("DB_HOST", "127.0.0.1")
-DB_PORT: Final = int(os.environ.get("DB_PORT", 3306))
-DB_USER: Final = os.environ.get("DB_USER")
-DB_PASSWD: Final = os.environ.get("DB_PASSWD")
-DB_NAME: Final = os.environ.get("DB_NAME", "romm")
-ROMM_DB_DRIVER: Final = os.environ.get("ROMM_DB_DRIVER", "mariadb")
+DB_HOST: Final[str | None] = os.environ.get("DB_HOST", "127.0.0.1") or None
+DB_PORT: Final[int | None] = (
+    int(os.environ.get("DB_PORT", 3306)) if os.environ.get("DB_PORT") != "" else None
+)
+DB_USER: Final[str | None] = os.environ.get("DB_USER")
+DB_PASSWD: Final[str | None] = os.environ.get("DB_PASSWD")
+DB_NAME: Final[str] = os.environ.get("DB_NAME", "romm")
+DB_QUERY_JSON: Final[str | None] = os.environ.get("DB_QUERY_JSON")
+ROMM_DB_DRIVER: Final[str] = os.environ.get("ROMM_DB_DRIVER", "mariadb")
 
 # REDIS
 REDIS_HOST: Final = os.environ.get("REDIS_HOST", "127.0.0.1")

--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from typing import Final
 
@@ -8,6 +9,7 @@ from config import (
     DB_NAME,
     DB_PASSWD,
     DB_PORT,
+    DB_QUERY_JSON,
     DB_USER,
     LIBRARY_BASE_PATH,
     ROMM_BASE_PATH,
@@ -95,6 +97,14 @@ class ConfigManager:
             )
             sys.exit(3)
 
+        query: dict[str, str] = {}
+        if DB_QUERY_JSON:
+            try:
+                query = json.loads(DB_QUERY_JSON)
+            except ValueError as exc:
+                log.critical(f"Invalid JSON in DB_QUERY_JSON: {exc}")
+                sys.exit(3)
+
         return URL.create(
             drivername=driver,
             username=DB_USER,
@@ -102,6 +112,7 @@ class ConfigManager:
             host=DB_HOST,
             port=DB_PORT,
             database=DB_NAME,
+            query=query,
         )
 
     def _parse_config(self):


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
This change adds a new environment variable `DB_QUERY_JSON` that allows users to specify querystring values for additional database connection parameters. This is useful for passing custom query parameters to the database connection URL.

The `DB_QUERY_JSON` variable should contain a JSON string with key-value pairs of strings, which is the required format for the SQLAlchemy URL `query` parameter. If the variable is not set, no additional query parameters will be added to the database connection URL.

Closes #2093.

**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes