### PR TITLE
Fix OIDC login role downgrading for users without claims

### DIFF
--- a/backend/handler/auth/base_handler.py
+++ b/backend/handler/auth/base_handler.py
@@ -337,7 +337,9 @@ class OpenIDHandler:
             )
 
         role = Role.VIEWER
+        claims_provided = False
         if OIDC_CLAIM_ROLES and OIDC_CLAIM_ROLES in userinfo:
+            claims_provided = True
             roles = userinfo[OIDC_CLAIM_ROLES] or []
             if OIDC_ROLE_ADMIN and OIDC_ROLE_ADMIN in roles:
                 role = Role.ADMIN
@@ -368,7 +370,7 @@ class OpenIDHandler:
                 role=role,
             )
             user = db_user_handler.add_user(new_user)
-        elif OIDC_CLAIM_ROLES and user.role != role:
+        elif claims_provided and user.role != role:
             user = db_user_handler.update_user(user.id, {"role": role})
 
         if not user.enabled:

--- a/backend/tests/handler/auth/test_oidc.py
+++ b/backend/tests/handler/auth/test_oidc.py
@@ -350,6 +350,38 @@ async def test_oidc_token_without_email_verified_claim(
     assert userinfo.get("email") == mock_jwt_payload.claims.get("email")
 
 
+async def test_oidc_valid_no_edit_user_role_if_claim_not_in_userinfo(
+    mocker,
+    mock_oidc_enabled,
+    mock_token,
+    mock_openid_configuration,
+):
+    """Test that role is not changed for existing user on login if OIDC role claim is configured but not provided by the OIDC provider."""
+    mocker.patch("handler.auth.base_handler.OIDC_CLAIM_ROLES", "roles")
+    mocker.patch("handler.auth.base_handler.OIDC_ROLE_ADMIN", "admin")
+    # The OIDC provider does NOT include the roles claim in userinfo
+    mock_token["userinfo"].pop("roles", None)
+    mock_user = MagicMock(enabled=True, role=Role.ADMIN)
+    mocker.patch(
+        "handler.database.db_user_handler.get_user_by_email", return_value=mock_user
+    )
+    mock_edit_user = mocker.patch(
+        "handler.database.db_user_handler.update_user", return_value=mock_user
+    )
+    mocker.patch.object(
+        StarletteOAuth2App,
+        "load_server_metadata",
+        return_value=mock_openid_configuration,
+    )
+
+    oidc_handler = OpenIDHandler()
+    user, _ = await oidc_handler.get_current_active_user_from_openid_token(mock_token)
+
+    # The user's existing ADMIN role should be preserved
+    mock_edit_user.assert_not_called()
+    assert user.role == Role.ADMIN
+
+
 async def test_oidc_invalid_token_signature(mock_oidc_enabled):
     """Test token decoding raises exception for invalid signature."""
     oidc_handler = OpenIDHandler()


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
This pull request makes improvements to the OpenID Connect (OIDC) authentication flow, specifically around how user roles are updated based on OIDC claims. The main change is to ensure that a user's role is only updated if the OIDC provider actually supplies the relevant role claim, preventing unintended role changes when the claim is absent. Additionally, new tests have been added to verify this behavior.

OIDC role claim handling improvements:

* The logic in `get_current_active_user_from_openid_token` (`base_handler.py`) now checks whether the OIDC role claim is present in `userinfo` before attempting to update a user's role, using a new `claims_provided` flag.
* Role updates for existing users are now only performed if the OIDC role claim was actually provided, preventing accidental overwrites when the claim is missing.

Testing enhancements:

* Added a new test `test_oidc_valid_no_edit_user_role_if_claim_not_in_userinfo` to ensure that user roles are not changed when the OIDC role claim is configured but not provided by the OIDC provider.

**Checklist**
<sup>Please check all that apply.</sup>

- [ x] I've tested the changes locally
- [x ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ x] I've added unit tests that cover the changes


