### PR TITLE
[ROMM-2554] Remove htlb from manual search

### DIFF
--- a/backend/endpoints/responses/search.py
+++ b/backend/endpoints/responses/search.py
@@ -11,7 +11,6 @@ class SearchRomSchema(BaseModel):
     sgdb_id: int | None = None
     flashpoint_id: str | None = None
     launchbox_id: int | None = None
-    hltb_id: int | None = None
     platform_id: int
     name: str
     slug: str = ""
@@ -22,7 +21,6 @@ class SearchRomSchema(BaseModel):
     sgdb_url_cover: str = ""
     flashpoint_url_cover: str = ""
     launchbox_url_cover: str = ""
-    hltb_url_cover: str = ""
     is_unidentified: bool
     is_identified: bool
 

--- a/backend/endpoints/rom.py
+++ b/backend/endpoints/rom.py
@@ -53,7 +53,6 @@ from handler.filesystem import fs_resource_handler, fs_rom_handler
 from handler.filesystem.base_handler import CoverSize
 from handler.metadata import (
     meta_flashpoint_handler,
-    meta_hltb_handler,
     meta_igdb_handler,
     meta_launchbox_handler,
     meta_moby_handler,
@@ -739,15 +738,7 @@ async def update_rom(
         "ss_id": data.get("ss_id", rom.ss_id),
         "launchbox_id": data.get("launchbox_id", rom.launchbox_id),
         "flashpoint_id": data.get("flashpoint_id", rom.flashpoint_id),
-        "hltb_id": data.get("hltb_id", rom.hltb_id),
     }
-
-    if (
-        cleaned_data.get("hltb_id", "")
-        and int(cleaned_data.get("hltb_id", "")) != rom.hltb_id
-    ):
-        hltb_rom = await meta_hltb_handler.get_rom_by_id(cleaned_data["hltb_id"])
-        cleaned_data.update(hltb_rom)
 
     if (
         cleaned_data.get("flashpoint_id", "")

--- a/backend/endpoints/search.py
+++ b/backend/endpoints/search.py
@@ -9,7 +9,6 @@ from handler.auth.constants import Scope
 from handler.database import db_rom_handler
 from handler.metadata import (
     meta_flashpoint_handler,
-    meta_hltb_handler,
     meta_igdb_handler,
     meta_launchbox_handler,
     meta_moby_handler,
@@ -17,7 +16,6 @@ from handler.metadata import (
     meta_ss_handler,
 )
 from handler.metadata.flashpoint_handler import FlashpointRom
-from handler.metadata.hltb_handler import HLTBRom
 from handler.metadata.igdb_handler import IGDBRom
 from handler.metadata.launchbox_handler import LaunchboxRom
 from handler.metadata.moby_handler import MobyGamesRom
@@ -63,7 +61,6 @@ async def search_rom(
         and not meta_moby_handler.is_enabled()
         and not meta_flashpoint_handler.is_enabled()
         and not meta_launchbox_handler.is_enabled()
-        and not meta_hltb_handler.is_enabled()
     ):
         log.error("Search error: No metadata providers enabled")
         raise HTTPException(
@@ -94,7 +91,6 @@ async def search_rom(
     ss_matched_roms: list[SSRom] = []
     flashpoint_matched_roms: list[FlashpointRom] = []
     launchbox_matched_roms: list[LaunchboxRom] = []
-    hltb_matched_roms: list[HLTBRom] = []
 
     if search_by.lower() == "id":
         try:
@@ -120,7 +116,6 @@ async def search_rom(
             ss_matched_roms,
             flashpoint_matched_roms,
             launchbox_matched_roms,
-            hltb_matched_roms,
         ) = await asyncio.gather(
             meta_igdb_handler.get_matched_roms_by_name(
                 search_term, get_main_platform_igdb_id(rom.platform)
@@ -135,7 +130,6 @@ async def search_rom(
             meta_launchbox_handler.get_matched_roms_by_name(
                 search_term, rom.platform.slug
             ),
-            meta_hltb_handler.get_matched_roms_by_name(search_term, rom.platform.slug),
         )
 
     merged_dict: dict[str, dict] = {}
@@ -213,21 +207,6 @@ async def search_rom(
                 "platform_id": rom.platform_id,
                 "launchbox_url_cover": launchbox_rom.pop("url_cover", ""),
                 **merged_dict.get(launchbox_name, {}),
-            }
-
-    for hltb_rom in hltb_matched_roms:
-        if hltb_rom["hltb_id"]:
-            hltb_name = meta_hltb_handler.normalize_search_term(
-                hltb_rom.get("name", ""),
-                remove_articles=False,
-            )
-            merged_dict[hltb_name] = {
-                **hltb_rom,
-                "is_identified": True,
-                "is_unidentified": False,
-                "platform_id": rom.platform_id,
-                "hltb_url_cover": hltb_rom.pop("url_cover", ""),
-                **merged_dict.get(hltb_name, {}),
             }
 
     async def get_sgdb_rom(name: str) -> tuple[str, SGDBRom]:

--- a/frontend/src/__generated__/models/SearchRomSchema.ts
+++ b/frontend/src/__generated__/models/SearchRomSchema.ts
@@ -10,7 +10,6 @@ export type SearchRomSchema = {
     sgdb_id?: (number | null);
     flashpoint_id?: (string | null);
     launchbox_id?: (number | null);
-    hltb_id?: (number | null);
     platform_id: number;
     name: string;
     slug?: string;
@@ -21,7 +20,6 @@ export type SearchRomSchema = {
     sgdb_url_cover?: string;
     flashpoint_url_cover?: string;
     launchbox_url_cover?: string;
-    hltb_url_cover?: string;
     is_unidentified: boolean;
     is_identified: boolean;
 };

--- a/frontend/src/components/common/Game/Card/Base.vue
+++ b/frontend/src/components/common/Game/Card/Base.vue
@@ -154,8 +154,7 @@ const largeCover = computed(() => {
       props.rom.moby_url_cover ||
       props.rom.ss_url_cover ||
       props.rom.launchbox_url_cover ||
-      props.rom.flashpoint_url_cover ||
-      props.rom.hltb_url_cover
+      props.rom.flashpoint_url_cover
     );
   const pathCoverLarge = isWebpEnabled.value
     ? props.rom.path_cover_large?.replace(EXTENSION_REGEX, ".webp")
@@ -270,8 +269,7 @@ onBeforeUnmount(() => {
                         !rom.ss_url_cover &&
                         !rom.sgdb_url_cover &&
                         !rom.launchbox_url_cover &&
-                        !rom.flashpoint_url_cover &&
-                        !rom.hltb_url_cover)
+                        !rom.flashpoint_url_cover)
                     "
                     class="translucent text-white"
                     :class="

--- a/frontend/src/components/common/Game/Card/Sources.vue
+++ b/frontend/src/components/common/Game/Card/Sources.vue
@@ -101,24 +101,5 @@ defineProps<{ rom: SearchRomSchema }>();
         </v-avatar>
       </template>
     </v-tooltip>
-    <v-tooltip
-      location="top"
-      class="tooltip"
-      transition="fade-transition"
-      text="HowLongToBeat matched"
-      open-delay="500"
-    >
-      <template #activator="{ props }">
-        <v-avatar
-          v-bind="props"
-          v-if="rom.hltb_id"
-          class="mr-1 mb-1"
-          size="28"
-          rounded="1"
-        >
-          <v-img src="/assets/scrappers/hltb.png" />
-        </v-avatar>
-      </template>
-    </v-tooltip>
   </v-row>
 </template>

--- a/frontend/src/components/common/Game/Dialog/MatchRom.vue
+++ b/frontend/src/components/common/Game/Dialog/MatchRom.vue
@@ -25,7 +25,6 @@ type MatchedSource = {
     | "Screenscraper"
     | "Flashpoint"
     | "Launchbox"
-    | "HowLongToBeat"
     | "SteamGridDB";
   logo_path: string;
 };
@@ -56,7 +55,6 @@ const isMobyFiltered = ref(true);
 const isSSFiltered = ref(true);
 const isFlashpointFiltered = ref(true);
 const isLaunchboxFiltered = ref(true);
-const isHLTBFiltered = ref(true);
 const computedAspectRatio = computed(() => {
   const ratio =
     platfotmsStore.getAspectRatio(rom.value?.platform_id ?? -1) ||
@@ -101,20 +99,15 @@ function toggleSourceFilter(source: MatchedSource["name"]) {
     heartbeat.value.METADATA_SOURCES.LAUNCHBOX_API_ENABLED
   ) {
     isLaunchboxFiltered.value = !isLaunchboxFiltered.value;
-  } else if (
-    source == "HowLongToBeat" &&
-    heartbeat.value.METADATA_SOURCES.HLTB_API_ENABLED
-  ) {
-    isHLTBFiltered.value = !isHLTBFiltered.value;
   }
+
   filteredMatchedRoms.value = matchedRoms.value.filter((rom) => {
     if (
       (rom.igdb_id && isIGDBFiltered.value) ||
       (rom.moby_id && isMobyFiltered.value) ||
       (rom.ss_id && isSSFiltered.value) ||
       (rom.flashpoint_id && isFlashpointFiltered.value) ||
-      (rom.launchbox_id && isLaunchboxFiltered.value) ||
-      (rom.hltb_id && isHLTBFiltered.value)
+      (rom.launchbox_id && isLaunchboxFiltered.value)
     ) {
       return true;
     }
@@ -146,8 +139,7 @@ async function searchRom() {
             (rom.moby_id && isMobyFiltered.value) ||
             (rom.ss_id && isSSFiltered.value) ||
             (rom.flashpoint_id && isFlashpointFiltered.value) ||
-            (rom.launchbox_id && isLaunchboxFiltered.value) ||
-            (rom.hltb_id && isHLTBFiltered.value)
+            (rom.launchbox_id && isLaunchboxFiltered.value)
           ) {
             return true;
           }
@@ -219,13 +211,6 @@ function showSources(matchedRom: SearchRomSchema) {
       logo_path: "/assets/scrappers/launchbox.png",
     });
   }
-  if (matchedRom.hltb_url_cover) {
-    sources.value.push({
-      url_cover: matchedRom.hltb_url_cover,
-      name: "HowLongToBeat",
-      logo_path: "/assets/scrappers/hltb.png",
-    });
-  }
   if (sources.value.length == 1) {
     selectedCover.value = sources.value[0];
   }
@@ -277,7 +262,6 @@ async function updateRom(
     moby_id: selectedRom.moby_id || null,
     flashpoint_id: selectedRom.flashpoint_id || null,
     launchbox_id: selectedRom.launchbox_id || null,
-    hltb_id: selectedRom.hltb_id || null,
     name: selectedRom.name || null,
     slug: selectedRom.slug || null,
     summary: selectedRom.summary || null,
@@ -288,7 +272,6 @@ async function updateRom(
       selectedRom.moby_url_cover ||
       selectedRom.flashpoint_url_cover ||
       selectedRom.launchbox_url_cover ||
-      selectedRom.hltb_url_cover ||
       null,
   };
 
@@ -497,35 +480,6 @@ onBeforeUnmount(() => {
             rounded="1"
           >
             <v-img src="/assets/scrappers/flashpoint.png" />
-          </v-avatar>
-        </template>
-      </v-tooltip>
-      <v-tooltip
-        location="top"
-        class="tooltip"
-        transition="fade-transition"
-        :text="
-          heartbeat.value.METADATA_SOURCES.HLTB_API_ENABLED
-            ? 'Filter HowLongToBeat matches'
-            : 'HowLongToBeat source is not enabled'
-        "
-        open-delay="500"
-        ><template #activator="{ props }">
-          <v-avatar
-            @click="toggleSourceFilter('HowLongToBeat')"
-            v-bind="props"
-            class="ml-3 cursor-pointer opacity-40"
-            :class="{
-              'opacity-100':
-                isHLTBFiltered &&
-                heartbeat.value.METADATA_SOURCES.HLTB_API_ENABLED,
-              'cursor-not-allowed':
-                !heartbeat.value.METADATA_SOURCES.HLTB_API_ENABLED,
-            }"
-            size="30"
-            rounded="1"
-          >
-            <v-img src="/assets/scrappers/hltb.png" />
           </v-avatar>
         </template>
       </v-tooltip>

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -273,7 +273,6 @@ async function updateRom({
     formData.append("launchbox_id", rom.launchbox_id.toString());
   if (rom.flashpoint_id)
     formData.append("flashpoint_id", rom.flashpoint_id.toString());
-  if (rom.hltb_id) formData.append("hltb_id", rom.hltb_id.toString());
   formData.append("name", rom.name || "");
   formData.append("fs_name", rom.fs_name);
   formData.append("summary", rom.summary || "");


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

HLTB has no endpoint to fetch games by ID, so we're removing it from the manual match window and search endpoint.

Fixes #2554 

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
