### PR TITLE
Decompress 7z archives on the fly rather than extracting to disk

### DIFF
--- a/backend/utils/archive_7zip.py
+++ b/backend/utils/archive_7zip.py
@@ -69,17 +69,18 @@ def process_file_7z(
             [SEVEN_ZIP_PATH, "e", str(file_path), largest_file, "-so", "-y"],
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            shell=False,
+            shell=False,  # trunk-ignore(bandit/B603): 7z path is hardcoded, args are validated
         ) as process:
-            while chunk := process.stdout.read(FILE_READ_CHUNK_SIZE):
-                elapsed_time = time.monotonic() - start_decompression_time
+            if process.stdout:
+                while chunk := process.stdout.read(FILE_READ_CHUNK_SIZE):
+                    elapsed_time = time.monotonic() - start_decompression_time
 
-                if elapsed_time > SEVEN_ZIP_TIMEOUT:
-                    process.terminate()
-                    log.error("7z extraction timed out")
-                    return False
+                    if elapsed_time > SEVEN_ZIP_TIMEOUT:
+                        process.terminate()
+                        log.error("7z extraction timed out")
+                        return False
 
-                fn_hash_update(chunk)
+                    fn_hash_update(chunk)
 
         if process.returncode != 0:
             log.error(f"7z extraction failed with return code {process.returncode}")


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

It looks to me that we don't need to 7z archive to a temporary file and we can instead stream-decompress them, calculating the hases on the fly. It can't OOM since the pipes have a finite size.

Tested happy and timeout paths, it works well.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)
