### PR TITLE
misc: Move cache initialization to startup script

### DIFF
--- a/backend/models/firmware.py
+++ b/backend/models/firmware.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import json
-import os
 from functools import cached_property
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
 
-from handler.metadata.base_hander import conditionally_set_cache
 from handler.redis_handler import sync_cache
 from models.base import (
     FILE_EXTENSION_MAX_LENGTH,
@@ -19,6 +18,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 if TYPE_CHECKING:
     from models.platform import Platform
 
+FIRMWARE_FIXTURES_DIR: Final = Path(__file__).parent / "fixtures"
 KNOWN_BIOS_KEY = "romm:known_bios_files"
 
 
@@ -46,13 +46,6 @@ class Firmware(BaseModel):
     platform: Mapped[Platform] = relationship(lazy="joined", back_populates="firmware")
 
     missing_from_fs: Mapped[bool] = mapped_column(default=False, nullable=False)
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        conditionally_set_cache(
-            KNOWN_BIOS_KEY, "known_bios_files.json", os.path.dirname(__file__)
-        )
 
     @property
     def platform_slug(self) -> str:

--- a/backend/startup.py
+++ b/backend/startup.py
@@ -9,12 +9,23 @@ from config import (
     ENABLE_SCHEDULED_UPDATE_SWITCH_TITLEDB,
     SENTRY_DSN,
 )
+from handler.metadata.base_hander import (
+    MAME_XML_KEY,
+    METADATA_FIXTURES_DIR,
+    PS1_SERIAL_INDEX_KEY,
+    PS2_OPL_KEY,
+    PS2_SERIAL_INDEX_KEY,
+    PSP_SERIAL_INDEX_KEY,
+)
+from handler.redis_handler import async_cache
 from logger.logger import log
+from models.firmware import FIRMWARE_FIXTURES_DIR, KNOWN_BIOS_KEY
 from opentelemetry import trace
 from tasks.scheduled.scan_library import scan_library_task
 from tasks.scheduled.update_launchbox_metadata import update_launchbox_metadata_task
 from tasks.scheduled.update_switch_titledb import update_switch_titledb_task
 from utils import get_version
+from utils.cache import conditionally_set_cache
 from utils.context import initialize_context
 
 tracer = trace.get_tracer(__name__)
@@ -37,6 +48,32 @@ async def main() -> None:
         if ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA:
             log.info("Starting scheduled update launchbox metadata")
             update_launchbox_metadata_task.init()
+
+        log.info("Initializing cache with fixtures data")
+        await conditionally_set_cache(
+            async_cache, MAME_XML_KEY, METADATA_FIXTURES_DIR / "mame_index.json"
+        )
+        await conditionally_set_cache(
+            async_cache, PS2_OPL_KEY, METADATA_FIXTURES_DIR / "ps2_opl_index.json"
+        )
+        await conditionally_set_cache(
+            async_cache,
+            PS1_SERIAL_INDEX_KEY,
+            METADATA_FIXTURES_DIR / "ps1_serial_index.json",
+        )
+        await conditionally_set_cache(
+            async_cache,
+            PS2_SERIAL_INDEX_KEY,
+            METADATA_FIXTURES_DIR / "ps2_serial_index.json",
+        )
+        await conditionally_set_cache(
+            async_cache,
+            PSP_SERIAL_INDEX_KEY,
+            METADATA_FIXTURES_DIR / "psp_serial_index.json",
+        )
+        await conditionally_set_cache(
+            async_cache, KNOWN_BIOS_KEY, FIRMWARE_FIXTURES_DIR / "known_bios_files.json"
+        )
 
         log.info("Startup tasks completed")
 

--- a/backend/tests/utils/test_cache.py
+++ b/backend/tests/utils/test_cache.py
@@ -1,0 +1,55 @@
+from unittest.mock import AsyncMock
+
+from handler.metadata.base_hander import MAME_XML_KEY, METADATA_FIXTURES_DIR
+from handler.redis_handler import async_cache
+from redis.asyncio import Redis as AsyncRedis
+from utils.cache import conditionally_set_cache
+
+
+class TestConditionallySetCache:
+    """Test the conditionally_set_cache function."""
+
+    async def test_cache_not_exists_loads_data(self, mocker):
+        """Test loading data when cache doesn't exist."""
+        mock_cache_exists = mocker.patch.object(
+            AsyncRedis, "exists", side_effect=AsyncMock(return_value=False)
+        )
+        mock_pipeline = AsyncMock()
+        mock_cache_pipeline = mocker.patch.object(AsyncRedis, "pipeline")
+        mock_cache_pipeline.return_value.__aenter__.return_value = mock_pipeline
+
+        await conditionally_set_cache(
+            async_cache, MAME_XML_KEY, METADATA_FIXTURES_DIR / "mame_index.json"
+        )
+
+        mock_cache_exists.assert_called_once_with(MAME_XML_KEY)
+        mock_cache_pipeline.return_value.__aenter__.assert_called_once()
+        mock_pipeline.hset.assert_called()
+        mock_pipeline.execute.assert_called_once()
+
+    async def test_cache_exists_skips_loading(self, mocker):
+        """Test skipping load when cache already exists."""
+        mock_cache_exists = mocker.patch.object(
+            AsyncRedis, "exists", side_effect=AsyncMock(return_value=True)
+        )
+        mock_cache_pipeline = mocker.patch.object(AsyncRedis, "pipeline")
+
+        await conditionally_set_cache(
+            async_cache, MAME_XML_KEY, METADATA_FIXTURES_DIR / "mame_index.json"
+        )
+
+        mock_cache_exists.assert_called_once_with(MAME_XML_KEY)
+        mock_cache_pipeline.assert_not_called()
+
+    async def test_exception_handling(self, mocker):
+        """Test exception handling when file loading fails."""
+        mocker.patch.object(
+            AsyncRedis, "exists", side_effect=AsyncMock(return_value=False)
+        )
+        mock_cache_pipeline = mocker.patch.object(AsyncRedis, "pipeline")
+
+        await conditionally_set_cache(
+            async_cache, MAME_XML_KEY, METADATA_FIXTURES_DIR / "nonexistent.json"
+        )
+
+        mock_cache_pipeline.assert_not_called()

--- a/backend/utils/cache.py
+++ b/backend/utils/cache.py
@@ -1,0 +1,24 @@
+import json
+from itertools import batched
+from pathlib import Path
+
+from anyio import open_file
+from logger.logger import log
+from redis.asyncio import Redis as AsyncRedis
+
+
+async def conditionally_set_cache(cache: AsyncRedis, key: str, file_path: Path) -> None:
+    """Set the content of a JSON file to the cache, if it does not already exist."""
+    try:
+        if await cache.exists(key):
+            return
+        async with await open_file(file_path, "r") as file:
+            index_data = json.loads(await file.read())
+            async with cache.pipeline() as pipe:
+                for data_batch in batched(index_data.items(), 2000, strict=False):
+                    data_map = {k: json.dumps(v) for k, v in dict(data_batch).items()}
+                    await pipe.hset(key, mapping=data_map)
+                await pipe.execute()
+    except Exception as e:
+        # Log the error but don't fail - this allows migrations to run even if Redis is not available
+        log.warning(f"Failed to initialize cache for {key}: {e}")

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -284,6 +284,7 @@ else
 	error_log "Failed to run database migrations"
 fi
 
+# Startup process requires database and cache to be already available
 run_startup
 
 # main loop


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Guarantee that cache is initialized during startup, and only once, instead of every time a `MetadataHandler` object is instantiated.

Also, improve logic to determine `fixtures` paths.

**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes