### PR TITLE
[HOTFIX] Set metadata fields as nullable

### DIFF
--- a/backend/handler/metadata/flashpoint_handler.py
+++ b/backend/handler/metadata/flashpoint_handler.py
@@ -46,14 +46,14 @@ class FlashpointGame(TypedDict):
 class FlashpointMetadata(TypedDict):
     franchises: list[str]
     companies: list[str]
-    source: str
+    source: str | None
     genres: list[str]
     first_release_date: str
     game_modes: list[str]
-    status: str
-    version: str
-    language: str
-    notes: str
+    status: str | None
+    version: str | None
+    language: str | None
+    notes: str | None
 
 
 class FlashpointRom(TypedDict):

--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -71,8 +71,8 @@ class IGDBRelatedGame(TypedDict):
 
 
 class IGDBMetadata(TypedDict):
-    total_rating: str
-    aggregated_rating: str
+    total_rating: str | None
+    aggregated_rating: str | None
     first_release_date: int | None
     youtube_video_id: str | None
     genres: list[str]

--- a/backend/handler/metadata/moby_handler.py
+++ b/backend/handler/metadata/moby_handler.py
@@ -43,7 +43,7 @@ class MobyMetadataPlatform(TypedDict):
 
 
 class MobyMetadata(TypedDict):
-    moby_score: str
+    moby_score: str | None
     genres: list[str]
     alternate_titles: list[str]
     platforms: list[MobyMetadataPlatform]

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -121,7 +121,7 @@ class SSMetadataMedia(TypedDict):
 
 
 class SSMetadata(SSMetadataMedia):
-    ss_score: str
+    ss_score: str | None
     first_release_date: int | None
     alternative_names: list[str]
     companies: list[str]

--- a/frontend/src/__generated__/models/RomFlashpointMetadata.ts
+++ b/frontend/src/__generated__/models/RomFlashpointMetadata.ts
@@ -5,13 +5,13 @@
 export type RomFlashpointMetadata = {
     franchises?: Array<string>;
     companies?: Array<string>;
-    source?: string;
+    source?: (string | null);
     genres?: Array<string>;
     first_release_date?: string;
     game_modes?: Array<string>;
-    status?: string;
-    version?: string;
-    language?: string;
-    notes?: string;
+    status?: (string | null);
+    version?: (string | null);
+    language?: (string | null);
+    notes?: (string | null);
 };
 

--- a/frontend/src/__generated__/models/RomIGDBMetadata.ts
+++ b/frontend/src/__generated__/models/RomIGDBMetadata.ts
@@ -6,8 +6,8 @@ import type { IGDBAgeRating } from './IGDBAgeRating';
 import type { IGDBMetadataPlatform } from './IGDBMetadataPlatform';
 import type { IGDBRelatedGame } from './IGDBRelatedGame';
 export type RomIGDBMetadata = {
-    total_rating?: string;
-    aggregated_rating?: string;
+    total_rating?: (string | null);
+    aggregated_rating?: (string | null);
     first_release_date?: (number | null);
     youtube_video_id?: (string | null);
     genres?: Array<string>;

--- a/frontend/src/__generated__/models/RomMobyMetadata.ts
+++ b/frontend/src/__generated__/models/RomMobyMetadata.ts
@@ -4,7 +4,7 @@
 /* eslint-disable */
 import type { MobyMetadataPlatform } from './MobyMetadataPlatform';
 export type RomMobyMetadata = {
-    moby_score?: string;
+    moby_score?: (string | null);
     genres?: Array<string>;
     alternate_titles?: Array<string>;
     platforms?: Array<MobyMetadataPlatform>;

--- a/frontend/src/__generated__/models/RomSSMetadata.ts
+++ b/frontend/src/__generated__/models/RomSSMetadata.ts
@@ -29,7 +29,7 @@ export type RomSSMetadata = {
     marquee_path?: (string | null);
     logo_path?: (string | null);
     video_path?: (string | null);
-    ss_score?: string;
+    ss_score?: (string | null);
     first_release_date?: (number | null);
     alternative_names?: Array<string>;
     companies?: Array<string>;


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

If a user accidentally sets a value in the metadata JSON to `null` via the UI, pydantic will crash and they won't be able to fix it.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes