### PR TITLE
feat: Add OpenTelemetry integration to file watcher

### DIFF
--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -206,7 +206,7 @@ start_bin_watcher() {
 	info_log "Starting watcher"
 	watchfiles \
 		--target-type command \
-		'python3 watcher.py' \
+		"opentelemetry-instrument --service_name '${OTEL_SERVICE_NAME_PREFIX-}watcher' python3 watcher.py" \
 		/romm/library &
 	WATCHER_PID=$!
 	echo "${WATCHER_PID}" >/tmp/watcher.pid


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Run file watcher using `opentelemetry-instrument` to enable tracing for the watcher service.

**Checklist**
- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes