### PR TITLE
[ROMM-2835] Fix appearance of chevron screenshot buttons

### DIFF
--- a/frontend/src/components/Details/Info/MediaCarousel.vue
+++ b/frontend/src/components/Details/Info/MediaCarousel.vue
@@ -70,11 +70,7 @@ const carouselHeight = computed(() => {
     :height="carouselHeight"
   >
     <template #prev="{ props: prevProps }">
-      <v-btn
-        icon="mdi-chevron-left"
-        class="translucent"
-        @click="prevProps.onClick"
-      />
+      <v-btn icon="mdi-chevron-left" @click="prevProps.onClick" />
     </template>
     <v-carousel-item
       v-if="youtubeVideoId"
@@ -87,7 +83,15 @@ const carouselHeight = computed(() => {
         :src="`${heartbeat.FRONTEND.YOUTUBE_BASE_URL}/embed/${youtubeVideoId}`"
         title="YouTube video player"
         frameborder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allow="
+          accelerometer;
+          autoplay;
+          clipboard-write;
+          encrypted-media;
+          gyroscope;
+          picture-in-picture;
+          web-share;
+        "
         referrerpolicy="strict-origin-when-cross-origin"
         allowfullscreen
       />
@@ -120,11 +124,7 @@ const carouselHeight = computed(() => {
       />
     </template>
     <template #next="{ props: nextProps }">
-      <v-btn
-        icon="mdi-chevron-right"
-        class="translucent"
-        @click="nextProps.onClick"
-      />
+      <v-btn icon="mdi-chevron-right" @click="nextProps.onClick" />
     </template>
   </v-carousel>
 </template>


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #2835 

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

<img width="97" height="97" alt="Screenshot 2026-01-02 at 11 30 03 AM" src="https://github.com/user-attachments/assets/f337f8d2-4c5c-4310-99e3-586078a9af02" />
<img width="81" height="80" alt="Screenshot 2026-01-02 at 11 30 06 AM" src="https://github.com/user-attachments/assets/ac5e88ba-f7d0-4dee-ae72-57d2169b7133" />
