### PR TITLE
fix: Correctly mock async response.json() in unit tests

### DIFF
--- a/backend/tests/adapters/services/test_mobygames.py
+++ b/backend/tests/adapters/services/test_mobygames.py
@@ -86,10 +86,10 @@ class TestMobyGamesServiceUnit:
     async def test_request_success(self, service):
         """Test successful API request."""
         mock_session = AsyncMock()
-        mock_response = AsyncMock()
-        mock_response.json.return_value = {
-            "games": [{"game_id": 1, "title": "Test Game"}]
-        }
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(
+            return_value={"games": [{"game_id": 1, "title": "Test Game"}]},
+        )
         mock_response.raise_for_status.return_value = None
         mock_session.get.return_value = mock_response
 
@@ -125,8 +125,8 @@ class TestMobyGamesServiceUnit:
     async def test_request_timeout_with_retry(self, service):
         """Test request timeout with successful retry."""
         mock_session = AsyncMock()
-        mock_response = AsyncMock()
-        mock_response.json.return_value = {"games": []}
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(return_value={"games": []})
         mock_response.raise_for_status.return_value = None
 
         # First call times out, second succeeds
@@ -167,8 +167,8 @@ class TestMobyGamesServiceUnit:
     async def test_request_rate_limit_with_retry(self, service):
         """Test rate limit handling with retry."""
         mock_session = AsyncMock()
-        mock_response = AsyncMock()
-        mock_response.json.return_value = {"games": []}
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(return_value={"games": []})
         mock_response.raise_for_status.return_value = None
 
         # First call hits rate limit, second succeeds
@@ -195,7 +195,7 @@ class TestMobyGamesServiceUnit:
     async def test_request_json_decode_error(self, service):
         """Test handling of JSON decode error."""
         mock_session = AsyncMock()
-        mock_response = AsyncMock()
+        mock_response = MagicMock()
         mock_response.raise_for_status.return_value = None
         mock_response.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
         mock_session.get.return_value = mock_response
@@ -622,8 +622,8 @@ class TestMobyGamesServicePerformance:
 
         # Simulate timeout on first call, success on retry
         timeout_error = aiohttp.ServerTimeoutError("Request timeout")
-        success_response = AsyncMock()
-        success_response.json.return_value = {"games": []}
+        success_response = MagicMock()
+        success_response.json = AsyncMock(return_value={"games": []})
         success_response.raise_for_status.return_value = None
 
         mock_session.get.side_effect = [timeout_error, success_response]
@@ -717,8 +717,8 @@ class TestMobyGamesServiceEdgeCases:
     async def test_request_with_custom_timeout(self, service):
         """Test request with custom timeout."""
         mock_session = AsyncMock()
-        mock_response = AsyncMock()
-        mock_response.json.return_value = {"games": []}
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(return_value={"games": []})
         mock_response.raise_for_status.return_value = None
         mock_session.get.return_value = mock_response
 

--- a/backend/tests/adapters/services/test_screenscraper.py
+++ b/backend/tests/adapters/services/test_screenscraper.py
@@ -125,9 +125,13 @@ class TestScreenScraperServiceUnit:
     async def test_request_success(self, service):
         """Test successful API request."""
         mock_session = AsyncMock()
-        mock_response = AsyncMock()
-        mock_response.json.return_value = {"response": {"jeu": {"id": "1", "noms": []}}}
-        mock_response.text.return_value = '{"response": {"jeu": {"id": "1"}}}'
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(
+            return_value={"response": {"jeu": {"id": "1", "noms": []}}}
+        )
+        mock_response.text = AsyncMock(
+            return_value='{"response": {"jeu": {"id": "1"}}}'
+        )
         mock_response.raise_for_status.return_value = None
         mock_session.get.return_value = mock_response
 
@@ -148,8 +152,10 @@ class TestScreenScraperServiceUnit:
     async def test_request_login_error(self, service):
         """Test request with login error in response text."""
         mock_session = AsyncMock()
-        mock_response = AsyncMock()
-        mock_response.text.return_value = "Erreur de login: invalid credentials"
+        mock_response = MagicMock()
+        mock_response.text = AsyncMock(
+            return_value="Erreur de login: invalid credentials"
+        )
         mock_response.raise_for_status.return_value = None
         mock_session.get.return_value = mock_response
 
@@ -184,9 +190,9 @@ class TestScreenScraperServiceUnit:
     async def test_request_timeout_with_retry(self, service):
         """Test request timeout with successful retry."""
         mock_session = AsyncMock()
-        mock_response = AsyncMock()
-        mock_response.json.return_value = {"response": {"jeu": {}}}
-        mock_response.text.return_value = '{"response": {"jeu": {}}}'
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(return_value={"response": {"jeu": {}}})
+        mock_response.text = AsyncMock(return_value='{"response": {"jeu": {}}}')
         mock_response.raise_for_status.return_value = None
 
         # First call times out, second succeeds
@@ -257,8 +263,8 @@ class TestScreenScraperServiceUnit:
     async def test_request_json_decode_error(self, service):
         """Test handling of JSON decode error."""
         mock_session = AsyncMock()
-        mock_response = AsyncMock()
-        mock_response.text.return_value = "Valid response text"
+        mock_response = MagicMock()
+        mock_response.text = AsyncMock(return_value="Valid response text")
         mock_response.raise_for_status.return_value = None
         mock_response.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
         mock_session.get.return_value = mock_response
@@ -725,9 +731,9 @@ class TestScreenScraperServicePerformance:
 
         # Simulate timeout on first call, success on retry
         timeout_error = aiohttp.ServerTimeoutError("Request timeout")
-        success_response = AsyncMock()
-        success_response.json.return_value = {"response": {"jeu": {}}}
-        success_response.text.return_value = '{"response": {"jeu": {}}}'
+        success_response = MagicMock()
+        success_response.json = AsyncMock(return_value={"response": {"jeu": {}}})
+        success_response.text = AsyncMock(return_value='{"response": {"jeu": {}}}')
         success_response.raise_for_status.return_value = None
 
         mock_session.get.side_effect = [timeout_error, success_response]
@@ -831,9 +837,9 @@ class TestScreenScraperServiceEdgeCases:
     async def test_request_with_custom_timeout(self, service):
         """Test request with custom timeout."""
         mock_session = AsyncMock()
-        mock_response = AsyncMock()
-        mock_response.json.return_value = {"response": {}}
-        mock_response.text.return_value = '{"response": {}}'
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(return_value={"response": {}})
+        mock_response.text = AsyncMock(return_value='{"response": {}}')
         mock_response.raise_for_status.return_value = None
         mock_session.get.return_value = mock_response
 
@@ -857,8 +863,8 @@ class TestScreenScraperServiceEdgeCases:
 
         # First call times out, second call has login error
         timeout_error = aiohttp.ServerTimeoutError("Timeout")
-        login_error_response = AsyncMock()
-        login_error_response.text.return_value = "Erreur de login detected"
+        login_error_response = MagicMock()
+        login_error_response.text = AsyncMock(return_value="Erreur de login detected")
         login_error_response.raise_for_status.return_value = None
 
         mock_session.get.side_effect = [timeout_error, login_error_response]

--- a/backend/tests/adapters/services/test_steamgriddb.py
+++ b/backend/tests/adapters/services/test_steamgriddb.py
@@ -84,8 +84,10 @@ class TestSteamGridDBServiceUnit:
     async def test_request_success(self, service):
         """Test successful API request."""
         mock_session = AsyncMock()
-        mock_response = AsyncMock()
-        mock_response.json.return_value = {"data": [{"id": 1, "name": "Test Game"}]}
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(
+            return_value={"data": [{"id": 1, "name": "Test Game"}]}
+        )
         mock_response.raise_for_status.return_value = None
         mock_session.get.return_value = mock_response
 
@@ -146,7 +148,7 @@ class TestSteamGridDBServiceUnit:
     async def test_request_json_decode_error(self, service):
         """Test handling of JSON decode error."""
         mock_session = AsyncMock()
-        mock_response = AsyncMock()
+        mock_response = MagicMock()
         mock_response.raise_for_status.return_value = None
         mock_response.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
         mock_session.get.return_value = mock_response
@@ -804,8 +806,8 @@ class TestSteamGridDBServiceEdgeCases:
     async def test_request_with_custom_timeout(self, service):
         """Test request with custom timeout."""
         mock_session = AsyncMock()
-        mock_response = AsyncMock()
-        mock_response.json.return_value = {"data": []}
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(return_value={"data": []})
         mock_response.raise_for_status.return_value = None
         mock_session.get.return_value = mock_response
 

--- a/backend/tests/utils/test_cache.py
+++ b/backend/tests/utils/test_cache.py
@@ -50,7 +50,11 @@ class TestConditionallySetCache:
         """Test skipping load when cache already exists and file hash matches."""
         fake_md5_hash = "d41d8cd98f00b204e9800998ecf8427e"
         mocker.patch(
-            "hashlib.md5", return_value=AsyncMock(hexdigest=lambda: fake_md5_hash)
+            "hashlib.md5",
+            return_value=AsyncMock(
+                hexdigest=lambda: fake_md5_hash,
+                update=lambda x: None,
+            ),
         )
         mock_cache_exists = mocker.patch.object(
             AsyncRedis, "exists", side_effect=AsyncMock(return_value=True)


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Fixes warnings triggered by unawaited coroutines in test cases.

- Before: `552 passed, 1 skipped, 78 warnings`
- After: `552 passed, 1 skipped, 61 warnings`

**Checklist**
- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes