### PR TITLE
Add OpenBOR metadata entry for screenscraper

### DIFF
--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -843,6 +843,7 @@ SCREENSAVER_PLATFORM_LIST: dict[UPS, SlugToSSId] = {
     UPS.NINTENDO_DSI: {"id": 15, "name": "Nintendo DS"},
     UPS.SWITCH: {"id": 225, "name": "Switch"},
     UPS.ODYSSEY_2: {"id": 104, "name": "Videopac G7000"},
+    UPS.OPENBOR: {"id": 214, "name": "OpenBOR"},
     UPS.ORIC: {"id": 131, "name": "Oric 1 / Atmos"},
     UPS.PC_8800_SERIES: {"id": 221, "name": "NEC PC-8801"},
     UPS.PC_9800_SERIES: {"id": 208, "name": "NEC PC-9801"},


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Added missing screenscraper platform id for operBOR</sup>

- [x ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

