### PR TITLE
fix: Improve performance on asset screenshot retrieval

### DIFF
--- a/backend/endpoints/saves.py
+++ b/backend/endpoints/saves.py
@@ -107,8 +107,10 @@ async def add_save(
             platform_fs_slug=rom.platform_slug,
             rom_id=rom.id,
         )
-        db_screenshot = db_screenshot_handler.get_screenshot_by_filename(
-            rom_id=rom.id, user_id=request.user.id, file_name=screenshotFile.filename
+        db_screenshot = db_screenshot_handler.get_screenshot(
+            filename=screenshotFile.filename,
+            rom_id=rom.id,
+            user_id=request.user.id,
         )
         if db_screenshot:
             db_screenshot = db_screenshot_handler.update_screenshot(
@@ -193,10 +195,10 @@ async def update_save(request: Request, id: int) -> SaveSchema:
             platform_fs_slug=db_save.rom.platform_slug,
             rom_id=db_save.rom.id,
         )
-        db_screenshot = db_screenshot_handler.get_screenshot_by_filename(
+        db_screenshot = db_screenshot_handler.get_screenshot(
+            filename=screenshotFile.filename,
             rom_id=db_save.rom.id,
             user_id=request.user.id,
-            file_name=screenshotFile.filename,
         )
         if db_screenshot:
             db_screenshot = db_screenshot_handler.update_screenshot(

--- a/backend/endpoints/screenshots.py
+++ b/backend/endpoints/screenshots.py
@@ -65,8 +65,10 @@ async def add_screenshot(
         platform_fs_slug=rom.platform_slug,
         rom_id=rom.id,
     )
-    db_screenshot = db_screenshot_handler.get_screenshot_by_filename(
-        rom_id=rom.id, user_id=current_user.id, file_name=screenshotFile.filename
+    db_screenshot = db_screenshot_handler.get_screenshot(
+        filename=screenshotFile.filename,
+        rom_id=rom.id,
+        user_id=current_user.id,
     )
     if db_screenshot:
         db_screenshot = db_screenshot_handler.update_screenshot(

--- a/backend/endpoints/states.py
+++ b/backend/endpoints/states.py
@@ -107,8 +107,10 @@ async def add_state(
             platform_fs_slug=rom.platform_slug,
             rom_id=rom.id,
         )
-        db_screenshot = db_screenshot_handler.get_screenshot_by_filename(
-            rom_id=rom.id, user_id=request.user.id, file_name=screenshotFile.filename
+        db_screenshot = db_screenshot_handler.get_screenshot(
+            filename=screenshotFile.filename,
+            rom_id=rom.id,
+            user_id=request.user.id,
         )
         if db_screenshot:
             db_screenshot = db_screenshot_handler.update_screenshot(
@@ -195,10 +197,10 @@ async def update_state(request: Request, id: int) -> StateSchema:
             platform_fs_slug=db_state.rom.platform_slug,
             rom_id=db_state.rom.id,
         )
-        db_screenshot = db_screenshot_handler.get_screenshot_by_filename(
+        db_screenshot = db_screenshot_handler.get_screenshot(
+            filename=screenshotFile.filename,
             rom_id=db_state.rom.id,
             user_id=request.user.id,
-            file_name=screenshotFile.filename,
         )
         if db_screenshot:
             db_screenshot = db_screenshot_handler.update_screenshot(

--- a/backend/models/assets.py
+++ b/backend/models/assets.py
@@ -59,17 +59,12 @@ class Save(RomAsset):
 
     @cached_property
     def screenshot(self) -> Screenshot | None:
-        from handler.database import db_rom_handler
+        from handler.database import db_screenshot_handler
 
-        db_rom = db_rom_handler.get_rom(self.rom_id)
-        if db_rom is None:
-            return None
-
-        for screenshot in db_rom.screenshots:
-            if screenshot.file_name_no_ext == self.file_name_no_ext:
-                return screenshot
-
-        return None
+        return db_screenshot_handler.get_screenshot(
+            filename_no_ext=self.file_name_no_ext,
+            rom_id=self.rom_id,
+        )
 
 
 class State(RomAsset):
@@ -83,17 +78,12 @@ class State(RomAsset):
 
     @cached_property
     def screenshot(self) -> Screenshot | None:
-        from handler.database import db_rom_handler
+        from handler.database import db_screenshot_handler
 
-        db_rom = db_rom_handler.get_rom(self.rom_id)
-        if db_rom is None:
-            return None
-
-        for screenshot in db_rom.screenshots:
-            if screenshot.file_name_no_ext == self.file_name_no_ext:
-                return screenshot
-
-        return None
+        return db_screenshot_handler.get_screenshot(
+            filename_no_ext=self.file_name_no_ext,
+            rom_id=self.rom_id,
+        )
 
 
 class Screenshot(RomAsset):

--- a/backend/tests/handler/test_db_handler.py
+++ b/backend/tests/handler/test_db_handler.py
@@ -196,14 +196,16 @@ def test_screenshots(screenshot: Screenshot, platform: Platform, admin_user: Use
     assert rom is not None
     assert len(rom.screenshots) == 2
 
-    new_screenshot = db_screenshot_handler.get_screenshot(id=rom.screenshots[0].id)
+    new_screenshot = db_screenshot_handler.get_screenshot_by_id(
+        id=rom.screenshots[0].id
+    )
     assert new_screenshot is not None
     assert new_screenshot.file_name == "test_screenshot.png"
 
     db_screenshot_handler.update_screenshot(
         new_screenshot.id, {"file_name": "test_screenshot_2.png"}
     )
-    new_screenshot = db_screenshot_handler.get_screenshot(id=new_screenshot.id)
+    new_screenshot = db_screenshot_handler.get_screenshot_by_id(id=new_screenshot.id)
     assert new_screenshot is not None
     assert new_screenshot.file_name == "test_screenshot_2.png"
 


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
When retrieving the related screenshot for a `Save` or `State`, we were retrieving a very heavy representation of the associated `Rom` object, only to iterate through its screenshots to find the one we needed.

This change modifies the `Save` and `State` models to directly query the `Screenshot` model, which is much faster and more efficient. The `DBScreenshotsHandler` has been updated to include a new `filter` method that will simplify building queries using SQLAlchemy, something we can extend to other handlers in the future.

Fixes #1925.

**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes