### PR TITLE
[ROMM-1863] Set default bios file in config.yml

### DIFF
--- a/frontend/src/console/views/Play.vue
+++ b/frontend/src/console/views/Play.vue
@@ -389,23 +389,15 @@ async function boot() {
       platformId: rom.platform_id,
     });
 
-    function getFirmware(): FirmwareSchema | null {
-      // Check for last-used bios file
-      const firmwareFromStorage = playerStorage.biosId.value
-        ? firmware.find((f) => f.id === parseInt(playerStorage.biosId.value!))
-        : null;
+    const biosFromStorage = playerStorage.biosId.value
+      ? firmware.find((f) => f.id === parseInt(playerStorage.biosId.value!))
+      : undefined;
 
-      if (firmwareFromStorage) return firmwareFromStorage;
+    const biosFromConfig = coreOptions["bios_file"]
+      ? firmware.find((f) => f.file_name === coreOptions["bios_file"])
+      : undefined;
 
-      // Use default bios file if set in config.yml
-      if (!coreOptions["bios_file"]) return null;
-      const firmwareFromConfig =
-        firmware.find((f) => f.file_name === coreOptions["bios_file"]) ?? null;
-
-      return firmwareFromConfig;
-    }
-
-    const bios = getFirmware();
+    const bios = biosFromStorage ?? biosFromConfig ?? null;
     window.EJS_biosUrl = bios
       ? `/api/firmware/${bios.id}/content/${bios.file_name}`
       : "";

--- a/frontend/src/views/Player/EmulatorJS/Base.vue
+++ b/frontend/src/views/Player/EmulatorJS/Base.vue
@@ -212,23 +212,23 @@ onMounted(async () => {
     selectedCore.value = supportedCores.value[0];
   }
 
-  // Use default bios file if set in config.yml
   const coreOptions = configStore.getEJSCoreOptions(selectedCore.value);
-  if (coreOptions["bios_file"]) {
-    selectedFirmware.value =
-      firmwareOptions.value.find(
-        (f) => f.file_name === coreOptions["bios_file"],
-      ) ?? null;
-  }
-
   const storedBiosID = localStorage.getItem(
     `player:${rom.value.platform_slug}:bios_id`,
   );
-  if (storedBiosID) {
-    selectedFirmware.value =
-      firmwareOptions.value.find((f) => f.id === parseInt(storedBiosID)) ??
-      null;
-  }
+
+  const biosFromStorage = storedBiosID
+    ? firmwareOptions.value.find((f) => f.id === parseInt(storedBiosID))
+    : undefined;
+
+  // Use default bios file if set in config.yml
+  const biosFromConfig = coreOptions["bios_file"]
+    ? firmwareOptions.value.find(
+        (f) => f.file_name === coreOptions["bios_file"],
+      )
+    : undefined;
+
+  selectedFirmware.value = biosFromStorage ?? biosFromConfig ?? null;
 });
 
 onBeforeUnmount(async () => {


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Pass a filename for each emulator core via config.yml and we'll use by default for all players:

```yaml
emulatorjs:
  settings:
    mgba:
      bios_file: gba_bios.bin
```

Fixes #1863

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)
