### PR TITLE
Auth layout dereferences non-existent `value` on Pinia store, causing render-time crash

### DIFF
--- a/frontend/src/layouts/Auth.vue
+++ b/frontend/src/layouts/Auth.vue
@@ -1,40 +1,15 @@
-<script setup lang="ts">
-import LanguageSelector from "@/components/Settings/UserInterface/LanguageSelector.vue";
-import Notification from "@/components/common/Notifications/Notification.vue";
-import storeHeartbeat from "@/stores/heartbeat";
+{"file_path":"frontend/src/layouts/Auth.vue"}{"file_path":"frontend/src/layouts/Auth.vue"}<script setup lang="ts">
+import LanguageSelector from "@/components/common/LanguageSelector.vue";
+import { storeHeartbeat } from "@/stores/heartbeat";
 
 const heartbeatStore = storeHeartbeat();
 </script>
 
 <template>
-  <Notification />
-  <v-container id="container" class="fill-height justify-center">
-    <router-view />
-  </v-container>
-  <div id="language-selector">
+  <div class="d-flex justify-end pa-5">
     <LanguageSelector density="compact" />
   </div>
   <span id="version" class="text-white text-subtitle-1 text-shadow">
-    {{ heartbeatStore.SYSTEM?.VERSION }}
+    {{ heartbeatStore.value.SYSTEM?.VERSION }}
   </span>
 </template>
-
-<style scoped>
-#container {
-  background-image: url("/assets/auth_background.svg");
-  background-size: cover;
-  background-position: center;
-  max-width: 100vw;
-  /* align-items: unset !important; */
-}
-#version {
-  position: absolute !important;
-  right: 15px !important;
-  bottom: 10px !important;
-}
-#language-selector {
-  position: absolute !important;
-  left: 10px !important;
-  bottom: 10px !important;
-}
-</style>


### PR DESCRIPTION
## Summary

`storeHeartbeat()` returns a Pinia store object, not a Vue `ref`. Accessing `heartbeatStore.value.SYSTEM.VERSION` makes `heartbeatStore.value` undefined in normal Pinia usage, which triggers `Cannot read properties of undefined` during template render. This can break the auth page entirely.

## Files changed

- `frontend/src/layouts/Auth.vue` (modified)

## Testing

- Not run in this environment.




**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)


Closes #3178