### PR TITLE
fix: Correctly upload manual to resources path

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -814,10 +814,10 @@ async def add_rom_manuals(
         raise RomNotFoundInDatabaseException(id)
 
     manuals_path = f"{rom.fs_resources_path}/manual"
-    file_location = fs_rom_handler.validate_path(f"{manuals_path}/{rom.id}.pdf")
+    file_location = fs_resource_handler.validate_path(f"{manuals_path}/{rom.id}.pdf")
     log.info(f"Uploading manual to {hl(str(file_location))}")
 
-    await fs_rom_handler.make_directory(manuals_path)
+    await fs_resource_handler.make_directory(manuals_path)
 
     parser = StreamingFormDataParser(headers=request.headers)
     parser.register("x-upload-platform", NullTarget())


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Use the right filesystem handler for the manual to be uploaded to the `resources` path instead of the `rom` path.

Fixes #2253.

**Checklist**
- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes