### PR TITLE
POC: raw SQL bypass for GET /api/roms (39s to ~2s at limit=10000)

### DIFF
--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -348,6 +348,31 @@ class SiblingRomSchema(BaseModel):
 
 
 class SimpleRomSchema(RomSchema):
+    # Defaults for fields not needed in list views
+    summary: str | None = None
+    alternative_names: list[str] = []
+    youtube_video_id: str | None = None
+    igdb_metadata: RomIGDBMetadata | None = None
+    moby_metadata: RomMobyMetadata | None = None
+    launchbox_metadata: RomLaunchboxMetadata | None = None
+    hasheous_metadata: RomHasheousMetadata | None = None
+    flashpoint_metadata: RomFlashpointMetadata | None = None
+    hltb_metadata: RomHLTBMetadata | None = None
+    manual_metadata: ManualMetadata | None = None
+    path_manual: str | None = None
+    url_manual: str | None = None
+    revision: str | None = None
+    crc_hash: str | None = None
+    md5_hash: str | None = None
+    sha1_hash: str | None = None
+    ra_hash: str | None = None
+    has_simple_single_file: bool = False
+    has_nested_single_file: bool = False
+    has_multiple_files: bool = False
+    files: list[RomFileSchema] = []
+    siblings: list[SiblingRomSchema] = []
+    merged_ra_metadata: RomRAMetadata | None = None
+
     @classmethod
     def from_orm_with_request(cls, db_rom: Rom, request: Request) -> SimpleRomSchema:
         db_rom = cls.populate_properties(db_rom, request)


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

This is a rough proof of concept to demonstrate the performance gains, not a proposal for what the code should look like. The dict-building is admittedly ugly. It exists because bypassing the ORM means we lose the computed properties on the Rom model (path_cover_small, is_unidentified, platform_display_name, etc.) and have to reconstruct them by hand.

The two things that matter for performance:
  1. Raw SQL skips hydrating 10 unused JSON metadata blobs per row
  2. Siblings (loaded via the sibling_roms VIEW) are skipped entirely; they aren't needed for list views

Of these, skipping siblings alone accounts for most of the gain (39s to ~6s). The raw SQL on top brings it from ~6s to ~2s.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes