### PR TITLE
Improve performance of queries on roms table

### DIFF
--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -106,7 +106,7 @@ def with_details(func):
     def wrapper(*args, **kwargs):
         kwargs["query"] = select(Rom).options(
             # Ensure platform is loaded for main ROM objects
-            joinedload(Rom.platform),
+            selectinload(Rom.platform),
             selectinload(Rom.saves).options(
                 noload(Save.rom),
                 noload(Save.user),
@@ -138,7 +138,7 @@ def with_simple(func):
     def wrapper(*args, **kwargs):
         kwargs["query"] = select(Rom).options(
             # Ensure platform is loaded for main ROM objects
-            joinedload(Rom.platform),
+            selectinload(Rom.platform),
             # Display properties for the current user (last_played)
             selectinload(Rom.rom_users).options(noload(RomUser.rom)),
             # Sort table by metadata (first_release_date)


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

The queries on the roms become painfully slow when attempting to query later pages in large databases. As an example my database contains ~25k roms, and getting the first 500 roms (`api/roms?limit=500&offset=0`) is pretty quick, but getting a similar chunk towards the end (`api/roms?limit=500&offset=20000`) takes several minutes.

I use a PostgreSQL database, so that is what the queries below will be for, but the same problem may also occur on other database engines.

Digging into the generated queries the query that's causing the issues looks something like this:

```psql
SELECT
	roms.id,
	roms.igdb_id,
	roms.sgdb_id,
	roms.moby_id,
	roms.ss_id,
	roms.ra_id,
	roms.launchbox_id,
	roms.hasheous_id,
	roms.tgdb_id,
	roms.flashpoint_id,
	roms.hltb_id,
	roms.gamelist_id,
	roms.fs_name,
	roms.fs_name_no_tags,
	roms.fs_name_no_ext,
	roms.fs_extension,
	roms.fs_path,
	roms.fs_size_bytes,
	roms.name,
	roms.slug,
	roms.summary,
	roms.igdb_metadata,
	roms.moby_metadata,
	roms.ss_metadata,
	roms.ra_metadata,
	roms.launchbox_metadata,
	roms.hasheous_metadata,
	roms.flashpoint_metadata,
	roms.hltb_metadata,
	roms.gamelist_metadata,
	roms.path_cover_s,
	roms.path_cover_l,
	roms.url_cover,
	roms.path_manual,
	roms.url_manual,
	roms.path_screenshots,
	roms.url_screenshots,
	roms.revision,
	roms.regions,
	roms.languages,
	roms.tags,
	roms.crc_hash,
	roms.md5_hash,
	roms.sha1_hash,
	roms.ra_hash,
	roms.missing_from_fs,
	roms.platform_id,
	roms.created_at,
	roms.updated_at,
	(
		SELECT
			count(roms.id) AS count_1
		FROM
			roms
		WHERE
			roms.platform_id = platforms_1.id
	) AS anon_1,
	(
		SELECT
			coalesce(sum(roms.fs_size_bytes), $1::integer) AS coalesce_1
		FROM
			roms
		WHERE
			roms.platform_id = platforms_1.id
	) AS anon_2,
	platforms_1.id AS id_1,
	platforms_1.igdb_id AS igdb_id_1,
	platforms_1.sgdb_id AS sgdb_id_1,
	platforms_1.moby_id AS moby_id_1,
	platforms_1.ss_id AS ss_id_1,
	platforms_1.ra_id AS ra_id_1,
	platforms_1.launchbox_id AS launchbox_id_1,
	platforms_1.hasheous_id AS hasheous_id_1,
	platforms_1.tgdb_id AS tgdb_id_1,
	platforms_1.flashpoint_id AS flashpoint_id_1,
	platforms_1.igdb_slug,
	platforms_1.moby_slug,
	platforms_1.hltb_slug,
	platforms_1.slug AS slug_1,
	platforms_1.fs_slug,
	platforms_1.name AS name_1,
	platforms_1.custom_name,
	platforms_1.category,
	platforms_1.generation,
	platforms_1.family_name,
	platforms_1.family_slug,
	platforms_1.url,
	platforms_1.url_logo,
	platforms_1.aspect_ratio,
	platforms_1.temp_old_slug,
	platforms_1.missing_from_fs AS missing_from_fs_1,
	platforms_1.created_at AS created_at_1,
	platforms_1.updated_at AS updated_at_1
FROM roms
LEFT OUTER JOIN rom_user ON rom_user.rom_id = roms.id AND rom_user.user_id = $2::integer
LEFT OUTER JOIN platforms AS platforms_1 ON platforms_1.id = roms.platform_id
WHERE
	rom_user.hidden IS FALSE
	OR rom_user.hidden IS NULL
ORDER BY trim(REGEXP_REPLACE(lower(roms.name), $3::varchar, $4::varchar, 'i')) ASC
LIMIT $5::integer
OFFSET $6::integer
```

Running two query plans with offset 0 & 10000 shows the drastic increase in cost as the offset increases:

```
Cost       4,630.05 ..  3,871,521.30
Cost  7,7348,030.44 .. 81,214,986.38
```

The plans didn't really make it clear to me where this difference was coming from though. I spent some time removing parts of the query and running plans on it to track this down, and found that the portion of the query that causes all the pain are the subqueries for `anon_1` and `anon_2`, which correspond to the `rom_count` and `fs_size_bytes` fields of `Platform`. Changing these properties to instead use a query that always returns 0 verified that these subqueries were indeed the cause, making the API request that previously took minutes take less than a second (as it should).

It makes sense that these subqueries are an expensive part of the query as they require reading the entire roms table, meaning that this has a complexity of `O(n^2)`. I'm somewhat surprised this is worse for larger offsets though since evaluating these queries doesn't seem necessary to determine the set of roms to operate on. Either way it doesn't really make sense to calculate this for each rom since it's a property of the platform, not the rom. A much more efficient way to do this would be to join on a subquery in which these fields are calculated for each platform, like so:

```psql
SELECT
	roms.id,
	roms.igdb_id,
	roms.sgdb_id,
	roms.moby_id,
	roms.ss_id,
	roms.ra_id,
	roms.launchbox_id,
	roms.hasheous_id,
	roms.tgdb_id,
	roms.flashpoint_id,
	roms.hltb_id,
	roms.gamelist_id,
	roms.fs_name,
	roms.fs_name_no_tags,
	roms.fs_name_no_ext,
	roms.fs_extension,
	roms.fs_path,
	roms.fs_size_bytes,
	roms.name,
	roms.slug,
	roms.summary,
	roms.igdb_metadata,
	roms.moby_metadata,
	roms.ss_metadata,
	roms.ra_metadata,
	roms.launchbox_metadata,
	roms.hasheous_metadata,
	roms.flashpoint_metadata,
	roms.hltb_metadata,
	roms.gamelist_metadata,
	roms.path_cover_s,
	roms.path_cover_l,
	roms.url_cover,
	roms.path_manual,
	roms.url_manual,
	roms.path_screenshots,
	roms.url_screenshots,
	roms.revision,
	roms.regions,
	roms.languages,
	roms.tags,
	roms.crc_hash,
	roms.md5_hash,
	roms.sha1_hash,
	roms.ra_hash,
	roms.missing_from_fs,
	roms.platform_id,
	roms.created_at,
	roms.updated_at,
	platforms_1.id AS id_1,
	platforms_1.igdb_id AS igdb_id_1,
	platforms_1.sgdb_id AS sgdb_id_1,
	platforms_1.moby_id AS moby_id_1,
	platforms_1.ss_id AS ss_id_1,
	platforms_1.ra_id AS ra_id_1,
	platforms_1.launchbox_id AS launchbox_id_1,
	platforms_1.hasheous_id AS hasheous_id_1,
	platforms_1.tgdb_id AS tgdb_id_1,
	platforms_1.flashpoint_id AS flashpoint_id_1,
	platforms_1.igdb_slug,
	platforms_1.moby_slug,
	platforms_1.hltb_slug,
	platforms_1.slug AS slug_1,
	platforms_1.fs_slug,
	platforms_1.name AS name_1,
	platforms_1.custom_name,
	platforms_1.category,
	platforms_1.generation,
	platforms_1.family_name,
	platforms_1.family_slug,
	platforms_1.url,
	platforms_1.url_logo,
	platforms_1.aspect_ratio,
	platforms_1.temp_old_slug,
	platforms_1.missing_from_fs AS missing_from_fs_1,
	platforms_1.created_at AS created_at_1,
	platforms_1.updated_at AS updated_at_1,
	platforms_1.anon_1 AS anon_1,
	platforms_1.anon_2 AS anon_2
FROM roms
LEFT OUTER JOIN rom_user ON rom_user.rom_id = roms.id AND rom_user.user_id = $2::integer
LEFT OUTER JOIN
	(
		SELECT
			*,
			(
				SELECT
					count(roms.id) AS count_1
				FROM
					roms
				WHERE
					roms.platform_id = id
			) AS anon_1,
			(
				SELECT
					coalesce(sum(roms.fs_size_bytes), $1::integer) AS coalesce_1
				FROM
					roms
				WHERE
					roms.platform_id = id
			) AS anon_2
		FROM platforms
	)
	AS platforms_1
	ON platforms_1.id = roms.platform_id
WHERE
	rom_user.hidden IS FALSE
	OR rom_user.hidden IS NULL
ORDER BY trim(REGEXP_REPLACE(lower(roms.name), $3::varchar, $4::varchar, 'i')) ASC
LIMIT $5::integer
OFFSET $6::integer
```

Running two query plans for this altered query (using the same offsets as before) confirms that this is much more efficient & scales much better:

```
Cost  12,362.15 .. 12,363.40
Cost  18,137.54 .. 18,212.24
```

Of course, we're not going to be changing the queries directly, but this does confirm that the thing we need to change to resolve this issue is how the `platforms` table is joined on in this query.

My first attempt at this was to change this join from `joinedload` to `selectinload`. This didn't result in the exact same changes to the query as in the manually-improved version — in fact, the platform table no longer even appeared in any of the queries I logged — but it did result in the desired performance improvement. Perplexed by this I ran the tests and found they all passed. I also did some manual checking with the frontend, and did not encounter any issues there either.

At this point I assumed this join was only added when needed & I just hadn't logged any of those queries. To confirm this I removed it altogether and… got the same results.

That leads to this PR, which ~~removes the offending joins~~. Everything I've tested suggest they are not needed, but I'm curious to hear from someone more knowledgeable about this project whether this is actually true or whether I've just missed a case where they are required.

EDIT: Switched to using `selectinload` instead of removing, see later comments.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes