### PR TITLE
Allow keyboard lock

### DIFF
--- a/frontend/src/views/Player/EmulatorJS/Base.vue
+++ b/frontend/src/views/Player/EmulatorJS/Base.vue
@@ -45,7 +45,7 @@ declare global {
   interface Navigator {
     keyboard: {
       lock: (keys: string[]) => Promise<void>;
-      unlock: () => Promise<void>;
+      unlock: () => void;
     };
   }
 }
@@ -188,7 +188,7 @@ onMounted(async () => {
         navigator.keyboard
           .lock(["Escape", "Tab", "AltLeft", "ControlLeft", "MetaLeft"])
           .catch(() => {});
-      } else if (!document.fullscreenElement) {
+      } else {
         navigator.keyboard.unlock();
       }
     });


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

This adds a config option to enable keyboard lock for the EmulatorJS player.  If the config option is set, it adds a listener for when fullscreen changes.  When the element goes fullscreen, the keyboard is locked; among other things, this allows escape to be used as a normal keypress in `dosbox_pure`, although there may be other uses available as well.  When the element ceases to be fullscreen, the keyboard is explicitly unlocked.

This lets games that use escape to function normally in fullscreen mode, and while I believe it may not be implemented in all browsers, I've put the functionality behind a conditional to check before attempting to execute it.  By default the option is off.  I've prepared a pull request for the documentation repository pending any changes/rejections here.

I did use Gemini as a sounding board for finding information about fullscreen mode, but every text character in this was written by me with no autocomplete or other copilot/AI enhancement.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes