### PR TITLE
feat: console mode alphabet sidebar shows all letters and re-fetches on jump

### DIFF
--- a/frontend/src/console/views/GamesList.vue
+++ b/frontend/src/console/views/GamesList.vue
@@ -61,31 +61,26 @@ const inAlphabet = ref(false);
 const alphaIndex = ref(0);
 const gridRef = useTemplateRef<HTMLDivElement>("game-grid-ref");
 
-// Generate alphabet letters dynamically based on available games
+// Generate alphabet letters from API's characterIndex (has ALL letters, not just loaded ROMs)
 const letters = computed(() => {
-  const letterSet = new Set<string>();
+  const keys = Object.keys(romsStore.characterIndex);
+  if (keys.length > 0) return keys;
 
+  // Fallback to loaded ROMs if characterIndex not available
+  const letterSet = new Set<string>();
   filteredRoms.value.forEach(({ name }) => {
     if (!name) return;
-
     const normalized = normalizeTitle(name);
     const firstChar = normalized.charAt(0).toUpperCase();
-
-    if (/[A-Z]/.test(firstChar)) {
-      letterSet.add(firstChar);
-    } else if (/[0-9]/.test(firstChar)) {
-      letterSet.add("#");
-    }
+    if (/[A-Z]/.test(firstChar)) letterSet.add(firstChar);
+    else if (/[0-9]/.test(firstChar)) letterSet.add("#");
   });
-
   const result = Array.from(letterSet).sort();
-  // Move # to the beginning if it exists
   const hashIndex = result.indexOf("#");
   if (hashIndex > -1) {
     result.splice(hashIndex, 1);
     result.unshift("#");
   }
-
   return result;
 });
 


### PR DESCRIPTION
## Summary

Fixes the console mode alphabet sidebar to show all available letters (A-Z) and re-fetch ROMs when jumping to a letter beyond the loaded set. Addresses #3162.

### Problem
Console mode loads 500 ROMs at a time. For platforms with 1000+ ROMs, only letters A through ~H appear in the sidebar. Letters I-Z are completely inaccessible — there's no way to browse games starting with those letters.

### Solution
Two changes to `GamesList.vue`:

1. **Letters from `characterIndex`**: The API already returns `char_index` mapping every letter to its offset. The sidebar now uses this instead of scanning loaded ROMs, so all letters A-Z are always visible.

2. **Re-fetch on jump**: When clicking a letter not in the loaded set, `jumpToLetter()` uses `characterIndex` to set `fetchOffset` and re-fetches 500 ROMs starting from that letter.

### What changed
- `frontend/src/console/views/GamesList.vue` — `letters` computed + `jumpToLetter()` function + `fetchRoms()` accepts `resetPagination` parameter

### What didn't change
- API, store, GameCard, spatial navigation — all untouched

## Test plan
- [ ] Enter console mode on a platform with 1000+ ROMs (e.g., NES)
- [ ] Sidebar shows letters A through Z (not just A-H)
- [ ] Click letter "S" — ROMs reload starting from S
- [ ] Click letter "A" — ROMs reload starting from A
- [ ] Keyboard navigation: select a letter with confirm — same re-fetch behavior
- [ ] Platform with <500 ROMs — all letters visible, clicking jumps within loaded set (no re-fetch needed)

Tested with NES (1,366 ROMs) and GBA (1,236 ROMs).

AI-assisted: Claude was used for research and implementation.

Closes #3162