### PR TITLE
[ROMM-3026] Region/language shortcodes should be case sensitive

### DIFF
--- a/backend/handler/filesystem/base_handler.py
+++ b/backend/handler/filesystem/base_handler.py
@@ -83,10 +83,10 @@ REGIONS = (
     ("W", "World"),
 )
 
-REGIONS_BY_SHORTCODE = {region[0].lower(): region[1] for region in REGIONS}
+REGIONS_BY_SHORTCODE = {region[0]: region[1] for region in REGIONS}
 REGIONS_NAME_KEYS = frozenset(region[1].lower() for region in REGIONS)
 
-LANGUAGES_BY_SHORTCODE = {lang[0].lower(): lang[1] for lang in LANGUAGES}
+LANGUAGES_BY_SHORTCODE = {lang[0]: lang[1] for lang in LANGUAGES}
 LANGUAGES_NAME_KEYS = frozenset(lang[1].lower() for lang in LANGUAGES)
 
 

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -334,46 +334,46 @@ class FSRomsHandler(FSHandler):
         regions, languages, other_tags = [], [], []
         version = revision = ""
 
-        for raw in tags:
-            tag = raw.lower()
+        for raw_tag in tags:
+            lower_tag = raw_tag.lower()
 
             # Region by code
-            if tag in REGIONS_BY_SHORTCODE.keys():
-                regions.append(REGIONS_BY_SHORTCODE[tag])
+            if raw_tag in REGIONS_BY_SHORTCODE.keys():
+                regions.append(REGIONS_BY_SHORTCODE[raw_tag])
                 continue
-            if tag in REGIONS_NAME_KEYS:
-                regions.append(raw)
+            if lower_tag in REGIONS_NAME_KEYS:
+                regions.append(raw_tag)
                 continue
 
             # Language by code
-            if tag in LANGUAGES_BY_SHORTCODE.keys():
-                languages.append(LANGUAGES_BY_SHORTCODE[tag])
+            if raw_tag in LANGUAGES_BY_SHORTCODE.keys():
+                languages.append(LANGUAGES_BY_SHORTCODE[raw_tag])
                 continue
-            if tag in LANGUAGES_NAME_KEYS:
-                languages.append(raw)
+            if lower_tag in LANGUAGES_NAME_KEYS:
+                languages.append(raw_tag)
                 continue
 
             # Version
-            version_match = VERSION_TAG_REGEX.match(raw)
+            version_match = VERSION_TAG_REGEX.match(raw_tag)
             if version_match:
                 version = version_match[1]
                 continue
 
             # Region prefix
-            region_match = REGION_TAG_REGEX.match(raw)
+            region_match = REGION_TAG_REGEX.match(raw_tag)
             if region_match:
                 key = region_match[1].lower()
                 regions.append(REGIONS_BY_SHORTCODE.get(key, region_match[1]))
                 continue
 
             # Revision prefix
-            revision_match = REVISION_TAG_REGEX.match(raw)
+            revision_match = REVISION_TAG_REGEX.match(raw_tag)
             if revision_match:
                 revision = revision_match[1]
                 continue
 
             # Anything else
-            other_tags.append(raw)
+            other_tags.append(raw_tag)
 
         return ParsedTags(
             version=version,


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3026

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes