### PR TITLE
Replace usage of localStorage with vuewuse useLocalStorage

### DIFF
--- a/frontend/src/RomM.vue
+++ b/frontend/src/RomM.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import consoleStore from "@/stores/console";
 import languageStore from "@/stores/language";
-import { useIdle } from "@vueuse/core";
+import { useIdle, useLocalStorage } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { ref } from "vue";
 import { useI18n } from "vue-i18n";
@@ -11,10 +11,10 @@ const storeLanguage = languageStore();
 const storeConsole = consoleStore();
 const { consoleMode } = storeToRefs(storeConsole);
 const { defaultLanguage, languages } = storeToRefs(storeLanguage);
+const localeStorage = useLocalStorage("settings.locale", "");
 const selectedLanguage = ref(
-  languages.value.find(
-    (lang) => lang.value === localStorage.getItem("settings.locale"),
-  ) || defaultLanguage.value,
+  languages.value.find((lang) => lang.value === localeStorage.value) ||
+    defaultLanguage.value,
 );
 locale.value = selectedLanguage.value.value;
 storeLanguage.setLanguage(selectedLanguage.value);

--- a/frontend/src/components/Home/Collections.vue
+++ b/frontend/src/components/Home/Collections.vue
@@ -3,6 +3,7 @@ import CollectionCard from "@/components/common/Collection/Card.vue";
 import RSection from "@/components/common/RSection.vue";
 import { type CollectionType } from "@/stores/collections";
 import { views } from "@/utils";
+import { useLocalStorage } from "@vueuse/core";
 import { isNull, throttle } from "lodash";
 import { onBeforeUnmount, onMounted, ref } from "vue";
 
@@ -15,24 +16,14 @@ const props = defineProps<{
     | "gridSmartCollections";
 }>();
 
-const storedCollections = localStorage.getItem(`settings.${props.setting}`);
-const gridCollections = ref(
-  isNull(storedCollections) ? false : storedCollections === "true",
-);
-const storedEnable3DEffect = localStorage.getItem("settings.enable3DEffect");
-const enable3DEffect = ref(
-  isNull(storedEnable3DEffect) ? false : storedEnable3DEffect === "true",
-);
+const gridCollections = useLocalStorage(`settings.${props.setting}`, false);
+const enable3DEffect = useLocalStorage("settings.enable3DEffect", false);
 const visibleCollections = ref(72);
 const isHovering = ref(false);
 const hoveringCollectionId = ref();
 
 function toggleGridCollections() {
   gridCollections.value = !gridCollections.value;
-  localStorage.setItem(
-    `settings.${props.setting}`,
-    gridCollections.value.toString(),
-  );
 }
 
 function onHover(emitData: { isHovering: boolean; id: number }) {

--- a/frontend/src/components/Home/ContinuePlaying.vue
+++ b/frontend/src/components/Home/ContinuePlaying.vue
@@ -3,7 +3,7 @@ import GameCard from "@/components/common/Game/Card/Base.vue";
 import RSection from "@/components/common/RSection.vue";
 import storeRoms from "@/stores/roms";
 import { views } from "@/utils";
-import { isNull } from "lodash";
+import { useLocalStorage } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { ref } from "vue";
 import { useI18n } from "vue-i18n";
@@ -11,16 +11,11 @@ import { useI18n } from "vue-i18n";
 const { t } = useI18n();
 const romsStore = storeRoms();
 const { continuePlayingRoms } = storeToRefs(romsStore);
-const storedContinuePlaying = localStorage.getItem(
+const gridContinuePlayingRoms = useLocalStorage(
   "settings.gridContinuePlayingRoms",
+  false,
 );
-const gridContinuePlayingRoms = ref(
-  isNull(storedContinuePlaying) ? false : storedContinuePlaying === "true",
-);
-const storedEnable3DEffect = localStorage.getItem("settings.enable3DEffect");
-const enable3DEffect = ref(
-  isNull(storedEnable3DEffect) ? false : storedEnable3DEffect === "true",
-);
+const enable3DEffect = useLocalStorage("settings.enable3DEffect", false);
 const isHovering = ref(false);
 const hoveringRomId = ref();
 const openedMenu = ref(false);
@@ -28,10 +23,6 @@ const openedMenuRomId = ref();
 
 function toggleGridContinuePlaying() {
   gridContinuePlayingRoms.value = !gridContinuePlayingRoms.value;
-  localStorage.setItem(
-    "settings.gridContinuePlayingRoms",
-    gridContinuePlayingRoms.value.toString(),
-  );
 }
 
 function onHover(emitData: { isHovering: boolean; id: number }) {

--- a/frontend/src/components/Home/Platforms.vue
+++ b/frontend/src/components/Home/Platforms.vue
@@ -3,6 +3,7 @@ import PlatformCard from "@/components/common/Platform/Card.vue";
 import RSection from "@/components/common/RSection.vue";
 import storePlatforms from "@/stores/platforms";
 import { views } from "@/utils";
+import { useLocalStorage } from "@vueuse/core";
 import { isNull } from "lodash";
 import { storeToRefs } from "pinia";
 import { ref } from "vue";
@@ -11,23 +12,13 @@ import { useI18n } from "vue-i18n";
 const { t } = useI18n();
 const platformsStore = storePlatforms();
 const { filledPlatforms } = storeToRefs(platformsStore);
-const storedPlatforms = localStorage.getItem("settings.gridPlatforms");
-const gridPlatforms = ref(
-  isNull(storedPlatforms) ? false : storedPlatforms === "true",
-);
-const storedEnable3DEffect = localStorage.getItem("settings.enable3DEffect");
-const enable3DEffect = ref(
-  isNull(storedEnable3DEffect) ? false : storedEnable3DEffect === "true",
-);
+const gridPlatforms = useLocalStorage("settings.gridPlatforms", false);
+const enable3DEffect = useLocalStorage("settings.enable3DEffect", false);
 const isHovering = ref(false);
 const hoveringPlatformId = ref();
 
 function toggleGridPlatforms() {
   gridPlatforms.value = !gridPlatforms.value;
-  localStorage.setItem(
-    "settings.gridPlatforms",
-    gridPlatforms.value.toString(),
-  );
 }
 
 function onHover(emitData: { isHovering: boolean; id: number }) {

--- a/frontend/src/components/Home/PlatformsSkeleton.vue
+++ b/frontend/src/components/Home/PlatformsSkeleton.vue
@@ -2,15 +2,13 @@
 import Skeleton from "@/components/common/Game/Card/Skeleton.vue";
 import RSection from "@/components/common/RSection.vue";
 import { views } from "@/utils";
+import { useLocalStorage } from "@vueuse/core";
 import { isNull } from "lodash";
 import { ref } from "vue";
 import { useI18n } from "vue-i18n";
 
 const { t } = useI18n();
-const storedPlatforms = localStorage.getItem("settings.gridPlatforms");
-const gridPlatforms = ref(
-  isNull(storedPlatforms) ? false : storedPlatforms === "true",
-);
+const gridPlatforms = useLocalStorage("settings.gridPlatforms", false);
 const PLATFORM_SKELETON_COUNT = 12;
 </script>
 

--- a/frontend/src/components/Home/RecentAdded.vue
+++ b/frontend/src/components/Home/RecentAdded.vue
@@ -3,6 +3,7 @@ import GameCard from "@/components/common/Game/Card/Base.vue";
 import RSection from "@/components/common/RSection.vue";
 import storeRoms from "@/stores/roms";
 import { views } from "@/utils";
+import { useLocalStorage } from "@vueuse/core";
 import { isNull } from "lodash";
 import { storeToRefs } from "pinia";
 import { ref } from "vue";
@@ -11,14 +12,8 @@ import { useI18n } from "vue-i18n";
 const { t } = useI18n();
 const romsStore = storeRoms();
 const { recentRoms } = storeToRefs(romsStore);
-const storedGridRecentRoms = localStorage.getItem("settings.gridRecentRoms");
-const gridRecentRoms = ref(
-  isNull(storedGridRecentRoms) ? false : storedGridRecentRoms === "true",
-);
-const storedEnable3DEffect = localStorage.getItem("settings.enable3DEffect");
-const enable3DEffect = ref(
-  isNull(storedEnable3DEffect) ? false : storedEnable3DEffect === "true",
-);
+const gridRecentRoms = useLocalStorage("settings.gridRecentRoms", false);
+const enable3DEffect = useLocalStorage("settings.enable3DEffect", false);
 const isHovering = ref(false);
 const hoveringRomId = ref();
 const openedMenu = ref(false);
@@ -26,10 +21,6 @@ const openedMenuRomId = ref();
 
 function toggleGridRecentRoms() {
   gridRecentRoms.value = !gridRecentRoms.value;
-  localStorage.setItem(
-    "settings.gridRecentRoms",
-    gridRecentRoms.value.toString(),
-  );
 }
 
 function onHover(emitData: { isHovering: boolean; id: number }) {

--- a/frontend/src/components/Settings/UserInterface/Interface.vue
+++ b/frontend/src/components/Settings/UserInterface/Interface.vue
@@ -2,8 +2,9 @@
 import InterfaceOption from "@/components/Settings/UserInterface/InterfaceOption.vue";
 import RSection from "@/components/common/RSection.vue";
 import storeCollections from "@/stores/collections";
+import { useLocalStorage } from "@vueuse/core";
 import { isNull } from "lodash";
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { useDisplay } from "vuetify";
 
@@ -11,89 +12,40 @@ const { t } = useI18n();
 const { smAndDown } = useDisplay();
 const collectionsStore = storeCollections();
 
-// Initialize refs from localStorage
-
 // Home
-const storedShowStats = localStorage.getItem("settings.showStats");
-const showStatsRef = ref(
-  isNull(storedShowStats) ? true : storedShowStats === "true",
-);
-const storedShowRecentRoms = localStorage.getItem("settings.showRecentRoms");
-const showRecentRomsRef = ref(
-  isNull(storedShowRecentRoms) ? true : storedShowRecentRoms === "true",
-);
-
-const storedShowContinuePlaying = localStorage.getItem(
+const showStatsRef = useLocalStorage("settings.showStats", true);
+const showRecentRomsRef = useLocalStorage("settings.showRecentRoms", true);
+const showContinuePlayingRef = useLocalStorage(
   "settings.showContinuePlaying",
+  true,
 );
-const showContinuePlayingRef = ref(
-  isNull(storedShowContinuePlaying)
-    ? true
-    : storedShowContinuePlaying === "true",
-);
-const storedShowPlatforms = localStorage.getItem("settings.showPlatforms");
-const showPlatformsRef = ref(
-  isNull(storedShowPlatforms) ? true : storedShowPlatforms === "true",
-);
-const storedShowCollections = localStorage.getItem("settings.showCollections");
-const showCollectionsRef = ref(
-  isNull(storedShowCollections) ? true : storedShowCollections === "true",
-);
+const showPlatformsRef = useLocalStorage("settings.showPlatforms", true);
+const showCollectionsRef = useLocalStorage("settings.showCollections", true);
 
 // Virtual collections
-const storedShowVirtualCollections = localStorage.getItem(
+const showVirtualCollectionsRef = useLocalStorage(
   "settings.showVirtualCollections",
+  true,
 );
-const showVirtualCollectionsRef = ref(
-  isNull(storedShowVirtualCollections)
-    ? true
-    : storedShowVirtualCollections === "true",
-);
-const storedVirtualCollectionType = localStorage.getItem(
+const virtualCollectionTypeRef = useLocalStorage(
   "settings.virtualCollectionType",
-);
-const virtualCollectionTypeRef = ref(
-  isNull(storedVirtualCollectionType)
-    ? "collection"
-    : storedVirtualCollectionType,
+  "collection",
 );
 
 // Platforms drawer
-const storedPlatformsGroupBy = localStorage.getItem(
+const platformsGroupByRef = useLocalStorage<string | null>(
   "settings.platformsGroupBy",
-);
-const platformsGroupByRef = ref(
-  isNull(storedPlatformsGroupBy) || storedPlatformsGroupBy === "null"
-    ? null
-    : storedPlatformsGroupBy,
+  null,
 );
 
 // Gallery
-const storedGroupRoms = localStorage.getItem("settings.groupRoms");
-const groupRomsRef = ref(
-  isNull(storedGroupRoms) ? true : storedGroupRoms === "true",
-);
-const storedSiblings = localStorage.getItem("settings.showSiblings");
-const siblingsRef = ref(
-  isNull(storedSiblings) ? true : storedSiblings === "true",
-);
-const storedRegions = localStorage.getItem("settings.showRegions");
-const regionsRef = ref(isNull(storedRegions) ? true : storedRegions === "true");
-const storedLanguages = localStorage.getItem("settings.showLanguages");
-const languagesRef = ref(
-  isNull(storedLanguages) ? true : storedLanguages === "true",
-);
-const storedStatus = localStorage.getItem("settings.showStatus");
-const statusRef = ref(isNull(storedStatus) ? true : storedStatus === "true");
-
-const storedActionBar = localStorage.getItem("settings.showActionBar");
-const actionBarRef = ref(
-  isNull(storedActionBar) ? false : storedActionBar === "true",
-);
-const stored3DEffect = localStorage.getItem("settings.enable3DEffect");
-const enable3DEffectRef = ref(
-  isNull(stored3DEffect) ? false : stored3DEffect === "true",
-);
+const groupRomsRef = useLocalStorage("settings.groupRoms", true);
+const siblingsRef = useLocalStorage("settings.showSiblings", true);
+const regionsRef = useLocalStorage("settings.showRegions", true);
+const languagesRef = useLocalStorage("settings.showLanguages", true);
+const statusRef = useLocalStorage("settings.showStatus", true);
+const actionBarRef = useLocalStorage("settings.showActionBar", false);
+const enable3DEffectRef = useLocalStorage("settings.enable3DEffect", false);
 
 const homeOptions = computed(() => [
   {
@@ -211,72 +163,57 @@ const galleryOptions = computed(() => [
 
 const setPlatformDrawerGroupBy = (value: string) => {
   platformsGroupByRef.value = value;
-  localStorage.setItem("settings.platformsGroupBy", value);
 };
 const toggleShowContinuePlaying = (value: boolean) => {
   showContinuePlayingRef.value = value;
-  localStorage.setItem("settings.showContinuePlaying", value.toString());
 };
 const toggleShowPlatforms = (value: boolean) => {
   showPlatformsRef.value = value;
-  localStorage.setItem("settings.showPlatforms", value.toString());
 };
 const toggleShowCollections = (value: boolean) => {
   showCollectionsRef.value = value;
-  localStorage.setItem("settings.showCollections", value.toString());
 };
 const toggleShowVirtualCollections = (value: boolean) => {
   showVirtualCollectionsRef.value = value;
-  localStorage.setItem("settings.showVirtualCollections", value.toString());
 };
 const setVirtualCollectionType = async (value: string) => {
   virtualCollectionTypeRef.value = value;
-  localStorage.setItem("settings.virtualCollectionType", value);
   collectionsStore.fetchVirtualCollections(value);
 };
 
 const toggleShowStats = (value: boolean) => {
   showStatsRef.value = value;
-  localStorage.setItem("settings.showStats", value.toString());
 };
 
 const toggleShowRecentRoms = (value: boolean) => {
   showRecentRomsRef.value = value;
-  localStorage.setItem("settings.showRecentRoms", value.toString());
 };
 
 const toggleGroupRoms = (value: boolean) => {
   groupRomsRef.value = value;
-  localStorage.setItem("settings.groupRoms", value.toString());
 };
 
 const toggleSiblings = (value: boolean) => {
   siblingsRef.value = value;
-  localStorage.setItem("settings.showSiblings", value.toString());
 };
 
 const toggleRegions = (value: boolean) => {
   regionsRef.value = value;
-  localStorage.setItem("settings.showRegions", value.toString());
 };
 
 const toggleLanguages = (value: boolean) => {
   languagesRef.value = value;
-  localStorage.setItem("settings.showLanguages", value.toString());
 };
 
 const toggleStatus = (value: boolean) => {
   statusRef.value = value;
-  localStorage.setItem("settings.showStatus", value.toString());
 };
 
 const toggleActionBar = (value: boolean) => {
   actionBarRef.value = value;
-  localStorage.setItem("settings.showActionBar", value.toString());
 };
 const toggle3DEffect = (value: boolean) => {
   enable3DEffectRef.value = value;
-  localStorage.setItem("settings.enable3DEffect", value.toString());
 };
 </script>
 <template>

--- a/frontend/src/components/Settings/UserInterface/LanguageSelector.vue
+++ b/frontend/src/components/Settings/UserInterface/LanguageSelector.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
 import languageStore from "@/stores/language";
+import { useLocalStorage } from "@vueuse/core";
 import { storeToRefs } from "pinia";
-import { ref } from "vue";
 import { useI18n } from "vue-i18n";
 
 const { locale } = useI18n();
 const storeLanguage = languageStore();
 const { languages, selectedLanguage } = storeToRefs(storeLanguage);
 
+const localeStorage = useLocalStorage("settings.locale", "");
+
 function changeLanguage() {
   locale.value = selectedLanguage.value.value;
-  localStorage.setItem("settings.locale", selectedLanguage.value.value);
+  localeStorage.value = selectedLanguage.value.value;
 }
 </script>
 <template>

--- a/frontend/src/components/Settings/UserInterface/Theme.vue
+++ b/frontend/src/components/Settings/UserInterface/Theme.vue
@@ -3,14 +3,14 @@ import ThemeOption from "@/components/Settings/UserInterface/ThemeOption.vue";
 import RSection from "@/components/common/RSection.vue";
 import { autoThemeKey, themes } from "@/styles/themes";
 import { isKeyof } from "@/types";
-import { computed, ref } from "vue";
+import { useLocalStorage } from "@vueuse/core";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { useTheme } from "vuetify";
 
 const { t } = useI18n();
 const theme = useTheme();
-const storedTheme = parseInt(localStorage.getItem("settings.theme") ?? "");
-const selectedTheme = ref(isNaN(storedTheme) ? autoThemeKey : storedTheme);
+const selectedTheme = useLocalStorage("settings.theme", autoThemeKey);
 const themeOptions = computed(() => [
   {
     name: "dark",
@@ -27,7 +27,6 @@ const themeOptions = computed(() => [
 ]);
 
 function toggleTheme() {
-  localStorage.setItem("settings.theme", selectedTheme.value.toString());
   const mediaMatch = window.matchMedia("(prefers-color-scheme: dark)");
   if (selectedTheme.value === autoThemeKey) {
     theme.global.name.value = mediaMatch.matches ? "dark" : "light";

--- a/frontend/src/components/common/Game/Card/Base.vue
+++ b/frontend/src/components/common/Game/Card/Base.vue
@@ -15,6 +15,7 @@ import storeRoms from "@/stores/roms";
 import { type SimpleRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import { getMissingCoverImage, getUnmatchedCoverImage } from "@/utils/covers";
+import { useLocalStorage } from "@vueuse/core";
 import { isNull } from "lodash";
 import type { Emitter } from "mitt";
 import VanillaTilt from "vanilla-tilt";
@@ -110,15 +111,8 @@ const fallbackCoverImage = computed(() =>
 );
 const activeMenu = ref(false);
 
-const showActionBarAlways = isNull(
-  localStorage.getItem("settings.showActionBar"),
-)
-  ? false
-  : localStorage.getItem("settings.showActionBar") === "true";
-
-const showSiblings = isNull(localStorage.getItem("settings.showSiblings"))
-  ? true
-  : localStorage.getItem("settings.showSiblings") === "true";
+const showActionBarAlways = useLocalStorage("settings.showActionBar", false);
+const showSiblings = useLocalStorage("settings.showSiblings", true);
 
 const hasNotes = computed(() => {
   if (!romsStore.isSimpleRom(props.rom)) return false;

--- a/frontend/src/components/common/Game/Card/Flags.vue
+++ b/frontend/src/components/common/Game/Card/Flags.vue
@@ -6,19 +6,14 @@ import {
   getEmojiForStatus,
   getTextForStatus,
 } from "@/utils";
+import { useLocalStorage } from "@vueuse/core";
 import { identity, isNull } from "lodash";
 import { computed } from "vue";
 
 const props = defineProps<{ rom: SimpleRom }>();
-const showRegions = isNull(localStorage.getItem("settings.showRegions"))
-  ? true
-  : localStorage.getItem("settings.showRegions") === "true";
-const showLanguages = isNull(localStorage.getItem("settings.showLanguages"))
-  ? true
-  : localStorage.getItem("settings.showLanguages") === "true";
-const showStatus = isNull(localStorage.getItem("settings.showStatus"))
-  ? true
-  : localStorage.getItem("settings.showStatus") === "true";
+const showRegions = useLocalStorage("settings.showRegions", true);
+const showLanguages = useLocalStorage("settings.showLanguages", true);
+const showStatus = useLocalStorage("settings.showStatus", true);
 
 const playingStatus = computed(() => {
   const { now_playing, backlogged, status } = props.rom?.rom_user ?? {};

--- a/frontend/src/components/common/Game/Card/Skeleton.vue
+++ b/frontend/src/components/common/Game/Card/Skeleton.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import storeGalleryView from "@/stores/galleryView";
 import storePlatforms from "@/stores/platforms";
+import { useLocalStorage } from "@vueuse/core";
 import { isNull } from "lodash";
 import { computed } from "vue";
 import { useDisplay } from "vuetify";
@@ -22,11 +23,7 @@ const { smAndDown } = useDisplay();
 const platformsStore = storePlatforms();
 const galleryViewStore = storeGalleryView();
 
-const showActionBarAlways = isNull(
-  localStorage.getItem("settings.showActionBar"),
-)
-  ? false
-  : localStorage.getItem("settings.showActionBar") === "true";
+const showActionBarAlways = useLocalStorage("settings.showActionBar", false);
 
 const showActionBar = computed(() => smAndDown.value || showActionBarAlways);
 

--- a/frontend/src/components/common/Game/Table.vue
+++ b/frontend/src/components/common/Game/Table.vue
@@ -19,6 +19,7 @@ import {
   languageToEmoji,
   regionToEmoji,
 } from "@/utils";
+import { useLocalStorage } from "@vueuse/core";
 import { isNull } from "lodash";
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
@@ -32,9 +33,7 @@ withDefaults(
     showPlatformIcon: false,
   },
 );
-const showSiblings = isNull(localStorage.getItem("settings.showSiblings"))
-  ? true
-  : localStorage.getItem("settings.showSiblings") === "true";
+const showSiblings = useLocalStorage("settings.showSiblings", true);
 const router = useRouter();
 const downloadStore = storeDownload();
 const romsStore = storeRoms();

--- a/frontend/src/components/common/Navigation/CollectionsDrawer.vue
+++ b/frontend/src/components/common/Navigation/CollectionsDrawer.vue
@@ -5,6 +5,7 @@ import CollectionListItem from "@/components/common/Collection/ListItem.vue";
 import storeCollections from "@/stores/collections";
 import storeNavigation from "@/stores/navigation";
 import type { Events } from "@/types/emitter";
+import { useLocalStorage } from "@vueuse/core";
 import { isNull } from "lodash";
 import type { Emitter } from "mitt";
 import { storeToRefs } from "pinia";
@@ -27,11 +28,10 @@ const emitter = inject<Emitter<Events>>("emitter");
 const visibleVirtualCollections = ref(72);
 const tabIndex = computed(() => (activeCollectionsDrawer.value ? 0 : -1));
 
-const showVirtualCollections = isNull(
-  localStorage.getItem("settings.showVirtualCollections"),
-)
-  ? true
-  : localStorage.getItem("settings.showVirtualCollections") === "true";
+const showVirtualCollections = useLocalStorage(
+  "settings.showVirtualCollections",
+  true,
+);
 
 async function addCollection() {
   emitter?.emit("showCreateCollectionDialog", null);

--- a/frontend/src/components/common/Navigation/MainAppBar.vue
+++ b/frontend/src/components/common/Navigation/MainAppBar.vue
@@ -12,6 +12,7 @@ import SettingsDrawer from "@/components/common/Navigation/SettingsDrawer.vue";
 import UploadBtn from "@/components/common/Navigation/UploadBtn.vue";
 import UserBtn from "@/components/common/Navigation/UserBtn.vue";
 import storeNavigation from "@/stores/navigation";
+import { useLocalStorage } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { useDisplay } from "vuetify";
 
@@ -19,12 +20,14 @@ const { smAndDown } = useDisplay();
 const navigationStore = storeNavigation();
 const { mainBarCollapsed } = storeToRefs(navigationStore);
 
+const mainBarCollapsedStorage = useLocalStorage(
+  "settings.mainBarCollapsed",
+  false,
+);
+
 function collapse() {
   mainBarCollapsed.value = !mainBarCollapsed.value;
-  localStorage.setItem(
-    "settings.mainBarCollapsed",
-    mainBarCollapsed.value.toString(),
-  );
+  mainBarCollapsedStorage.value = mainBarCollapsed.value;
 }
 </script>
 <template>

--- a/frontend/src/components/common/Navigation/PlatformsDrawer.vue
+++ b/frontend/src/components/common/Navigation/PlatformsDrawer.vue
@@ -3,34 +3,28 @@ import PlatformListItem from "@/components/common/Platform/ListItem.vue";
 import storeNavigation from "@/stores/navigation";
 import type { Platform } from "@/stores/platforms";
 import storePlatforms from "@/stores/platforms";
+import { useLocalStorage } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { ref, watch, computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { useDisplay } from "vuetify";
 
+type GroupByType = "family_name" | "generation" | "category" | null;
+
 const { t } = useI18n();
 const { mdAndUp, smAndDown } = useDisplay();
-
 const navigationStore = storeNavigation();
 const platformsStore = storePlatforms();
 const { filteredPlatforms, filterText } = storeToRefs(platformsStore);
 const { activePlatformsDrawer } = storeToRefs(navigationStore);
-
-const ALLOWED_GROUP_BY = ["family_name", "generation", "category"] as const;
-type GroupByType = (typeof ALLOWED_GROUP_BY)[number] | null;
-
 const textFieldRef = ref();
 const triggerElement = ref<HTMLElement | null>(null);
 const openPanels = ref<number[]>([]);
 
-const initializeGroupBy = (): GroupByType => {
-  const stored = localStorage.getItem("settings.platformsGroupBy");
-  return stored && ALLOWED_GROUP_BY.includes(stored as any)
-    ? (stored as GroupByType)
-    : null;
-};
-
-const groupBy = ref<GroupByType>(initializeGroupBy());
+const groupBy = useLocalStorage<GroupByType | null>(
+  "settings.platformsGroupBy",
+  null,
+);
 
 const tabIndex = computed(() => (activePlatformsDrawer.value ? 0 : -1));
 

--- a/frontend/src/components/common/NewVersionDialog.vue
+++ b/frontend/src/components/common/NewVersionDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import storeHeartbeat from "@/stores/heartbeat";
+import { useLocalStorage } from "@vueuse/core";
 import semver from "semver";
 import { onMounted, ref } from "vue";
 
@@ -7,9 +8,10 @@ const heartbeat = storeHeartbeat();
 const { VERSION } = heartbeat.value.SYSTEM;
 const GITHUB_VERSION = ref(VERSION);
 const latestVersionDismissed = ref(VERSION === "development");
+const dismissedVersion = useLocalStorage("dismissedVersion", "");
 
 function dismissVersionBanner() {
-  localStorage.setItem("dismissedVersion", GITHUB_VERSION.value);
+  dismissedVersion.value = GITHUB_VERSION.value;
   latestVersionDismissed.value = true;
 }
 
@@ -26,7 +28,7 @@ async function fetchLatestVersion() {
       // Hide if the version is not valid
       !semver.valid(VERSION) ||
       // Hide if the version is the same as the dismissed version
-      json.tag_name === localStorage.getItem("dismissedVersion") ||
+      json.tag_name === dismissedVersion.value ||
       // Hide if the version is less than 2 hours old
       publishedAt.getTime() + 2 * 60 * 60 * 1000 > Date.now();
   } catch (error) {

--- a/frontend/src/console/utils/sfx.ts
+++ b/frontend/src/console/utils/sfx.ts
@@ -1,21 +1,18 @@
 import type { InputAction } from "../input/actions";
+import { useLocalStorage } from "@vueuse/core";
 
-let sfxEnabled = true;
+const sfxEnabled = useLocalStorage("console-sfx-enabled", true);
 
 export function setSfxEnabled(enabled: boolean): void {
-  sfxEnabled = enabled;
-  localStorage.setItem("console-sfx-enabled", enabled ? "true" : "false");
+  sfxEnabled.value = enabled;
 }
 
 export function getSfxEnabled(): boolean {
-  return sfxEnabled;
+  return sfxEnabled.value;
 }
 
 export function initializeSfx(): void {
-  const saved = localStorage.getItem("console-sfx-enabled");
-  if (saved !== null) {
-    sfxEnabled = saved === "true";
-  }
+  // No need to initialize since useLocalStorage handles it automatically
 }
 
 let ctx: AudioContext | null = null;
@@ -130,7 +127,7 @@ function playClick(opts: ClickOpts = {}) {
 }
 
 export function playSfx(kind: SfxType) {
-  if (!sfxEnabled) return;
+  if (!sfxEnabled.value) return;
 
   // Lazy resume (required on some browsers until user gesture)
   ensureCtx()

--- a/frontend/src/layouts/Main.vue
+++ b/frontend/src/layouts/Main.vue
@@ -22,7 +22,7 @@ import storeCollections from "@/stores/collections";
 import storeNavigation from "@/stores/navigation";
 import storePlatforms from "@/stores/platforms";
 import type { Events } from "@/types/emitter";
-import { isNull } from "lodash";
+import { useLocalStorage } from "@vueuse/core";
 import type { Emitter } from "mitt";
 import { inject, onBeforeMount, ref } from "vue";
 
@@ -35,19 +35,13 @@ emitter?.on("refreshDrawer", async () => {
   platformsStore.fetchPlatforms();
 });
 
-const showVirtualCollections = isNull(
-  localStorage.getItem("settings.showVirtualCollections"),
-)
-  ? true
-  : localStorage.getItem("settings.showVirtualCollections") === "true";
-
-const storedVirtualCollectionType = localStorage.getItem(
-  "settings.virtualCollectionType",
+const showVirtualCollections = useLocalStorage(
+  "settings.showVirtualCollections",
+  true,
 );
-const virtualCollectionTypeRef = ref(
-  isNull(storedVirtualCollectionType)
-    ? "collection"
-    : storedVirtualCollectionType,
+const virtualCollectionTypeRef = useLocalStorage(
+  "settings.virtualCollectionType",
+  "collection",
 );
 
 function unhackNavbar() {

--- a/frontend/src/plugins/vuetify.ts
+++ b/frontend/src/plugins/vuetify.ts
@@ -1,6 +1,7 @@
 import { themes, dark, light, autoThemeKey } from "@/styles/themes";
 import { isKeyof } from "@/types";
 import "@mdi/font/css/materialdesignicons.css";
+import { useLocalStorage } from "@vueuse/core";
 import { createVuetify } from "vuetify";
 import "vuetify/styles";
 
@@ -10,14 +11,13 @@ mediaMatch.addEventListener("change", (event) => {
 });
 
 function getTheme() {
-  const storedTheme = parseInt(localStorage.getItem("settings.theme") ?? "");
+  const storedTheme = useLocalStorage("settings.theme", autoThemeKey);
 
   if (
-    !isNaN(storedTheme) &&
-    storedTheme !== autoThemeKey &&
-    isKeyof(storedTheme, themes)
+    storedTheme.value !== autoThemeKey &&
+    isKeyof(storedTheme.value, themes)
   ) {
-    return themes[storedTheme];
+    return themes[storedTheme.value];
   }
 
   return mediaMatch.matches ? "dark" : "light";

--- a/frontend/src/stores/consoleTheme.ts
+++ b/frontend/src/stores/consoleTheme.ts
@@ -1,25 +1,22 @@
 import { resolveAsset, clearAssetCache } from "@/console/utils/assetResolver";
+import { useLocalStorage } from "@vueuse/core";
 import { defineStore } from "pinia";
-import { ref, computed } from "vue";
+import { computed } from "vue";
 
 export const useConsoleTheme = defineStore("consoleTheme", () => {
-  const themeName = ref<string>("default");
+  const themeName = useLocalStorage("console-theme", "default");
   const availableThemes = ["default", "neon"];
 
   function setTheme(newThemeName: string): void {
     clearAssetCache();
 
     themeName.value = newThemeName;
-    localStorage.setItem("console-theme", newThemeName);
 
     updateThemeCSS();
     updateBackgroundCSS();
   }
 
   function initializeTheme(): void {
-    const savedTheme = localStorage.getItem("console-theme") || "default";
-
-    themeName.value = savedTheme;
     updateThemeCSS();
     updateBackgroundCSS();
   }

--- a/frontend/src/stores/galleryView.ts
+++ b/frontend/src/stores/galleryView.ts
@@ -1,7 +1,10 @@
+import { useLocalStorage } from "@vueuse/core";
 import { defineStore } from "pinia";
 
+const currentViewStorage = useLocalStorage("currentView", 0);
+
 const defaultGalleryState = {
-  currentView: JSON.parse(localStorage.getItem("currentView") ?? "0") as number,
+  currentView: currentViewStorage.value,
   defaultAspectRatioCover: 2 / 3,
   defaultAspectRatioCollection: 2 / 3,
   defaultAspectRatioScreenshot: 16 / 9,
@@ -16,7 +19,7 @@ export default defineStore("galleryView", {
   actions: {
     setView(view: number) {
       this.currentView = view;
-      localStorage.setItem("currentView", this.currentView.toString());
+      currentViewStorage.value = view;
     },
     switchActiveFirmwareDrawer() {
       this.activeFirmwareDrawer = !this.activeFirmwareDrawer;

--- a/frontend/src/stores/navigation.ts
+++ b/frontend/src/stores/navigation.ts
@@ -1,6 +1,8 @@
 import { ROUTES } from "@/plugins/router";
-import { isNull } from "lodash";
+import { useLocalStorage } from "@vueuse/core";
 import { defineStore } from "pinia";
+
+const mainBarCollapsed = useLocalStorage("settings.mainBarCollapsed", false);
 
 const defaultNavigationState = {
   activePlatformsDrawer: false,
@@ -8,9 +10,7 @@ const defaultNavigationState = {
   activeSettingsDrawer: false,
   activePlatformInfoDrawer: false,
   activeCollectionInfoDrawer: false,
-  mainBarCollapsed: isNull(localStorage.getItem("settings.mainBarCollapsed"))
-    ? false
-    : localStorage.getItem("settings.mainBarCollapsed") === "true",
+  mainBarCollapsed: mainBarCollapsed.value,
 };
 
 export default defineStore("navigation", {

--- a/frontend/src/stores/roms.ts
+++ b/frontend/src/stores/roms.ts
@@ -9,8 +9,11 @@ import {
 import storeGalleryFilter from "@/stores/galleryFilter";
 import { type Platform } from "@/stores/platforms";
 import type { ExtractPiniaStoreType } from "@/types";
+import { useLocalStorage } from "@vueuse/core";
 import { isNull, isUndefined } from "lodash";
 import { defineStore } from "pinia";
+
+const groupRomsStorage = useLocalStorage("settings.groupRoms", true);
 
 type GalleryFilterStore = ExtractPiniaStoreType<typeof storeGalleryFilter>;
 
@@ -66,9 +69,7 @@ export default defineStore("roms", {
 
   actions: {
     _shouldGroupRoms(): boolean {
-      return isNull(localStorage.getItem("settings.groupRoms"))
-        ? true
-        : localStorage.getItem("settings.groupRoms") === "true";
+      return groupRomsStorage.value;
     },
     setCurrentPlatform(platform: Platform | null) {
       this.currentPlatform = platform;

--- a/frontend/src/views/Gallery/Collection/BaseCollection.vue
+++ b/frontend/src/views/Gallery/Collection/BaseCollection.vue
@@ -13,11 +13,12 @@ import storeGalleryView from "@/stores/galleryView";
 import storeRoms, { type SimpleRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import { views } from "@/utils";
-import { isNull, throttle } from "lodash";
+import { useLocalStorage } from "@vueuse/core";
+import { throttle } from "lodash";
 import type { Emitter } from "mitt";
 import { storeToRefs } from "pinia";
 import { inject, onBeforeUnmount, onMounted, ref, watch } from "vue";
-import { onBeforeRouteUpdate, useRoute, useRouter } from "vue-router";
+import { onBeforeRouteUpdate, useRoute } from "vue-router";
 
 const props = defineProps<{
   collections: CollectionType[];
@@ -38,16 +39,12 @@ const {
   fetchTotalRoms,
 } = storeToRefs(romsStore);
 const noCollectionError = ref(false);
-const router = useRouter();
 const emitter = inject<Emitter<Events>>("emitter");
 const isHovering = ref(false);
 const hoveringRomId = ref();
 const openedMenu = ref(false);
 const openedMenuRomId = ref();
-const storedEnable3DEffect = localStorage.getItem("settings.enable3DEffect");
-const enable3DEffect = ref(
-  isNull(storedEnable3DEffect) ? false : storedEnable3DEffect === "true",
-);
+const enable3DEffect = useLocalStorage("settings.enable3DEffect", false);
 let timeout: ReturnType<typeof setTimeout>;
 
 async function fetchRoms() {

--- a/frontend/src/views/Gallery/Platform.vue
+++ b/frontend/src/views/Gallery/Platform.vue
@@ -13,6 +13,7 @@ import storePlatforms from "@/stores/platforms";
 import storeRoms, { type SimpleRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import { views } from "@/utils";
+import { useLocalStorage } from "@vueuse/core";
 import { isNull, throttle } from "lodash";
 import type { Emitter } from "mitt";
 import { storeToRefs } from "pinia";
@@ -41,10 +42,7 @@ const isHovering = ref(false);
 const hoveringRomId = ref();
 const openedMenu = ref(false);
 const openedMenuRomId = ref();
-const storedEnable3DEffect = localStorage.getItem("settings.enable3DEffect");
-const enable3DEffect = ref(
-  isNull(storedEnable3DEffect) ? false : storedEnable3DEffect === "true",
-);
+const enable3DEffect = useLocalStorage("settings.enable3DEffect", false);
 let timeout: ReturnType<typeof setTimeout>;
 
 async function fetchRoms() {

--- a/frontend/src/views/Gallery/Search.vue
+++ b/frontend/src/views/Gallery/Search.vue
@@ -12,6 +12,7 @@ import storeGalleryView from "@/stores/galleryView";
 import storeRoms, { type SimpleRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import { views } from "@/utils";
+import { useLocalStorage } from "@vueuse/core";
 import { isNull, throttle } from "lodash";
 import type { Emitter } from "mitt";
 import { storeToRefs } from "pinia";
@@ -36,10 +37,7 @@ const isHovering = ref(false);
 const hoveringRomId = ref();
 const openedMenu = ref(false);
 const openedMenuRomId = ref();
-const storedEnable3DEffect = localStorage.getItem("settings.enable3DEffect");
-const enable3DEffect = ref(
-  isNull(storedEnable3DEffect) ? false : storedEnable3DEffect === "true",
-);
+const enable3DEffect = useLocalStorage("settings.enable3DEffect", false);
 let timeout: ReturnType<typeof setTimeout>;
 
 function onHover(emitData: { isHovering: boolean; id: number }) {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -10,6 +10,7 @@ import Stats from "@/components/Home/Stats.vue";
 import storeCollections from "@/stores/collections";
 import storePlatforms from "@/stores/platforms";
 import storeRoms from "@/stores/roms";
+import { useLocalStorage } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { onBeforeMount, ref, computed } from "vue";
 import { useI18n } from "vue-i18n";
@@ -29,18 +30,22 @@ const {
   fetchingVirtualCollections,
 } = storeToRefs(collectionsStore);
 
-function getSettingValue(key: string, defaultValue: boolean = true): boolean {
-  const stored = localStorage.getItem(`settings.${key}`);
-  return stored === null ? defaultValue : stored === "true";
-}
-
-const showStats = getSettingValue("showStats");
-const showRecentRoms = getSettingValue("showRecentRoms");
-const showContinuePlaying = getSettingValue("showContinuePlaying");
-const showPlatforms = getSettingValue("showPlatforms");
-const showCollections = getSettingValue("showCollections");
-const showVirtualCollections = getSettingValue("showVirtualCollections");
-const showSmartCollections = getSettingValue("showSmartCollections");
+const showStats = useLocalStorage("settings.showStats", true);
+const showRecentRoms = useLocalStorage("settings.showRecentRoms", true);
+const showContinuePlaying = useLocalStorage(
+  "settings.showContinuePlaying",
+  true,
+);
+const showPlatforms = useLocalStorage("settings.showPlatforms", true);
+const showCollections = useLocalStorage("settings.showCollections", true);
+const showVirtualCollections = useLocalStorage(
+  "settings.showVirtualCollections",
+  true,
+);
+const showSmartCollections = useLocalStorage(
+  "settings.showSmartCollections",
+  true,
+);
 
 const fetchingRecentAdded = ref(false);
 const fetchingContinuePlaying = ref(false);

--- a/frontend/src/views/Player/EmulatorJS/Base.vue
+++ b/frontend/src/views/Player/EmulatorJS/Base.vue
@@ -14,6 +14,7 @@ import { formatTimestamp, getSupportedEJSCores } from "@/utils";
 import { getEmptyCoverImage } from "@/utils/covers";
 import CacheDialog from "@/views/Player/EmulatorJS/CacheDialog.vue";
 import Player from "@/views/Player/EmulatorJS/Player.vue";
+import { useLocalStorage } from "@vueuse/core";
 import { formatDistanceToNow } from "date-fns";
 import { isNull } from "lodash";
 import { storeToRefs } from "pinia";
@@ -42,8 +43,7 @@ const selectedCore = ref<string | null>(null);
 const selectedDisc = ref<number | null>(null);
 const supportedCores = ref<string[]>([]);
 const gameRunning = ref(false);
-const storedFSOP = localStorage.getItem("fullScreenOnPlay");
-const fullScreenOnPlay = ref(isNull(storedFSOP) ? true : storedFSOP === "true");
+const fullScreenOnPlay = useLocalStorage("fullScreenOnPlay", true);
 
 function onPlay() {
   if (rom.value && auth.scopes.includes("roms.user.write")) {
@@ -90,7 +90,6 @@ function onPlay() {
 
 function onFullScreenChange() {
   fullScreenOnPlay.value = !fullScreenOnPlay.value;
-  localStorage.setItem("fullScreenOnPlay", fullScreenOnPlay.value.toString());
 }
 
 async function onlyQuit() {

--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -19,6 +19,7 @@ import {
   getControlSchemeForPlatform,
   getDownloadPath,
 } from "@/utils";
+import { useLocalStorage } from "@vueuse/core";
 import type { Emitter } from "mitt";
 import { storeToRefs } from "pinia";
 import { inject, onBeforeUnmount, onMounted, ref } from "vue";

--- a/frontend/src/views/Player/RuffleRS/Base.vue
+++ b/frontend/src/views/Player/RuffleRS/Base.vue
@@ -4,7 +4,7 @@ import { ROUTES } from "@/plugins/router";
 import romApi from "@/services/api/rom";
 import type { DetailedRom } from "@/stores/roms";
 import { getDownloadPath } from "@/utils";
-import { isNull } from "lodash";
+import { useLocalStorage } from "@vueuse/core";
 import { nextTick, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
@@ -16,8 +16,7 @@ const { t } = useI18n();
 const route = useRoute();
 const rom = ref<DetailedRom | null>(null);
 const gameRunning = ref(false);
-const storedFSOP = localStorage.getItem("fullScreenOnPlay");
-const fullScreenOnPlay = ref(isNull(storedFSOP) ? true : storedFSOP === "true");
+const fullScreenOnPlay = useLocalStorage("fullScreenOnPlay", true);
 const backgroundColor = ref(DEFAULT_BACKGROUND_COLOR);
 
 declare global {
@@ -57,7 +56,6 @@ function onPlay() {
 
 function onFullScreenChange() {
   fullScreenOnPlay.value = !fullScreenOnPlay.value;
-  localStorage.setItem("fullScreenOnPlay", fullScreenOnPlay.value.toString());
 }
 
 function onBackgroundColorChange() {


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

`useLocalStorage` is reactive and accepts a default value, which makes it an ideal replacement for most usage of `window.localStorage`.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes