### PR TITLE
[ROMM-2438] Add metadata sources admin page

### DIFF
--- a/backend/adapters/services/mobygames.py
+++ b/backend/adapters/services/mobygames.py
@@ -106,6 +106,19 @@ class MobyGamesService:
             log.error("Error decoding JSON response from ScreenScraper: %s", exc)
             return {}
 
+    async def list_groups(self, limit: int | None = None) -> list[dict]:
+        """Retrieve a list of groups.
+
+        Reference: https://www.mobygames.com/info/api/#groups
+        """
+        params: dict[str, list[str]] = {}
+        if limit is not None:
+            params["limit"] = [str(limit)]
+
+        url = self.url.joinpath("groups").with_query(**params)
+        response = await self._request(str(url))
+        return response.get("groups", [])
+
     @overload
     async def list_games(
         self,

--- a/backend/adapters/services/retroachievements.py
+++ b/backend/adapters/services/retroachievements.py
@@ -111,6 +111,15 @@ class RetroAchievementsService:
             log.error("Error decoding JSON response from ScreenScraper: %s", exc)
             return {}
 
+    async def get_achievement_of_the_week(self) -> dict:
+        """Retrieve the achievement of the week.
+
+        Reference: https://api-docs.retroachievements.org/v1/get-achievement-of-the-week.html
+        """
+        url = self.url.joinpath("API_GetAchievementOfTheWeek.php")
+        response = await self._request(str(url))
+        return response
+
     async def get_game_extended_details(self, game_id: int) -> RAGameExtendedDetails:
         """Retrieve extended metadata about a game, targeted via its unique ID.
 

--- a/backend/adapters/services/screenscraper.py
+++ b/backend/adapters/services/screenscraper.py
@@ -129,6 +129,14 @@ class ScreenScraperService:
             log.error("Error decoding JSON response from ScreenScraper: %s", exc)
             return {}
 
+    async def get_infra_info(self) -> dict:
+        """Retrieve information about the infrastructure.
+
+        Reference: https://api.screenscraper.fr/webapi2.php#infraInfos
+        """
+        url = self.url.joinpath("ssinfraInfos.php")
+        return await self._request(str(url))
+
     async def get_game_info(
         self,
         *,

--- a/backend/adapters/services/steamgriddb.py
+++ b/backend/adapters/services/steamgriddb.py
@@ -186,7 +186,7 @@ class SteamGridDBService:
 
         Reference: https://www.steamgriddb.com/api/v2#tag/GAMES/operation/getGameById
         """
-        url = self.url.joinpath("games", str(game_id))
+        url = self.url.joinpath("games/id", str(game_id))
         response = await self._request(str(url))
         if not response or "data" not in response:
             return None

--- a/backend/endpoints/heartbeat.py
+++ b/backend/endpoints/heartbeat.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from config import (
     DISABLE_EMULATOR_JS,
     DISABLE_RUFFLE_RS,
@@ -47,6 +49,13 @@ async def heartbeat() -> HeartbeatResponse:
         HeartbeatReturn: TypedDict structure with all the defined values in the HeartbeatReturn class.
     """
 
+    # Run async operations in parallel
+    igdb_heartbeat, flashpoint_heartbeat, fs_platforms = await asyncio.gather(
+        meta_igdb_handler.heartbeat(),
+        meta_flashpoint_handler.heartbeat(),
+        fs_platform_handler.get_platforms(),
+    )
+
     return {
         "SYSTEM": {
             "VERSION": get_version(),
@@ -65,6 +74,7 @@ async def heartbeat() -> HeartbeatResponse:
                 or meta_hltb_handler.is_enabled()
             ),
             "IGDB_API_ENABLED": meta_igdb_handler.is_enabled(),
+            "IGDB_API_HEARTBEAT": igdb_heartbeat,
             "SS_API_ENABLED": meta_ss_handler.is_enabled(),
             "MOBY_API_ENABLED": meta_moby_handler.is_enabled(),
             "STEAMGRIDDB_API_ENABLED": meta_sgdb_handler.is_enabled(),
@@ -74,10 +84,11 @@ async def heartbeat() -> HeartbeatResponse:
             "PLAYMATCH_API_ENABLED": meta_playmatch_handler.is_enabled(),
             "TGDB_API_ENABLED": meta_tgdb_handler.is_enabled(),
             "FLASHPOINT_API_ENABLED": meta_flashpoint_handler.is_enabled(),
+            "FLASHPOINT_API_HEARTBEAT": flashpoint_heartbeat,
             "HLTB_API_ENABLED": meta_hltb_handler.is_enabled(),
         },
         "FILESYSTEM": {
-            "FS_PLATFORMS": await fs_platform_handler.get_platforms(),
+            "FS_PLATFORMS": fs_platforms,
         },
         "EMULATION": {
             "DISABLE_EMULATOR_JS": DISABLE_EMULATOR_JS,

--- a/backend/endpoints/heartbeat.py
+++ b/backend/endpoints/heartbeat.py
@@ -119,11 +119,11 @@ async def heartbeat() -> HeartbeatResponse:
     }
 
 
-@router.get("/heartbeat/metadata")
-async def metadata_heartbeat(metadata_source: str) -> bool:
+@router.get("/heartbeat/metadata/{source}")
+async def metadata_heartbeat(source: str) -> bool:
     """Endpoint to return the heartbeat of the metadata sources"""
     try:
-        metadata_source = MetadataSource(metadata_source)
+        metadata_source = MetadataSource(source)
     except ValueError as e:
         raise HTTPException(status_code=400, detail="Invalid metadata source") from e
 

--- a/backend/endpoints/responses/heartbeat.py
+++ b/backend/endpoints/responses/heartbeat.py
@@ -9,6 +9,7 @@ class SystemDict(TypedDict):
 class MetadataSourcesDict(TypedDict):
     ANY_SOURCE_ENABLED: bool
     IGDB_API_ENABLED: bool
+    IGDB_API_HEARTBEAT: bool
     MOBY_API_ENABLED: bool
     SS_API_ENABLED: bool
     STEAMGRIDDB_API_ENABLED: bool
@@ -18,6 +19,7 @@ class MetadataSourcesDict(TypedDict):
     HASHEOUS_API_ENABLED: bool
     TGDB_API_ENABLED: bool
     FLASHPOINT_API_ENABLED: bool
+    FLASHPOINT_API_HEARTBEAT: bool
     HLTB_API_ENABLED: bool
 
 

--- a/backend/endpoints/responses/heartbeat.py
+++ b/backend/endpoints/responses/heartbeat.py
@@ -9,17 +9,15 @@ class SystemDict(TypedDict):
 class MetadataSourcesDict(TypedDict):
     ANY_SOURCE_ENABLED: bool
     IGDB_API_ENABLED: bool
-    IGDB_API_HEARTBEAT: bool
-    MOBY_API_ENABLED: bool
     SS_API_ENABLED: bool
+    MOBY_API_ENABLED: bool
     STEAMGRIDDB_API_ENABLED: bool
     RA_API_ENABLED: bool
     LAUNCHBOX_API_ENABLED: bool
-    PLAYMATCH_API_ENABLED: bool
     HASHEOUS_API_ENABLED: bool
+    PLAYMATCH_API_ENABLED: bool
     TGDB_API_ENABLED: bool
     FLASHPOINT_API_ENABLED: bool
-    FLASHPOINT_API_HEARTBEAT: bool
     HLTB_API_ENABLED: bool
 
 

--- a/backend/handler/metadata/flashpoint_handler.py
+++ b/backend/handler/metadata/flashpoint_handler.py
@@ -152,7 +152,6 @@ class FlashpointHandler(MetadataHandler):
         if not self.is_enabled():
             return False
 
-        # make a request to the Flashpoint API to check if the API is working
         try:
             response = await self._request(self.platforms_url, {})
         except Exception as e:

--- a/backend/handler/metadata/flashpoint_handler.py
+++ b/backend/handler/metadata/flashpoint_handler.py
@@ -97,6 +97,7 @@ class FlashpointHandler(MetadataHandler):
 
     def __init__(self) -> None:
         self.base_url = "https://db-api.unstable.life"
+        self.platforms_url = f"{self.base_url}/platforms"
         self.search_url = f"{self.base_url}/search"
         self.min_similarity_score: Final = 0.75
 
@@ -120,21 +121,19 @@ class FlashpointHandler(MetadataHandler):
             for key, value in query.items()
             if value is not None and value != ""  # drop None and ""
         }
-
-        url_with_query = yarl.URL(url).update_query(**filtered_query)
+        if filtered_query:
+            url = str(yarl.URL(url).update_query(**filtered_query))
 
         log.debug(
             "Flashpoint API request: URL=%s, Timeout=%s",
-            url_with_query,
+            url,
             60,
         )
 
         headers = {"user-agent": f"RomM/{get_version()}"}
 
         try:
-            res = await httpx_client.get(
-                str(url_with_query), headers=headers, timeout=60
-            )
+            res = await httpx_client.get(url, headers=headers, timeout=60)
             res.raise_for_status()
             return res.json()
         except (httpx.HTTPStatusError, httpx.ConnectError, httpx.ReadTimeout) as exc:
@@ -148,6 +147,14 @@ class FlashpointHandler(MetadataHandler):
         except json.JSONDecodeError as exc:
             log.error("Error decoding JSON response from Flashpoint API: %s", exc)
             return {}
+
+    async def heartbeat(self) -> bool:
+        if not self.is_enabled():
+            return False
+
+        # make a request to the Flashpoint API to check if the API is working
+        response = await self._request(self.platforms_url, {})
+        return bool(response)
 
     async def search_games(self, search_term: str) -> list[FlashpointGame]:
         """

--- a/backend/handler/metadata/flashpoint_handler.py
+++ b/backend/handler/metadata/flashpoint_handler.py
@@ -153,7 +153,12 @@ class FlashpointHandler(MetadataHandler):
             return False
 
         # make a request to the Flashpoint API to check if the API is working
-        response = await self._request(self.platforms_url, {})
+        try:
+            response = await self._request(self.platforms_url, {})
+        except Exception as e:
+            log.error("Error checking Flashpoint API: %s", e)
+            return False
+
         return bool(response)
 
     async def search_games(self, search_term: str) -> list[FlashpointGame]:

--- a/backend/handler/metadata/hasheous_handler.py
+++ b/backend/handler/metadata/hasheous_handler.py
@@ -129,6 +129,21 @@ class HasheousHandler(MetadataHandler):
         """Return whether this metadata handler is enabled."""
         return HASHEOUS_API_ENABLED
 
+    async def heartbeat(self) -> bool:
+        return True
+
+    #     if not self.is_enabled():
+    #         return False
+
+    #     # make a request to the Hasheous API to check if the API is working
+    #     try:
+    #         response = await self._request(self.platform_endpoint, "GET")
+    #     except Exception as e:
+    #         log.error("Error checking Hasheous API: %s", e)
+    #         return False
+
+    #     return bool(response)
+
     async def _request(
         self,
         url: str,

--- a/backend/handler/metadata/hasheous_handler.py
+++ b/backend/handler/metadata/hasheous_handler.py
@@ -183,7 +183,6 @@ class HasheousHandler(MetadataHandler):
             if method == "POST":
                 request_kwargs["json"] = data
 
-            # Make the request
             res = await httpx_client.request(method, **request_kwargs)
             res.raise_for_status()
             return res.json()

--- a/backend/handler/metadata/hltb_handler.py
+++ b/backend/handler/metadata/hltb_handler.py
@@ -178,6 +178,23 @@ class HowLongToBeatHandler(MetadataHandler):
     def is_enabled(cls) -> bool:
         return HLTB_API_ENABLED
 
+    async def heartbeat(self) -> bool:
+        return True
+
+    #     if not self.is_enabled():
+    #         return False
+
+    #     # make a request to the HLTB API to check if the API is working
+    #     try:
+    #         async with ctx_httpx_client() as client:
+    #             response = await client.get(self.search_url, params={"q": "test"})
+    #             response.raise_for_status()
+    #     except Exception as e:
+    #         log.error("Error checking HLTB API: %s", e)
+    #         return False
+
+    #     return True
+
     @staticmethod
     def extract_hltb_id_from_filename(fs_name: str) -> int | None:
         """Extract HLTB ID from filename tag like (hltb-12345)."""

--- a/backend/handler/metadata/hltb_handler.py
+++ b/backend/handler/metadata/hltb_handler.py
@@ -171,6 +171,7 @@ class HowLongToBeatHandler(MetadataHandler):
 
     def __init__(self) -> None:
         self.base_url = "https://howlongtobeat.com"
+        self.user_endpoint = f"{self.base_url}/api/user"
         self.search_url = f"{self.base_url}/api/seek/28b235595e8e894c"
         self.min_similarity_score: Final = 0.85
 
@@ -179,21 +180,18 @@ class HowLongToBeatHandler(MetadataHandler):
         return HLTB_API_ENABLED
 
     async def heartbeat(self) -> bool:
+        if not self.is_enabled():
+            return False
+
+        httpx_client = ctx_httpx_client.get()
+        try:
+            response = await httpx_client.get(self.user_endpoint)
+            response.raise_for_status()
+        except Exception as e:
+            log.error("Error checking HLTB API: %s", e)
+            return False
+
         return True
-
-    #     if not self.is_enabled():
-    #         return False
-
-    #     # make a request to the HLTB API to check if the API is working
-    #     try:
-    #         async with ctx_httpx_client() as client:
-    #             response = await client.get(self.search_url, params={"q": "test"})
-    #             response.raise_for_status()
-    #     except Exception as e:
-    #         log.error("Error checking HLTB API: %s", e)
-    #         return False
-
-    #     return True
 
     @staticmethod
     def extract_hltb_id_from_filename(fs_name: str) -> int | None:

--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -314,10 +314,14 @@ class IGDBHandler(MetadataHandler):
             return False
 
         # make a request to the IGDB API to check if the API is working
-        roms = await self.igdb_service.list_games(
-            fields=["id"],
-            limit=1,
-        )
+        try:
+            roms = await self.igdb_service.list_games(
+                fields=["id"],
+                limit=1,
+            )
+        except Exception as e:
+            log.error("Error checking IGDB API: %s", e)
+            return False
 
         return bool(roms)
 

--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -313,7 +313,6 @@ class IGDBHandler(MetadataHandler):
         if not self.is_enabled():
             return False
 
-        # make a request to the IGDB API to check if the API is working
         try:
             roms = await self.igdb_service.list_games(
                 fields=["id"],

--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -309,6 +309,18 @@ class IGDBHandler(MetadataHandler):
 
         return None
 
+    async def heartbeat(self) -> bool:
+        if not self.is_enabled():
+            return False
+
+        # make a request to the IGDB API to check if the API is working
+        roms = await self.igdb_service.list_games(
+            fields=["id"],
+            limit=1,
+        )
+
+        return bool(roms)
+
     def get_platform(self, slug: str) -> IGDBPlatform:
         if slug in IGDB_PLATFORM_LIST:
             platform = IGDB_PLATFORM_LIST[UPS(slug)]

--- a/backend/handler/metadata/launchbox_handler.py
+++ b/backend/handler/metadata/launchbox_handler.py
@@ -127,6 +127,9 @@ class LaunchboxHandler(MetadataHandler):
     def is_enabled(cls) -> bool:
         return LAUNCHBOX_API_ENABLED
 
+    async def heartbeat(self) -> bool:
+        return self.is_enabled()
+
     @staticmethod
     def extract_launchbox_id_from_filename(fs_name: str) -> int | None:
         """Extract LaunchBox ID from filename tag like (launchbox-12345)."""

--- a/backend/handler/metadata/moby_handler.py
+++ b/backend/handler/metadata/moby_handler.py
@@ -82,6 +82,18 @@ class MobyGamesHandler(MetadataHandler):
     def is_enabled(cls) -> bool:
         return bool(MOBYGAMES_API_KEY)
 
+    async def heartbeat(self) -> bool:
+        if not self.is_enabled():
+            return False
+
+        try:
+            response = await self.moby_service.list_groups(limit=1)
+        except Exception as e:
+            log.error("Error checking MobyGames API: %s", e)
+            return False
+
+        return bool(response)
+
     @staticmethod
     def extract_mobygames_id_from_filename(fs_name: str) -> int | None:
         """Extract MobyGames ID from filename tag like (moby-12345)."""

--- a/backend/handler/metadata/playmatch_handler.py
+++ b/backend/handler/metadata/playmatch_handler.py
@@ -48,25 +48,23 @@ class PlaymatchHandler(MetadataHandler):
     def __init__(self):
         self.base_url = "https://playmatch.retrorealm.dev/api"
         self.identify_url = f"{self.base_url}/identify/ids"
+        self.healthcheck_url = f"{self.base_url}/health"
 
     @classmethod
     def is_enabled(cls) -> bool:
         return PLAYMATCH_API_ENABLED
 
     async def heartbeat(self) -> bool:
-        return True
+        if not self.is_enabled():
+            return False
 
-    #     if not self.is_enabled():
-    #         return False
+        try:
+            response = await self._request(self.healthcheck_url, {})
+        except Exception as e:
+            log.error("Error checking Playmatch API: %s", e)
+            return False
 
-    #     # make a request to the Playmatch API to check if the API is working
-    #     try:
-    #         response = await self._request(self.identify_url, {"hashes": ["test"]})
-    #     except Exception as e:
-    #         log.error("Error checking Playmatch API: %s", e)
-    #         return False
-
-    #     return bool(response)
+        return bool(response)
 
     async def _request(self, url: str, query: dict) -> dict:
         """

--- a/backend/handler/metadata/playmatch_handler.py
+++ b/backend/handler/metadata/playmatch_handler.py
@@ -53,6 +53,21 @@ class PlaymatchHandler(MetadataHandler):
     def is_enabled(cls) -> bool:
         return PLAYMATCH_API_ENABLED
 
+    async def heartbeat(self) -> bool:
+        return True
+
+    #     if not self.is_enabled():
+    #         return False
+
+    #     # make a request to the Playmatch API to check if the API is working
+    #     try:
+    #         response = await self._request(self.identify_url, {"hashes": ["test"]})
+    #     except Exception as e:
+    #         log.error("Error checking Playmatch API: %s", e)
+    #         return False
+
+    #     return bool(response)
+
     async def _request(self, url: str, query: dict) -> dict:
         """
         Sends a Request to Playmatch API.

--- a/backend/handler/metadata/ra_handler.py
+++ b/backend/handler/metadata/ra_handler.py
@@ -132,6 +132,21 @@ class RAHandler(MetadataHandler):
     def is_enabled(cls) -> bool:
         return bool(RETROACHIEVEMENTS_API_KEY)
 
+    async def heartbeat(self) -> bool:
+        return True
+
+    #     if not self.is_enabled():
+    #         return False
+
+    #     # make a request to the RetroAchievements API to check if the API is working
+    #     try:
+    #         response = await self.ra_service.get_console_ids()
+    #     except Exception as e:
+    #         log.error("Error checking RetroAchievements API: %s", e)
+    #         return False
+
+    #     return bool(response)
+
     @staticmethod
     def extract_ra_id_from_filename(fs_name: str) -> int | None:
         """Extract RetroAchievements ID from filename tag like (ra-12345)."""

--- a/backend/handler/metadata/ra_handler.py
+++ b/backend/handler/metadata/ra_handler.py
@@ -133,19 +133,16 @@ class RAHandler(MetadataHandler):
         return bool(RETROACHIEVEMENTS_API_KEY)
 
     async def heartbeat(self) -> bool:
-        return True
+        if not self.is_enabled():
+            return False
 
-    #     if not self.is_enabled():
-    #         return False
+        try:
+            response = await self.ra_service.get_achievement_of_the_week()
+        except Exception as e:
+            log.error("Error checking RetroAchievements API: %s", e)
+            return False
 
-    #     # make a request to the RetroAchievements API to check if the API is working
-    #     try:
-    #         response = await self.ra_service.get_console_ids()
-    #     except Exception as e:
-    #         log.error("Error checking RetroAchievements API: %s", e)
-    #         return False
-
-    #     return bool(response)
+        return bool(response)
 
     @staticmethod
     def extract_ra_id_from_filename(fs_name: str) -> int | None:

--- a/backend/handler/metadata/sgdb_handler.py
+++ b/backend/handler/metadata/sgdb_handler.py
@@ -34,6 +34,21 @@ class SGDBBaseHandler(MetadataHandler):
     def is_enabled(cls) -> bool:
         return bool(STEAMGRIDDB_API_KEY)
 
+    async def heartbeat(self) -> bool:
+        return True
+
+    #     if not self.is_enabled():
+    #         return False
+
+    #     # make a request to the SteamGridDB API to check if the API is working
+    #     try:
+    #         response = await self.sgdb_service.get_platforms()
+    #     except Exception as e:
+    #         log.error("Error checking SteamGridDB API: %s", e)
+    #         return False
+
+    #     return bool(response)
+
     async def get_rom_by_id(self, sgdb_id: int) -> SGDBRom:
         """Get ROM details by SteamGridDB ID."""
         if not self.is_enabled():

--- a/backend/handler/metadata/sgdb_handler.py
+++ b/backend/handler/metadata/sgdb_handler.py
@@ -35,19 +35,16 @@ class SGDBBaseHandler(MetadataHandler):
         return bool(STEAMGRIDDB_API_KEY)
 
     async def heartbeat(self) -> bool:
-        return True
+        if not self.is_enabled():
+            return False
 
-    #     if not self.is_enabled():
-    #         return False
+        try:
+            response = await self.sgdb_service.get_game_by_id(1)
+        except Exception as e:
+            log.error("Error checking SteamGridDB API: %s", e)
+            return False
 
-    #     # make a request to the SteamGridDB API to check if the API is working
-    #     try:
-    #         response = await self.sgdb_service.get_platforms()
-    #     except Exception as e:
-    #         log.error("Error checking SteamGridDB API: %s", e)
-    #         return False
-
-    #     return bool(response)
+        return bool(response)
 
     async def get_rom_by_id(self, sgdb_id: int) -> SGDBRom:
         """Get ROM details by SteamGridDB ID."""

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -282,6 +282,18 @@ class SSHandler(MetadataHandler):
     def is_enabled(cls) -> bool:
         return bool(SCREENSCRAPER_USER and SCREENSCRAPER_PASSWORD)
 
+    async def heartbeat(self) -> bool:
+        if not self.is_enabled():
+            return False
+
+        try:
+            response = await self.ss_service.get_infra_info()
+        except Exception as e:
+            log.error("Error checking ScreenScraper API: %s", e)
+            return False
+
+        return bool(response.get("response", {}))
+
     @staticmethod
     def extract_ss_id_from_filename(fs_name: str) -> int | None:
         """Extract ScreenScraper ID from filename tag like (ss-12345)."""

--- a/backend/handler/metadata/tgdb_handler.py
+++ b/backend/handler/metadata/tgdb_handler.py
@@ -28,6 +28,9 @@ class TGDBHandler(MetadataHandler):
     def is_enabled(cls) -> bool:
         return TGDB_API_ENABLED
 
+    async def heartbeat(self) -> bool:
+        return self.is_enabled()
+
     def get_platform(self, slug: str) -> TGDBPlatform:
         if slug not in TGDB_PLATFORM_LIST:
             return TGDBPlatform(tgdb_id=None, slug=slug)

--- a/backend/tests/endpoints/test_heartbeat.py
+++ b/backend/tests/endpoints/test_heartbeat.py
@@ -27,6 +27,7 @@ def test_heartbeat(client):
     metadata = heartbeat["METADATA_SOURCES"]
     assert isinstance(metadata["ANY_SOURCE_ENABLED"], bool)
     assert isinstance(metadata["IGDB_API_ENABLED"], bool)
+    assert isinstance(metadata["IGDB_API_HEARTBEAT"], bool)
     assert isinstance(metadata["MOBY_API_ENABLED"], bool)
     assert isinstance(metadata["SS_API_ENABLED"], bool)
     assert isinstance(metadata["STEAMGRIDDB_API_ENABLED"], bool)
@@ -36,6 +37,7 @@ def test_heartbeat(client):
     assert isinstance(metadata["HASHEOUS_API_ENABLED"], bool)
     assert isinstance(metadata["TGDB_API_ENABLED"], bool)
     assert isinstance(metadata["FLASHPOINT_API_ENABLED"], bool)
+    assert isinstance(metadata["FLASHPOINT_API_HEARTBEAT"], bool)
 
     assert "FILESYSTEM" in heartbeat
     filesystem = heartbeat["FILESYSTEM"]

--- a/backend/tests/endpoints/test_heartbeat.py
+++ b/backend/tests/endpoints/test_heartbeat.py
@@ -55,3 +55,16 @@ def test_heartbeat(client):
     oidc = heartbeat["OIDC"]
     assert isinstance(oidc["ENABLED"], bool)
     assert isinstance(oidc["PROVIDER"], str)
+
+
+def test_heartbeat_metadata(client):
+    response = client.get("/api/heartbeat/metadata/flashpoint")
+    assert response.status_code == status.HTTP_200_OK
+
+    heartbeat = response.json()
+    assert heartbeat
+
+
+def test_heartbeat_metadata_unknown_source(client):
+    response = client.get("/api/heartbeat/metadata/unknown")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/backend/tests/endpoints/test_heartbeat.py
+++ b/backend/tests/endpoints/test_heartbeat.py
@@ -58,7 +58,7 @@ def test_heartbeat(client):
 
 
 def test_heartbeat_metadata(client):
-    response = client.get("/api/heartbeat/metadata/flashpoint")
+    response = client.get("/api/heartbeat/metadata/lb")
     assert response.status_code == status.HTTP_200_OK
 
     heartbeat = response.json()

--- a/backend/tests/endpoints/test_heartbeat.py
+++ b/backend/tests/endpoints/test_heartbeat.py
@@ -27,7 +27,6 @@ def test_heartbeat(client):
     metadata = heartbeat["METADATA_SOURCES"]
     assert isinstance(metadata["ANY_SOURCE_ENABLED"], bool)
     assert isinstance(metadata["IGDB_API_ENABLED"], bool)
-    assert isinstance(metadata["IGDB_API_HEARTBEAT"], bool)
     assert isinstance(metadata["MOBY_API_ENABLED"], bool)
     assert isinstance(metadata["SS_API_ENABLED"], bool)
     assert isinstance(metadata["STEAMGRIDDB_API_ENABLED"], bool)
@@ -37,7 +36,6 @@ def test_heartbeat(client):
     assert isinstance(metadata["HASHEOUS_API_ENABLED"], bool)
     assert isinstance(metadata["TGDB_API_ENABLED"], bool)
     assert isinstance(metadata["FLASHPOINT_API_ENABLED"], bool)
-    assert isinstance(metadata["FLASHPOINT_API_HEARTBEAT"], bool)
 
     assert "FILESYSTEM" in heartbeat
     filesystem = heartbeat["FILESYSTEM"]

--- a/frontend/src/__generated__/models/MetadataSourcesDict.ts
+++ b/frontend/src/__generated__/models/MetadataSourcesDict.ts
@@ -5,13 +5,13 @@
 export type MetadataSourcesDict = {
     ANY_SOURCE_ENABLED: boolean;
     IGDB_API_ENABLED: boolean;
-    MOBY_API_ENABLED: boolean;
     SS_API_ENABLED: boolean;
+    MOBY_API_ENABLED: boolean;
     STEAMGRIDDB_API_ENABLED: boolean;
     RA_API_ENABLED: boolean;
     LAUNCHBOX_API_ENABLED: boolean;
-    PLAYMATCH_API_ENABLED: boolean;
     HASHEOUS_API_ENABLED: boolean;
+    PLAYMATCH_API_ENABLED: boolean;
     TGDB_API_ENABLED: boolean;
     FLASHPOINT_API_ENABLED: boolean;
     HLTB_API_ENABLED: boolean;

--- a/frontend/src/__generated__/models/MetadataSourcesDict.ts
+++ b/frontend/src/__generated__/models/MetadataSourcesDict.ts
@@ -5,7 +5,6 @@
 export type MetadataSourcesDict = {
     ANY_SOURCE_ENABLED: boolean;
     IGDB_API_ENABLED: boolean;
-    IGDB_API_HEARTBEAT: boolean;
     MOBY_API_ENABLED: boolean;
     SS_API_ENABLED: boolean;
     STEAMGRIDDB_API_ENABLED: boolean;
@@ -15,7 +14,6 @@ export type MetadataSourcesDict = {
     HASHEOUS_API_ENABLED: boolean;
     TGDB_API_ENABLED: boolean;
     FLASHPOINT_API_ENABLED: boolean;
-    FLASHPOINT_API_HEARTBEAT: boolean;
     HLTB_API_ENABLED: boolean;
 };
 

--- a/frontend/src/__generated__/models/MetadataSourcesDict.ts
+++ b/frontend/src/__generated__/models/MetadataSourcesDict.ts
@@ -5,6 +5,7 @@
 export type MetadataSourcesDict = {
     ANY_SOURCE_ENABLED: boolean;
     IGDB_API_ENABLED: boolean;
+    IGDB_API_HEARTBEAT: boolean;
     MOBY_API_ENABLED: boolean;
     SS_API_ENABLED: boolean;
     STEAMGRIDDB_API_ENABLED: boolean;
@@ -14,6 +15,7 @@ export type MetadataSourcesDict = {
     HASHEOUS_API_ENABLED: boolean;
     TGDB_API_ENABLED: boolean;
     FLASHPOINT_API_ENABLED: boolean;
+    FLASHPOINT_API_HEARTBEAT: boolean;
     HLTB_API_ENABLED: boolean;
 };
 

--- a/frontend/src/components/common/Navigation/SettingsDrawer.vue
+++ b/frontend/src/components/common/Navigation/SettingsDrawer.vue
@@ -135,6 +135,17 @@ function onClose() {
         {{ t("common.library-management") }}
       </v-list-item>
       <v-list-item
+        :tabindex="tabIndex"
+        class="mt-1"
+        rounded
+        append-icon="mdi-database-cog"
+        aria-label="Metadata sources"
+        role="listitem"
+        :to="{ name: ROUTES.METADATA_SOURCES }"
+      >
+        {{ t("scan.metadata-sources") }}
+      </v-list-item>
+      <v-list-item
         v-if="scopes.includes('users.write')"
         :tabindex="tabIndex"
         class="mt-1"

--- a/frontend/src/plugins/router.ts
+++ b/frontend/src/plugins/router.ts
@@ -31,6 +31,7 @@ export const ROUTES = {
   USER_PROFILE: "user-profile",
   USER_INTERFACE: "user-interface",
   LIBRARY_MANAGEMENT: "library-management",
+  METADATA_SOURCES: "metadata-sources",
   ADMINISTRATION: "administration",
   SERVER_STATS: "server-stats",
   NOT_FOUND: "404",
@@ -207,6 +208,14 @@ const routes = [
           title: i18n.global.t("common.library-management"),
         },
         component: () => import("@/views/Settings/LibraryManagement.vue"),
+      },
+      {
+        path: "metadata-sources",
+        name: ROUTES.METADATA_SOURCES,
+        meta: {
+          title: i18n.global.t("common.metadata-sources"),
+        },
+        component: () => import("@/views/Settings/MetadataSources.vue"),
       },
       {
         path: "administration",

--- a/frontend/src/plugins/router.ts
+++ b/frontend/src/plugins/router.ts
@@ -213,7 +213,7 @@ const routes = [
         path: "metadata-sources",
         name: ROUTES.METADATA_SOURCES,
         meta: {
-          title: i18n.global.t("common.metadata-sources"),
+          title: i18n.global.t("scan.metadata-sources"),
         },
         component: () => import("@/views/Settings/MetadataSources.vue"),
       },

--- a/frontend/src/stores/heartbeat.ts
+++ b/frontend/src/stores/heartbeat.ts
@@ -75,6 +75,16 @@ export default defineStore("heartbeat", {
       }
     },
 
+    async fetchMetadataHeartbeat(source: string): Promise<boolean> {
+      try {
+        const response = await api.get(`/heartbeat/metadata/${source}`);
+        return response.data;
+      } catch (error) {
+        console.error("Error fetching metadata heartbeat: ", error);
+        return false;
+      }
+    },
+
     getAllMetadataOptions(): MetadataOption[] {
       return [
         {

--- a/frontend/src/stores/heartbeat.ts
+++ b/frontend/src/stores/heartbeat.ts
@@ -19,7 +19,6 @@ const defaultHeartbeat: Heartbeat = {
   METADATA_SOURCES: {
     ANY_SOURCE_ENABLED: false,
     IGDB_API_ENABLED: false,
-    IGDB_API_HEARTBEAT: false,
     SS_API_ENABLED: false,
     MOBY_API_ENABLED: false,
     RA_API_ENABLED: false,
@@ -29,7 +28,6 @@ const defaultHeartbeat: Heartbeat = {
     HASHEOUS_API_ENABLED: false,
     TGDB_API_ENABLED: false,
     FLASHPOINT_API_ENABLED: false,
-    FLASHPOINT_API_HEARTBEAT: false,
     HLTB_API_ENABLED: false,
   },
   FILESYSTEM: {

--- a/frontend/src/stores/heartbeat.ts
+++ b/frontend/src/stores/heartbeat.ts
@@ -19,6 +19,7 @@ const defaultHeartbeat: Heartbeat = {
   METADATA_SOURCES: {
     ANY_SOURCE_ENABLED: false,
     IGDB_API_ENABLED: false,
+    IGDB_API_HEARTBEAT: false,
     SS_API_ENABLED: false,
     MOBY_API_ENABLED: false,
     RA_API_ENABLED: false,
@@ -28,6 +29,7 @@ const defaultHeartbeat: Heartbeat = {
     HASHEOUS_API_ENABLED: false,
     TGDB_API_ENABLED: false,
     FLASHPOINT_API_ENABLED: false,
+    FLASHPOINT_API_HEARTBEAT: false,
     HLTB_API_ENABLED: false,
   },
   FILESYSTEM: {

--- a/frontend/src/views/Auth/Setup.vue
+++ b/frontend/src/views/Auth/Setup.vue
@@ -49,7 +49,7 @@ const metadataOptions = computed(() => [
   },
   {
     name: "Launchbox",
-    value: "launchbox",
+    value: "lb",
     logo_path: "/assets/scrappers/launchbox.png",
     disabled: !heartbeat.value.METADATA_SOURCES?.LAUNCHBOX_API_ENABLED,
   },

--- a/frontend/src/views/Settings/MetadataSources.vue
+++ b/frontend/src/views/Settings/MetadataSources.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { computed, inject } from "vue";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import storeHeartbeat from "@/stores/heartbeat";
-import type { Events } from "@/types/emitter";
 
 const { t } = useI18n();
 const heartbeat = storeHeartbeat();
@@ -14,7 +13,6 @@ const metadataOptions = computed(() => [
     value: "igdb",
     logo_path: "/assets/scrappers/igdb.png",
     disabled: !heartbeat.value.METADATA_SOURCES?.IGDB_API_ENABLED,
-    heartbeat: heartbeat.value.METADATA_SOURCES?.IGDB_API_HEARTBEAT,
   },
   {
     name: "MobyGames",
@@ -51,7 +49,6 @@ const metadataOptions = computed(() => [
     value: "flashpoint",
     logo_path: "/assets/scrappers/flashpoint.png",
     disabled: !heartbeat.value.METADATA_SOURCES?.FLASHPOINT_API_ENABLED,
-    heartbeat: heartbeat.value.METADATA_SOURCES?.FLASHPOINT_API_HEARTBEAT,
   },
   {
     name: "HowLongToBeat",
@@ -107,12 +104,6 @@ const metadataOptions = computed(() => [
                 >
                   <v-icon
                     :icon="source.disabled ? 'mdi-close' : 'mdi-check'"
-                    class="mr-1"
-                    size="small"
-                  />
-                  <v-icon
-                    v-if="source.heartbeat"
-                    icon="mdi-check"
                     class="mr-1"
                     size="small"
                   />

--- a/frontend/src/views/Settings/MetadataSources.vue
+++ b/frontend/src/views/Settings/MetadataSources.vue
@@ -88,14 +88,12 @@ const metadataOptions = computed(() => [
 
 // Fetch heartbeat status for all metadata sources in parallel
 async function fetchAllHeartbeats() {
-  Promise.all(
-    metadataOptions.value
-      .filter((source) => !source.disabled)
-      .map(async (source) => {
-        const result = await heartbeat.fetchMetadataHeartbeat(source.value);
-        heartbeatStatus.value[source.value] = result;
-      }),
-  );
+  metadataOptions.value
+    .filter((source) => !source.disabled)
+    .map(async (source) => {
+      const result = await heartbeat.fetchMetadataHeartbeat(source.value);
+      heartbeatStatus.value[source.value] = result;
+    });
 }
 
 onMounted(() => {
@@ -136,7 +134,7 @@ onMounted(() => {
                         ? "API key set and valid"
                         : source.heartbeat === false
                           ? "API key invalid!"
-                          : "API key set, connection in progress..."
+                          : "Connection in progress..."
                   }}
                 </p>
               </div>
@@ -158,7 +156,9 @@ onMounted(() => {
                     ? 'success'
                     : source.heartbeat === false
                       ? 'error'
-                      : 'warning'
+                      : source.disabled
+                        ? 'surface'
+                        : 'warning'
                 "
                 size="large"
                 :title="`${source.heartbeat === true ? 'Connection successful' : source.heartbeat === false ? 'Connection failed' : 'Connection in progress...'}`"
@@ -170,7 +170,9 @@ onMounted(() => {
                       ? "mdi-web-check"
                       : source.heartbeat === false
                         ? "mdi-web-remove"
-                        : "mdi-web-refresh"
+                        : source.disabled
+                          ? "mdi-web-off"
+                          : "mdi-web-refresh"
                   }}
                 </v-icon>
               </v-avatar>

--- a/frontend/src/views/Settings/MetadataSources.vue
+++ b/frontend/src/views/Settings/MetadataSources.vue
@@ -1,10 +1,23 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { isUndefined } from "lodash";
+import { computed, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import storeHeartbeat from "@/stores/heartbeat";
 
 const { t } = useI18n();
 const heartbeat = storeHeartbeat();
+
+const heartbeatStatus = ref<Record<string, boolean | undefined>>({
+  igdb: undefined,
+  moby: undefined,
+  ss: undefined,
+  ra: undefined,
+  hasheous: undefined,
+  lb: undefined,
+  flashpoint: undefined,
+  hltb: undefined,
+  sgdb: undefined,
+});
 
 // Use a computed property to reactively update metadataOptions based on heartbeat
 const metadataOptions = computed(() => [
@@ -13,56 +26,81 @@ const metadataOptions = computed(() => [
     value: "igdb",
     logo_path: "/assets/scrappers/igdb.png",
     disabled: !heartbeat.value.METADATA_SOURCES?.IGDB_API_ENABLED,
+    heartbeat: heartbeatStatus.value.igdb,
   },
   {
     name: "MobyGames",
     value: "moby",
     logo_path: "/assets/scrappers/moby.png",
     disabled: !heartbeat.value.METADATA_SOURCES?.MOBY_API_ENABLED,
+    heartbeat: heartbeatStatus.value.moby,
   },
   {
     name: "ScreenScrapper",
     value: "ss",
     logo_path: "/assets/scrappers/ss.png",
     disabled: !heartbeat.value.METADATA_SOURCES?.SS_API_ENABLED,
+    heartbeat: heartbeatStatus.value.ss,
   },
   {
     name: "RetroAchievements",
     value: "ra",
     logo_path: "/assets/scrappers/ra.png",
     disabled: !heartbeat.value.METADATA_SOURCES?.RA_API_ENABLED,
+    heartbeat: heartbeatStatus.value.ra,
   },
   {
     name: "Hasheous",
     value: "hasheous",
     logo_path: "/assets/scrappers/hasheous.png",
     disabled: !heartbeat.value.METADATA_SOURCES?.HASHEOUS_API_ENABLED,
+    heartbeat: heartbeatStatus.value.hasheous,
   },
   {
     name: "Launchbox",
-    value: "launchbox",
+    value: "lb",
     logo_path: "/assets/scrappers/launchbox.png",
     disabled: !heartbeat.value.METADATA_SOURCES?.LAUNCHBOX_API_ENABLED,
+    heartbeat: heartbeatStatus.value.lb,
   },
   {
     name: "Flashpoint Project",
     value: "flashpoint",
     logo_path: "/assets/scrappers/flashpoint.png",
     disabled: !heartbeat.value.METADATA_SOURCES?.FLASHPOINT_API_ENABLED,
+    heartbeat: heartbeatStatus.value.flashpoint,
   },
   {
     name: "HowLongToBeat",
     value: "hltb",
     logo_path: "/assets/scrappers/hltb.png",
     disabled: !heartbeat.value.METADATA_SOURCES?.HLTB_API_ENABLED,
+    heartbeat: heartbeatStatus.value.hltb,
   },
   {
     name: "SteamgridDB",
     value: "sgdb",
     logo_path: "/assets/scrappers/sgdb.png",
     disabled: !heartbeat.value.METADATA_SOURCES?.STEAMGRIDDB_API_ENABLED,
+    heartbeat: heartbeatStatus.value.sgdb,
   },
 ]);
+
+// Fetch heartbeat status for all metadata sources in parallel
+async function fetchAllHeartbeats() {
+  Promise.all(
+    metadataOptions.value
+      .filter((source) => !source.disabled)
+      .map(async (source) => {
+        const result = await heartbeat.fetchMetadataHeartbeat(source.value);
+        heartbeatStatus.value[source.value] = result;
+      }),
+  );
+}
+
+onMounted(() => {
+  fetchAllHeartbeats();
+});
 </script>
 
 <template>
@@ -97,20 +135,59 @@ const metadataOptions = computed(() => [
                 </v-avatar>
               </template>
               <template #append>
-                <v-chip
-                  :color="source.disabled ? 'error' : 'success'"
-                  :variant="source.disabled ? 'tonal' : 'flat'"
-                  size="small"
-                >
-                  <v-icon
-                    :icon="source.disabled ? 'mdi-close' : 'mdi-check'"
-                    class="mr-1"
+                <div class="d-flex align-center gap-2">
+                  <!-- Heartbeat status indicator -->
+                  <v-chip
+                    v-if="!source.disabled"
+                    :color="
+                      source.heartbeat === true
+                        ? 'success'
+                        : source.heartbeat === false
+                          ? 'error'
+                          : 'warning'
+                    "
+                    :variant="source.heartbeat === undefined ? 'tonal' : 'flat'"
                     size="small"
-                  />
-                  {{
-                    source.disabled ? t("common.disabled") : t("common.enabled")
-                  }}
-                </v-chip>
+                  >
+                    <v-icon
+                      :icon="
+                        source.heartbeat === true
+                          ? 'mdi-heart-pulse'
+                          : source.heartbeat === false
+                            ? 'mdi-heart-broken'
+                            : 'mdi-loading'
+                      "
+                      class="mr-1"
+                      size="small"
+                      :class="{ 'mdi-spin': source.heartbeat === undefined }"
+                    />
+                    {{
+                      source.heartbeat
+                        ? t("common.connected")
+                        : isUndefined(source.heartbeat)
+                          ? t("common.checking")
+                          : t("common.disconnected")
+                    }}
+                  </v-chip>
+
+                  <!-- Enabled/Disabled status -->
+                  <v-chip
+                    :color="source.disabled ? 'error' : 'success'"
+                    :variant="source.disabled ? 'tonal' : 'flat'"
+                    size="small"
+                  >
+                    <v-icon
+                      :icon="source.disabled ? 'mdi-close' : 'mdi-check'"
+                      class="mr-1"
+                      size="small"
+                    />
+                    {{
+                      source.disabled
+                        ? t("common.disabled")
+                        : t("common.enabled")
+                    }}
+                  </v-chip>
+                </div>
               </template>
             </v-list-item>
           </v-list>

--- a/frontend/src/views/Settings/MetadataSources.vue
+++ b/frontend/src/views/Settings/MetadataSources.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { isUndefined } from "lodash";
 import { computed, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
+import RSection from "@/components/common/RSection.vue";
 import storeHeartbeat from "@/stores/heartbeat";
 
 const { t } = useI18n();
@@ -104,95 +104,80 @@ onMounted(() => {
 </script>
 
 <template>
-  <v-row no-gutters class="pa-2">
-    <v-col cols="12">
-      <v-card class="pa-4">
-        <v-card-title class="text-h5 mb-4">
-          <v-icon class="mr-2">mdi-database-cog</v-icon>
-          {{ t("scan.metadata-sources") }}
-        </v-card-title>
-
-        <v-card-text>
-          <p class="text-body-1 mb-4">
-            {{ t("settings.metadata-sources-description") }}
-          </p>
-
-          <v-list class="bg-transparent">
-            <v-list-item
-              v-for="source in metadataOptions"
-              :key="source.value"
-              class="text-white text-shadow mb-2"
-              :title="source.name"
-              :subtitle="
-                source.disabled
-                  ? t('settings.api-key-missing-or-invalid')
-                  : t('settings.api-key-valid')
-              "
-            >
-              <template #prepend>
-                <v-avatar size="40" rounded="1">
-                  <v-img :src="source.logo_path" />
-                </v-avatar>
-              </template>
-              <template #append>
-                <div class="d-flex align-center gap-2">
-                  <!-- Heartbeat status indicator -->
-                  <v-chip
-                    v-if="!source.disabled"
-                    :color="
-                      source.heartbeat === true
-                        ? 'success'
+  <RSection
+    icon="mdi-database-cog"
+    :title="t('scan.metadata-sources')"
+    class="ma-2"
+  >
+    <template #content>
+      <v-row no-gutters class="mt-2 cols-12">
+        <v-col
+          v-for="source in metadataOptions"
+          :key="source.value"
+          cols="12"
+          sm="6"
+          md="4"
+          lg="3"
+          xl="2"
+          class="pa-2"
+        >
+          <v-card class="pa-4 h-100 bg-toplayer" variant="elevated">
+            <div class="d-flex align-center mb-3">
+              <v-avatar size="48" rounded="1" class="mr-3">
+                <v-img :src="source.logo_path" />
+              </v-avatar>
+              <div class="flex-grow-1">
+                <h3 class="text-h6 text-white">{{ source.name }}</h3>
+                <p class="text-caption text-grey-lighten-1 mb-0">
+                  {{
+                    source.disabled
+                      ? "API key missing!"
+                      : source.heartbeat === true
+                        ? "API key set and valid"
                         : source.heartbeat === false
-                          ? 'error'
-                          : 'warning'
-                    "
-                    :variant="source.heartbeat === undefined ? 'tonal' : 'flat'"
-                    size="small"
-                  >
-                    <v-icon
-                      :icon="
-                        source.heartbeat === true
-                          ? 'mdi-heart-pulse'
-                          : source.heartbeat === false
-                            ? 'mdi-heart-broken'
-                            : 'mdi-loading'
-                      "
-                      class="mr-1"
-                      size="small"
-                      :class="{ 'mdi-spin': source.heartbeat === undefined }"
-                    />
-                    {{
-                      source.heartbeat
-                        ? t("common.connected")
-                        : isUndefined(source.heartbeat)
-                          ? t("common.checking")
-                          : t("common.disconnected")
-                    }}
-                  </v-chip>
+                          ? "API key invalid!"
+                          : "API key set, connection in progress..."
+                  }}
+                </p>
+              </div>
+            </div>
 
-                  <!-- Enabled/Disabled status -->
-                  <v-chip
-                    :color="source.disabled ? 'error' : 'success'"
-                    :variant="source.disabled ? 'tonal' : 'flat'"
-                    size="small"
-                  >
-                    <v-icon
-                      :icon="source.disabled ? 'mdi-close' : 'mdi-check'"
-                      class="mr-1"
-                      size="small"
-                    />
-                    {{
-                      source.disabled
-                        ? t("common.disabled")
-                        : t("common.enabled")
-                    }}
-                  </v-chip>
-                </div>
-              </template>
-            </v-list-item>
-          </v-list>
-        </v-card-text>
-      </v-card>
-    </v-col>
-  </v-row>
+            <v-row no-gutters class="flex justify-center">
+              <v-avatar
+                :color="source.disabled ? 'error' : 'success'"
+                size="large"
+                :title="`${source.disabled ? 'API key missing or source disabled' : 'API key set'}`"
+              >
+                <v-icon>
+                  {{ source.disabled ? "mdi-key-alert" : "mdi-key" }}
+                </v-icon>
+              </v-avatar>
+              <v-avatar
+                :color="
+                  source.heartbeat === true
+                    ? 'success'
+                    : source.heartbeat === false
+                      ? 'error'
+                      : 'warning'
+                "
+                size="large"
+                :title="`${source.heartbeat === true ? 'Connection successful' : source.heartbeat === false ? 'Connection failed' : 'Connection in progress...'}`"
+                class="ml-4"
+              >
+                <v-icon>
+                  {{
+                    source.heartbeat === true
+                      ? "mdi-web-check"
+                      : source.heartbeat === false
+                        ? "mdi-web-remove"
+                        : "mdi-web-refresh"
+                  }}
+                </v-icon>
+              </v-avatar>
+            </v-row>
+          </v-card>
+        </v-col>
+      </v-row>
+    </template>
+  </RSection>
 </template>

--- a/frontend/src/views/Settings/MetadataSources.vue
+++ b/frontend/src/views/Settings/MetadataSources.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { computed, inject } from "vue";
+import { useI18n } from "vue-i18n";
+import storeHeartbeat from "@/stores/heartbeat";
+import type { Events } from "@/types/emitter";
+
+const { t } = useI18n();
+const heartbeat = storeHeartbeat();
+
+// Use a computed property to reactively update metadataOptions based on heartbeat
+const metadataOptions = computed(() => [
+  {
+    name: "IGDB",
+    value: "igdb",
+    logo_path: "/assets/scrappers/igdb.png",
+    disabled: !heartbeat.value.METADATA_SOURCES?.IGDB_API_ENABLED,
+    heartbeat: heartbeat.value.METADATA_SOURCES?.IGDB_API_HEARTBEAT,
+  },
+  {
+    name: "MobyGames",
+    value: "moby",
+    logo_path: "/assets/scrappers/moby.png",
+    disabled: !heartbeat.value.METADATA_SOURCES?.MOBY_API_ENABLED,
+  },
+  {
+    name: "ScreenScrapper",
+    value: "ss",
+    logo_path: "/assets/scrappers/ss.png",
+    disabled: !heartbeat.value.METADATA_SOURCES?.SS_API_ENABLED,
+  },
+  {
+    name: "RetroAchievements",
+    value: "ra",
+    logo_path: "/assets/scrappers/ra.png",
+    disabled: !heartbeat.value.METADATA_SOURCES?.RA_API_ENABLED,
+  },
+  {
+    name: "Hasheous",
+    value: "hasheous",
+    logo_path: "/assets/scrappers/hasheous.png",
+    disabled: !heartbeat.value.METADATA_SOURCES?.HASHEOUS_API_ENABLED,
+  },
+  {
+    name: "Launchbox",
+    value: "launchbox",
+    logo_path: "/assets/scrappers/launchbox.png",
+    disabled: !heartbeat.value.METADATA_SOURCES?.LAUNCHBOX_API_ENABLED,
+  },
+  {
+    name: "Flashpoint Project",
+    value: "flashpoint",
+    logo_path: "/assets/scrappers/flashpoint.png",
+    disabled: !heartbeat.value.METADATA_SOURCES?.FLASHPOINT_API_ENABLED,
+    heartbeat: heartbeat.value.METADATA_SOURCES?.FLASHPOINT_API_HEARTBEAT,
+  },
+  {
+    name: "HowLongToBeat",
+    value: "hltb",
+    logo_path: "/assets/scrappers/hltb.png",
+    disabled: !heartbeat.value.METADATA_SOURCES?.HLTB_API_ENABLED,
+  },
+  {
+    name: "SteamgridDB",
+    value: "sgdb",
+    logo_path: "/assets/scrappers/sgdb.png",
+    disabled: !heartbeat.value.METADATA_SOURCES?.STEAMGRIDDB_API_ENABLED,
+  },
+]);
+</script>
+
+<template>
+  <v-row no-gutters class="pa-2">
+    <v-col cols="12">
+      <v-card class="pa-4">
+        <v-card-title class="text-h5 mb-4">
+          <v-icon class="mr-2">mdi-database-cog</v-icon>
+          {{ t("scan.metadata-sources") }}
+        </v-card-title>
+
+        <v-card-text>
+          <p class="text-body-1 mb-4">
+            {{ t("settings.metadata-sources-description") }}
+          </p>
+
+          <v-list class="bg-transparent">
+            <v-list-item
+              v-for="source in metadataOptions"
+              :key="source.value"
+              class="text-white text-shadow mb-2"
+              :title="source.name"
+              :subtitle="
+                source.disabled
+                  ? t('settings.api-key-missing-or-invalid')
+                  : t('settings.api-key-valid')
+              "
+            >
+              <template #prepend>
+                <v-avatar size="40" rounded="1">
+                  <v-img :src="source.logo_path" />
+                </v-avatar>
+              </template>
+              <template #append>
+                <v-chip
+                  :color="source.disabled ? 'error' : 'success'"
+                  :variant="source.disabled ? 'tonal' : 'flat'"
+                  size="small"
+                >
+                  <v-icon
+                    :icon="source.disabled ? 'mdi-close' : 'mdi-check'"
+                    class="mr-1"
+                    size="small"
+                  />
+                  <v-icon
+                    v-if="source.heartbeat"
+                    icon="mdi-check"
+                    class="mr-1"
+                    size="small"
+                  />
+                  {{
+                    source.disabled ? t("common.disabled") : t("common.enabled")
+                  }}
+                </v-chip>
+              </template>
+            </v-list-item>
+          </v-list>
+        </v-card-text>
+      </v-card>
+    </v-col>
+  </v-row>
+</template>


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

This PR adds a new metadata sources admin page that displays the status and configuration of all supported metadata sources/scrapers. The new `/heartbeat/metadata` endpoint makes requests to each metadata provider to test to connection (where relevant).

Fixes #2438 

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots

<img width="1412" height="548" alt="Screenshot 2025-09-20 at 7 06 53 PM" src="https://github.com/user-attachments/assets/ba9ae6f9-5019-4c0a-8748-801aff48bd01" />