### PR TITLE
Add a persisted “manual entry” source flag to ROM records

### DIFF
--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -50,6 +50,11 @@ class RomFileCategory(enum.StrEnum):
     CHEAT = "cheat"
 
 
+class RomSource(enum.StrEnum):
+    FILESYSTEM = "filesystem"
+    MANUAL = "manual"
+
+
 class SiblingRom(BaseModel):
     __tablename__ = "sibling_roms"
 
@@ -148,6 +153,9 @@ class Rom(BaseModel):
     __tablename__ = "roms"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    source: Mapped[RomSource] = mapped_column(
+        Enum(RomSource), default=RomSource.FILESYSTEM, nullable=False
+    )
 
     igdb_id: Mapped[int | None] = mapped_column(Integer(), default=None)
     sgdb_id: Mapped[int | None] = mapped_column(Integer(), default=None)


### PR DESCRIPTION
## Summary

Add a first-class database field on `Rom` to represent entries that were created without a physical file. This avoids overloading tags for core behavior and allows backend logic/UI to reliably branch on source type. The flag should be queryable, serializable in API responses, and default to current behavior for existing ROMs.

## Files changed

- `backend/models/rom.py` (modified)

## Testing

- Not run in this environment.




**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)


Closes #3175