### PR TITLE
feat: Manual Match metada priority

### DIFF
--- a/backend/endpoints/search.py
+++ b/backend/endpoints/search.py
@@ -175,7 +175,7 @@ async def search_rom(
         source_matched_roms, meta_handler, id_key, cover_key = source_configs[
             meta_source
         ]
-        for source_rom in source_matched_roms:
+        for source_rom in source_matched_roms:  # trunk-ignore(mypy/attr-defined)
             if source_rom[id_key]:
                 normalized_name = meta_handler.normalize_search_term(
                     source_rom.get("name", ""),
@@ -186,7 +186,7 @@ async def search_rom(
                     "is_identified": True,
                     "is_unidentified": False,
                     "platform_id": rom.platform_id,
-                    cover_key: source_rom.pop("url_cover", ""),
+                    cover_key: source_rom.get("url_cover", ""),
                     **merged_dict.get(normalized_name, {}),
                 }
 


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description** 
When a game returns multiple merged sources from a manual match, it previously always prioritised IGDB data over other sources. This pull request changes the logic so that the merged result uses the same priority list configured for scans.

**Checklist**
- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes