### PR TITLE
Invalid category values fix

### DIFF
--- a/backend/alembic/versions/0062_rom_file_category_enum.py
+++ b/backend/alembic/versions/0062_rom_file_category_enum.py
@@ -74,7 +74,9 @@ def upgrade() -> None:
         )
 
         with op.batch_alter_table("rom_files", schema=None) as batch_op:
-            batch_op.alter_column("category", type_=rom_file_category_enum, nullable=True)
+            batch_op.alter_column(
+                "category", type_=rom_file_category_enum, nullable=True
+            )
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/0062_rom_file_category_enum.py
+++ b/backend/alembic/versions/0062_rom_file_category_enum.py
@@ -73,8 +73,8 @@ def upgrade() -> None:
             name="romfilecategory",
         )
 
-    with op.batch_alter_table("rom_files", schema=None) as batch_op:
-        batch_op.alter_column("category", type_=rom_file_category_enum, nullable=True)
+        with op.batch_alter_table("rom_files", schema=None) as batch_op:
+            batch_op.alter_column("category", type_=rom_file_category_enum, nullable=True)
 
 
 def downgrade() -> None:


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

<sup>Explicitly dropped in queries for postgres to fix an edge case where bad values can be in place "dlc", "translation", etc.
Fixed an error where postgres requires the USING clause to cast enum

Caught the following error during migrations:

`ERROR: column "category" cannot be cast automatically to type romfilecategory 
HINT: You might need to specify "USING category::romfilecategory"
STATEMENT: ALTER TABLE rom_files ALTER COLUMN category TYPE romfilecategory`

AI disclaimer: Used Claude and Gemini for sanity check on Alembic and dev environment setup but code is all me

</sup>

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)
