### PR TITLE
[HOTFIX] getEjsControls should return null if no controls for core or default

### DIFF
--- a/frontend/src/console/views/Play.vue
+++ b/frontend/src/console/views/Play.vue
@@ -416,7 +416,8 @@ async function boot() {
     rewindEnabled: "enabled",
     ...coreOptions,
   };
-  window.EJS_defaultControls = configStore.getEJSControls(core);
+  const ejsControls = configStore.getEJSControls(core);
+  if (ejsControls) window.EJS_defaultControls = ejsControls;
   window.EJS_language = selectedLanguage.value.value.replace("_", "-");
   window.EJS_disableAutoLang = true;
   window.EJS_DEBUG_XX = configStore.config.EJS_DEBUG;

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -84,10 +84,10 @@ export default defineStore("config", {
       if (!core) {
         if (!defaultControls) return null;
         return {
-          0: defaultControls["_0"],
-          1: defaultControls["_1"],
-          2: defaultControls["_2"],
-          3: defaultControls["_3"],
+          0: defaultControls["_0"] || {},
+          1: defaultControls["_1"] || {},
+          2: defaultControls["_2"] || {},
+          3: defaultControls["_3"] || {},
         };
       }
 
@@ -95,29 +95,29 @@ export default defineStore("config", {
       if (!coreControls) return null;
       if (!defaultControls) {
         return {
-          0: coreControls["_0"],
-          1: coreControls["_1"],
-          2: coreControls["_2"],
-          3: coreControls["_3"],
+          0: coreControls["_0"] || {},
+          1: coreControls["_1"] || {},
+          2: coreControls["_2"] || {},
+          3: coreControls["_3"] || {},
         };
       }
 
       return {
         0: {
-          ...defaultControls["_0"],
-          ...coreControls["_0"],
+          ...(defaultControls["_0"] || {}),
+          ...(coreControls["_0"] || {}),
         },
         1: {
-          ...defaultControls["_1"],
-          ...coreControls["_1"],
+          ...(defaultControls["_1"] || {}),
+          ...(coreControls["_1"] || {}),
         },
         2: {
-          ...defaultControls["_2"],
-          ...coreControls["_2"],
+          ...(defaultControls["_2"] || {}),
+          ...(coreControls["_2"] || {}),
         },
         3: {
-          ...defaultControls["_3"],
-          ...coreControls["_3"],
+          ...(defaultControls["_3"] || {}),
+          ...(coreControls["_3"] || {}),
         },
       };
     },

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -79,31 +79,45 @@ export default defineStore("config", {
     },
     getEJSControls(
       core: string | null,
-    ): Record<number, Record<number, EjsControlsButton>> {
-      const defaultControls = {
-        0: this.config.EJS_CONTROLS["default"]?.["_0"] || {},
-        1: this.config.EJS_CONTROLS["default"]?.["_1"] || {},
-        2: this.config.EJS_CONTROLS["default"]?.["_2"] || {},
-        3: this.config.EJS_CONTROLS["default"]?.["_3"] || {},
-      };
-      if (!core) return defaultControls;
+    ): Record<number, Record<number, EjsControlsButton>> | null {
+      const defaultControls = this.config.EJS_CONTROLS["default"];
+      if (!core) {
+        if (!defaultControls) return null;
+        return {
+          0: defaultControls["_0"],
+          1: defaultControls["_1"],
+          2: defaultControls["_2"],
+          3: defaultControls["_3"],
+        };
+      }
+
+      const coreControls = this.config.EJS_CONTROLS[core];
+      if (!coreControls) return null;
+      if (!defaultControls) {
+        return {
+          0: coreControls["_0"],
+          1: coreControls["_1"],
+          2: coreControls["_2"],
+          3: coreControls["_3"],
+        };
+      }
 
       return {
         0: {
-          ...defaultControls[0],
-          ...(this.config.EJS_CONTROLS[core]?.["_0"] || {}),
+          ...defaultControls["_0"],
+          ...coreControls["_0"],
         },
         1: {
-          ...defaultControls[1],
-          ...(this.config.EJS_CONTROLS[core]?.["_1"] || {}),
+          ...defaultControls["_1"],
+          ...coreControls["_1"],
         },
         2: {
-          ...defaultControls[2],
-          ...(this.config.EJS_CONTROLS[core]?.["_2"] || {}),
+          ...defaultControls["_2"],
+          ...coreControls["_2"],
         },
         3: {
-          ...defaultControls[3],
-          ...(this.config.EJS_CONTROLS[core]?.["_3"] || {}),
+          ...defaultControls["_3"],
+          ...coreControls["_3"],
         },
       };
     },

--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -125,7 +125,8 @@ window.EJS_defaultOptions = {
   rewindEnabled: "enabled",
   ...coreOptions,
 };
-window.EJS_defaultControls = configStore.getEJSControls(props.core);
+const ejsControls = configStore.getEJSControls(props.core);
+if (ejsControls) window.EJS_defaultControls = ejsControls;
 // Set a valid game name
 window.EJS_gameName = romRef.value.fs_name_no_tags
   .replace(INVALID_CHARS_REGEX, "")


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

This should stop us wiping the emulatorjs control values (will need to clear localstorage)

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes