### PR TITLE
[ROMM-2336] Config entry for EJS_CacheLimit

### DIFF
--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -59,6 +59,7 @@ class Config:
     FIRMWARE_FOLDER_NAME: str
     HIGH_PRIO_STRUCTURE_PATH: str
     EJS_DEBUG: bool
+    EJS_CACHE_LIMIT: int | None
     EJS_SETTINGS: dict[str, EjsOption]  # core_name -> EjsOption
     EJS_CONTROLS: dict[str, EjsControls]  # core_name -> EjsControls
 
@@ -169,6 +170,9 @@ class ConfigManager:
                 self._raw_config, "filesystem.firmware_folder", "bios"
             ),
             EJS_DEBUG=pydash.get(self._raw_config, "emulatorjs.debug", False),
+            EJS_CACHE_LIMIT=pydash.get(
+                self._raw_config, "emulatorjs.cache_limit", None
+            ),
             EJS_SETTINGS=pydash.get(self._raw_config, "emulatorjs.settings", {}),
             EJS_CONTROLS=self._get_ejs_controls(),
         )
@@ -271,6 +275,14 @@ class ConfigManager:
 
         if not isinstance(self.config.EJS_DEBUG, bool):
             log.critical("Invalid config.yml: emulatorjs.debug must be a boolean")
+            sys.exit(3)
+
+        if self.config.EJS_CACHE_LIMIT is not None and not isinstance(
+            self.config.EJS_CACHE_LIMIT, int
+        ):
+            log.critical(
+                "Invalid config.yml: emulatorjs.cache_limit must be an integer"
+            )
             sys.exit(3)
 
         if not isinstance(self.config.EJS_SETTINGS, dict):

--- a/backend/endpoints/configs.py
+++ b/backend/endpoints/configs.py
@@ -37,6 +37,7 @@ def get_config() -> ConfigResponse:
             PLATFORMS_BINDING=cfg.PLATFORMS_BINDING,
             PLATFORMS_VERSIONS=cfg.PLATFORMS_VERSIONS,
             EJS_DEBUG=cfg.EJS_DEBUG,
+            EJS_CACHE_LIMIT=cfg.EJS_CACHE_LIMIT,
             EJS_CONTROLS=cfg.EJS_CONTROLS,
             EJS_SETTINGS=cfg.EJS_SETTINGS,
         )

--- a/backend/endpoints/responses/config.py
+++ b/backend/endpoints/responses/config.py
@@ -13,5 +13,6 @@ class ConfigResponse(TypedDict):
     PLATFORMS_BINDING: dict[str, str]
     PLATFORMS_VERSIONS: dict[str, str]
     EJS_DEBUG: bool
+    EJS_CACHE_LIMIT: int | None
     EJS_SETTINGS: dict[str, dict[str, str]]
     EJS_CONTROLS: dict[str, EjsControls]

--- a/backend/tests/config/fixtures/config/config.yml
+++ b/backend/tests/config/fixtures/config/config.yml
@@ -32,6 +32,7 @@ filesystem:
 
 emulatorjs:
   debug: true
+  cache_limit: 1000
   settings:
     parallel_n64:
       vsync: disable

--- a/backend/tests/config/test_config_loader.py
+++ b/backend/tests/config/test_config_loader.py
@@ -53,6 +53,6 @@ def test_empty_config_loader():
     assert loader.config.ROMS_FOLDER_NAME == "roms"
     assert loader.config.FIRMWARE_FOLDER_NAME == "bios"
     assert not loader.config.EJS_DEBUG
-    assert not loader.config.EJS_CACHE_LIMIT
+    assert loader.config.EJS_CACHE_LIMIT is None
     assert loader.config.EJS_SETTINGS == {}
     assert loader.config.EJS_CONTROLS == {}

--- a/backend/tests/config/test_config_loader.py
+++ b/backend/tests/config/test_config_loader.py
@@ -20,6 +20,7 @@ def test_config_loader():
     assert loader.config.ROMS_FOLDER_NAME == "ROMS"
     assert loader.config.FIRMWARE_FOLDER_NAME == "BIOS"
     assert loader.config.EJS_DEBUG
+    assert loader.config.EJS_CACHE_LIMIT == 1000
     assert loader.config.EJS_SETTINGS == {
         "parallel_n64": {"vsync": "disable"},
         "snes9x": {"snes9x_region": "ntsc"},
@@ -52,5 +53,6 @@ def test_empty_config_loader():
     assert loader.config.ROMS_FOLDER_NAME == "roms"
     assert loader.config.FIRMWARE_FOLDER_NAME == "bios"
     assert not loader.config.EJS_DEBUG
+    assert not loader.config.EJS_CACHE_LIMIT
     assert loader.config.EJS_SETTINGS == {}
     assert loader.config.EJS_CONTROLS == {}

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -50,6 +50,7 @@ filesystem: {} # { roms_folder: 'roms' } For example if your folder structure is
 # EmulatorJS per-core options
 emulatorjs:
   # debug: true # Available options will be logged to the browser console
+  # cache_limit: 100000000 # Cache limit per ROM (in bytes)
   settings:
     parallel_n64: # Use the exact core name
     #   vsync: disable

--- a/frontend/src/__generated__/models/ConfigResponse.ts
+++ b/frontend/src/__generated__/models/ConfigResponse.ts
@@ -13,6 +13,7 @@ export type ConfigResponse = {
     PLATFORMS_BINDING: Record<string, string>;
     PLATFORMS_VERSIONS: Record<string, string>;
     EJS_DEBUG: boolean;
+    EJS_CACHE_LIMIT: (number | null);
     EJS_SETTINGS: Record<string, Record<string, string>>;
     EJS_CONTROLS: Record<string, EjsControls>;
 };

--- a/frontend/src/components/common/Navigation/ConsoleModeBtn.vue
+++ b/frontend/src/components/common/Navigation/ConsoleModeBtn.vue
@@ -55,7 +55,7 @@ function enterConsoleMode() {
           class="text-caption text-center"
           :class="{ 'text-primary': route.path.startsWith('/console') }"
         >
-          Play
+          Console
         </span>
       </v-expand-transition>
     </div>

--- a/frontend/src/console/views/Play.vue
+++ b/frontend/src/console/views/Play.vue
@@ -420,7 +420,10 @@ async function boot() {
   if (ejsControls) window.EJS_defaultControls = ejsControls;
   window.EJS_language = selectedLanguage.value.value.replace("_", "-");
   window.EJS_disableAutoLang = true;
-  window.EJS_DEBUG_XX = configStore.config.EJS_DEBUG;
+
+  const { EJS_DEBUG, EJS_CACHE_LIMIT } = configStore.config;
+  if (EJS_CACHE_LIMIT) window.EJS_CacheLimit = EJS_CACHE_LIMIT;
+  window.EJS_DEBUG_XX = EJS_DEBUG;
 
   // Set a valid game name (affects per-game settings keys)
   window.EJS_gameName = rom.fs_name_no_tags

--- a/frontend/src/console/views/Play.vue
+++ b/frontend/src/console/views/Play.vue
@@ -422,7 +422,7 @@ async function boot() {
   window.EJS_disableAutoLang = true;
 
   const { EJS_DEBUG, EJS_CACHE_LIMIT } = configStore.config;
-  if (EJS_CACHE_LIMIT) window.EJS_CacheLimit = EJS_CACHE_LIMIT;
+  if (EJS_CACHE_LIMIT !== null) window.EJS_CacheLimit = EJS_CACHE_LIMIT;
   window.EJS_DEBUG_XX = EJS_DEBUG;
 
   // Set a valid game name (affects per-game settings keys)

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -21,7 +21,7 @@ const defaultConfig = {
   PLATFORMS_BINDING: {},
   PLATFORMS_VERSIONS: {},
   EJS_DEBUG: false,
-  EJS_CACHE_LIMIT: 1073741824,
+  EJS_CACHE_LIMIT: null,
   EJS_SETTINGS: {},
   EJS_CONTROLS: {},
 } as ConfigResponse;

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -21,6 +21,7 @@ const defaultConfig = {
   PLATFORMS_BINDING: {},
   PLATFORMS_VERSIONS: {},
   EJS_DEBUG: false,
+  EJS_CACHE_LIMIT: 1073741824,
   EJS_SETTINGS: {},
   EJS_CONTROLS: {},
 } as ConfigResponse;

--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -139,7 +139,7 @@ window.EJS_language = selectedLanguage.value.value.replace("_", "-");
 window.EJS_disableAutoLang = true;
 
 const { EJS_DEBUG, EJS_CACHE_LIMIT } = configStore.config;
-if (EJS_CACHE_LIMIT) window.EJS_CacheLimit = EJS_CACHE_LIMIT;
+if (EJS_CACHE_LIMIT !== null) window.EJS_CacheLimit = EJS_CACHE_LIMIT;
 window.EJS_DEBUG_XX = EJS_DEBUG;
 
 onMounted(() => {

--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -80,6 +80,7 @@ declare global {
     EJS_language: string;
     EJS_disableAutoLang: boolean;
     EJS_DEBUG_XX: boolean;
+    EJS_CacheLimit: number;
     EJS_Buttons: Record<string, boolean>;
     EJS_VirtualGamepadSettings: {};
     EJS_onGameStart: () => void;
@@ -136,7 +137,10 @@ window.EJS_gameName = romRef.value.fs_name_no_tags
   .trim();
 window.EJS_language = selectedLanguage.value.value.replace("_", "-");
 window.EJS_disableAutoLang = true;
-window.EJS_DEBUG_XX = configStore.config.EJS_DEBUG;
+
+const { EJS_DEBUG, EJS_CACHE_LIMIT } = configStore.config;
+if (EJS_CACHE_LIMIT) window.EJS_CacheLimit = EJS_CACHE_LIMIT;
+window.EJS_DEBUG_XX = EJS_DEBUG;
 
 onMounted(() => {
   window.scrollTo(0, 0);


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

This PR sets `EJS_CacheLimit`, the cache limit per-game, in bytes (default value is 1GB).

Fixes #2336 

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
