### PR TITLE
fix: Disable OpenTelemetry integration if not configured

### DIFF
--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -269,6 +269,12 @@ trap 'exited=1 && shutdown' SIGINT SIGTERM EXIT
 # clear any leftover PID files
 rm /tmp/*.pid -f
 
+# Disable OpenTelemetry if no OTEL_ prefixed environment variables are set
+if ! printenv | grep -q '^OTEL_'; then
+	info_log "No OpenTelemetry environment variables found, disabling OpenTelemetry SDK"
+	export OTEL_SDK_DISABLED=true
+fi
+
 # Start Valkey server if REDIS_HOST is not set (which would mean user is using an external Redis/Valkey)
 if [[ -z ${REDIS_HOST} ]]; then
 	watchdog_process_pid valkey-server


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
OpenTelemetry tries to send traces to a default `localhost:4317` endpoint if no configuration is provided, which is not what we want if users don't configure OpenTelemetry explicitly.

This change sets the `OTEL_SDK_DISABLED` environment variable to `true` if no `OTEL_` prefixed environment variables are found, which disables the OpenTelemetry SDK.

**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes