### PR TITLE
Fix: skip opentelemetry-instrument when OTEL is disabled

### DIFF
--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -219,10 +219,19 @@ start_bin_rq_worker() {
 
 start_bin_watcher() {
 	info_log "Starting watcher"
-	watchfiles \
-		--target-type command \
-		"opentelemetry-instrument --service_name '${OTEL_SERVICE_NAME_PREFIX-}watcher' python3 watcher.py" \
-		/romm/library &
+	if [[ ${OTEL_SDK_DISABLED:-false} == "true" ]]; then
+		# Skip opentelemetry-instrument when OTEL is disabled to ensure
+		# WATCHFILES_CHANGES env var is properly passed to watcher.py
+		watchfiles \
+			--target-type command \
+			"python3 watcher.py" \
+			/romm/library &
+	else
+		watchfiles \
+			--target-type command \
+			"opentelemetry-instrument --service_name '${OTEL_SERVICE_NAME_PREFIX-}watcher' python3 watcher.py" \
+			/romm/library &
+	fi
 	WATCHER_PID=$!
 	echo "${WATCHER_PID}" >/tmp/watcher.pid
 }


### PR DESCRIPTION
**Description**

When `OTEL_SDK_DISABLED=true` (set automatically when no `OTEL_` env vars are present), the `opentelemetry-instrument` wrapper does not pass through the `WATCHFILES_CHANGES` environment variable to `watcher.py`.

This causes the filesystem watcher to silently fail: `watchfiles` detects changes but `watcher.py` receives an empty `WATCHFILES_CHANGES` and exits immediately without scheduling rescans.

**The fix:** Skip the `opentelemetry-instrument` wrapper when OTEL is disabled, allowing `watchfiles` to pass `WATCHFILES_CHANGES` directly to `watcher.py`.

This fixes `ENABLE_RESCAN_ON_FILESYSTEM_CHANGE=true` for users who don't configure OpenTelemetry.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

Before fix (watcher exits immediately, no rescan scheduled):
```
[22:49:51] 1 change detected
[22:49:51] process already dead, exit code: 0
```

After fix (watcher processes changes and schedules rescan):
```
[22:49:51] 1 change detected
INFO: [RomM][watcher] Filesystem event: added /roms/gba/test.txt
INFO: [RomM][watcher] Change detected in gba folder, rescanning in 2 minutes.
```
