### PR TITLE
Fix RuffleRS scaling and overflow issues on large and small screens

### DIFF
--- a/frontend/src/views/Player/RuffleRS/Base.vue
+++ b/frontend/src/views/Player/RuffleRS/Base.vue
@@ -53,6 +53,8 @@ function onPlay() {
       allowFullScreen: true,
       autoplay: "on",
       backgroundColor: backgroundColor.value,
+      forceAlign: true,
+      forceScale: true,
       letterbox: "on",
       openUrlMode: "confirm",
       publicPath: "/assets/ruffle/",

--- a/frontend/src/views/Player/RuffleRS/Base.vue
+++ b/frontend/src/views/Player/RuffleRS/Base.vue
@@ -53,6 +53,7 @@ function onPlay() {
       allowFullScreen: true,
       autoplay: "on",
       backgroundColor: backgroundColor.value,
+      letterbox: "on",
       openUrlMode: "confirm",
       publicPath: "/assets/ruffle/",
       url: getDownloadPath({ rom: rom.value }),


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Added letterbox configuration to Ruffle player, which adds black bars around the player area preventing debug objects from rendering in fullscreen or on large screens.

https://ruffle.rs/js-docs/master/enums/Config.Letterbox.html

Fixes https://github.com/rommapp/romm/issues/3244

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

Current version of RoMM:
<img width="1091" height="1008" alt="{7B255C72-F4C1-4BC3-89E1-486D49094546}" src="https://github.com/user-attachments/assets/1637f4d9-06be-4a7f-83ef-1841323de973" />

With patch applied:
<img width="1091" height="1007" alt="image" src="https://github.com/user-attachments/assets/e99a8b27-ab88-496e-9b3d-6bdb5f90d8d7" />

