### PR TITLE
[AIKIDO-13126609] Raise HTTP exception if device not found

### DIFF
--- a/backend/endpoints/saves.py
+++ b/backend/endpoints/saves.py
@@ -435,12 +435,6 @@ def confirm_download(
         )
 
     device = _resolve_device(device_id, request.user.id)
-    if device is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Device with ID {device_id} not found",
-        )
-
     sync = db_device_save_sync_handler.upsert_sync(
         device_id=device_id,
         save_id=save.id,
@@ -585,12 +579,6 @@ def track_save(
         )
 
     device = _resolve_device(device_id, request.user.id)
-    if device is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Device with ID {device_id} not found",
-        )
-
     sync = db_device_save_sync_handler.set_untracked(
         device_id=device_id, save_id=id, untracked=False
     )
@@ -613,12 +601,6 @@ def untrack_save(
         )
 
     device = _resolve_device(device_id, request.user.id)
-    if device is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Device with ID {device_id} not found",
-        )
-
     sync = db_device_save_sync_handler.set_untracked(
         device_id=device_id, save_id=id, untracked=True
     )


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

When running Python in production in optimized mode, assert calls are not executed. This mode is enabled by setting the PYTHONOPTIMIZE command line flag. Optimized mode is usually ON in production. Any safety check done using assert will not be executed.

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes