### PR TITLE
config.example.yml - Corrects the indentation level of the "media" list

### DIFF
--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -82,25 +82,25 @@ filesystem: {} # { roms_folder: 'roms' } For example if your folder structure is
 #       - "fr"
 #     # Media assets to download
 #     # Only used by Screenscraper and ES-DE gamelist.xml
-#     media:
-#       # Used as alternative cover art
-#       - box2d  # Normal cover art (always enabled)
-#       - box3d  # 3D box art
-#       - miximage  # Mixed image of multiple media
-#       - physical  # Disc, cartridge, etc.
-#       # Added to the screenshots carousel
-#       - screenshot  # Screenshot (enabled by default)
-#       - title_screen  # Title screen
-#       - fanart  # User uploaded artwork
-#       # Bezel displayed around the emulatorjs window
-#       - bezel
-#       # Manual in PDF format
-#       - manual (enabled by default)
-#       # Gameplay video
-#       - video  # Video (warning: large file size)
-#       # Other media assets (might be used in the future)
-#       - marquee  # Custom marquee
-#       - logo  # Transparent logo
+#   media:
+#     # Used as alternative cover art
+#     - box2d  # Normal cover art (always enabled)
+#     - box3d  # 3D box art
+#     - miximage  # Mixed image of multiple media
+#     - physical  # Disc, cartridge, etc.
+#     # Added to the screenshots carousel
+#     - screenshot  # Screenshot (enabled by default)
+#     - title_screen  # Title screen
+#     - fanart  # User uploaded artwork
+#     # Bezel displayed around the emulatorjs window
+#     - bezel
+#     # Manual in PDF format
+#     - manual # Manual (enabled by default)
+#     # Gameplay video
+#     - video  # Video (warning: large file size)
+#     # Other media assets (might be used in the future)
+#     - marquee  # Custom marquee
+#     - logo  # Transparent logo
 
 # EmulatorJS per-core options
 # emulatorjs:


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Correction of the indentation level of the "media" list.
It should be under the "scan" section, not under "priority".

**Checklist**
- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
