### PR TITLE
feat: sort comboboxes alphabetically in the dialog of PlatformBinding

### DIFF
--- a/frontend/src/components/Settings/LibraryManagement/Config/Dialog/CreatePlatformBinding.vue
+++ b/frontend/src/components/Settings/LibraryManagement/Config/Dialog/CreatePlatformBinding.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Emitter } from "mitt";
-import { inject, ref } from "vue";
+import { computed, inject, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useDisplay } from "vuetify";
 import PlatformIcon from "@/components/common/Platform/PlatformIcon.vue";
@@ -21,15 +21,25 @@ const supportedPlatforms = ref<Platform[]>();
 const heartbeat = storeHeartbeat();
 const fsSlugToCreate = ref<string>("");
 const selectedPlatform = ref<Platform>();
+
+const sortedFsPlatforms = computed(() => {
+  return heartbeat.value.FILESYSTEM.FS_PLATFORMS?.slice().sort((a, b) =>
+    a.localeCompare(b),
+  ) ?? [];
+});
+
+const sortedSupportedPlatforms = computed(() => {
+  return supportedPlatforms.value?.slice().sort((a, b) =>
+    a.name.localeCompare(b.name),
+  ) ?? [];
+});
 emitter?.on(
   "showCreatePlatformBindingDialog",
   async ({ fsSlug = "", slug = "" }) => {
     await platformApi
       .getSupportedPlatforms()
       .then(({ data }) => {
-        supportedPlatforms.value = data.sort((a, b) => {
-          return a.name.localeCompare(b.name);
-        });
+        supportedPlatforms.value = data;
       })
       .catch(({ response, message }) => {
         emitter?.emit("snackbarShow", {
@@ -100,7 +110,7 @@ function closeDialog() {
         <v-col cols="6">
           <v-select
             v-model="fsSlugToCreate"
-            :items="heartbeat.value.FILESYSTEM.FS_PLATFORMS"
+            :items="sortedFsPlatforms"
             :label="t('settings.folder-name')"
             variant="outlined"
             required
@@ -116,7 +126,7 @@ function closeDialog() {
             v-model="selectedPlatform"
             class="text-primary"
             :label="t('settings.romm-platform')"
-            :items="supportedPlatforms"
+            :items="sortedSupportedPlatforms"
             color="primary"
             base-color="primary"
             variant="outlined"


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Sort both comboboxes in the CreatePlatformBinding dialog alphabetically:
- **Filesystem platforms combobox**: Now sorted alphabetically using `localeCompare()`
- **ROMM platforms autocomplete**: Now sorted by platform name using a computed property

**Implementation Details**
- Added `computed` import from Vue
- Created `sortedFsPlatforms` computed property to sort filesystem platforms
- Created `sortedSupportedPlatforms` computed property to sort supported platforms
- Updated both combobox bindings to use the sorted computed properties
- Removed inline sorting from the API response for consistency

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

