### PR TITLE
misc: Use proper SPDX identifier for license in pyproject.yaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 requires-python = ">=3.13"
 readme = "README.md"
-license = "GNU AGPLv3"
+license = "AGPL-3.0-only"
 dependencies = [
   "PyYAML ~= 6.0",
   "SQLAlchemy[mariadb-connector,mysql-connector,postgresql-psycopg] ~= 2.0",


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>
According to [PEP 639](https://peps.python.org/pep-0639/) the license field in pyproject.yaml should be a valid SPDX identifier.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
