### PR TITLE
Fixed link to documentation in filestructure error

### DIFF
--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -15,10 +15,10 @@ from endpoints.responses import TaskType
 from endpoints.responses.platform import PlatformSchema
 from endpoints.responses.rom import SimpleRomSchema
 from exceptions.fs_exceptions import (
+    FOLDER_STRUCT_MSG,
     FirmwareNotFoundException,
     FolderStructureNotMatchException,
     RomsNotFoundException,
-    FOLDER_STRUCT_MSG
 )
 from exceptions.socket_exceptions import ScanStoppedException
 from handler.database import db_firmware_handler, db_platform_handler, db_rom_handler

--- a/backend/exceptions/fs_exceptions.py
+++ b/backend/exceptions/fs_exceptions.py
@@ -1,7 +1,7 @@
 from logger.formatter import BLUE
 from logger.formatter import highlight as hl
 
-FOLDER_STRUCT_MSG  = "Check RomM folder structure here: https://docs.romm.app/latest/Getting-Started/Folder-Structure/ for more details"
+FOLDER_STRUCT_MSG = "Check RomM folder structure here: https://docs.romm.app/latest/Getting-Started/Folder-Structure/ for more details"
 
 
 class FolderStructureNotMatchException(Exception):


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

When encountering a `exceptions.fs_exceptions.RomsNotFoundException` the error message points to the wrong documentation link:

```
exceptions.fs_exceptions.RomsNotFoundException: Roms not found for platform [34mwonderswan[0m. Check RomM folder structure here: https://github.com/rommapp/romm?tab=readme-ov-file#folder-structure
```

I updated the link the correct URL of https://docs.romm.app/latest/Getting-Started/Folder-Structure/


**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots

<img width="1844" height="158" alt="image" src="https://github.com/user-attachments/assets/b9fb7047-3e2b-4777-b83a-37ba87137cbf" />