### PR TITLE
misc: Create startup script to run initial tasks before main application

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging.config
 import re
 from collections.abc import AsyncGenerator
@@ -11,9 +12,6 @@ from config import (
     DEV_HOST,
     DEV_PORT,
     DISABLE_CSRF_PROTECTION,
-    ENABLE_SCHEDULED_RESCAN,
-    ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA,
-    ENABLE_SCHEDULED_UPDATE_SWITCH_TITLEDB,
     IS_PYTEST_RUN,
     ROMM_AUTH_SECRET_KEY,
     SENTRY_DSN,
@@ -44,11 +42,8 @@ from handler.auth.hybrid_auth import HybridAuthBackend
 from handler.auth.middleware import CustomCSRFMiddleware, SessionMiddleware
 from handler.socket_handler import socket_handler
 from logger.log_middleware import LOGGING_CONFIG, CustomLoggingMiddleware
-from logger.logger import log
 from starlette.middleware.authentication import AuthenticationMiddleware
-from tasks.scheduled.scan_library import scan_library_task
-from tasks.scheduled.update_launchbox_metadata import update_launchbox_metadata_task
-from tasks.scheduled.update_switch_titledb import update_switch_titledb_task
+from startup import main
 from utils import get_version
 from utils.context import (
     ctx_aiohttp_session,
@@ -139,22 +134,14 @@ app.mount("/ws", socket_handler.socket_app)
 add_pagination(app)
 
 
+# NOTE: This code is only executed when running the application directly, not by Production
+# deployments using Gunicorn.
 if __name__ == "__main__":
     # Run migrations
     alembic.config.main(argv=["upgrade", "head"])
 
-    # Initialize scheduled tasks
-    if ENABLE_SCHEDULED_RESCAN:
-        log.info("Starting scheduled rescan")
-        scan_library_task.init()
-
-    if ENABLE_SCHEDULED_UPDATE_SWITCH_TITLEDB:
-        log.info("Starting scheduled update switch titledb")
-        update_switch_titledb_task.init()
-
-    if ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA:
-        log.info("Starting scheduled update launchbox metadata")
-        update_launchbox_metadata_task.init()
+    # Run startup tasks
+    asyncio.run(main())
 
     # Run application
     app.add_middleware(CustomLoggingMiddleware)

--- a/backend/startup.py
+++ b/backend/startup.py
@@ -1,0 +1,50 @@
+"""Startup script to run tasks before the main application is started."""
+
+import asyncio
+
+import sentry_sdk
+from config import (
+    ENABLE_SCHEDULED_RESCAN,
+    ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA,
+    ENABLE_SCHEDULED_UPDATE_SWITCH_TITLEDB,
+    SENTRY_DSN,
+)
+from logger.logger import log
+from opentelemetry import trace
+from tasks.scheduled.scan_library import scan_library_task
+from tasks.scheduled.update_launchbox_metadata import update_launchbox_metadata_task
+from tasks.scheduled.update_switch_titledb import update_switch_titledb_task
+from utils import get_version
+from utils.context import initialize_context
+
+tracer = trace.get_tracer(__name__)
+
+
+@tracer.start_as_current_span("main")
+async def main() -> None:
+    """Run startup tasks."""
+
+    async with initialize_context():
+        log.info("Running startup tasks")
+
+        # Initialize scheduled tasks
+        if ENABLE_SCHEDULED_RESCAN:
+            log.info("Starting scheduled rescan")
+            scan_library_task.init()
+        if ENABLE_SCHEDULED_UPDATE_SWITCH_TITLEDB:
+            log.info("Starting scheduled update switch titledb")
+            update_switch_titledb_task.init()
+        if ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA:
+            log.info("Starting scheduled update launchbox metadata")
+            update_launchbox_metadata_task.init()
+
+        log.info("Startup tasks completed")
+
+
+if __name__ == "__main__":
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        release=f"romm@{get_version()}",
+    )
+
+    asyncio.run(main())

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# trunk-ignore-all(shellcheck/SC2016)
 
 set -o errexit           # treat errors as fatal
 set -o nounset           # treat unset variables as an error
@@ -64,6 +63,15 @@ warn_log() {
 error_log() {
 	echo -e "${RED}ERROR:    ${BLUE}[RomM]${LIGHTMAGENTA}[init]${CYAN}[$(date +"%Y-%m-%d %T")]${RESET}" "${@}" || true
 	exit 1
+}
+
+# Commands to run initial startup tasks
+run_startup() {
+	if ! PYTHONPATH="/backend:${PYTHONPATH-}" opentelemetry-instrument \
+		--service_name "${OTEL_SERVICE_NAME_PREFIX-}startup" \
+		python3 /backend/startup.py; then
+		error_log "Startup script failed, exiting"
+	fi
 }
 
 wait_for_gunicorn_socket() {
@@ -182,7 +190,7 @@ start_bin_rq_scheduler() {
 
 # Commands to start RQ worker
 start_bin_rq_worker() {
-	info_log "Starting rq worker"
+	info_log "Starting RQ worker"
 
 	# Build Redis URL properly
 	local redis_url
@@ -275,6 +283,8 @@ if alembic upgrade head; then
 else
 	error_log "Failed to run database migrations"
 fi
+
+run_startup
 
 # main loop
 while ! ((exited)); do


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
For steps that need to run before the web application starts, such as scheduling tasks, this new `startup.py` script is introduced.

This fixes a recently introduced issue where task scheduling was not being triggered, because of it being included in the `if __name__ == "__main__":` block, which is not executed when the application is run by Gunicorn in production environments.

We do not include this logic as part of FastAPI's lifespan implementation, as running multiple workers with Gunicorn would cause this logic to be executed multiple times.

**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes