### PR TITLE
Split `rom.multi` into more specific fields

### DIFF
--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -256,7 +256,7 @@ class RomSchema(BaseModel):
     sha1_hash: str | None
 
     # TODO: Remove this after 4.3 release
-    multi: Annotated[int, Field(deprecated="Replaced by has_multiple_files")]
+    multi: Annotated[bool, Field(deprecated="Replaced by has_multiple_files")]
     has_simple_single_file: bool
     has_nested_single_file: bool
     has_multiple_files: bool

--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timezone
-from typing import NotRequired, TypedDict, get_type_hints
+from typing import Annotated, NotRequired, TypedDict, get_type_hints
 
 from fastapi import Request
-from pydantic import computed_field, field_validator
+from pydantic import Field, computed_field, field_validator
 
 from endpoints.responses.assets import SaveSchema, ScreenshotSchema, StateSchema
 from handler.metadata.flashpoint_handler import FlashpointMetadata
@@ -255,7 +255,11 @@ class RomSchema(BaseModel):
     md5_hash: str | None
     sha1_hash: str | None
 
-    multi: bool
+    # TODO: Remove this after 4.3 release
+    multi: Annotated[int, Field(deprecated="Replaced by has_multiple_files")]
+    has_simple_single_file: bool
+    has_nested_single_file: bool
+    has_multiple_files: bool
     files: list[RomFileSchema]
     full_path: str
     created_at: datetime

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -378,7 +378,6 @@ async def head_rom_content(
     if file_ids:
         file_id_values = {int(f.strip()) for f in file_ids.split(",") if f.strip()}
         files = [f for f in rom.files if f.id in file_id_values]
-
     files.sort(key=lambda x: x.file_name)
 
     # Serve the file directly in development mode for emulatorjs

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -378,6 +378,7 @@ async def head_rom_content(
     if file_ids:
         file_id_values = {int(f.strip()) for f in file_ids.split(",") if f.strip()}
         files = [f for f in rom.files if f.id in file_id_values]
+
     files.sort(key=lambda x: x.file_name)
 
     # Serve the file directly in development mode for emulatorjs

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -200,7 +200,6 @@ async def _identify_rom(
                 tags=fs_other_tags,
                 platform_id=platform.id,
                 name=fs_rom["fs_name"],
-                multi=fs_rom["multi"],
                 url_cover="",
                 url_manual="",
                 url_screenshots=[],

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -93,8 +93,9 @@ FILE_READ_CHUNK_SIZE = 1024 * 8
 
 
 class FSRom(TypedDict):
-    multi: bool
     fs_name: str
+    flat: bool
+    nested: bool
     files: list[RomFile]
     crc_hash: str
     md5_hash: str
@@ -247,7 +248,7 @@ class FSRomsHandler(FSHandler):
             other_tags.append(tag)
         return regs, rev, langs, other_tags
 
-    def _exclude_multi_roms(self, roms: list[str]) -> list[str]:
+    def exclude_multi_roms(self, roms: list[str]) -> list[str]:
         excluded_names = cm.get_config().EXCLUDED_MULTI_FILES
         filtered_files: list = []
 
@@ -511,18 +512,19 @@ class FSRomsHandler(FSHandler):
             raise RomsNotFoundException(platform=platform.fs_slug) from e
 
         fs_roms: list[dict] = [
-            {"multi": False, "fs_name": rom}
+            {"fs_name": rom, "flat": True, "nested": False}
             for rom in self.exclude_single_files(fs_single_roms)
         ] + [
-            {"multi": True, "fs_name": rom}
-            for rom in self._exclude_multi_roms(fs_multi_roms)
+            {"fs_name": rom, "flat": False, "nested": True}
+            for rom in self.exclude_multi_roms(fs_multi_roms)
         ]
 
         return sorted(
             [
                 FSRom(
-                    multi=rom["multi"],
                     fs_name=rom["fs_name"],
+                    flat=rom["flat"],
+                    nested=rom["nested"],
                     files=[],
                     crc_hash="",
                     md5_hash="",

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -295,7 +295,6 @@ async def scan_rom(
         "platform_id": platform.id,
         "name": fs_rom["fs_name"],
         "fs_name": fs_rom["fs_name"],
-        "multi": fs_rom["multi"],
         "crc_hash": fs_rom["crc_hash"],
         "md5_hash": fs_rom["md5_hash"],
         "sha1_hash": fs_rom["sha1_hash"],
@@ -741,7 +740,8 @@ async def scan_rom(
         f"{hl(rom_attrs['fs_name'])} identified as {hl(rom_attrs['name'], color=BLUE)} {emoji.EMOJI_ALIEN_MONSTER}",
         extra=LOGGER_MODULE_NAME,
     )
-    if rom.multi:
+
+    if rom.has_nested_single_file or rom.has_multiple_files:
         for file in fs_rom["files"]:
             log.info(
                 f"\t · {hl(file.file_name, color=LIGHTYELLOW)}",

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -100,6 +100,10 @@ class RomFile(BaseModel):
 
         return fs_rom_handler.parse_file_extension(self.file_name)
 
+    @cached_property
+    def is_nested(self) -> bool:
+        return self.file_path.count("/") > 1
+
     def file_name_for_download(self, rom: Rom, hidden_folder: bool = False) -> str:
         # This needs a trailing slash in the path to work!
         return self.full_path.replace(
@@ -286,11 +290,22 @@ class Rom(BaseModel):
 
         return []
 
+    # TODO: Remove this after 4.3 release
     @cached_property
     def multi(self) -> bool:
-        return len(self.files) > 1 or (
-            len(self.files) > 0 and len(self.files[0].full_path.split("/")) > 3
-        )
+        return self.has_nested_single_file or self.has_multiple_files
+
+    @cached_property
+    def has_simple_single_file(self) -> bool:
+        return len(self.files) == 1 and not self.files[0].is_nested
+
+    @cached_property
+    def has_nested_single_file(self) -> bool:
+        return len(self.files) == 1 and self.files[0].is_nested
+
+    @cached_property
+    def has_multiple_files(self) -> bool:
+        return len(self.files) > 1
 
     @property
     def fs_resources_path(self) -> str:

--- a/backend/tests/handler/filesystem/test_roms_handler.py
+++ b/backend/tests/handler/filesystem/test_roms_handler.py
@@ -164,7 +164,7 @@ class TestFSRomsHandler:
         assert languages == []
         assert other_tags == []
 
-    def testexclude_multi_roms_filters_excluded(self, handler: FSRomsHandler, config):
+    def test_exclude_multi_roms_filters_excluded(self, handler: FSRomsHandler, config):
         """Test exclude_multi_roms filters out excluded multi-file ROMs"""
         roms = ["Game1", "excluded_multi", "Game2", "Game3"]
 
@@ -176,7 +176,7 @@ class TestFSRomsHandler:
 
             assert result == expected
 
-    def testexclude_multi_roms_no_exclusions(self, handler: FSRomsHandler):
+    def test_exclude_multi_roms_no_exclusions(self, handler: FSRomsHandler):
         """Test exclude_multi_roms with no exclusions"""
         roms = ["Game1", "Game2", "Game3"]
         config = Config(

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -42,7 +42,6 @@ async def test_scan_rom():
         igdb_id=3340,
         fs_size_bytes=1024,
         tags=[],
-        multi=False,
     )
 
     async with initialize_context():
@@ -52,7 +51,6 @@ async def test_scan_rom():
             rom=rom,
             fs_rom={
                 "fs_name": "Paper Mario (USA).z64",
-                "multi": False,
                 "files": [
                     RomFile(
                         file_name="Paper Mario (USA).z64",
@@ -76,4 +74,5 @@ async def test_scan_rom():
     assert rom.igdb_id == 3340
     assert rom.fs_size_bytes == 1024
     assert rom.tags == []
-    assert not rom.multi
+    assert rom.has_simple_single_file
+    assert not rom.has_multiple_files

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -51,6 +51,8 @@ async def test_scan_rom():
             rom=rom,
             fs_rom={
                 "fs_name": "Paper Mario (USA).z64",
+                "flat": True,
+                "nested": False,
                 "files": [
                     RomFile(
                         file_name="Paper Mario (USA).z64",
@@ -71,8 +73,7 @@ async def test_scan_rom():
     assert type(rom) is Rom
     assert rom.fs_name == "Paper Mario (USA).z64"
     assert rom.name == "Paper Mario"
+    assert rom.fs_path == "n64/Paper Mario (USA)"
     assert rom.igdb_id == 3340
     assert rom.fs_size_bytes == 1024
     assert rom.tags == []
-    assert rom.has_simple_single_file
-    assert not rom.has_multiple_files

--- a/frontend/src/__generated__/models/DetailedRomSchema.ts
+++ b/frontend/src/__generated__/models/DetailedRomSchema.ts
@@ -75,7 +75,7 @@ export type DetailedRomSchema = {
     /**
      * @deprecated
      */
-    multi: number;
+    multi: boolean;
     has_simple_single_file: boolean;
     has_nested_single_file: boolean;
     has_multiple_files: boolean;

--- a/frontend/src/__generated__/models/DetailedRomSchema.ts
+++ b/frontend/src/__generated__/models/DetailedRomSchema.ts
@@ -72,7 +72,13 @@ export type DetailedRomSchema = {
     crc_hash: (string | null);
     md5_hash: (string | null);
     sha1_hash: (string | null);
-    multi: boolean;
+    /**
+     * @deprecated
+     */
+    multi: number;
+    has_simple_single_file: boolean;
+    has_nested_single_file: boolean;
+    has_multiple_files: boolean;
     files: Array<RomFileSchema>;
     full_path: string;
     created_at: string;

--- a/frontend/src/__generated__/models/SimpleRomSchema.ts
+++ b/frontend/src/__generated__/models/SimpleRomSchema.ts
@@ -66,7 +66,13 @@ export type SimpleRomSchema = {
     crc_hash: (string | null);
     md5_hash: (string | null);
     sha1_hash: (string | null);
-    multi: boolean;
+    /**
+     * @deprecated
+     */
+    multi: number;
+    has_simple_single_file: boolean;
+    has_nested_single_file: boolean;
+    has_multiple_files: boolean;
     files: Array<RomFileSchema>;
     full_path: string;
     created_at: string;

--- a/frontend/src/__generated__/models/SimpleRomSchema.ts
+++ b/frontend/src/__generated__/models/SimpleRomSchema.ts
@@ -69,7 +69,7 @@ export type SimpleRomSchema = {
     /**
      * @deprecated
      */
-    multi: number;
+    multi: boolean;
     has_simple_single_file: boolean;
     has_nested_single_file: boolean;
     has_multiple_files: boolean;

--- a/frontend/src/components/Details/Info/FileInfo.vue
+++ b/frontend/src/components/Details/Info/FileInfo.vue
@@ -46,7 +46,11 @@ watch(
 <template>
   <v-row no-gutters>
     <v-col>
-      <v-row v-if="!rom.multi" class="align-center my-3" no-gutters>
+      <v-row
+        v-if="rom.has_simple_single_file"
+        class="align-center my-3"
+        no-gutters
+      >
         <v-col cols="3" xl="2" class="mr-2">
           <span>{{ t("rom.file") }}</span>
         </v-col>
@@ -58,7 +62,7 @@ watch(
           /><span class="text-body-1">{{ rom.fs_name }}</span>
         </v-col>
       </v-row>
-      <v-row v-if="rom.multi" class="align-center my-3" no-gutters>
+      <v-row v-else class="align-center my-3" no-gutters>
         <v-col cols="3" xl="2" class="mr-2">
           <span>{{ t("rom.files") }}</span>
         </v-col>

--- a/frontend/src/components/common/Game/Dialog/DeleteRom.vue
+++ b/frontend/src/components/common/Game/Dialog/DeleteRom.vue
@@ -52,7 +52,7 @@ async function deleteRoms() {
       });
       if (excludeOnDelete.value) {
         for (const rom of roms.value) {
-          if (!rom.multi) {
+          if (rom.has_simple_single_file) {
             configApi.addExclusion({
               exclusionValue: rom.fs_name,
               exclusionType: "EXCLUDED_SINGLE_FILES",

--- a/frontend/src/components/common/Game/Dialog/EditRom.vue
+++ b/frontend/src/components/common/Game/Dialog/EditRom.vue
@@ -272,7 +272,11 @@ function closeDialog() {
             <v-text-field
               v-model="rom.fs_name"
               :rules="[(value: string) => !!value || t('common.required')]"
-              :label="rom.multi ? t('rom.folder-name') : t('rom.filename')"
+              :label="
+                rom.has_multiple_files
+                  ? t('rom.folder-name')
+                  : t('rom.filename')
+              "
               variant="outlined"
               class="my-2"
               @keyup.enter="updateRom"

--- a/frontend/src/views/Player/EmulatorJS/Base.vue
+++ b/frontend/src/views/Player/EmulatorJS/Base.vue
@@ -257,7 +257,7 @@ onBeforeUnmount(async () => {
         <v-col>
           <!-- disc selector -->
           <v-select
-            v-if="rom.multi"
+            v-if="rom.has_multiple_files"
             v-model="selectedDisc"
             class="mt-4"
             hide-details


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

* has_simple_single_file: single file, non-nested
* has_nested_single_file: single file, nested under a parent folder
* has_multiple_files: multiple files, obviously nested

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes