### PR TITLE
[ROMM-2416] Use python timezone aware datetime as defaults for created_at/updated_at

### DIFF
--- a/backend/models/base.py
+++ b/backend/models/base.py
@@ -1,6 +1,6 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
-from sqlalchemy import TIMESTAMP, func
+from sqlalchemy import TIMESTAMP
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 FILE_NAME_MAX_LENGTH = 450
@@ -10,8 +10,10 @@ FILE_EXTENSION_MAX_LENGTH = 100
 
 class BaseModel(DeclarativeBase):
     created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
+        TIMESTAMP(timezone=True), default=lambda: datetime.now(timezone.utc)
     )
     updated_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now()
+        TIMESTAMP(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
     )

--- a/backend/models/base.py
+++ b/backend/models/base.py
@@ -8,12 +8,16 @@ FILE_PATH_MAX_LENGTH = 1000
 FILE_EXTENSION_MAX_LENGTH = 100
 
 
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
 class BaseModel(DeclarativeBase):
     created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), default=lambda: datetime.now(timezone.utc)
+        TIMESTAMP(timezone=True), default=utc_now
     )
     updated_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True),
-        default=lambda: datetime.now(timezone.utc),
-        onupdate=lambda: datetime.now(timezone.utc),
+        default=utc_now,
+        onupdate=utc_now,
     )

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -162,7 +162,7 @@ export function formatTimestamp(timestamp: string | null) {
   if (!timestamp) return "-";
 
   const date = new Date(timestamp);
-  return date.toLocaleString("en-GB");
+  return date.toLocaleString("en-US");
 }
 
 /**


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #2416 

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes