### PR TITLE
misc: Configure and run deptry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "passlib[bcrypt] ~= 1.7",
   "pillow ~= 10.3",
   "psycopg[c] ~= 3.2",
+  "pydantic ~= 2.11",
   "pydash ~= 7.0",
   "python-dotenv ~= 1.0",
   "python-magic ~= 0.4",
@@ -49,11 +50,6 @@ dependencies = [
   "starlette ~= 0.49",
   "streaming-form-data ~= 1.19",
   "strsimpy ~= 0.2",
-  "types-colorama ~= 0.4",
-  "types-passlib ~= 1.7",
-  "types-pyyaml ~= 6.0",
-  "types-redis ~= 4.6",
-  "user-agents ~= 2.2",
   "uvicorn ~= 0.35",
   "uvicorn-worker ~= 0.3",
   "watchfiles ~= 1.1",
@@ -68,6 +64,10 @@ dev = [
   "memray ~= 1.15",
   "mypy ~= 1.13",
   "pyinstrument ~= 5.0",
+  "types-colorama ~= 0.4",
+  "types-passlib ~= 1.7",
+  "types-pyyaml ~= 6.0",
+  "types-redis ~= 4.6",
 ]
 test = [
   "fakeredis ~= 2.21",
@@ -82,6 +82,54 @@ test = [
 [project.urls]
 Homepage = "https://romm.app/"
 Source = "https://github.com/rommapp/romm"
+
+[tool.deptry]
+known_first_party = [
+  "__version__",
+  "adapters",
+  "config",
+  "decorators",
+  "endpoints",
+  "exceptions",
+  "handler",
+  "logger",
+  "main",
+  "models",
+  "startup",
+  "tasks",
+  "utils",
+]
+pep621_dev_dependency_groups = ["dev"]
+
+[tool.deptry.package_module_name_map]
+PyYAML = "yaml"
+opentelemetry-distro = "opentelemetry"
+pillow = "PIL"
+python-dotenv = "dotenv"
+python-magic = "magic"
+python-socketio = "socketio"
+
+[tool.deptry.per_rule_ignores]
+DEP002 = [ # DEP002 rule: Project should not contain unused dependencies
+  # Packages used within the server initialization script.
+  "gunicorn",
+  "uvicorn-worker",
+  "watchfiles",
+  # OpenTelemetry packages are used via auto-instrumentation.
+  "opentelemetry-exporter-otlp",
+  "opentelemetry-instrumentation-aiohttp-client",
+  "opentelemetry-instrumentation-fastapi",
+  "opentelemetry-instrumentation-httpx",
+  "opentelemetry-instrumentation-redis",
+  "opentelemetry-instrumentation-sqlalchemy",
+  # Database drivers are used via SQLAlchemy.
+  "psycopg",
+  # Pytest plugins are used via pytest only.
+  "pytest-cov",
+  "pytest-env",
+  "pytest-mock",
+  "pytest-recording",
+]
 
 [tool.uv]
 package = false

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "platform_python_implementation != 'PyPy'",
@@ -1923,6 +1923,7 @@ dependencies = [
     { name = "passlib", extra = ["bcrypt"] },
     { name = "pillow" },
     { name = "psycopg", extra = ["c"] },
+    { name = "pydantic" },
     { name = "pydash" },
     { name = "python-dotenv" },
     { name = "python-magic" },
@@ -1936,12 +1937,7 @@ dependencies = [
     { name = "starlette" },
     { name = "streaming-form-data" },
     { name = "strsimpy" },
-    { name = "types-colorama" },
-    { name = "types-passlib" },
-    { name = "types-pyyaml" },
-    { name = "types-redis" },
     { name = "unidecode" },
-    { name = "user-agents" },
     { name = "uvicorn" },
     { name = "uvicorn-worker" },
     { name = "watchfiles" },
@@ -1956,6 +1952,10 @@ dev = [
     { name = "memray" },
     { name = "mypy" },
     { name = "pyinstrument" },
+    { name = "types-colorama" },
+    { name = "types-passlib" },
+    { name = "types-pyyaml" },
+    { name = "types-redis" },
 ]
 test = [
     { name = "fakeredis" },
@@ -1996,6 +1996,7 @@ requires-dist = [
     { name = "passlib", extras = ["bcrypt"], specifier = "~=1.7" },
     { name = "pillow", specifier = "~=10.3" },
     { name = "psycopg", extras = ["c"], specifier = "~=3.2" },
+    { name = "pydantic", specifier = "~=2.11" },
     { name = "pydash", specifier = "~=7.0" },
     { name = "pyinstrument", marker = "extra == 'dev'", specifier = "~=5.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = "~=8.3" },
@@ -2016,12 +2017,11 @@ requires-dist = [
     { name = "starlette", specifier = "~=0.49" },
     { name = "streaming-form-data", specifier = "~=1.19" },
     { name = "strsimpy", specifier = "~=0.2" },
-    { name = "types-colorama", specifier = "~=0.4" },
-    { name = "types-passlib", specifier = "~=1.7" },
-    { name = "types-pyyaml", specifier = "~=6.0" },
-    { name = "types-redis", specifier = "~=4.6" },
+    { name = "types-colorama", marker = "extra == 'dev'", specifier = "~=0.4" },
+    { name = "types-passlib", marker = "extra == 'dev'", specifier = "~=1.7" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = "~=6.0" },
+    { name = "types-redis", marker = "extra == 'dev'", specifier = "~=4.6" },
     { name = "unidecode", specifier = "~=1.3" },
-    { name = "user-agents", specifier = "~=2.2" },
     { name = "uvicorn", specifier = "~=0.35" },
     { name = "uvicorn-worker", specifier = "~=0.3" },
     { name = "watchfiles", specifier = "~=1.1" },
@@ -2388,26 +2388,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ua-parser"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ua-parser-builtins" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/70/0e/ed98be735bc89d5040e0c60f5620d0b8c04e9e7da99ed1459e8050e90a77/ua_parser-1.0.1.tar.gz", hash = "sha256:f9d92bf19d4329019cef91707aecc23c6d65143ad7e29a233f0580fb0d15547d", size = 728106, upload-time = "2025-02-01T14:13:32.508Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/37/be6dfbfa45719aa82c008fb4772cfe5c46db765a2ca4b6f524a1fdfee4d7/ua_parser-1.0.1-py3-none-any.whl", hash = "sha256:b059f2cb0935addea7e551251cbbf42e9a8872f86134163bc1a4f79e0945ffea", size = 31410, upload-time = "2025-02-01T14:13:28.458Z" },
-]
-
-[[package]]
-name = "ua-parser-builtins"
-version = "0.18.0.post1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/d3/13adff37f15489c784cc7669c35a6c3bf94b87540229eedf52ef2a1d0175/ua_parser_builtins-0.18.0.post1-py3-none-any.whl", hash = "sha256:eb4f93504040c3a990a6b0742a2afd540d87d7f9f05fd66e94c101db1564674d", size = 86077, upload-time = "2024-12-05T18:44:36.732Z" },
-]
-
-[[package]]
 name = "uc-micro-py"
 version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2432,18 +2412,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930, upload-time = "2025-12-11T15:56:40.252Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182, upload-time = "2025-12-11T15:56:38.584Z" },
-]
-
-[[package]]
-name = "user-agents"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ua-parser" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/e1/63c5bfb485a945010c8cbc7a52f85573561737648d36b30394248730a7bc/user-agents-2.2.0.tar.gz", hash = "sha256:d36d25178db65308d1458c5fa4ab39c9b2619377010130329f3955e7626ead26", size = 9525, upload-time = "2020-08-23T06:01:56.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/1c/20bb3d7b2bad56d881e3704131ddedbb16eb787101306887dff349064662/user_agents-2.2.0-py3-none-any.whl", hash = "sha256:a98c4dc72ecbc64812c4534108806fb0a0b3a11ec3fd1eafe807cee5b0a942e7", size = 9614, upload-time = "2020-08-23T06:01:54.047Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

`deptry` [1] is a tool to check for unused and missing dependencies in Python projects.

By running it, we already found that `pydantic` should be added as a direct dependency, that `types-*` packages can be moved to the `dev` group, and that `user-agents` is no longer used and can be removed.

Ideally, a future PR can include the `trunk` related configuration to run `deptry` automatically.

[1] https://deptry.com/

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes