### PR TITLE
Fix files possibly not found in 7z archives

### DIFF
--- a/backend/utils/archive_7zip.py
+++ b/backend/utils/archive_7zip.py
@@ -45,7 +45,6 @@ def process_file_7z(
             line = line.lstrip()
             if line.startswith("Path = "):
                 current_file = line.split(" = ", 1)[1]
-                current_size = 0
             elif line.startswith("Size = "):
                 try:
                     current_size = int(line.split(" = ")[1].strip())


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

Some archives have an empty "Attributes" field, i.e. `Attributes = `. Here is an example of valid ROM within a `7z` archive;

```
Path = Persona 4 Arena (Europe) (En,Ja).iso
Size = 6669598720
Packed Size = 6690577597
Modified = 
Attributes = 
CRC = CCD39BB9
Encrypted = -
Method = LZMA:24:lc4
Block = 0


```

But because in the code we call `strip()` on each line, the line becomes `Attributes =` and the `elif` branch was never taken, resulting with `largest_file` being `None` after processing.

As a workaround, I just use `lstrip()` because `strip()` is re-called for each value anyway afterwards. The parser could be made more robust, but I don't know enough about the 7z specs. 

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)
