### PR TITLE
fix: Make default ROMM_AUTH_SECRET_KEY consistent between workers

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -1,5 +1,4 @@
 import os
-import secrets
 from typing import Final
 
 import yarl
@@ -9,7 +8,7 @@ load_dotenv()
 
 
 def str_to_bool(value: str) -> bool:
-    return value.lower() in ("true", "1")
+    return value.strip().lower() in ("1", "true", "yes", "on")
 
 
 ROMM_BASE_URL = os.environ.get("ROMM_BASE_URL", "http://0.0.0.0")
@@ -98,8 +97,11 @@ HASHEOUS_API_ENABLED: Final = str_to_bool(
 TGDB_API_ENABLED: Final = str_to_bool(os.environ.get("TGDB_API_ENABLED", "false"))
 
 # AUTH
-ROMM_AUTH_SECRET_KEY: Final = os.environ.get(
-    "ROMM_AUTH_SECRET_KEY", secrets.token_hex(32)
+# The secret key has a default value to not difer between concurrent workers.
+# For security reasons, you should change this to a unique and secure key.
+ROMM_AUTH_SECRET_KEY: Final[str] = os.environ.get(
+    "ROMM_AUTH_SECRET_KEY",
+    os.environ.get("HOSTNAME", "(H(3>X(V6n0~n@5>bzpe.'K^pG*T.q7_m0aETIs?X}aF#y{@z&"),
 )
 SESSION_MAX_AGE_SECONDS: Final = int(
     os.environ.get("SESSION_MAX_AGE_SECONDS", 14 * 24 * 60 * 60)


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
When the `ROMM_AUTH_SECRET_KEY` environment variable is not set, and the Gunicorn application server spawns multiple worker processes, each worker was generating a different random secret key. This led to intermittent authentication failures, hard to debug and reproduce.

To fix this, we now set a default secret key that is consistent across all workers. For security reasons, it is still recommended to set a unique and secure key via the `ROMM_AUTH_SECRET_KEY` environment variable. When not set, the default key is now derived from the Docker's `HOSTNAME` environment variable, or a hardcoded fallback value.

**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes