### PR TITLE
Add option to disable setup wizard

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -119,6 +119,7 @@ DISABLE_DOWNLOAD_ENDPOINT_AUTH = str_to_bool(
     os.environ.get("DISABLE_DOWNLOAD_ENDPOINT_AUTH", "false")
 )
 DISABLE_USERPASS_LOGIN = str_to_bool(os.environ.get("DISABLE_USERPASS_LOGIN", "false"))
+DISABLE_SETUP_WIZARD = str_to_bool(os.environ.get("DISABLE_SETUP_WIZARD", "false"))
 
 # OIDC
 OIDC_ENABLED: Final = str_to_bool(os.environ.get("OIDC_ENABLED", "false"))

--- a/backend/endpoints/heartbeat.py
+++ b/backend/endpoints/heartbeat.py
@@ -3,6 +3,7 @@ from fastapi import HTTPException
 from config import (
     DISABLE_EMULATOR_JS,
     DISABLE_RUFFLE_RS,
+    DISABLE_SETUP_WIZARD,
     DISABLE_USERPASS_LOGIN,
     ENABLE_SCHEDULED_CONVERT_IMAGES_TO_WEBP,
     ENABLE_SCHEDULED_RESCAN,
@@ -64,7 +65,8 @@ async def heartbeat() -> HeartbeatResponse:
     return {
         "SYSTEM": {
             "VERSION": get_version(),
-            "SHOW_SETUP_WIZARD": len(db_user_handler.get_admin_users()) == 0,
+            "SHOW_SETUP_WIZARD": len(db_user_handler.get_admin_users()) == 0
+            and not DISABLE_SETUP_WIZARD,
         },
         "METADATA_SOURCES": {
             "ANY_SOURCE_ENABLED": (


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

This adds an option to disable the setup wizard. The intended use for this is in combination with `DISABLE_USERPASS_LOGIN = true`, `OIDC_ENABLED = true`, and `OIDC_CLAIM_ROLES != ''`. In this situation there is virtually no point in defining the initial admin user; you won't be able to log in with it directly, and if it matches the email you log in with using OIDC your roles will be set based on the role mapping.

The only purpose this initial account could serve at this point is recovery in case OIDC login breaks. I'm personally not concerned about this scenario since OIDC is configured through the environment, so you won't actually need to log in to fix this. Still, I think it's a good idea for people to opt in to this so that they can make this choice for themselves.

Only makes sense once #2494 is merged.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes