### PR TITLE
fix: Invalidate fixture cache on file change

### DIFF
--- a/backend/tests/utils/test_cache.py
+++ b/backend/tests/utils/test_cache.py
@@ -27,10 +27,35 @@ class TestConditionallySetCache:
         mock_pipeline.hset.assert_called()
         mock_pipeline.execute.assert_called_once()
 
-    async def test_cache_exists_skips_loading(self, mocker):
-        """Test skipping load when cache already exists."""
+    async def test_cache_exists_and_hash_does_not_match_loads_data(self, mocker):
+        """Test loading data when cache exists but file hash does not match."""
         mock_cache_exists = mocker.patch.object(
             AsyncRedis, "exists", side_effect=AsyncMock(return_value=True)
+        )
+        mock_pipeline = AsyncMock()
+        mock_cache_pipeline = mocker.patch.object(AsyncRedis, "pipeline")
+        mock_cache_pipeline.return_value.__aenter__.return_value = mock_pipeline
+
+        await conditionally_set_cache(
+            async_cache, MAME_XML_KEY, METADATA_FIXTURES_DIR / "mame_index.json"
+        )
+
+        mock_cache_exists.assert_called_once_with(MAME_XML_KEY)
+        mock_cache_pipeline.return_value.__aenter__.assert_called_once()
+        mock_pipeline.hset.assert_called()
+        mock_pipeline.execute.assert_called_once()
+
+    async def test_cache_exists_and_hash_matches_skips_loading(self, mocker):
+        """Test skipping load when cache already exists and file hash matches."""
+        fake_md5_hash = "d41d8cd98f00b204e9800998ecf8427e"
+        mocker.patch(
+            "hashlib.md5", return_value=AsyncMock(hexdigest=lambda: fake_md5_hash)
+        )
+        mock_cache_exists = mocker.patch.object(
+            AsyncRedis, "exists", side_effect=AsyncMock(return_value=True)
+        )
+        mock_cache_get = mocker.patch.object(
+            AsyncRedis, "get", side_effect=AsyncMock(return_value=fake_md5_hash)
         )
         mock_cache_pipeline = mocker.patch.object(AsyncRedis, "pipeline")
 
@@ -39,6 +64,7 @@ class TestConditionallySetCache:
         )
 
         mock_cache_exists.assert_called_once_with(MAME_XML_KEY)
+        mock_cache_get.assert_called_once_with(f"{MAME_XML_KEY}:file_hash")
         mock_cache_pipeline.assert_not_called()
 
     async def test_exception_handling(self, mocker):

--- a/backend/utils/cache.py
+++ b/backend/utils/cache.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from itertools import batched
 from pathlib import Path
@@ -8,17 +9,42 @@ from redis.asyncio import Redis as AsyncRedis
 
 
 async def conditionally_set_cache(cache: AsyncRedis, key: str, file_path: Path) -> None:
-    """Set the content of a JSON file to the cache, if it does not already exist."""
+    """Set the content of a JSON file to the cache, if it does not already exist or is outdated.
+
+    The MD5 hash of the file is stored alongside the data to determine if the content has changed.
+    """
+
+    hash_key = f"{key}:file_hash"
+
     try:
-        if await cache.exists(key):
+        # Calculate file's MD5 hash to determine if content has changed.
+        async with await open_file(file_path, "rb") as file:
+            file_content = await file.read()
+            md5_h = hashlib.md5(usedforsecurity=False)
+            md5_h.update(file_content)
+            file_hash = md5_h.hexdigest().lower()
+
+        # If cache key exists, and hash matches, do nothing.
+        data_exists = await cache.exists(key)
+        cached_hash = await cache.get(hash_key)
+        if data_exists and cached_hash == file_hash:
+            log.debug(f"Cache is up to date, skipping initialization for {key}")
             return
-        async with await open_file(file_path, "r") as file:
-            index_data = json.loads(await file.read())
-            async with cache.pipeline() as pipe:
-                for data_batch in batched(index_data.items(), 2000, strict=False):
-                    data_map = {k: json.dumps(v) for k, v in dict(data_batch).items()}
-                    await pipe.hset(key, mapping=data_map)
-                await pipe.execute()
+
+        # Set the content of the file to the cache, and update the hash.
+        index_data = json.loads(file_content)
+        async with cache.pipeline() as pipe:
+            # Clear existing data to avoid stale entries.
+            if data_exists:
+                await pipe.delete(key)
+            for data_batch in batched(index_data.items(), 2000, strict=False):
+                data_map = {k: json.dumps(v) for k, v in data_batch}
+                await pipe.hset(key, mapping=data_map)
+            await pipe.set(hash_key, file_hash)
+            await pipe.execute()
+            log.debug(
+                f"Cache successfully set for {key}, total items: {len(index_data)}"
+            )
     except Exception as e:
         # Log the error but don't fail - this allows migrations to run even if Redis is not available
         log.warning(f"Failed to initialize cache for {key}: {e}")


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
The cache for fixture files was being set without a TTL, which meant that updates to the fixture files were not reflected in the cache.

This change saves the MD5 hash of the fixture file in a different key, and compares it to the current hash of the file before deciding whether to update the cache.

Fixes #2347

**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes