### PR TITLE
fix devcontainer launch

### DIFF
--- a/.devcontainer/dev.env
+++ b/.devcontainer/dev.env
@@ -1,0 +1,18 @@
+# Development environment overrides for Dev Containers
+DEV_MODE=true
+DEV_HTTPS=false
+# Pick a host port that doesn't conflict with local services
+DEV_PORT=5001
+# Database defaults for development
+DB_HOST=romm-db-dev
+DB_NAME=romm
+DB_USER=romm
+DB_PASSWD=romm
+DB_ROOT_PASSWD=rootpassword
+# Redis
+REDIS_PORT=6379
+# Authentik defaults
+AUTHENTIK_SECRET_KEY=secret-key-default
+AUTHENTIK_BOOTSTRAP_PASSWORD=password
+# Logging
+LOGLEVEL=DEBUG

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,5 @@
 {
   "name": "ROMM Development",
-  // Use the repository root docker-compose.yml so the romm-dev service uses the project's root Dockerfile
   "dockerComposeFile": ["../docker-compose.yml"],
   "service": "romm-dev",
   "workspaceFolder": "/app",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "ROMM Development",
-  "dockerComposeFile": "docker-compose.yml",
+  "dockerComposeFile": "../docker-compose.yml",
   "service": "romm-dev",
   "workspaceFolder": "/app",
   "shutdownAction": "stopCompose",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "name": "ROMM Development",
-  "dockerComposeFile": "../docker-compose.yml",
+  // Use the repository root docker-compose.yml so the romm-dev service uses the project's root Dockerfile
+  "dockerComposeFile": ["../docker-compose.yml"],
   "service": "romm-dev",
   "workspaceFolder": "/app",
   "shutdownAction": "stopCompose",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: romm-dev
-    env_file: env.template
+    env_file: .env
     environment:
       - REDIS_HOST=romm-valkey-dev
       - DB_HOST=${DB_HOST:-romm-db-dev}
@@ -35,7 +35,7 @@ services:
     image: mariadb:11.3.2
     container_name: romm-db-dev
     restart: unless-stopped
-    env_file: env.template
+    env_file: .env
     environment:
       - MARIADB_ROOT_PASSWORD=${DB_ROOT_PASSWD:-rootpassword}
       - MARIADB_DATABASE=${DB_NAME:-romm}
@@ -50,7 +50,7 @@ services:
     image: valkey/valkey:8
     container_name: romm-valkey-dev
     restart: unless-stopped
-    env_file: env.template
+    env_file: .env
     ports:
       - "${REDIS_PORT:-6379}:6379"
 
@@ -58,7 +58,7 @@ services:
     image: postgres:16-alpine
     container_name: romm-postgresql-dev
     restart: unless-stopped
-    env_file: env.template
+    env_file: .env
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWD:-postgres}
       POSTGRES_USER: ${DB_USER:-postgres}
@@ -73,7 +73,7 @@ services:
     container_name: romm-authentik-server
     restart: unless-stopped
     command: server
-    env_file: env.template
+    env_file: .env
     environment:
       AUTHENTIK_REDIS__HOST: romm-valkey-dev
       AUTHENTIK_POSTGRESQL__HOST: romm-postgres-dev
@@ -97,7 +97,7 @@ services:
     container_name: romm-authentik-worker
     restart: unless-stopped
     command: worker
-    env_file: env.template
+    env_file: .env
     environment:
       AUTHENTIK_REDIS__HOST: romm-valkey-dev
       AUTHENTIK_POSTGRESQL__HOST: romm-postgres-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: romm-dev
-    env_file: .env
+    env_file: env.template
     environment:
       - REDIS_HOST=romm-valkey-dev
       - DB_HOST=${DB_HOST:-romm-db-dev}
@@ -35,7 +35,7 @@ services:
     image: mariadb:11.3.2
     container_name: romm-db-dev
     restart: unless-stopped
-    env_file: .env
+    env_file: env.template
     environment:
       - MARIADB_ROOT_PASSWORD=${DB_ROOT_PASSWD:-rootpassword}
       - MARIADB_DATABASE=${DB_NAME:-romm}
@@ -50,7 +50,7 @@ services:
     image: valkey/valkey:8
     container_name: romm-valkey-dev
     restart: unless-stopped
-    env_file: .env
+    env_file: env.template
     ports:
       - "${REDIS_PORT:-6379}:6379"
 
@@ -58,7 +58,7 @@ services:
     image: postgres:16-alpine
     container_name: romm-postgresql-dev
     restart: unless-stopped
-    env_file: .env
+    env_file: env.template
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWD:-postgres}
       POSTGRES_USER: ${DB_USER:-postgres}
@@ -73,7 +73,7 @@ services:
     container_name: romm-authentik-server
     restart: unless-stopped
     command: server
-    env_file: .env
+    env_file: env.template
     environment:
       AUTHENTIK_REDIS__HOST: romm-valkey-dev
       AUTHENTIK_POSTGRESQL__HOST: romm-postgres-dev
@@ -97,7 +97,7 @@ services:
     container_name: romm-authentik-worker
     restart: unless-stopped
     command: worker
-    env_file: .env
+    env_file: env.template
     environment:
       AUTHENTIK_REDIS__HOST: romm-valkey-dev
       AUTHENTIK_POSTGRESQL__HOST: romm-postgres-dev


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
issue: devcontainer doesn't launch properly as is

problematic code: filepath for docker-compose.yml and not using the existing env.template file

fix: change filepath to refer to root and use env.template in the devcontainer for faster usage

**Checklist**
<sup>Please check all that apply.</sup>

- [X] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes