### PR TITLE
Implement DB-level ROM filtering by save/save-state presence

### DIFF
--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -16,8 +16,13 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    exists,
     func,
+    not_,
+    or_,
+    select,
 )
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from config import FRONTEND_RESOURCES_PATH
@@ -148,6 +153,18 @@ class Rom(BaseModel):
     __tablename__ = "roms"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+
+    @hybrid_property
+    def has_saves(self) -> bool:
+        return bool(self.saves or self.states)
+
+    @has_saves.expression
+    def has_saves(cls):
+        from models.assets import Save, State
+
+        save_exists = select(Save.id).where(Save.rom_id == cls.id)
+        state_exists = select(State.id).where(State.rom_id == cls.id)
+        return or_(exists(save_exists), exists(state_exists))
 
     igdb_id: Mapped[int | None] = mapped_column(Integer(), default=None)
     sgdb_id: Mapped[int | None] = mapped_column(Integer(), default=None)


### PR DESCRIPTION
## Summary

Update the ROM query/filter builder to support the new `has_saves` criterion. The filter must treat “has saves” as true when a ROM has either a save file or a save state entry, and false only when it has neither. This logic should run in SQL to preserve pagination correctness and performance.

## Files changed

- `backend/models/rom.py` (modified)

## Testing

- Not run in this environment.




**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)


Closes #3140