### PR TITLE
feat: Add COEP and COOP headers for EmulatorJS within Nginx config

### DIFF
--- a/docker/nginx/templates/default.conf.template
+++ b/docker/nginx/templates/default.conf.template
@@ -8,6 +8,18 @@ map $http_x_forwarded_proto $forwardscheme {
     https https;
 }
 
+# COEP and COOP headers for cross-origin isolation, which are set only for the
+# EmulatorJS player path, to enable SharedArrayBuffer support, which is needed
+# for multi-threaded cores.
+map $request_uri $coep_header {
+    default        "";
+    ~^/rom/.*/ejs$ "require-corp";
+}
+map $request_uri $coop_header {
+    default        "";
+    ~^/rom/.*/ejs$ "same-origin";
+}
+
 server {
     root /var/www/html;
     listen ${ROMM_PORT};
@@ -19,13 +31,14 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $forwardscheme;
 
-
     location / {
         try_files $uri $uri/ /index.html;
         proxy_redirect off;
         add_header Access-Control-Allow-Origin *;
         add_header Access-Control-Allow-Methods *;
         add_header Access-Control-Allow-Headers *;
+        add_header Cross-Origin-Embedder-Policy $coep_header;
+        add_header Cross-Origin-Opener-Policy $coop_header;
     }
 
     # Static files


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
The COEP (Cross-Origin Embedder Policy) and COOP (Cross-Origin Opener Policy) headers are needed by EmulatorJS to use the `SharedArrayBuffer` feature, and enable multi-threaded cores.

These headers are only being set by Nginx for responses to requests made to the EmulatorJS player path. This is because cross-origin isolation breaks other features in the application (such as YouTube embeds), so we only want to enable it for the EmulatorJS player.

It's important to mention that this change does not work when `DEV_MODE` is set, as we would need Vite server to also set these headers in that case. This could be implemented separately, if needed.

These changes are not enough to enable multi-threaded cores in the frontend. Because our application is a SPA, we also need to ensure that navigation to the EmulatorJS player path results in a full page reload, so that the cross-origin isolation can be applied. This will be handled in a separate PR.

**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes