### PR TITLE
fix: type error when role claim is null

### DIFF
--- a/backend/handler/auth/base_handler.py
+++ b/backend/handler/auth/base_handler.py
@@ -332,7 +332,7 @@ class OpenIDHandler:
 
         role = Role.VIEWER
         if OIDC_CLAIM_ROLES and OIDC_CLAIM_ROLES in userinfo:
-            roles = userinfo[OIDC_CLAIM_ROLES]
+            roles = userinfo[OIDC_CLAIM_ROLES] or []
             if OIDC_ROLE_ADMIN and OIDC_ROLE_ADMIN in roles:
                 role = Role.ADMIN
             elif OIDC_ROLE_EDITOR and OIDC_ROLE_EDITOR in roles:


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

In my example, using Authelia + LLDAP and `OIDC_CLAIM_ROLES=groups`, when a user is part of no group, the claim will be returned as `null`.
<img width="564" height="265" alt="image" src="https://github.com/user-attachments/assets/4c1242f5-6888-4a92-ab5c-c2728ffb8693" />

Which results in a type error in RomM:
```
File "/backend/endpoints/auth.py", line 256, in auth_openid
await oidc_handler.get_current_active_user_from_openid_token(token)
File "/backend/handler/auth/base_handler.py", line 336, in get_current_active_user_from_openid_token
if OIDC_ROLE_ADMIN and OIDC_ROLE_ADMIN in roles:
                                    ^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
 ```

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

