### PR TITLE
fix: Reverted filter null attributes from games

### DIFF
--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -620,7 +620,7 @@ class DBRomsHandler(DBBaseHandler):
 
         if user_id and hasattr(RomUser, order_by) and not hasattr(Rom, order_by):
             order_attr = getattr(RomUser, order_by)
-            query = query.filter(RomUser.user_id == user_id, order_attr.isnot(None))
+            query = query.filter(order_attr.isnot(None))
         elif hasattr(RomMetadata, order_by) and not hasattr(Rom, order_by):
             order_attr = getattr(RomMetadata, order_by)
             query = query.outerjoin(RomMetadata, RomMetadata.rom_id == Rom.id).filter(


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>
#2804 introduced a change to try to fix #2791 but that caused #2816. That change shouldn't be neccessary.
Locally tested and filter unmatched games or matched games without some attributes like rating from metadata providers work as expected
When makind the endpoint request with a ``order_by`` attribute that some games has as empty (like ``average_rating``) they still show, at the end or at the beginning depending in the ``order_dir``.

**_NOTE: maybe since i'm getting an empty list instead of a ``null`` from unidentified game in the ``average_rating`` is what is making my test to work_**

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

<img width="591" height="429" alt="image" src="https://github.com/user-attachments/assets/af03d183-9fc8-4153-8b05-899e8951fbf7" />

<img width="475" height="400" alt="image" src="https://github.com/user-attachments/assets/99c49cfa-5a59-44bd-b0f3-108341dd4219" />

<img width="1910" height="843" alt="image" src="https://github.com/user-attachments/assets/79e3aece-42a5-41b7-9c10-d09836505c0c" />

Closes #2816
