### PR TITLE
Add more plateforms to cover styles

### DIFF
--- a/frontend/src/components/Gallery/AppBar/Platform/PlatformInfoDrawer.vue
+++ b/frontend/src/components/Gallery/AppBar/Platform/PlatformInfoDrawer.vue
@@ -43,10 +43,25 @@ const DVD_PLATFORMS = new Set([
   "wiiu",
   "xbox",
   "xbox360",
+  "win",
 ]);
-const BLU_RAY_PLATFORMS = new Set(["blu-ray-player", "ps3", "ps4"]);
-const DS_3DS_PLATFORMS = new Set(["3ds", "nds", "new-nintendo-3ds"]);
+const BLU_RAY_PLATFORMS = new Set([
+  "blu-ray-player",
+  "ps3",
+  "ps4",
+  "ps5",
+  "psvita",
+  "xboxone",
+  "series-x-s",
+]);
+const DS_3DS_PLATFORMS = new Set([
+  "nds",
+  "nintendo-dsi",
+  "3ds",
+  "new-nintendo-3ds",
+]);
 const PSP_PLATFORMS = new Set(["psp", "psp-minis"]);
+const SWITCH_PLATFORMS = new Set(["switch", "switch-2"]);
 
 const aspectRatioOptions = computed(() => {
   const slug = currentPlatform.value?.slug?.toLowerCase() ?? "";
@@ -109,6 +124,15 @@ const aspectRatioOptions = computed(() => {
             name: "0.58 / 1",
             size: 0.58 / 1,
             source: "PSP",
+          },
+        ]
+      : []),
+    ...(SWITCH_PLATFORMS.has(slug)
+      ? [
+          {
+            name: "0.62 / 1",
+            size: 0.62 / 1,
+            source: "Switch",
           },
         ]
       : []),


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Thanks for merging #3060.

My initial plan wasn’t to show the new cover only on specific platforms. I wanted each platform to be able to choose whichever style fits best. However, the current approach also works, and I understand that having fewer options can make the implementation cleaner.

In this PR, I’ve added support for a few more platforms so they work with the same system as well.

**Checklist**

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

