### PR TITLE
feat: Add metadata locale selection for IGDB and ScreenScraper

### DIFF
--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -213,13 +213,13 @@ def extract_metadata_from_igdb_rom(self: MetadataHandler, rom: Game) -> IGDBMeta
 # Mapping from scan.priority.region codes to IGDB game_localizations region identifiers
 # IGDB's game_localizations provides regional titles and cover art, but NOT localized descriptions
 REGION_TO_IGDB_LOCALE: dict[str, str | None] = {
-    "us": None,        # United States - use default (no localization needed)
-    "wor": None,       # World - use default
-    "eu": "EU",        # Europe region
-    "jp": "ja-JP",     # Japan
-    "kr": "ko-KR",     # Korea
-    "cn": "zh-CN",     # China (Simplified Chinese)
-    "tw": "zh-TW",     # Taiwan (Traditional Chinese)
+    "us": None,  # United States - use default (no localization needed)
+    "wor": None,  # World - use default
+    "eu": "EU",  # Europe region
+    "jp": "ja-JP",  # Japan
+    "kr": "ko-KR",  # Korea
+    "cn": "zh-CN",  # China (Simplified Chinese)
+    "tw": "zh-TW",  # Taiwan (Traditional Chinese)
 }
 
 
@@ -240,7 +240,7 @@ def get_igdb_preferred_locale() -> str | None:
         if igdb_locale is not None:
             return igdb_locale
 
-    return None  # Default - no localization
+    return None
 
 
 def extract_localized_data(rom: Game, preferred_locale: str | None) -> tuple[str, str]:
@@ -281,11 +281,15 @@ def extract_localized_data(rom: Game, preferred_locale: str | None) -> tuple[str
             return localized_name, cover_url
 
     # Locale not found, fall back to default
-    log.warning(f"IGDB locale '{preferred_locale}' not found for '{default_name}', using default")
+    log.warning(
+        f"IGDB locale '{preferred_locale}' not found for '{default_name}', using default"
+    )
     return default_name, default_cover
 
 
-def build_igdb_rom(handler: "IGDBHandler", rom: Game, preferred_locale: str | None) -> "IGDBRom":
+def build_igdb_rom(
+    handler: "IGDBHandler", rom: Game, preferred_locale: str | None
+) -> "IGDBRom":
     """Build an IGDBRom from IGDB game data with localization support.
 
     Args:

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -413,7 +413,9 @@ def build_ss_game(rom: Rom, game: SSGame) -> SSRom:
 
     # Log warning if we had to fall back from the preferred locale
     if preferred_languages and used_lang and used_lang != preferred_languages[0]:
-        log.warning(f"ScreenScraper locale '{preferred_languages[0]}' not found for '{res_name}', using '{used_lang}'")
+        log.warning(
+            f"ScreenScraper locale '{preferred_languages[0]}' not found for '{res_name}', using '{used_lang}'"
+        )
 
     url_cover = ss_metadata["box2d_url"]
     url_manual = (

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -71,13 +71,13 @@ filesystem: {} # { roms_folder: 'roms' } For example if your folder structure is
 #       - "hasheous" # Hasheous
 #       - "flashpoint" # Flashpoint Project
 #       - "hltb" # HowLongToBeat
-#     region: # Cover art and game title (only used by Screenscraper)
+#     region: # Used by IGDB and ScreenScraper for regional variants
 #       - "us"
 #       - "wor"
 #       - "ss"
 #       - "eu"
 #       - "jp"
-#     language: # Cover art and game title (only used by Screenscraper)
+#     language: # Used by ScreenScraper for descriptions
 #       - "en"
 #       - "fr"
 #     # Media assets to download

--- a/frontend/src/views/Settings/MetadataSources.vue
+++ b/frontend/src/views/Settings/MetadataSources.vue
@@ -2,8 +2,8 @@
 import { computed, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import RSection from "@/components/common/RSection.vue";
-import storeHeartbeat from "@/stores/heartbeat";
 import storeConfig from "@/stores/config";
+import storeHeartbeat from "@/stores/heartbeat";
 
 const { t } = useI18n();
 const heartbeat = storeHeartbeat();


### PR DESCRIPTION
**Description**

Having the possibility to pull metadata in my language and proper jacket for my version of the games is something I really want :)

This PR adds the possibility to choose a locale for compatible metadata sources. It is a bit crude for now but I find it to be a nice first step.

- Add provider-specific locale configuration for IGDB and ScreenScraper
- IGDB: Support for ja-JP, ko-KR, zh-CN, zh-TW, and EU regions
- ScreenScraper: Support for en, fr, de, es, it, pt languages
- Settings UI with locale dropdowns in Metadata Sources section
- Fallback warnings when requested locale is not available

> This PR was written primarily by Claude Code.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots
<img width="996" height="1167" alt="{0DC08048-F618-47E4-84FC-CC0E002FEA2D}" src="https://github.com/user-attachments/assets/2c43d67e-f55e-400b-8a89-a23e25d1ef36" />
<img width="1555" height="635" alt="{190C5F0E-6369-4F36-BEC4-1D2337E5EE6D}" src="https://github.com/user-attachments/assets/83aaaa55-c314-4f3c-9062-0f89c88f74ba" />
<img width="993" height="811" alt="{990C93E6-A83C-4830-93BB-C4D4FF4F38B1}" src="https://github.com/user-attachments/assets/2459e72d-9c4b-4469-8aff-87ed5527bab9" />