### PR TITLE
[ROMM-2639][ROMM-2627] Stop running scans during migration

### DIFF
--- a/backend/alembic/versions/0025_roms_hashes.py
+++ b/backend/alembic/versions/0025_roms_hashes.py
@@ -9,11 +9,6 @@ Create Date: 2024-08-11 21:50:53.301352
 import sqlalchemy as sa
 from alembic import op
 
-from config import IS_PYTEST_RUN, SCAN_TIMEOUT
-from endpoints.sockets.scan import scan_platforms
-from handler.redis_handler import high_prio_queue
-from handler.scan_handler import ScanType
-
 # revision identifiers, used by Alembic.
 revision = "0025_roms_hashes"
 down_revision = "0024_sibling_roms_db_view"

--- a/backend/alembic/versions/0033_rom_file_and_hashes.py
+++ b/backend/alembic/versions/0033_rom_file_and_hashes.py
@@ -10,10 +10,6 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects.postgresql import ENUM
 
-from config import IS_PYTEST_RUN, SCAN_TIMEOUT
-from endpoints.sockets.scan import scan_platforms
-from handler.redis_handler import high_prio_queue
-from handler.scan_handler import ScanType
 from utils.database import CustomJSON, is_postgresql
 
 # revision identifiers, used by Alembic.


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

It's been over a year since these migrations have run for most users, and we don't want them to run for new users anymore (instead users should manually trigger the scan they want).

Fixes #2639
Fixes #2627

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
