### PR TITLE
Add OIDC_CLAIM_ROLES to the requested scope in order for it to be filled in the token userinfo

### DIFF
--- a/backend/decorators/auth.py
+++ b/backend/decorators/auth.py
@@ -10,6 +10,7 @@ from starlette.authentication import requires
 from starlette.config import Config
 
 from config import (
+    OIDC_CLAIM_ROLES,
     OIDC_CLIENT_ID,
     OIDC_CLIENT_SECRET,
     OIDC_ENABLED,
@@ -58,7 +59,7 @@ oauth.register(
         config.get("OIDC_SERVER_APPLICATION_URL"), external=True
     ),
     client_kwargs={
-        "scope": "openid profile email",
+        "scope": "openid profile email" + ((" " + OIDC_CLAIM_ROLES) if OIDC_CLAIM_ROLES else ""),
         "verify": OIDC_TLS_CACERTFILE,
     },
 )

--- a/backend/decorators/auth.py
+++ b/backend/decorators/auth.py
@@ -59,7 +59,7 @@ oauth.register(
         config.get("OIDC_SERVER_APPLICATION_URL"), external=True
     ),
     client_kwargs={
-        "scope": "openid profile email" + ((" " + OIDC_CLAIM_ROLES) if OIDC_CLAIM_ROLES else ""),
+        "scope": f"openid profile email {OIDC_CLAIM_ROLES}".strip(),
         "verify": OIDC_TLS_CACERTFILE,
     },
 )


### PR DESCRIPTION
Adds OIDC_CLAIM_ROLES to the requested scope in order for it to be filled in the token userinfo.

<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Authelia doesn't add the OIDC_CLAIM_ROLES to the token userinfo unless requested in the scope.</sup>

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
