### PR TITLE
perf(scan): replace deep watch with computed to reduce reactivity overhead

### DIFF
--- a/frontend/src/views/Scan.vue
+++ b/frontend/src/views/Scan.vue
@@ -90,16 +90,18 @@ watch(metadataOptions, (newOptions) => {
   );
 });
 
-// Adding each new scanned platform to panelIndex to be open by default
-watch(
-  scanningPlatforms,
-  () => {
-    panels.value = scanningPlatforms.value
-      .map((p, index) => (p.roms.length > 0 ? index : -1))
-      .filter((index) => index !== -1);
-  },
-  { deep: true },
+// Track which platforms have ROMs without a deep watch on the entire array.
+// The computed returns a stable string that only changes when a platform
+// transitions from 0→>0 ROMs (or back), so the watch fires O(n_platforms)
+// times rather than O(n_roms) times.
+const platformsWithRomsKey = computed(() =>
+  scanningPlatforms.value.map((p) => (p.roms.length > 0 ? 1 : 0)).join(""),
 );
+watch(platformsWithRomsKey, () => {
+  panels.value = scanningPlatforms.value
+    .map((p, index) => (p.roms.length > 0 ? index : -1))
+    .filter((index) => index !== -1);
+});
 
 const scanOptions = [
   {


### PR DESCRIPTION
## Problem

During a scan with large collections, the scan page becomes slow or unresponsive.

I don't think this one change is a full fix for some of the sluggishness/crashing I've seen on the scan page with 1000+ items but I wanted to find a small change that could help.


## Cause
`Scan.vue` watches `scanningPlatforms` with `{ deep: true }`, which fires on every ROM addition — causing Vue to deeply traverse all nested platform and ROM data on each update. With thousands of ROMs across multiple platforms this results in a large number of redundant traversals. And with multiple parallel scanners, it's multiple traversals per second.


## Fix

The watch's only job is deciding which panels are open. A panel should open when a platform first receives ROMs — after that, its open/closed state doesn't need to change regardless of how many more ROMs arrive.

Replace with a computed that maps each platform to a boolean (`roms.length > 0`), so the watch callback only fires on that one meaningful transition per platform. The ROM list inside each panel continues to update reactively as normal — this change only affects the panel open/close logic.

No visual or functional changes.

## AI Disclosure

This PR was written with AI assistance (Claude Code).