### PR TITLE
Fix documentation link in docker-compose example

### DIFF
--- a/examples/docker-compose.example.yml
+++ b/examples/docker-compose.example.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - romm_resources:/romm/resources # Resources fetched from IGDB (covers, screenshots, etc.)
       - romm_redis_data:/redis-data # Cached data for background tasks
-      - /path/to/library:/romm/library # Your game library. Check https://github.com/rommapp/romm?tab=readme-ov-file#folder-structure for more details.
+      - /path/to/library:/romm/library # Your game library. Check https://docs.romm.app/latest/Getting-Started/Folder-Structure/ for more details.
       - /path/to/assets:/romm/assets # Uploaded saves, states, etc.
       - /path/to/config:/romm/config # Path where config.yml is stored
     ports:


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Updated documentation link for game library path. The current one seem to be outdated

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally - n/a
- [ ] I've updated relevant comments - n/a
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes - n/a

#### Screenshots
