### PR TITLE
fix: add missing platforms to playable game filter

### DIFF
--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -97,6 +97,10 @@ EJS_SUPPORTED_PLATFORMS = [
     UPS.WONDERSWAN_COLOR,
 ]
 
+OTHER_SUPPORTED_PLATFORMS = [
+    UPS.BROWSER,
+]
+
 STRIP_ARTICLES_REGEX = r"^(the|a|an)\s+"
 
 
@@ -305,7 +309,7 @@ class DBRomsHandler(DBBaseHandler):
         """Filter based on whether the rom is playable on supported platforms."""
         predicate = or_(
             Platform.slug.in_(EJS_SUPPORTED_PLATFORMS),
-            Platform.slug == UPS.BROWSER
+            Platform.slug.in_(OTHER_SUPPORTED_PLATFORMS),
         )
         if not value:
             predicate = not_(predicate)


### PR DESCRIPTION
**Description**

Noticed some games not showing up in my "playable" smart collection, turns out a couple supported platforms weren't included in the _filter_by_playable function.

**Checklist**

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes
