### PR TITLE
[HOTFIX] Fix all roms displayed in all platforms

### DIFF
--- a/frontend/src/stores/roms.ts
+++ b/frontend/src/stores/roms.ts
@@ -97,18 +97,18 @@ export default defineStore("roms", {
     },
     // Fetching multiple roms
     _buildRequestParams(galleryFilter: GalleryFilterStore) {
-      // Determine platform IDs - use multiselect platforms if available, otherwise convert single platform to array
+      // Determine platform IDs
       let platformIds: number[] | null = null;
-      if (galleryFilter.selectedPlatforms.length > 0) {
+
+      // Prioritize currentPlatform if set, as it indicates a single platform view
+      if (this.currentPlatform) {
+        platformIds = [this.currentPlatform.id];
+      } else if (galleryFilter.selectedPlatforms.length > 0) {
+        // Otherwise, use multi-select platforms from filter
         platformIds = galleryFilter.selectedPlatforms.map((p) => p.id);
-      } else {
-        const singlePlatformId =
-          this.currentPlatform?.id ??
-          galleryFilter.selectedPlatform?.id ??
-          null;
-        if (singlePlatformId) {
-          platformIds = [singlePlatformId];
-        }
+      } else if (galleryFilter.selectedPlatform) {
+        // Fallback to single selected platform from filter
+        platformIds = [galleryFilter.selectedPlatform.id];
       }
 
       const params = {


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Some users are seeing all roms in each platform view, and this PR attempts to fix that without a) being able to duplicate it or b) affecting working installs.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)
