### PR TITLE
misc: Create IGDB service adapter

### DIFF
--- a/backend/adapters/services/igdb.py
+++ b/backend/adapters/services/igdb.py
@@ -1,0 +1,202 @@
+import asyncio
+import http
+import json
+from collections.abc import Sequence
+from functools import partial
+from typing import TYPE_CHECKING
+
+import aiohttp
+import yarl
+from adapters.services.igdb_types import Game
+from aiohttp.client import ClientTimeout
+from config import IGDB_CLIENT_ID
+from fastapi import HTTPException, status
+from logger.logger import log
+from unidecode import unidecode
+from utils.context import ctx_aiohttp_session
+
+if TYPE_CHECKING:
+    from handler.metadata.igdb_handler import TwitchAuth
+
+
+class IGDBInvalidCredentialsException(Exception):
+    """Exception raised when IGDB credentials are invalid."""
+
+
+async def auth_middleware(
+    req: aiohttp.ClientRequest,
+    handler: aiohttp.ClientHandlerType,
+    *,
+    twitch_auth: "TwitchAuth",
+) -> aiohttp.ClientResponse:
+    """IGDB API authentication mechanism.
+
+    Reference: https://api-docs.igdb.com/#authentication
+    """
+    token = await twitch_auth.get_oauth_token()
+    if not token:
+        raise IGDBInvalidCredentialsException()
+    req.headers.update(
+        {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "Client-ID": IGDB_CLIENT_ID,
+        }
+    )
+    return await handler(req)
+
+
+class IGDBService:
+    """Service to interact with the IGDB API.
+
+    Reference: https://api-docs.igdb.com/
+    """
+
+    def __init__(
+        self,
+        twitch_auth: "TwitchAuth",
+        base_url: str | None = None,
+    ) -> None:
+        self.url = yarl.URL(base_url or "https://api.igdb.com/v4")
+        self.twitch_auth = twitch_auth
+        self.auth_middleware = partial(auth_middleware, twitch_auth=self.twitch_auth)
+
+    async def _request(
+        self,
+        url: str,
+        search_term: str | None = None,
+        fields: Sequence[str] | None = None,
+        where: str | None = None,
+        limit: int | None = None,
+        request_timeout: int = 120,
+    ) -> list:
+        aiohttp_session = ctx_aiohttp_session.get()
+
+        content = ""
+        if search_term:
+            content += f'search "{unidecode(search_term)}"; '
+        if fields:
+            content += f"fields {','.join(fields)}; "
+        if where:
+            content += f"where {where}; "
+        if limit is not None:
+            content += f"limit {limit}; "
+        content = content.strip()
+
+        log.debug(
+            "API request: URL=%s, Content=%s, Timeout=%s",
+            url,
+            content,
+            request_timeout,
+        )
+
+        try:
+            res = await aiohttp_session.post(
+                url,
+                data=content,
+                middlewares=(self.auth_middleware,),
+                timeout=ClientTimeout(total=request_timeout),
+            )
+            res.raise_for_status()
+            return await res.json()
+        except aiohttp.ServerTimeoutError:
+            # Retry the request once if it times out
+            log.debug("Request to URL=%s timed out. Retrying...", url)
+        except IGDBInvalidCredentialsException as exc:
+            log.critical("IGDB Error: Invalid IGDB_CLIENT_ID or IGDB_CLIENT_SECRET")
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Invalid IGDB credentials",
+            ) from exc
+        except aiohttp.ClientConnectionError as exc:
+            log.critical("Connection error: can't connect to IGDB", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Can't connect to IGDB, check your internet connection",
+            ) from exc
+        except aiohttp.ClientResponseError as exc:
+            if exc.status == http.HTTPStatus.UNAUTHORIZED:
+                # Refresh the token and retry if the auth token is invalid
+                log.info("Twitch token invalid: fetching a new one...")
+                await self.twitch_auth._update_twitch_token()
+            elif exc.status == http.HTTPStatus.TOO_MANY_REQUESTS:
+                # Retry after 2 seconds if rate limit hit
+                await asyncio.sleep(2)
+            else:
+                # Log the error and return an empty list if the request fails with a different code
+                log.error(exc)
+                return []
+        except json.JSONDecodeError as exc:
+            log.error("Error decoding JSON response from IGDB: %s", exc)
+            return []
+
+        # Retry the request once if it times out
+        try:
+            log.debug(
+                "API request: URL=%s, Content=%s, Timeout=%s",
+                url,
+                content,
+                request_timeout,
+            )
+            res = await aiohttp_session.post(
+                url,
+                data=content,
+                middlewares=(self.auth_middleware,),
+                timeout=ClientTimeout(total=request_timeout),
+            )
+            res.raise_for_status()
+            return await res.json()
+        except (aiohttp.ClientResponseError, aiohttp.ServerTimeoutError) as exc:
+            if (
+                isinstance(exc, aiohttp.ClientResponseError)
+                and exc.status == http.HTTPStatus.UNAUTHORIZED
+            ):
+                return []
+
+            log.error(exc)
+            return []
+        except json.JSONDecodeError as exc:
+            log.error("Error decoding JSON response from IGDB: %s", exc)
+            return []
+
+    async def list_games(
+        self,
+        *,
+        search_term: str | None = None,
+        fields: Sequence[str] | None = None,
+        where: str | None = None,
+        limit: int | None = None,
+    ) -> list[Game]:
+        """Retrieve games.
+
+        Reference: https://api-docs.igdb.com/#game
+        """
+        url = self.url.joinpath("games")
+        return await self._request(
+            str(url),
+            search_term=search_term,
+            fields=fields,
+            where=where,
+            limit=limit,
+        )
+
+    async def search(
+        self,
+        *,
+        search_term: str | None = None,
+        fields: Sequence[str] | None = None,
+        where: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict]:
+        """Search for different entities.
+
+        Reference: https://api-docs.igdb.com/#search
+        """
+        url = self.url.joinpath("search")
+        return await self._request(
+            str(url),
+            search_term=search_term,
+            fields=fields,
+            where=where,
+            limit=limit,
+        )

--- a/backend/adapters/services/igdb_types.py
+++ b/backend/adapters/services/igdb_types.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
 import enum
-from typing import Literal, NewType, TypedDict
+from typing import Literal, NewType, TypedDict, TypeGuard
 
 # https://api-docs.igdb.com/#expander
 type ExpandableField[T] = T | int
+
+
+def mark_expanded[T](value: ExpandableField[T]) -> TypeGuard[T]:
+    """Type guard to narrow an `ExpandableField` to its expanded type."""
+    return True
+
+
+def mark_list_expanded[T](value: list[ExpandableField[T]]) -> TypeGuard[list[T]]:
+    """Type guard to narrow an `ExpandableField` list to its expanded type."""
+    return True
+
 
 # TODO: Add missing structures until all are implemented.
 UnimplementedEntity = NewType("UnimplementedEntity", dict)
@@ -95,7 +106,7 @@ class AgeRating(IGDBEntity, total=False):
     category: AgeRatingCategory
     checksum: str  # uuid
     content_descriptions: list[ExpandableField[AgeRatingContentDescription]]
-    rating: AgeRatingRating
+    rating_category: AgeRatingRating
     rating_cover_url: str
     synopsis: str
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -37,6 +37,15 @@ def clear_database():
         s.query(User).delete(synchronize_session="evaluate")
 
 
+@pytest.fixture(scope="module")
+def vcr_config():
+    """Fixture to configure VCR.py settings."""
+    return {
+        # Default `match_on`, plus raw_body.
+        "match_on": ["method", "scheme", "host", "port", "path", "query", "raw_body"],
+    }
+
+
 @pytest.fixture
 def platform():
     platform = Platform(

--- a/backend/tests/handler/cassettes/test_fastapi/test_scan_rom.yaml
+++ b/backend/tests/handler/cassettes/test_fastapi/test_scan_rom.yaml
@@ -1,761 +1,5 @@
 interactions:
   - request:
-      body:
-        search "Paper Mario"; fields id,name,slug,summary,total_rating,aggregated_rating,first_release_date,artworks.url,cover.url,screenshots.url,platforms.id,platforms.name,alternative_names.name,genres.name,franchise.name,franchises.name,collections.name,game_modes.name,involved_companies.company.name,expansions.id,expansions.slug,expansions.name,expansions.cover.url,expanded_games.id,expanded_games.slug,expanded_games.name,expanded_games.cover.url,dlcs.id,dlcs.name,dlcs.slug,dlcs.cover.url,remakes.id,remakes.slug,remakes.name,remakes.cover.url,remasters.id,remasters.slug,remasters.name,remasters.cover.url,ports.id,ports.slug,ports.name,ports.cover.url,similar_games.id,similar_games.slug,similar_games.name,similar_games.cover.url;
-        where platforms=[4] & (category=0 | category=10); limit 200;
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate, br
-        authorization:
-          - Bearer test_token
-        client-id:
-          - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        connection:
-          - keep-alive
-        content-length:
-          - "796"
-        host:
-          - api.igdb.com
-        user-agent:
-          - python-httpx/0.27.0
-      method: POST
-      uri: https://api.igdb.com/v4/games
-    response:
-      body:
-        string:
-          "{\n  \"message\": \"Authorization Failure. Have you tried:\",\n  \"\
-          Tip 1\":   \"Ensure you are sending Authorization and Client-ID as headers.\"\
-          ,\n  \"Tip 2\":   \"Ensure Authorization value starts with 'Bearer ', including\
-          \ the space\",\n  \"Tip 3\":   \"Ensure Authorization value ends with the\
-          \ App Access Token you generated, NOT your Client Secret.\",\n  \"Docs\":\
-          \    \"https://api-docs.igdb.com/#authentication\",\n  \"Discord\": \"https://discord.gg/igdb\"\
-          \n}\n"
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8c0445b39b8dabd6-YYZ
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "434"
-        Content-Type:
-          - application/json
-        Date:
-          - Mon, 09 Sep 2024 04:00:36 GMT
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - __cf_bm=ZTkzLY1Wz3Lq3KdkQQpVj0yhgTOXkbAP9lPgbSV.fTY-1725854436-1.0.1.1-.UtTECTjipcRDIa3.6ZWDiOQNj0q9mHlDSCB2265Xcox2wuSZ6hHVY_mke1BBtuYQIMilhWlObkmR7PM1tX6RQ;
-            path=/; expires=Mon, 09-Sep-24 04:30:36 GMT; domain=.igdb.com; HttpOnly; Secure;
-            SameSite=None
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        X-Content-Type-Options:
-          - nosniff
-        alt-svc:
-          - h3=":443"; ma=86400
-        via:
-          - 1.1 1005873908b937da8d6e408eda0fb9e0.cloudfront.net (CloudFront)
-        x-amz-apigw-id:
-          - d0bjwHzrPHcEtQg=
-        x-amz-cf-id:
-          - Sf46nvswLwbFt_dJ5Ve5KvqLFp-odcsTS64D_cjG6rDGktuFotMRNw==
-        x-amz-cf-pop:
-          - YTO50-P1
-        x-amzn-errortype:
-          - AccessDeniedException
-        x-amzn-requestid:
-          - fe684a1e-715f-47ce-9b11-a000f167acbd
-        x-cache:
-          - Error from cloudfront
-      status:
-        code: 401
-        message: Unauthorized
-  - request:
-      body: ""
-      headers:
-        accept:
-          - "*/*"
-        accept-encoding:
-          - gzip, deflate, br
-        connection:
-          - keep-alive
-        content-length:
-          - "0"
-        host:
-          - id.twitch.tv
-        user-agent:
-          - python-httpx/0.27.0
-      method: POST
-      uri: https://id.twitch.tv/oauth2/token?client_id=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&client_secret=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&grant_type=client_credentials
-    response:
-      body:
-        string:
-          '{"access_token":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","expires_in":4930334,"token_type":"bearer"}
-
-          '
-      headers:
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "93"
-        Content-Type:
-          - application/json
-        Date:
-          - Mon, 09 Sep 2024 04:00:37 GMT
-        Server:
-          - nginx
-        X-Ctxlog-Logid:
-          - 1-66de72e5-20e8932a7697667d209b366f
-      status:
-        code: 200
-        message: OK
-  - request:
-      body:
-        search "Paper Mario"; fields id,name,slug,summary,total_rating,aggregated_rating,first_release_date,artworks.url,cover.url,screenshots.url,platforms.id,platforms.name,alternative_names.name,genres.name,franchise.name,franchises.name,collections.name,game_modes.name,involved_companies.company.name,expansions.id,expansions.slug,expansions.name,expansions.cover.url,expanded_games.id,expanded_games.slug,expanded_games.name,expanded_games.cover.url,dlcs.id,dlcs.name,dlcs.slug,dlcs.cover.url,remakes.id,remakes.slug,remakes.name,remakes.cover.url,remasters.id,remasters.slug,remasters.name,remasters.cover.url,ports.id,ports.slug,ports.name,ports.cover.url,similar_games.id,similar_games.slug,similar_games.name,similar_games.cover.url;
-        where platforms=[4] & (category=0 | category=10); limit 200;
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate, br
-        authorization:
-          - Bearer xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        client-id:
-          - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        connection:
-          - keep-alive
-        content-length:
-          - "796"
-        cookie:
-          - __cf_bm=ZTkzLY1Wz3Lq3KdkQQpVj0yhgTOXkbAP9lPgbSV.fTY-1725854436-1.0.1.1-.UtTECTjipcRDIa3.6ZWDiOQNj0q9mHlDSCB2265Xcox2wuSZ6hHVY_mke1BBtuYQIMilhWlObkmR7PM1tX6RQ
-        host:
-          - api.igdb.com
-        user-agent:
-          - python-httpx/0.27.0
-      method: POST
-      uri: https://api.igdb.com/v4/games
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAA/61YS28cRRC+51e09hSkHXvej9xiIqKQh0xsQCREq96Z3pnenenedPesM4u44EMC
-          As6REJwIEShHDoDyb6wQRUn+A9W7Xns3jHcmtiVb9nRX1VdfdVX14+4FhL6CX4Q6NOlcQo7jmt35
-          N05TQVKsSNITWFGWwnRkbhxN54oIBhMT0mO4IBKm786mFhaXrEaW6XWPB7U8DHfuZBRtU8zQTSwo
-          7xwKfN09wYxnBZFVY+Zg/5eD/T8OvoGfvw/2Hx3sP9ef+89bGbRrDL7856+X3z589fuzVw+/f/Hk
-          SaOdIAyssMbOjBbaUVxUjTbC0AzrbOyUYyLmAUK3t68iu9GSZUG4g3W0Xnz307/PnjYbcgI7rFu3
-          tz8+fvPzn29/eI5eP330+rdnbx7/emRs9vfeIkmE2uNitC43Asd3oyWMUuQaYnOTFjglcoOmSX8j
-          5sWm/mc+uFmOc46TTdVTWVn0N7GwRkptDMdpvRcxnxABRhfQhwE3Q8dcAJ8GNubW/QQfwx7GsTOg
-          QqqeIDnBkvQSqCBdOb4XebZpLspnIDCLMyrX1k3o1kV/tVhWmKYg0it4stZqXQntQH3nBI1zXEGo
-          6m0TJtbbrSul2zwnhjYLAOgiJPAHzWnn19jZLQUz+hDQBEkF/YikFbq4u7XTbM6p43s5mRCmSkHq
-          uVI24fkEOh9kwBgzup63G9qWuwQyV6qWMu5YODC7y2MLf25RpghLjpZ14dAaXrbteUHYEtazfKcW
-          mH5SkvcFjVqChssZsYR5VeCEQvjfC9h33ZXEWAdse2YQ1EJfA9Q8p5DLCu1UUpFC1jixkgsL1W18
-          1Ig7h1OQ12rARbEuO9ya7FusNvLd5j2qRv9zShv13Lq0B0X0aX3Ky1gQwmTG1To2NizC8tZymm7t
-          CWdk5wMnTyd0IKr4PklXeveJKQDY4dmws+RBKiMmyiqeiGmcTiQpW2OfcZeiaYQpK6MBETK7n1DG
-          H1htsZe7xmmwh1Pfl8RJSDwlCvtZ4layNbZ1NuzRkA0ic8jKxGfDYk9xR2Un79WSFjTHopc2HSm9
-          1da3usMvyVl2FHkrveBUW70/pv1lr5didsJhbUtwudFZEpJ5qc/QHamFjEILGX0QalwE3zfbcfUC
-          yzsHrgEbTZu5XsFwsFOckTqOydFk425v2n4rdlZouXZwdnbOZMqa2e1mBN0gsE8kiA/QHZIn+BK6
-          jG5QNkKKIwXT21iqOu4wZ+QzVYMPjKlWNbCRg6ahuKFnx1qzOTCO1y4wgRma7jkEhsnRKQOjB29S
-          RmWGPsTjtkHRY8VMy4hBqzkgfsua98IojM6hDvj0wSlqHjltqt5wmgnbYcvChytfYJ9Dk+PjvWbC
-          W4JglenV/4gKgq59Vke3PxPSaw3XIWLQSfNWA+foVmwjx3Sds5O1pnLYgixmQ25cx1POaW2n688E
-          RocCTSQdx43aFbVpRqZ5dpa2V8pmlktn23kx72a8lBiK9QuCBbrCuajjPsbHOa2LWS20KtAyEq3V
-          HBDParfqnhf55xAPS6TN8ZhX85elCZsTulHSlF5CszqXCsKxg1NcF455IHItbsiFtCG1dGPy204Y
-          tEsMJ/Cc8BwCUbm0ORDQ6QUsqO74OK7qSOdzCd3ctUT9oe7/+bK4QsmygO/qnSTsIozU8Y3/Y/3w
-          BVc2USHKZnvvfIGOHlHQHoWOhNEcYK6EiQRJRWOkCSyuavoZguSkAGuyiyQhcmZPUVXCsRPFGRY4
-          VuCHfrfSwmAe7eEKpAQv02yOXkr44gW6DhIJL2aJEkiUUFg18CbnMc7BsgbuUw4n2S4qCNGPqIgq
-          CSQy3KcKz3wY0DRTmZ4q4WKSV0CUFPRQW5BYlHSmiBnCQoAn0HgPnyU407YQFwk4DKcSzmKCIN1g
-          TOIJnFAEhREp0TbBcQbhApe1/3FeqjgDCDClv8mE5ug652M8Y4S2+J4kYnF47SiucH78CByGG4EZ
-          hI4Z2nA58Gzn6Jktz0mstFdrb5Dm+k20+UYcOetb2DtJeEH/d+8/eNAf8OoWAAA=
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8c0445b8f82eabd6-YYZ
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Length:
-          - "1529"
-        Content-Type:
-          - application/json
-        Date:
-          - Mon, 09 Sep 2024 04:00:37 GMT
-        Server:
-          - cloudflare
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        X-Content-Type-Options:
-          - nosniff
-        alt-svc:
-          - h3=":443"; ma=86400
-        via:
-          - 1.1 1005873908b937da8d6e408eda0fb9e0.cloudfront.net (CloudFront)
-        x-amz-apigw-id:
-          - d0bj4FrsPHcELQw=
-        x-amz-cf-id:
-          - nGKmz8x3MAZLbXpwAPNXo2hwQ7UwmchXiWql7aMqWaRVqrjVM60Lmw==
-        x-amz-cf-pop:
-          - YTO50-P1
-        x-amzn-remapped-content-length:
-          - "1529"
-        x-amzn-remapped-date:
-          - Mon, 09 Sep 2024 04:00:37 GMT
-        x-amzn-requestid:
-          - 0c112999-f30d-4510-95a9-d61502c7b12b
-        x-cache:
-          - Miss from cloudfront
-        x-count:
-          - "1"
-        x-pool:
-          - slow
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: fields video_id; where game=3340; limit 200;
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate, br
-        authorization:
-          - Bearer xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        client-id:
-          - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        connection:
-          - keep-alive
-        content-length:
-          - "44"
-        cookie:
-          - __cf_bm=ZTkzLY1Wz3Lq3KdkQQpVj0yhgTOXkbAP9lPgbSV.fTY-1725854436-1.0.1.1-.UtTECTjipcRDIa3.6ZWDiOQNj0q9mHlDSCB2265Xcox2wuSZ6hHVY_mke1BBtuYQIMilhWlObkmR7PM1tX6RQ
-        host:
-          - api.igdb.com
-        user-agent:
-          - python-httpx/0.27.0
-      method: POST
-      uri: https://api.igdb.com/v4/game_videos
-    response:
-      body:
-        string: !!binary |
-          IYADACBmzOlj1F902yUFkmNFSE45EAgww1Qyz6wdMaDDxpggjRmd0a1LwJcAgNczjhFF6hraT3wN
-          m0dc8LfePrXxmvsyE/A3pskXFTtL6eCWDE6fp399gjRcyF+39VJ2aqcrAlNRKfadenSd3OqynzIB
-          f+obAw==
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8c0445bb6a46abd6-YYZ
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - br
-        Content-Type:
-          - application/json
-        Date:
-          - Mon, 09 Sep 2024 04:00:38 GMT
-        Server:
-          - cloudflare
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        Transfer-Encoding:
-          - chunked
-        X-Content-Type-Options:
-          - nosniff
-        alt-svc:
-          - h3=":443"; ma=86400
-        via:
-          - 1.1 1005873908b937da8d6e408eda0fb9e0.cloudfront.net (CloudFront)
-        x-amz-apigw-id:
-          - d0bj9F_nvHcEe3Q=
-        x-amz-cf-id:
-          - z0uGc71xLQMm1sTPsdIwmh7Uso2jjYjrTjIL7yqbvs9WQ5RYHTciIQ==
-        x-amz-cf-pop:
-          - YTO50-P1
-        x-amzn-remapped-content-length:
-          - "225"
-        x-amzn-remapped-date:
-          - Mon, 09 Sep 2024 04:00:37 GMT
-        x-amzn-requestid:
-          - e7ec2d18-e037-4d50-8919-4f9d38c9abf6
-        x-cache:
-          - Miss from cloudfront
-        x-count:
-          - "4"
-        x-pool:
-          - slow
-      status:
-        code: 200
-        message: OK
-  - request:
-      body:
-        search "Paper Mario"; fields id,name,slug,summary,total_rating,aggregated_rating,first_release_date,artworks.url,cover.url,screenshots.url,platforms.id,platforms.name,alternative_names.name,genres.name,franchise.name,franchises.name,collections.name,game_modes.name,involved_companies.company.name,expansions.id,expansions.slug,expansions.name,expansions.cover.url,expanded_games.id,expanded_games.slug,expanded_games.name,expanded_games.cover.url,dlcs.id,dlcs.name,dlcs.slug,dlcs.cover.url,remakes.id,remakes.slug,remakes.name,remakes.cover.url,remasters.id,remasters.slug,remasters.name,remasters.cover.url,ports.id,ports.slug,ports.name,ports.cover.url,similar_games.id,similar_games.slug,similar_games.name,similar_games.cover.url;
-        where platforms=[4] & (category=0 | category=10); limit 200;
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate, br
-        authorization:
-          - Bearer test_token
-        client-id:
-          - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        connection:
-          - keep-alive
-        content-length:
-          - "796"
-        host:
-          - api.igdb.com
-        user-agent:
-          - python-httpx/0.27.0
-      method: POST
-      uri: https://api.igdb.com/v4/games
-    response:
-      body:
-        string:
-          "{\n  \"message\": \"Authorization Failure. Have you tried:\",\n  \"\
-          Tip 1\":   \"Ensure you are sending Authorization and Client-ID as headers.\"\
-          ,\n  \"Tip 2\":   \"Ensure Authorization value starts with 'Bearer ', including\
-          \ the space\",\n  \"Tip 3\":   \"Ensure Authorization value ends with the\
-          \ App Access Token you generated, NOT your Client Secret.\",\n  \"Docs\":\
-          \    \"https://api-docs.igdb.com/#authentication\",\n  \"Discord\": \"https://discord.gg/igdb\"\
-          \n}\n"
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8c0446168f587117-YYZ
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "434"
-        Content-Type:
-          - application/json
-        Date:
-          - Mon, 09 Sep 2024 04:00:52 GMT
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - __cf_bm=Uc538fsRMgVlaNKx20H7.wBHC_4yQvf5msLYDdiWHWw-1725854452-1.0.1.1-7HfoY3TYKBR5atKo7l9f8nL_QkBZtJl1R6cFz5Ui8Gn.XVLC7ok6KRWdNH4Gp_CQAqu5nw9PklMWrdGGcjvFWg;
-            path=/; expires=Mon, 09-Sep-24 04:30:52 GMT; domain=.igdb.com; HttpOnly; Secure;
-            SameSite=None
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        X-Content-Type-Options:
-          - nosniff
-        alt-svc:
-          - h3=":443"; ma=86400
-        via:
-          - 1.1 f92b450b48c98e711c027c1986c59944.cloudfront.net (CloudFront)
-        x-amz-apigw-id:
-          - d0bmNH1xvHcEIUg=
-        x-amz-cf-id:
-          - 5FhkJO2W64H2MJHbkQ1er_vxxHQ-9jWO50WmaiIjjklL3_w0Tc4fMA==
-        x-amz-cf-pop:
-          - YTO50-P1
-        x-amzn-errortype:
-          - AccessDeniedException
-        x-amzn-requestid:
-          - 17e5ffd1-9f99-43d2-abcb-d94bffc7911f
-        x-cache:
-          - Error from cloudfront
-      status:
-        code: 401
-        message: Unauthorized
-  - request:
-      body: ""
-      headers:
-        accept:
-          - "*/*"
-        accept-encoding:
-          - gzip, deflate, br
-        connection:
-          - keep-alive
-        content-length:
-          - "0"
-        host:
-          - id.twitch.tv
-        user-agent:
-          - python-httpx/0.27.0
-      method: POST
-      uri: https://id.twitch.tv/oauth2/token?client_id=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&client_secret=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&grant_type=client_credentials
-    response:
-      body:
-        string:
-          '{"access_token":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","expires_in":5391063,"token_type":"bearer"}
-
-          '
-      headers:
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "93"
-        Content-Type:
-          - application/json
-        Date:
-          - Mon, 09 Sep 2024 04:00:52 GMT
-        Server:
-          - nginx
-        X-Ctxlog-Logid:
-          - 1-66de72f4-66afdd221ca68b434444e2c7
-      status:
-        code: 200
-        message: OK
-  - request:
-      body:
-        search "Paper Mario"; fields id,name,slug,summary,total_rating,aggregated_rating,first_release_date,artworks.url,cover.url,screenshots.url,platforms.id,platforms.name,alternative_names.name,genres.name,franchise.name,franchises.name,collections.name,game_modes.name,involved_companies.company.name,expansions.id,expansions.slug,expansions.name,expansions.cover.url,expanded_games.id,expanded_games.slug,expanded_games.name,expanded_games.cover.url,dlcs.id,dlcs.name,dlcs.slug,dlcs.cover.url,remakes.id,remakes.slug,remakes.name,remakes.cover.url,remasters.id,remasters.slug,remasters.name,remasters.cover.url,ports.id,ports.slug,ports.name,ports.cover.url,similar_games.id,similar_games.slug,similar_games.name,similar_games.cover.url;
-        where platforms=[4] & (category=0 | category=10); limit 200;
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate, br
-        authorization:
-          - Bearer xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        client-id:
-          - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        connection:
-          - keep-alive
-        content-length:
-          - "796"
-        cookie:
-          - __cf_bm=Uc538fsRMgVlaNKx20H7.wBHC_4yQvf5msLYDdiWHWw-1725854452-1.0.1.1-7HfoY3TYKBR5atKo7l9f8nL_QkBZtJl1R6cFz5Ui8Gn.XVLC7ok6KRWdNH4Gp_CQAqu5nw9PklMWrdGGcjvFWg
-        host:
-          - api.igdb.com
-        user-agent:
-          - python-httpx/0.27.0
-      method: POST
-      uri: https://api.igdb.com/v4/games
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAA/61YS28cRRC+51e09hSkHXvej9xiIqKQh0xsQCREq96Z3pnenenedPesM4u44EMC
-          As6REJwIEShHDoDyb6wQRUn+A9W7Xns3jHcmtiVb9nRX1VdfdVX14+4FhL6CX4Q6NOlcQo7jmt35
-          N05TQVKsSNITWFGWwnRkbhxN54oIBhMT0mO4IBKm786mFhaXrEaW6XWPB7U8DHfuZBRtU8zQTSwo
-          7xwKfN09wYxnBZFVY+Zg/5eD/T8OvoGfvw/2Hx3sP9ef+89bGbRrDL7856+X3z589fuzVw+/f/Hk
-          SaOdIAyssMbOjBbaUVxUjTbC0AzrbOyUYyLmAUK3t68iu9GSZUG4g3W0Xnz307/PnjYbcgI7rFu3
-          tz8+fvPzn29/eI5eP330+rdnbx7/emRs9vfeIkmE2uNitC43Asd3oyWMUuQaYnOTFjglcoOmSX8j
-          5sWm/mc+uFmOc46TTdVTWVn0N7GwRkptDMdpvRcxnxABRhfQhwE3Q8dcAJ8GNubW/QQfwx7GsTOg
-          QqqeIDnBkvQSqCBdOb4XebZpLspnIDCLMyrX1k3o1kV/tVhWmKYg0it4stZqXQntQH3nBI1zXEGo
-          6m0TJtbbrSul2zwnhjYLAOgiJPAHzWnn19jZLQUz+hDQBEkF/YikFbq4u7XTbM6p43s5mRCmSkHq
-          uVI24fkEOh9kwBgzup63G9qWuwQyV6qWMu5YODC7y2MLf25RpghLjpZ14dAaXrbteUHYEtazfKcW
-          mH5SkvcFjVqChssZsYR5VeCEQvjfC9h33ZXEWAdse2YQ1EJfA9Q8p5DLCu1UUpFC1jixkgsL1W18
-          1Ig7h1OQ12rARbEuO9ya7FusNvLd5j2qRv9zShv13Lq0B0X0aX3Ky1gQwmTG1To2NizC8tZymm7t
-          CWdk5wMnTyd0IKr4PklXeveJKQDY4dmws+RBKiMmyiqeiGmcTiQpW2OfcZeiaYQpK6MBETK7n1DG
-          H1htsZe7xmmwh1Pfl8RJSDwlCvtZ4layNbZ1NuzRkA0ic8jKxGfDYk9xR2Un79WSFjTHopc2HSm9
-          1da3usMvyVl2FHkrveBUW70/pv1lr5didsJhbUtwudFZEpJ5qc/QHamFjEILGX0QalwE3zfbcfUC
-          yzsHrgEbTZu5XsFwsFOckTqOydFk425v2n4rdlZouXZwdnbOZMqa2e1mBN0gsE8kiA/QHZIn+BK6
-          jG5QNkKKIwXT21iqOu4wZ+QzVYMPjKlWNbCRg6ahuKFnx1qzOTCO1y4wgRma7jkEhsnRKQOjB29S
-          RmWGPsTjtkHRY8VMy4hBqzkgfsua98IojM6hDvj0wSlqHjltqt5wmgnbYcvChytfYJ9Dk+PjvWbC
-          W4JglenV/4gKgq59Vke3PxPSaw3XIWLQSfNWA+foVmwjx3Sds5O1pnLYgixmQ25cx1POaW2n688E
-          RocCTSQdx43aFbVpRqZ5dpa2V8pmlktn23kx72a8lBiK9QuCBbrCuajjPsbHOa2LWS20KtAyEq3V
-          HBDParfqnhf55xAPS6TN8ZhX85elCZsTulHSlF5CszqXCsKxg1NcF455IHItbsiFtCG1dGPy204Y
-          tEsMJ/Cc8BwCUbm0ORDQ6QUsqO74OK7qSOdzCd3ctUT9oe7/+bK4QsmygO/qnSTsIozU8Y3/Y/3w
-          BVc2USHKZnvvfIGOHlHQHoWOhNEcYK6EiQRJRWOkCSyuavoZguSkAGuyiyQhcmZPUVXCsRPFGRY4
-          VuCHfrfSwmAe7eEKpAQv02yOXkr44gW6DhIJL2aJEkiUUFg18CbnMc7BsgbuUw4n2S4qCNGPqIgq
-          CSQy3KcKz3wY0DRTmZ4q4WKSV0CUFPRQW5BYlHSmiBnCQoAn0HgPnyU407YQFwk4DKcSzmKCIN1g
-          TOIJnFAEhREp0TbBcQbhApe1/3FeqjgDCDClv8mE5ug652M8Y4S2+J4kYnF47SiucH78CByGG4EZ
-          hI4Z2nA58Gzn6Jktz0mstFdrb5Dm+k20+UYcOetb2DtJeEH/d+8/eNAf8OoWAAA=
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8c04461b49d77117-YYZ
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Length:
-          - "1529"
-        Content-Type:
-          - application/json
-        Date:
-          - Mon, 09 Sep 2024 04:00:53 GMT
-        Server:
-          - cloudflare
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        X-Content-Type-Options:
-          - nosniff
-        alt-svc:
-          - h3=":443"; ma=86400
-        via:
-          - 1.1 f92b450b48c98e711c027c1986c59944.cloudfront.net (CloudFront)
-        x-amz-apigw-id:
-          - d0bmWEgfPHcEc-Q=
-        x-amz-cf-id:
-          - ayWP5EBTRdWEN9F1pKi1KLnEFGM2irHDLDchaXiBhhZShZX-fHbmkQ==
-        x-amz-cf-pop:
-          - YTO50-P1
-        x-amzn-remapped-content-length:
-          - "1529"
-        x-amzn-remapped-date:
-          - Mon, 09 Sep 2024 04:00:53 GMT
-        x-amzn-requestid:
-          - 0ee33393-4abc-4943-a2c1-50908af51e6d
-        x-cache:
-          - Miss from cloudfront
-        x-count:
-          - "1"
-        x-pool:
-          - slow
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: fields video_id; where game=3340; limit 200;
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate, br
-        authorization:
-          - Bearer xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        client-id:
-          - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        connection:
-          - keep-alive
-        content-length:
-          - "44"
-        cookie:
-          - __cf_bm=Uc538fsRMgVlaNKx20H7.wBHC_4yQvf5msLYDdiWHWw-1725854452-1.0.1.1-7HfoY3TYKBR5atKo7l9f8nL_QkBZtJl1R6cFz5Ui8Gn.XVLC7ok6KRWdNH4Gp_CQAqu5nw9PklMWrdGGcjvFWg
-        host:
-          - api.igdb.com
-        user-agent:
-          - python-httpx/0.27.0
-      method: POST
-      uri: https://api.igdb.com/v4/game_videos
-    response:
-      body:
-        string: !!binary |
-          IYADACBmzOlj1F902yUFkmNFSE45EAgww1Qyz6wdMaDDxpggjRmd0a1LwJcAgNczjhFF6hraT3wN
-          m0dc8LfePrXxmvsyE/A3pskXFTtL6eCWDE6fp399gjRcyF+39VJ2aqcrAlNRKfadenSd3OqynzIB
-          f+obAw==
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8c04461dfb577117-YYZ
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - br
-        Content-Type:
-          - application/json
-        Date:
-          - Mon, 09 Sep 2024 04:00:53 GMT
-        Server:
-          - cloudflare
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        Transfer-Encoding:
-          - chunked
-        X-Content-Type-Options:
-          - nosniff
-        alt-svc:
-          - h3=":443"; ma=86400
-        via:
-          - 1.1 f92b450b48c98e711c027c1986c59944.cloudfront.net (CloudFront)
-        x-amz-apigw-id:
-          - d0bmaG4PPHcERHQ=
-        x-amz-cf-id:
-          - 8Hq3T2WEPlUJISXm2DY86rlSr9tTqhbNJCxndioQu8jCDrJZQlJbEw==
-        x-amz-cf-pop:
-          - YTO50-P1
-        x-amzn-remapped-content-length:
-          - "225"
-        x-amzn-remapped-date:
-          - Mon, 09 Sep 2024 04:00:53 GMT
-        x-amzn-requestid:
-          - 3c20676f-438f-4938-a2a9-6c45bd83542d
-        x-cache:
-          - Miss from cloudfront
-        x-count:
-          - "4"
-        x-pool:
-          - slow
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: ""
-      headers:
-        accept:
-          - "*/*"
-        accept-encoding:
-          - gzip, deflate, br
-        connection:
-          - keep-alive
-        host:
-          - playmatch.retrorealm.dev
-        user-agent:
-          - RomM/development (https://github.com/rommapp/romm)
-      method: GET
-      uri: https://playmatch.retrorealm.dev/api/identify/ids?fileName=Paper+Mario+(USA).z64&fileSize=1024
-    response:
-      body:
-        string: !!binary |
-          CxKAeyJnYW1lTWF0Y2hUeXBlIjoiTm9NYXRjaCIsImlkIjpudWxsfQM=
-      headers:
-        CF-RAY:
-          - 960c3d22a857aafd-YYZ
-        Cache-Control:
-          - max-age=14400
-        Cf-Cache-Status:
-          - MISS
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - br
-        Content-Type:
-          - application/json
-        Date:
-          - Thu, 17 Jul 2025 19:45:17 GMT
-        Last-Modified:
-          - Thu, 17 Jul 2025 19:45:17 GMT
-        Nel:
-          - '{"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}'
-        Report-To:
-          - '{"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=9JUfCfr%2F7%2FZoqqBJHiB5qF9ziPuJV7qv66gcciJwwpjnQIDhBSttsD7KV6ql0TDbbfq0CWnW5ibxL6AYbn4TJcneoCNXfdt4uLuAW64McLpWmYH94Um5bg%3D%3D"}]}'
-        Server:
-          - cloudflare
-        Transfer-Encoding:
-          - chunked
-        Vary:
-          - accept-encoding
-        X-Ratelimit-Limit:
-          - "20"
-        X-Ratelimit-Remaining:
-          - "19"
-        X-Version:
-          - 0.2.0
-        alt-svc:
-          - h3=":443"; ma=86400
-      status:
-        code: 200
-        message: OK
-  - request:
-      body:
-        search "paper mario"; fields id,name,slug,summary,total_rating,aggregated_rating,first_release_date,artworks.url,cover.url,screenshots.url,platforms.id,platforms.name,alternative_names.name,genres.name,franchise.name,franchises.name,collections.name,game_modes.name,involved_companies.company.name,expansions.id,expansions.slug,expansions.name,expansions.cover.url,expanded_games.id,expanded_games.slug,expanded_games.name,expanded_games.cover.url,dlcs.id,dlcs.name,dlcs.slug,dlcs.cover.url,remakes.id,remakes.slug,remakes.name,remakes.cover.url,remasters.id,remasters.slug,remasters.name,remasters.cover.url,ports.id,ports.slug,ports.name,ports.cover.url,similar_games.id,similar_games.slug,similar_games.name,similar_games.cover.url,age_ratings.rating_category,videos.video_id;
-        where platforms=[4] & game_type=(10,0,11,8,9); limit 200;
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate, br
-        authorization:
-          - Bearer test_token
-        client-id:
-          - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        connection:
-          - keep-alive
-        content-length:
-          - "837"
-        host:
-          - api.igdb.com
-        user-agent:
-          - python-httpx/0.28.1
-      method: POST
-      uri: https://api.igdb.com/v4/games
-    response:
-      body:
-        string:
-          "{\n  \"message\": \"Authorization Failure. Have you tried:\",\n  \"\
-          Tip 1\":   \"Ensure you are sending Authorization and Client-ID as headers.\"\
-          ,\n  \"Tip 2\":   \"Ensure Authorization value starts with 'Bearer ', including\
-          \ the space\",\n  \"Tip 3\":   \"Ensure Authorization value ends with the\
-          \ App Access Token you generated, NOT your Client Secret.\",\n  \"Docs\":\
-          \    \"https://api-docs.igdb.com/#authentication\",\n  \"Discord\": \"https://discord.gg/igdb\"\
-          \n}\n"
-      headers:
-        CF-RAY:
-          - 960c3d26bdf4a2b1-YUL
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "434"
-        Content-Type:
-          - application/json
-        Date:
-          - Thu, 17 Jul 2025 19:45:18 GMT
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - __cf_bm=_4MCQ4Hoa.vSuVLwJv0Cf13N9AtzMeo6Lsf1youc2AE-1752781518-1.0.1.1-FoQrxg2hkPKfZUzx7eq5qB9.MFXHtGytbxvcpZgBt0.pqLC.qNN8rXv9i90gvuBeba6bhN9x4Qk_KNglqEAqACb73fXFL.JCxRMxzIiT3cs;
-            path=/; expires=Thu, 17-Jul-25 20:15:18 GMT; domain=.igdb.com; HttpOnly; Secure;
-            SameSite=None
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        X-Content-Type-Options:
-          - nosniff
-        alt-svc:
-          - h3=":443"; ma=86400
-        cf-cache-status:
-          - DYNAMIC
-        via:
-          - 1.1 37504d411c7d230cb5e53aaf2809b804.cloudfront.net (CloudFront)
-        x-amz-apigw-id:
-          - N3ngPHXlPHcEq4A=
-        x-amz-cf-id:
-          - 6jiYssj_TKLwC8HpcE8Zuw9upf-jDgGyMBSiJHSW7aRA5MeNGrHaaQ==
-        x-amz-cf-pop:
-          - YUL62-C2
-        x-amzn-errortype:
-          - AccessDeniedException
-        x-amzn-requestid:
-          - fabb5960-a7d7-4b60-89b5-28f21d32dc7c
-        x-cache:
-          - Error from cloudfront
-      status:
-        code: 401
-        message: Unauthorized
-  - request:
-      body: ""
-      headers:
-        accept:
-          - "*/*"
-        accept-encoding:
-          - gzip, deflate, br
-        connection:
-          - keep-alive
-        content-length:
-          - "0"
-        host:
-          - id.twitch.tv
-        user-agent:
-          - python-httpx/0.28.1
-      method: POST
-      uri: https://id.twitch.tv/oauth2/token?client_id=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&client_secret=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&grant_type=client_credentials
-    response:
-      body:
-        string: '{"status":400,"message":"invalid client"}
-
-          '
-      headers:
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "42"
-        Content-Type:
-          - application/json
-        Date:
-          - Thu, 17 Jul 2025 19:45:18 GMT
-        Server:
-          - nginx
-        X-Ctxlog-Logid:
-          - 1-687952ce-39ee3f8949fa125a2e545cfd
-      status:
-        code: 400
-        message: Bad Request
-  - request:
       body: ""
       headers:
         accept:
@@ -814,81 +58,6 @@ interactions:
       status:
         code: 200
         message: OK
-  - request:
-      body:
-        search "paper mario"; fields id,name,slug,summary,total_rating,aggregated_rating,first_release_date,artworks.url,cover.url,screenshots.url,platforms.id,platforms.name,alternative_names.name,genres.name,franchise.name,franchises.name,collections.name,game_modes.name,involved_companies.company.name,expansions.id,expansions.slug,expansions.name,expansions.cover.url,expanded_games.id,expanded_games.slug,expanded_games.name,expanded_games.cover.url,dlcs.id,dlcs.name,dlcs.slug,dlcs.cover.url,remakes.id,remakes.slug,remakes.name,remakes.cover.url,remasters.id,remasters.slug,remasters.name,remasters.cover.url,ports.id,ports.slug,ports.name,ports.cover.url,similar_games.id,similar_games.slug,similar_games.name,similar_games.cover.url,age_ratings.rating_category,videos.video_id;
-        where platforms=[4] & game_type=(10,0,11,8,9); limit 200;
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate, br
-        authorization:
-          - Bearer test_token
-        client-id:
-          - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        connection:
-          - keep-alive
-        content-length:
-          - "837"
-        host:
-          - api.igdb.com
-        user-agent:
-          - python-httpx/0.28.1
-      method: POST
-      uri: https://api.igdb.com/v4/games
-    response:
-      body:
-        string:
-          "{\n  \"message\": \"Authorization Failure. Have you tried:\",\n  \"\
-          Tip 1\":   \"Ensure you are sending Authorization and Client-ID as headers.\"\
-          ,\n  \"Tip 2\":   \"Ensure Authorization value starts with 'Bearer ', including\
-          \ the space\",\n  \"Tip 3\":   \"Ensure Authorization value ends with the\
-          \ App Access Token you generated, NOT your Client Secret.\",\n  \"Docs\":\
-          \    \"https://api-docs.igdb.com/#authentication\",\n  \"Discord\": \"https://discord.gg/igdb\"\
-          \n}\n"
-      headers:
-        CF-RAY:
-          - 960c3f249c3aa27b-YUL
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "434"
-        Content-Type:
-          - application/json
-        Date:
-          - Thu, 17 Jul 2025 19:46:39 GMT
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - __cf_bm=7H47jGLCD7N0QVnBaGY2mcfCEMpUw5gT4iIyHC98cDI-1752781599-1.0.1.1-jMQsIcVHa.ZTNb4pn4Dz_Go2SV8eitqm2On0YIRpRn6fBle0M6lHqlb7lnTRZfW_fqr.YWC1nDlmEWXC6.LIqVtMGu_CnGWwR5Hui7Y.it8;
-            path=/; expires=Thu, 17-Jul-25 20:16:39 GMT; domain=.igdb.com; HttpOnly; Secure;
-            SameSite=None
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        X-Content-Type-Options:
-          - nosniff
-        alt-svc:
-          - h3=":443"; ma=86400
-        cf-cache-status:
-          - DYNAMIC
-        via:
-          - 1.1 612d3e065148a94cbbe94139733f662e.cloudfront.net (CloudFront)
-        x-amz-apigw-id:
-          - N3ns_HMuPHcEAQg=
-        x-amz-cf-id:
-          - I4eOgzOAu5AWusM-kY-kK46cQZEXmXwW_jDh9a4ZKdwIthmhgvQiLQ==
-        x-amz-cf-pop:
-          - YUL62-C2
-        x-amzn-errortype:
-          - AccessDeniedException
-        x-amzn-requestid:
-          - 7fa35dfa-2106-4321-a52c-0a6f503dc158
-        x-cache:
-          - Error from cloudfront
-      status:
-        code: 401
-        message: Unauthorized
   - request:
       body: ""
       headers:
@@ -957,35 +126,95 @@ interactions:
       uri: https://api.igdb.com/v4/games
     response:
       body:
-        string: !!binary |
-          g2oMAORStezVVDus3rZ4h8Dcfcr6FDUrcgVCAgEeAEpHeb52LDrXIU3vcdfHsbVMKCBhWbJRqKqu
-          qlNgd/FLLTsCXpiDKTIoVFWe4cHkPvtr/euWECZBXlHO9m4B8OUCACDRXdKAlBlbHg9BRWuPUVsV
-          kgYcuwN4oHkaJ6t5mS034E/XdSAKSQNVdT4tyVg9Z6UodCQBKlFlbvyM0XP7wGge5UlhpI7fDEkD
-          NTtLh/dsInmLUR9obXGg1DAra87yf5XFgZIGkre9hpVGCw/Ra5ewM1RZlbwihVGYMXgWnZ8/luW8
-          rMVH+/evP//95qv/f/3j/6++//vHH2l1WVWsik/ss2kkz9OMwdPVbRCxmmbOa87Ks7a/v/3hnz9+
-          Rhc5Nc0+Hp3fY3FcXopM1vHNN3mTNJCc/6lNvzOtus0wb31Vt9mwx/k0GofdeVyPp3X8c/Ry5KeJ
-          MRIfSJ78S5FJi8iCNCgYssAn2auBR9KET+RLAKvkR+gXO1rHLzokEHDFZKt9iGtPhjDQusNISQN1
-          kde5YCzU5U+2Hm3b6yANVVbZBX0oAsiC22VXONB6cJ2MlePLLykw3httlSEYDc7k6beArKfNKS2X
-          eOoMpaPBWVsFV56ubn+WT6QPdlgUVdBKeD55m/ZL8TBD9BhJzXDl+bVnJIuUPNP+RA4CNWSBtQLr
-          1g0jWs17h6wSXH3jHsVn1NE8iJd4p8cp4yNtI9kua0kYw2qDWSFEnpd10EiVQfS0WK23PXaabKTA
-          daPqOueFPLeefjIF3LDIMnBAczy0yFlZhvwn3bWRjNGKbIRnc4g0BO6RBR5I2HisUF+7JJvJOgG0
-          ZHCWZi17pbUkMEDFipQWQpHR4BT1hFdawwshRBawp684Q7dD76KcdxAZL0ogoWvsf3nu5V6YrTTq
-          oLd+bi9IFRd9KTJenv5LdqeiCCQ7ak8Usei7bA7hl2VRMP7XaFWjtlO9JR/6i05bd8n3elj9l/Td
-          pQq19dPcHvypVYdA084QS/5X3O/stmY7O3WF3Q3H6GTsy2uqq+oarVVFsRKZ6T+WYp7meBDOWM0U
-          r7AZGdg6kU9woWcahKL4/gae9wTPezcFtF36htDDDed8AuMCwUwqaSAZS/eu6YBeuzT2lEafamZC
-          n3YEE3BIqchZ/R82UWy54pkoAeXhZMd73hM8INVT1QvekumwgavwQNs9rLhFlysMMWFiYk+p8a6a
-          um16yp1iarTdpzGpejZiiIkDLmXOx7jO87o4AQruFV7vP+L9xJgo4MGklW6gRbDUENHDM1SIFRwl
-          6c2klU6DD9k0ECkAiRHeRcX4WHJelwKwcOPxba95wtiD28It7QnuvhQRp43Dh5i6bbrVnlJ94Jh3
-          JnM+5iWrWAYobdhzS0T75z3B/JFHpYfrOEpDTOwpHXz2LG1xhEAlMq+1QT5MW9R1zuOoN4w28JDX
-          vAtnKYCBnVCQPdt4F96tIHjG8BjXkmUy/wH5Kezu9hranUvv48k5Tbw6bRxJ7AX6GAFnRX+ZV3VV
-          fxHJs7dLd7rM1RqDvNYslUzXRlHosL7OS56jGLC0+9OSb6Dfh+hsrrp1DogTHIPthZBVuQz75mMu
-          y1xWgGLO9Bs+IOXRdvCAFLYzn87GlXxqiBNb+4JIE3pVxzXZHDINAxoXGfWnfktAiK3+6957uroN
-          ZKOfYRz+mEs3MKTkgqOOPSAEgpsK5kcKsaeo20lrk821cG0VGHdTLCEQBZoFoo6TQQ+mXQTG579A
-          rwMccQaz9nwPp9B75wborBQryk9RBuj0gXwgMK5FQyHwS220GygsYSCK2irQMcCYJZwwHmQ/lCf3
-          2iqYrJ/MDGRp0BRSeGr9pD3TluWknccZVtoEM020dzaA6XwgONtS37/PgoAHgpXXtqUQYLXMJZTV
-          ff7WTLHtKcAEE7aggzZw37kRuUoP19wxkFfIYslasdBMuydX1VnJCp7VNa9zLmThlLYeKtBGoop1
-          bSrB/Ditgf3gkkfFPh+u7/JXwxPtN5yCM85oPcTh7Ys6bOILNrQ74zDOxEO+UcZr5Xg6FuG4Yxqb
-          Gfv7cCfsX6xuteLGUyYe97x1xlAbtbOGBPG6qKLqkXShESzhUGFo5dLYbFFMtgD4tPhgAAM=
+        string:
+          "[\n  {\n    \"id\": 3340,\n    \"age_ratings\": [\n      {\n      \
+          \  \"id\": 49174,\n        \"rating_category\": 8\n      },\n      {\n   \
+          \     \"id\": 50726,\n        \"rating_category\": 3\n      },\n      {\n\
+          \        \"id\": 82846,\n        \"rating_category\": 13\n      }\n    ],\n\
+          \    \"aggregated_rating\": 90.0,\n    \"alternative_names\": [\n      {\n\
+          \        \"id\": 39105,\n        \"name\": \"Zhi Pian Mario\"\n      },\n\
+          \      {\n        \"id\": 78718,\n        \"name\": \"Mario Story\"\n    \
+          \  },\n      {\n        \"id\": 51792,\n        \"name\": \"\u7EB8\u7247\u9A6C\
+          \u91CC\u5965\"\n      },\n      {\n        \"id\": 88088,\n        \"name\"\
+          : \"Super Mario RPG 2\"\n      },\n      {\n        \"id\": 119107,\n    \
+          \    \"name\": \"\u7EB8\u7247\u9A6C\u529B\u6B27\"\n      }\n    ],\n    \"\
+          artworks\": [\n      {\n        \"id\": 172439,\n        \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/ar3p1z.jpg\"\
+          \n      },\n      {\n        \"id\": 172440,\n        \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/ar3p20.jpg\"\
+          \n      }\n    ],\n    \"cover\": {\n      \"id\": 80830,\n      \"url\":\
+          \ \"//images.igdb.com/igdb/image/upload/t_thumb/co1qda.jpg\"\n    },\n   \
+          \ \"first_release_date\": 965952000,\n    \"franchises\": [\n      {\n   \
+          \     \"id\": 845,\n        \"name\": \"Mario\"\n      }\n    ],\n    \"game_modes\"\
+          : [\n      {\n        \"id\": 1,\n        \"name\": \"Single player\"\n  \
+          \    }\n    ],\n    \"genres\": [\n      {\n        \"id\": 12,\n        \"\
+          name\": \"Role-playing (RPG)\"\n      },\n      {\n        \"id\": 16,\n \
+          \       \"name\": \"Turn-based strategy (TBS)\"\n      },\n      {\n     \
+          \   \"id\": 31,\n        \"name\": \"Adventure\"\n      }\n    ],\n    \"\
+          involved_companies\": [\n      {\n        \"id\": 148214,\n        \"company\"\
+          : {\n          \"id\": 70,\n          \"name\": \"Nintendo\"\n        }\n\
+          \      },\n      {\n        \"id\": 225579,\n        \"company\": {\n    \
+          \      \"id\": 812,\n          \"name\": \"Gradiente\"\n        }\n      },\n\
+          \      {\n        \"id\": 225578,\n        \"company\": {\n          \"id\"\
+          : 5163,\n          \"name\": \"iQue\"\n        }\n      },\n      {\n    \
+          \    \"id\": 264416,\n        \"company\": {\n          \"id\": 25077,\n \
+          \         \"name\": \"Intelligent Systems\"\n        }\n      }\n    ],\n\
+          \    \"name\": \"Paper Mario\",\n    \"platforms\": [\n      {\n        \"\
+          id\": 5,\n        \"name\": \"Wii\"\n      },\n      {\n        \"id\": 4,\n\
+          \        \"name\": \"Nintendo 64\"\n      },\n      {\n        \"id\": 41,\n\
+          \        \"name\": \"Wii U\"\n      }\n    ],\n    \"screenshots\": [\n  \
+          \    {\n        \"id\": 24167,\n        \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/a5r3k2lf3lgvifrycqeg.jpg\"\
+          \n      },\n      {\n        \"id\": 24170,\n        \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/jz66se3deczeta6hd4ys.jpg\"\
+          \n      },\n      {\n        \"id\": 24169,\n        \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/ig9ainu9fershqdinox1.jpg\"\
+          \n      },\n      {\n        \"id\": 24168,\n        \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/hdxgs9nruycvrzcgvseu.jpg\"\
+          \n      },\n      {\n        \"id\": 24171,\n        \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/kjnf90jnud6njmwto3th.jpg\"\
+          \n      }\n    ],\n    \"similar_games\": [\n      {\n        \"id\": 3349,\n\
+          \        \"cover\": {\n          \"id\": 100900,\n          \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/co25us.jpg\"\
+          \n        },\n        \"name\": \"Paper Mario: The Thousand-Year Door\",\n\
+          \        \"slug\": \"paper-mario-the-thousand-year-door\"\n      },\n    \
+          \  {\n        \"id\": 1026,\n        \"cover\": {\n          \"id\": 181427,\n\
+          \          \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/co3vzn.jpg\"\
+          \n        },\n        \"name\": \"The Legend of Zelda: A Link to the Past\"\
+          ,\n        \"slug\": \"the-legend-of-zelda-a-link-to-the-past\"\n      },\n\
+          \      {\n        \"id\": 3351,\n        \"cover\": {\n          \"id\": 95596,\n\
+          \          \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/co21rg.jpg\"\
+          \n        },\n        \"name\": \"Mario \\u0026 Luigi: Superstar Saga\",\n\
+          \        \"slug\": \"mario-luigi-superstar-saga\"\n      },\n      {\n   \
+          \     \"id\": 1280,\n        \"cover\": {\n          \"id\": 311972,\n   \
+          \       \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/co6opw.jpg\"\
+          \n        },\n        \"name\": \"Breath of Fire IV\",\n        \"slug\":\
+          \ \"breath-of-fire-iv\"\n      },\n      {\n        \"id\": 1035,\n      \
+          \  \"cover\": {\n          \"id\": 170804,\n          \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/co3nsk.jpg\"\
+          \n        },\n        \"name\": \"The Legend of Zelda: The Minish Cap\",\n\
+          \        \"slug\": \"the-legend-of-zelda-the-minish-cap\"\n      },\n    \
+          \  {\n        \"id\": 358,\n        \"cover\": {\n          \"id\": 312995,\n\
+          \          \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/co6pib.jpg\"\
+          \n        },\n        \"name\": \"Super Mario Bros.\",\n        \"slug\":\
+          \ \"super-mario-bros\"\n      },\n      {\n        \"id\": 2148,\n       \
+          \ \"cover\": {\n          \"id\": 93043,\n          \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/co1zsj.jpg\"\
+          \n        },\n        \"name\": \"Banjo-Kazooie\",\n        \"slug\": \"banjo-kazooie\"\
+          \n      },\n      {\n        \"id\": 1068,\n        \"cover\": {\n       \
+          \   \"id\": 358989,\n          \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/co7ozx.jpg\"\
+          \n        },\n        \"name\": \"Super Mario Bros. 3\",\n        \"slug\"\
+          : \"super-mario-bros-3\"\n      },\n      {\n        \"id\": 660,\n      \
+          \  \"cover\": {\n          \"id\": 357155,\n          \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/co7nkz.jpg\"\
+          \n        },\n        \"name\": \"Darkstone\",\n        \"slug\": \"darkstone\"\
+          \n      },\n      {\n        \"id\": 22387,\n        \"cover\": {\n      \
+          \    \"id\": 137538,\n          \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/co2y4i.jpg\"\
+          \n        },\n        \"name\": \"Legrand Legacy\",\n        \"slug\": \"\
+          legrand-legacy\"\n      }\n    ],\n    \"slug\": \"paper-mario\",\n    \"\
+          summary\": \"Paper Mario, a turn-based JRPG entry in the Mario franchise with\
+          \ a paper-based aesthetic and platforming elements, sees the titular character\
+          \ working his way through the Mushroom Kingdom\\u0027s diverse locales and\
+          \ biomes, meeting its inhabitants, fighthing unruly enemies and recruiting\
+          \ an array of companions in order to once again save Princess Peach from the\
+          \ clutches of the evil Koopa King Bowser.\",\n    \"total_rating\": 88.70635880423836,\n\
+          \    \"videos\": [\n      {\n        \"id\": 9914,\n        \"video_id\":\
+          \ \"N6k5mCj5WmQ\"\n      },\n      {\n        \"id\": 61010,\n        \"video_id\"\
+          : \"mZU9sbtU0mc\"\n      },\n      {\n        \"id\": 60102,\n        \"video_id\"\
+          : \"D7tB7pzw6sw\"\n      },\n      {\n        \"id\": 60118,\n        \"video_id\"\
+          : \"HskUPFc2DR0\"\n      }\n    ],\n    \"collections\": [\n      {\n    \
+          \    \"id\": 593,\n        \"name\": \"Paper Mario\"\n      },\n      {\n\
+          \        \"id\": 240,\n        \"name\": \"Super Mario\"\n      }\n    ]\n\
+          \  }\n]"
       headers:
         CF-RAY:
           - 960c3f28caa6a27b-YUL


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Add a new service adapter for the IGDB API, to separate concerns with RomM's handler for metadata. This adapter is agnostic to the handler and only provides methods to interact with the API, and correctly return typed responses.

The API authorization was also improved to not rely on decorating each method that makes requests, but instead using an `aiohttp` middleware to automatically add the required headers to each request.

Utils `mark_expanded` and `mark_list_expanded` where added to help narrow the types of IGDB's expandable fields when we know they are expanded, for `mypy` type checking.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes