### PR TITLE
Make default ROMM_AUTH_SECRET_KEY consistent between workers

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -1,5 +1,4 @@
 import os
-import secrets
 from typing import Final
 
 import yarl
@@ -9,7 +8,7 @@ load_dotenv()
 
 
 def str_to_bool(value: str) -> bool:
-    return value.lower() in ("true", "1")
+    return value.strip().lower() in ("1", "true", "yes", "on")
 
 
 ROMM_BASE_URL = os.environ.get("ROMM_BASE_URL", "http://0.0.0.0")
@@ -98,9 +97,8 @@ HASHEOUS_API_ENABLED: Final = str_to_bool(
 TGDB_API_ENABLED: Final = str_to_bool(os.environ.get("TGDB_API_ENABLED", "false"))
 
 # AUTH
-ROMM_AUTH_SECRET_KEY: Final = os.environ.get(
-    "ROMM_AUTH_SECRET_KEY", secrets.token_hex(32)
-)
+ROMM_AUTH_SECRET_KEY: Final = os.environ.get("ROMM_AUTH_SECRET_KEY")
+
 SESSION_MAX_AGE_SECONDS: Final = int(
     os.environ.get("SESSION_MAX_AGE_SECONDS", 14 * 24 * 60 * 60)
 )  # 14 days, in seconds

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -275,6 +275,13 @@ if ! printenv | grep -q '^OTEL_'; then
 	export OTEL_SDK_DISABLED=true
 fi
 
+# Set ROMM_AUTH_SECRET_KEY if not already set
+if [[ -z ${ROMM_AUTH_SECRET_KEY} ]]; then
+	ROMM_AUTH_SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+	info_log "ROMM_AUTH_SECRET_KEY not set, generating random secret key"
+	export ROMM_AUTH_SECRET_KEY
+fi
+
 # Start Valkey server if REDIS_HOST is not set (which would mean user is using an external Redis/Valkey)
 if [[ -z ${REDIS_HOST} ]]; then
 	watchdog_process_pid valkey-server

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# trunk-ignore-all(shellcheck/SC2016)
 
 set -e
 
@@ -32,6 +31,12 @@ function handle_termination() {
 
 # Trap SIGTERM and SIGINT signals
 trap handle_termination SIGTERM SIGINT
+
+# Set ROMM_AUTH_SECRET_KEY if not already set
+if [[ -z ${ROMM_AUTH_SECRET_KEY} ]]; then
+	ROMM_AUTH_SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+	export ROMM_AUTH_SECRET_KEY
+fi
 
 # Start all services in the background
 echo "Starting backend..."


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Tested locally by logging in/out. Also exec's into the container to ensure that the `ROMM_AUTH_SECRET_KEY` set in `.env` was still being used.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
