### PR TITLE
feat: Make EmulatorJS threads always available

### DIFF
--- a/frontend/src/components/common/Game/PlayBtn.vue
+++ b/frontend/src/components/common/Game/PlayBtn.vue
@@ -31,18 +31,21 @@ const isEmulationSupported = computed(() => {
   );
 });
 
-function goToPlayer(rom: SimpleRom) {
+async function goToPlayer(rom: SimpleRom) {
   if (
     isEJSEmulationSupported(rom.platform_slug, heartbeat.value, config.value)
   ) {
-    router.push({
+    await router.push({
       name: ROUTES.EMULATORJS,
       params: { rom: rom.id },
     });
+    // Force full reload to retrieve COEP/COOP headers from nginx, needed to enable multi-threading
+    // in EmulatorJS.
+    router.go(0);
   } else if (
     isRuffleEmulationSupported(rom.platform_slug, heartbeat.value, config.value)
   ) {
-    router.push({
+    await router.push({
       name: ROUTES.RUFFLE,
       params: { rom: rom.id },
     });

--- a/frontend/src/console/views/Play.vue
+++ b/frontend/src/console/views/Play.vue
@@ -659,6 +659,7 @@ onBeforeUnmount(() => {
 });
 
 onUnmounted(() => {
+  // Force full reload to reset COEP/COOP, so cross-origin isolation is turned off.
   window.location.reload();
 });
 </script>

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -336,7 +336,7 @@ export function languageToEmoji(language: string) {
 /**
  * Map of supported EJS cores for each platform.
  */
-const _EJS_CORES_MAP = {
+const _EJS_CORES_MAP: Record<string, string[]> = {
   "3do": ["opera"],
   acpc: ["cap32", "crocods"],
   amiga: ["puae"],
@@ -430,12 +430,7 @@ export type EJSPlatformSlug = keyof typeof _EJS_CORES_MAP;
  * @returns An array of supported cores.
  */
 export function getSupportedEJSCores(platformSlug: string): string[] {
-  const cores =
-    _EJS_CORES_MAP[platformSlug.toLowerCase() as EJSPlatformSlug] || [];
-  const threadsSupported = isEJSThreadsSupported();
-  return cores.filter(
-    (core) => !areThreadsRequiredForEJSCore(core) || threadsSupported,
-  );
+  return _EJS_CORES_MAP[platformSlug.toLowerCase() as EJSPlatformSlug] || [];
 }
 
 /**
@@ -471,18 +466,6 @@ export function isEJSEmulationSupported(
   return (
     getSupportedEJSCores(slug).length > 0 && gl instanceof WebGLRenderingContext
   );
-}
-
-/**
- * Check if EJS threads are supported.
- *
- * EmulatorJS threads are supported if SharedArrayBuffer is available.
- * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer
- *
- * @returns True if supported, false otherwise.
- */
-export function isEJSThreadsSupported(): boolean {
-  return typeof SharedArrayBuffer !== "undefined";
 }
 
 // This is a workaround to set the control scheme for Sega systems using the same cores

--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -369,6 +369,7 @@ window.EJS_onGameStart = async () => {
 };
 
 onUnmounted(() => {
+  // Force full reload to reset COEP/COOP, so cross-origin isolation is turned off.
   window.location.reload();
 });
 </script>


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Reload page before and after using EmulatorJS to ensure proper COEP/COOP headers are applied. This is needed to enable multi-threading in EmulatorJS, by allowing it to use `SharedArrayBuffer`.

**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes