### PR TITLE
fix: Remove mod_zip workaround for upstream subrequests to internal locations

### DIFF
--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -542,7 +542,7 @@ async def get_rom_content(
             filename=f.file_name_for_download(rom, hidden_folder),
         )
 
-    content_lines = [await create_zip_content(f, "/library-zip") for f in files]
+    content_lines = [await create_zip_content(f, "/library") for f in files]
 
     if not rom.has_m3u_file():
         m3u_encoded_content = "\n".join(

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -115,7 +115,7 @@ ARG NGINX_VERSION
 # The specified commit SHA is the latest commit on the `master` branch at the time of writing.
 # It includes a fix to correctly calculate CRC-32 checksums when using upstream subrequests.
 # TODO: Move to a tagged release of `mod_zip`, once a version newer than 1.3.0 is released.
-ARG NGINX_MOD_ZIP_SHA=8e65b82c82c7890f67a6107271c127e9881b6313
+ARG NGINX_MOD_ZIP_SHA=a9f9afa441117831cc712a832c98408b3f0416f6
 
 # Clone both nginx and `ngx_http_zip_module` repositories, needed to compile the module from source.
 # This is needed to be able to dinamically load it as a module in the final image. `nginx` Docker

--- a/docker/nginx/templates/default.conf.template
+++ b/docker/nginx/templates/default.conf.template
@@ -70,34 +70,9 @@ server {
         alias "${ROMM_BASE_PATH}/library/";
     }
 
-    # This location, and the related server at port 8081, are used to serve files when
-    # using the `mod_zip` module. This is because the `mod_zip` module does not support
-    # calculating CRC-32 values when using subrequests pointing directly to internal
-    # locations that access the filesystem.
-    # TODO: If that gets fixed, this workaround can be removed, and the `/library` location
-    # can be used directly (also removing the server at port 8081).
-    # Related issue: https://github.com/evanmiller/mod_zip/issues/90
-    location /library-zip {
-        internal;
-        rewrite ^/library-zip/(.*)$ /library/$1 break;
-        proxy_pass http://localhost:8081;
-        # Proxy buffering must be disabled, for the module to correctly calculate CRC-32 values.
-        proxy_buffering off;
-    }
-
     # Internal decoding endpoint, used to decode base64 encoded data
     location /decode {
         internal;
         js_content decode.decodeBase64;
-    }
-}
-
-server {
-    listen 8081;
-    listen [::]:8081;
-    server_name localhost;
-
-    location /library/ {
-        alias "${ROMM_BASE_PATH}/library/";
     }
 }


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Related `mod_zip` issue https://github.com/evanmiller/mod_zip/issues/90 has been fixed in commit https://github.com/evanmiller/mod_zip/commit/288d66541c25516a6cee5c9fb42af5f834f7ba28

By upgrading `mod_zip` to include this fix, we can remove the workaround that involved using a separate internal location and server to serve files for zipping.

**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes