### PR TITLE
Avoid loading external plugins for mdeditor

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,6 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#9205f2" />
     <meta name="msapplication-TileColor" content="#9205f2" />
     <meta name="theme-color" content="#2a0145" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RomM</title>
   </head>

--- a/frontend/src/components/Details/Info/GameInfo.vue
+++ b/frontend/src/components/Details/Info/GameInfo.vue
@@ -181,6 +181,9 @@ function onFilterClick(filter: FilterType, value: string) {
         <v-row no-gutters class="mt-4">
           <v-col class="text-caption">
             <MdPreview
+              no-highlight
+              no-katex
+              no-mermaid
               class="py-4 px-6"
               :model-value="rom.summary ?? ''"
               :theme="theme.name.value == 'dark' ? 'dark' : 'light'"

--- a/frontend/src/components/Details/Personal.vue
+++ b/frontend/src/components/Details/Personal.vue
@@ -313,15 +313,22 @@ watch(
             <template #content>
               <MdEditor
                 v-if="editingNote"
+                no-highlight
+                no-katex
+                no-mermaid
+                no-prettier
+                no-upload-img
                 :disabled="!scopes.includes('roms.user.write')"
                 v-model="romUser.note_raw_markdown"
                 :theme="theme.name.value == 'dark' ? 'dark' : 'light'"
                 language="en-US"
                 :preview="false"
-                :no-upload-img="true"
               />
               <MdPreview
                 v-else
+                no-highlight
+                no-katex
+                no-mermaid
                 :model-value="romUser.note_raw_markdown"
                 :theme="theme.name.value == 'dark' ? 'dark' : 'light'"
                 language="en-US"
@@ -348,6 +355,9 @@ watch(
                   </v-expansion-panel-title>
                   <v-expansion-panel-text class="bg-surface">
                     <MdPreview
+                      no-highlight
+                      no-katex
+                      no-mermaid
                       :model-value="note.note_raw_markdown"
                       :theme="theme.name.value == 'dark' ? 'dark' : 'light'"
                       language="en-US"

--- a/frontend/src/components/common/Game/Dialog/NoteDialog.vue
+++ b/frontend/src/components/common/Game/Dialog/NoteDialog.vue
@@ -34,6 +34,9 @@ emitter?.on("showNoteDialog", (romToShow) => {
       </v-card-title>
       <v-card-text class="pa-4">
         <MdPreview
+          no-highlight
+          no-katex
+          no-mermaid
           v-if="rom?.rom_user?.note_raw_markdown"
           :model-value="rom?.rom_user?.note_raw_markdown"
           :theme="theme.name.value == 'dark' ? 'dark' : 'light'"

--- a/frontend/src/plugins/mdeditor.ts
+++ b/frontend/src/plugins/mdeditor.ts
@@ -2,6 +2,11 @@ import { config, XSSPlugin } from "md-editor-v3";
 
 export async function configureMDEditor() {
   config({
+    editorExtensions: {
+      screenfull: {
+        instance: { isEnabled: false },
+      },
+    },
     markdownItPlugins(plugins) {
       return [
         ...plugins,


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

This PR disables a bunch of plugins for md-editor-v3, which in turn disables fetching them from CDN. Also stops preloading gstatic fonts we don't need now that Roboto is embedded in the source.

Fixes #2348 

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
