### PR TITLE
Set same_site to lax on session cookie if OIDC enabled

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,7 @@ from config import (
     DEV_PORT,
     DISABLE_CSRF_PROTECTION,
     IS_PYTEST_RUN,
+    OIDC_ENABLED,
     ROMM_AUTH_SECRET_KEY,
     SENTRY_DSN,
 )
@@ -105,7 +106,7 @@ app.add_middleware(
     SessionMiddleware,
     secret_key=ROMM_AUTH_SECRET_KEY,
     session_cookie="romm_session",
-    same_site="strict",
+    same_site="lax" if OIDC_ENABLED else "strict",
     https_only=False,
     jwt_alg=ALGORITHM,
 )


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Attempt at fixing parts of #1502 by setting the session cookie to `SameSite="Lax"` when OIDC is enabled, so the cookie can be forwarded to the provider/accessible in the redirect flow.

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
