### PR TITLE
Fix YAML indentation in netplay section of config example file

### DIFF
--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -146,13 +146,13 @@
 #       snes9x_region: ntsc
 #     default: # These settings apply to all cores
 #       fps: show
-# netplay:
-#   enabled: true
-#   ice_servers:
-#     - urls: "stun:stun.relay.metered.ca:80"
-#     - urls: "turn:global.relay.metered.ca:80"
-#       username: "<username>"
-#       credential: "<password>"
+#   netplay:
+#     enabled: true
+#     ice_servers:
+#       - urls: "stun:stun.relay.metered.ca:80"
+#       - urls: "turn:global.relay.metered.ca:80"
+#         username: "<username>"
+#         credential: "<password>"
 #   controls: # https://emulatorjs.org/docs4devs/control-mapping/
 #     snes9x:
 #       0: # Player 1


### PR DESCRIPTION
Corrected the indentation for the netplay configuration within the config example file.
