### PR TITLE
Lazy load images with small versions

### DIFF
--- a/frontend/src/components/Details/BackgroundHeader.vue
+++ b/frontend/src/components/Details/BackgroundHeader.vue
@@ -29,7 +29,6 @@ const unmatchedCoverImage = computed(() =>
     <v-img
       id="background-image"
       :src="currentRom?.path_cover_large || unmatchedCoverImage"
-      lazy
       cover
     >
       <template #error>

--- a/frontend/src/components/common/Collection/RAvatar.vue
+++ b/frontend/src/components/common/Collection/RAvatar.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import { type CollectionType } from "@/stores/collections";
-import storeCollections from "@/stores/collections";
 import { getCollectionCoverImage, getFavoriteCoverImage } from "@/utils/covers";
 import { computed, ref, watchEffect } from "vue";
-import { useTheme } from "vuetify";
 
 const props = withDefaults(
   defineProps<{
@@ -65,8 +63,8 @@ watchEffect(() => {
   };
 });
 
-const firstCover = computed(() => memoizedCovers.value.large[0]);
-const secondCover = computed(() => memoizedCovers.value.large[1]);
+const firstLargeCover = computed(() => memoizedCovers.value.large[0]);
+const secondLargeCover = computed(() => memoizedCovers.value.large[1]);
 const firstSmallCover = computed(() => memoizedCovers.value.small[0]);
 const secondSmallCover = computed(() => memoizedCovers.value.small[1]);
 </script>
@@ -74,16 +72,37 @@ const secondSmallCover = computed(() => memoizedCovers.value.small[1]);
 <template>
   <v-avatar :rounded="0" :size="size">
     <div class="image-container" :style="{ aspectRatio: 1 / 1 }">
-      <template v-if="collection.is_virtual || !collection.path_cover_large">
+      <template
+        v-if="
+          collection.is_virtual ||
+          !collection.path_cover_large ||
+          !collection.path_cover_small
+        "
+      >
         <div class="split-image first-image">
-          <v-img cover :src="firstCover" :aspect-ratio="1 / 1" />
+          <v-img
+            cover
+            :src="firstLargeCover"
+            :lazy-src="firstSmallCover"
+            :aspect-ratio="1 / 1"
+          />
         </div>
         <div class="split-image second-image">
-          <v-img cover :src="secondCover" :aspect-ratio="1 / 1" />
+          <v-img
+            cover
+            :src="secondLargeCover"
+            :lazy-src="secondSmallCover"
+            :aspect-ratio="1 / 1"
+          />
         </div>
       </template>
       <template v-else>
-        <v-img cover :src="collection.path_cover_large" :aspect-ratio="1 / 1" />
+        <v-img
+          cover
+          :src="collection.path_cover_large"
+          :lazy-src="collection.path_cover_small"
+          :aspect-ratio="1 / 1"
+        />
       </template>
     </div>
   </v-avatar>

--- a/frontend/src/components/common/Game/Card/Related.vue
+++ b/frontend/src/components/common/Game/Card/Related.vue
@@ -28,7 +28,6 @@ const missingCoverImage = computed(() => getMissingCoverImage(props.game.name));
         :src="game.cover_url || missingCoverImage"
         :aspect-ratio="galleryViewStore.defaultAspectRatioCover"
         cover
-        lazy
       >
         <v-chip
           class="px-2 position-absolute chip-type text-white translucent"

--- a/frontend/src/components/common/Game/Dialog/MatchRom.vue
+++ b/frontend/src/components/common/Game/Dialog/MatchRom.vue
@@ -488,7 +488,6 @@ onBeforeUnmount(() => {
                       :src="source.url_cover || missingCoverImage"
                       :aspect-ratio="computedAspectRatio"
                       cover
-                      lazy
                     >
                       <template #placeholder>
                         <div


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

This PR uses the small images to preload cards while the larger images are fetched from the server. Small images are 1/6 the size so should load and render much faster.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes