### PR TITLE
Prevent OIDC claim role escalation

### DIFF
--- a/backend/tests/handler/auth/test_oidc.py
+++ b/backend/tests/handler/auth/test_oidc.py
@@ -245,7 +245,8 @@ async def test_oidc_valid_edit_user_role(
     oidc_handler = OpenIDHandler()
     user, _ = await oidc_handler.get_current_active_user_from_openid_token(mock_token)
 
-    assert user == mock_user_edited
+    assert user is not None
+    assert user.role == Role.ADMIN
     mock_edit_user.assert_called_once_with(mock_user.id, {"role": Role.ADMIN})
 
 


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

> The OpenID token's roles claim (OIDC_CLAIM_ROLES) is treated as authoritative and the handler will unconditionally update the local user's role to the mapped Role value (including ADMIN) if it differs from the stored role. Because role updates happen during the single callback flow, an attacker who can present an OIDC token whose roles include the configured admin role will be promoted to ADMIN in a single request.

@MaienM Can you take a look at this?

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
