### PR TITLE
[ROMM-2146] Open rows in new tab with right click

### DIFF
--- a/frontend/src/components/common/Game/VirtualTable.vue
+++ b/frontend/src/components/common/Game/VirtualTable.vue
@@ -148,8 +148,7 @@ function updateOptions({ sortBy }: { sortBy: SortBy }) {
           selectedRomIDs.length < filteredRoms.length
         "
         :model-value="selectedRomIDs.length === filteredRoms.length"
-        @click.stop
-        @click="updateSelectAll"
+        @click.stop="updateSelectAll"
       />
     </template>
     <template #item="{ item }">
@@ -377,8 +376,7 @@ function updateOptions({ sortBy }: { sortBy: SortBy }) {
               download
               variant="text"
               size="small"
-              @click.prevent
-              @click="romApi.downloadRom({ rom: item })"
+              @click.prevent="romApi.downloadRom({ rom: item })"
             >
               <v-icon>mdi-download</v-icon>
             </v-btn>


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Required using the `#item` slot for `v-data-table-virtual` and defining the entire row, but totally works on desktop and tablet.

Fixes #2146

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots

<img width="1359" height="563" alt="Screenshot 2025-10-21 at 6 59 28 PM" src="https://github.com/user-attachments/assets/3314fdf3-41b4-4faa-bb5a-8250ab07957d" />