### PR TITLE
perf: skip RAHasher subprocess for archived disc-platform ROMs

### DIFF
--- a/backend/adapters/services/rahasher.py
+++ b/backend/adapters/services/rahasher.py
@@ -110,7 +110,7 @@ class RAHasherService:
         # RA platform needs an on-disk disc image. RAHasher would just spawn,
         # fail with "Unsupported console for buffer hash: {id}", and return
         # nothing — paying process-spawn overhead per ROM for no result.
-        if file_path.endswith(tuple(COMPRESSED_FILE_EXTENSIONS)):
+        if file_path.lower().endswith(tuple(COMPRESSED_FILE_EXTENSIONS)):
             if platform["ra_id"] in RA_BUFFER_HASH_UNSUPPORTED_IDS:
                 log.debug(
                     f"Skipping {hl('RAHasher', color=LIGHTMAGENTA)} for archived "

--- a/backend/adapters/services/rahasher.py
+++ b/backend/adapters/services/rahasher.py
@@ -1,8 +1,8 @@
 import asyncio
-import os
 import re
 
 from handler.metadata.base_handler import UniversalPlatformSlug as UPS
+from handler.metadata.ra_handler import RAGamesPlatform
 from logger.formatter import LIGHTMAGENTA
 from logger.formatter import highlight as hl
 from logger.logger import log
@@ -101,31 +101,31 @@ class RAHasherError(Exception): ...
 class RAHasherService:
     """Service to calculate RetroAchievements hashes using RAHasher."""
 
-    async def calculate_hash(self, platform_id: int, file_path: str) -> str:
-        from handler.metadata.ra_handler import RA_ID_TO_SLUG
-
+    async def calculate_hash(
+        self, platform: RAGamesPlatform, file_path: str, file_extension: str
+    ) -> str:
         # Skip the subprocess entirely when the file is an archive and the
         # RA platform needs an on-disk disc image. RAHasher would just spawn,
         # fail with "Unsupported console for buffer hash: {id}", and return
         # nothing — paying process-spawn overhead per ROM for no result.
-        ext = os.path.splitext(file_path)[1].lower()
-        if ext in COMPRESSED_FILE_EXTENSIONS:
+        normalized_ext = f".{file_extension.lstrip('.').lower()}"
+        if normalized_ext in COMPRESSED_FILE_EXTENSIONS:
             unsupported_ids = {
                 PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[ups]
                 for ups in RA_BUFFER_HASH_UNSUPPORTED
             }
-            if platform_id in unsupported_ids:
+            if platform["ra_id"] in unsupported_ids:
                 log.debug(
                     f"Skipping {hl('RAHasher', color=LIGHTMAGENTA)} for archived "
-                    f"{hl(RA_ID_TO_SLUG[platform_id])} file {hl(file_path.split('/')[-1])}: "
+                    f"{hl(platform['slug'], color=LIGHTMAGENTA)} file {hl(file_path.split('/')[-1])}: "
                     f"disc-based platforms don't support buffer hashing"
                 )
                 return ""
 
         log.debug(
-            f"Executing {hl('RAHasher', color=LIGHTMAGENTA)} for platform: {hl(RA_ID_TO_SLUG[platform_id])} - file: {hl(file_path.split('/')[-1])}"
+            f"Executing {hl('RAHasher', color=LIGHTMAGENTA)} for platform: {hl(platform['slug'], color=LIGHTMAGENTA)} - file: {hl(file_path.split('/')[-1])}"
         )
-        args = (str(platform_id), file_path)
+        args = (str(platform["ra_id"]), file_path)
 
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -154,14 +154,14 @@ class RAHasherService:
         file_hash = (await proc.stdout.read()).decode("utf-8").strip()
         if not file_hash:
             log.error(
-                f"RAHasher returned an empty hash for file {file_path} (platform ID: {platform_id})"
+                f"RAHasher returned an empty hash for file {file_path} (platform ID: {platform['ra_id']})"
             )
             return ""
 
         match = RAHASHER_VALID_HASH_REGEX.search(file_hash)
         if not match:
             log.error(
-                f"RAHasher returned invalid hash {file_hash} for file {file_path} (platform ID: {platform_id}"
+                f"RAHasher returned invalid hash {file_hash} for file {file_path} (platform ID: {platform['ra_id']})"
             )
             return ""
 

--- a/backend/adapters/services/rahasher.py
+++ b/backend/adapters/services/rahasher.py
@@ -94,6 +94,10 @@ PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID: dict[UPS, int] = {
     UPS.WONDERSWAN_COLOR: 53,
 }
 
+RA_BUFFER_HASH_UNSUPPORTED_IDS: frozenset[int] = frozenset(
+    PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[ups] for ups in RA_BUFFER_HASH_UNSUPPORTED
+)
+
 
 class RAHasherError(Exception): ...
 
@@ -101,29 +105,22 @@ class RAHasherError(Exception): ...
 class RAHasherService:
     """Service to calculate RetroAchievements hashes using RAHasher."""
 
-    async def calculate_hash(
-        self, platform: RAGamesPlatform, file_path: str, file_extension: str
-    ) -> str:
+    async def calculate_hash(self, platform: RAGamesPlatform, file_path: str) -> str:
         # Skip the subprocess entirely when the file is an archive and the
         # RA platform needs an on-disk disc image. RAHasher would just spawn,
         # fail with "Unsupported console for buffer hash: {id}", and return
         # nothing — paying process-spawn overhead per ROM for no result.
-        normalized_ext = f".{file_extension.lstrip('.').lower()}"
-        if normalized_ext in COMPRESSED_FILE_EXTENSIONS:
-            unsupported_ids = {
-                PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[ups]
-                for ups in RA_BUFFER_HASH_UNSUPPORTED
-            }
-            if platform["ra_id"] in unsupported_ids:
+        if file_path.endswith(tuple(COMPRESSED_FILE_EXTENSIONS)):
+            if platform["ra_id"] in RA_BUFFER_HASH_UNSUPPORTED_IDS:
                 log.debug(
                     f"Skipping {hl('RAHasher', color=LIGHTMAGENTA)} for archived "
-                    f"{hl(platform['slug'], color=LIGHTMAGENTA)} file {hl(file_path.split('/')[-1])}: "
+                    f"{platform['slug']} file {hl(file_path)}: "
                     f"disc-based platforms don't support buffer hashing"
                 )
                 return ""
 
         log.debug(
-            f"Executing {hl('RAHasher', color=LIGHTMAGENTA)} for platform: {hl(platform['slug'], color=LIGHTMAGENTA)} - file: {hl(file_path.split('/')[-1])}"
+            f"Executing {hl('RAHasher', color=LIGHTMAGENTA)} for platform: {hl(platform['slug'], color=LIGHTMAGENTA)} - file: {hl(file_path)}"
         )
         args = (str(platform["ra_id"]), file_path)
 

--- a/backend/adapters/services/rahasher.py
+++ b/backend/adapters/services/rahasher.py
@@ -1,12 +1,36 @@
 import asyncio
+import os
 import re
 
 from handler.metadata.base_handler import UniversalPlatformSlug as UPS
 from logger.formatter import LIGHTMAGENTA
 from logger.formatter import highlight as hl
 from logger.logger import log
+from utils.filesystem import COMPRESSED_FILE_EXTENSIONS
 
 RAHASHER_VALID_HASH_REGEX = re.compile(r"[0-9a-f]{32}")
+
+# Platforms whose hash algorithm requires an on-disk disc image
+# (ISO9660/bin+cue/CHD). When the source file is an archive, RAHasher falls
+# back to "buffer hash" mode which these consoles don't support, failing
+# with "Unsupported console for buffer hash: <id>" after paying a full
+# subprocess spawn.
+RA_BUFFER_HASH_UNSUPPORTED: frozenset[UPS] = frozenset(
+    {
+        UPS.SEGACD,
+        UPS.PSX,
+        UPS.PS2,
+        UPS.SATURN,
+        UPS.DC,
+        UPS.PSP,
+        UPS._3DO,
+        UPS.PC_FX,
+        UPS.NEO_GEO_CD,
+        UPS.TURBOGRAFX_CD,
+        UPS.ATARI_JAGUAR_CD,
+        UPS.WII,
+    }
+)
 
 PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID: dict[UPS, int] = {
     UPS._3DO: 43,
@@ -79,6 +103,24 @@ class RAHasherService:
 
     async def calculate_hash(self, platform_id: int, file_path: str) -> str:
         from handler.metadata.ra_handler import RA_ID_TO_SLUG
+
+        # Skip the subprocess entirely when the file is an archive and the
+        # RA platform needs an on-disk disc image. RAHasher would just spawn,
+        # fail with "Unsupported console for buffer hash: {id}", and return
+        # nothing — paying process-spawn overhead per ROM for no result.
+        ext = os.path.splitext(file_path)[1].lower()
+        if ext in COMPRESSED_FILE_EXTENSIONS:
+            unsupported_ids = {
+                PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[ups]
+                for ups in RA_BUFFER_HASH_UNSUPPORTED
+            }
+            if platform_id in unsupported_ids:
+                log.debug(
+                    f"Skipping {hl('RAHasher', color=LIGHTMAGENTA)} for archived "
+                    f"{hl(RA_ID_TO_SLUG[platform_id])} file {hl(file_path.split('/')[-1])}: "
+                    f"disc-based platforms don't support buffer hashing"
+                )
+                return ""
 
         log.debug(
             f"Executing {hl('RAHasher', color=LIGHTMAGENTA)} for platform: {hl(RA_ID_TO_SLUG[platform_id])} - file: {hl(file_path.split('/')[-1])}"

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -120,7 +120,7 @@ def is_compressed_file(file_path: str) -> bool:
     mime = magic.Magic(mime=True)
     file_type = mime.from_file(file_path)
 
-    return file_type in COMPRESSED_MIME_TYPES or file_path.endswith(
+    return file_type in COMPRESSED_MIME_TYPES or file_path.lower().endswith(
         tuple(COMPRESSED_FILE_EXTENSIONS)
     )
 

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -448,8 +448,9 @@ class FSRomsHandler(FSHandler):
                 ra_platform = meta_ra_handler.get_platform(rom.platform_slug)
                 if ra_platform and ra_platform["ra_id"]:
                     rom_ra_h = await RAHasherService().calculate_hash(
-                        ra_platform["ra_id"],
+                        ra_platform,
                         f"{abs_fs_path}/{rom.fs_name}/*",
+                        rom.fs_extension,
                     )
 
             for f_path, file_name in iter_files(
@@ -539,8 +540,9 @@ class FSRomsHandler(FSHandler):
                 ra_platform = meta_ra_handler.get_platform(rom.platform_slug)
                 if ra_platform and ra_platform["ra_id"]:
                     rom_ra_h = await RAHasherService().calculate_hash(
-                        ra_platform["ra_id"],
+                        ra_platform,
                         f"{abs_fs_path}/{rom.fs_name}",
+                        rom.fs_extension,
                     )
 
             file_hash = FileHash(

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -450,7 +450,6 @@ class FSRomsHandler(FSHandler):
                     rom_ra_h = await RAHasherService().calculate_hash(
                         ra_platform,
                         f"{abs_fs_path}/{rom.fs_name}/*",
-                        rom.fs_extension,
                     )
 
             for f_path, file_name in iter_files(
@@ -542,7 +541,6 @@ class FSRomsHandler(FSHandler):
                     rom_ra_h = await RAHasherService().calculate_hash(
                         ra_platform,
                         f"{abs_fs_path}/{rom.fs_name}",
-                        rom.fs_extension,
                     )
 
             file_hash = FileHash(

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -26,7 +26,7 @@ from handler.metadata.base_handler import UniversalPlatformSlug as UPS
 from models.platform import Platform
 from models.rom import Rom, RomFile, RomFileCategory
 from utils.archive_7zip import process_file_7z
-from utils.filesystem import iter_files
+from utils.filesystem import COMPRESSED_FILE_EXTENSIONS, iter_files
 from utils.hashing import crc32_to_hex
 
 from .base_handler import (
@@ -46,17 +46,6 @@ COMPRESSED_MIME_TYPES: Final = frozenset(
         "application/x-gzip",
         "application/x-tar",
         "application/zip",
-    )
-)
-
-# Known file extensions that are compressed
-COMPRESSED_FILE_EXTENSIONS = frozenset(
-    (
-        ".7z",
-        ".bz2",
-        ".gz",
-        ".tar",
-        ".zip",
     )
 )
 

--- a/backend/handler/metadata/ra_handler.py
+++ b/backend/handler/metadata/ra_handler.py
@@ -3,7 +3,7 @@ import os
 import re
 import time
 from datetime import datetime
-from typing import NotRequired, TypedDict
+from typing import NotRequired, TypedDict, cast
 
 import pydash
 from anyio import Path as AnyioPath
@@ -347,10 +347,13 @@ class RAHandler(MetadataHandler):
                     game_current_progression.get("highest_award_kind")
                     != highest_award_kind
                 ):
-                    game_current_progression = {
-                        **game_current_progression,
-                        "highest_award_kind": highest_award_kind,
-                    }
+                    game_current_progression = cast(
+                        RAUserGameProgression,
+                        {
+                            **game_current_progression,
+                            "highest_award_kind": highest_award_kind,
+                        },
+                    )
                 game_progressions.append(game_current_progression)
                 continue
 

--- a/backend/tests/adapters/services/test_rahasher.py
+++ b/backend/tests/adapters/services/test_rahasher.py
@@ -59,8 +59,9 @@ class TestRAHasherService:
         mock_proc.stderr = None
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            with patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {7: "nes"}):
-                result = await service.calculate_hash(7, "/path/to/game.nes")
+            result = await service.calculate_hash(
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+            )
 
         assert result == "a1b2c3d4e5f6789012345678901234ab"
         mock_proc.wait.assert_called_once()
@@ -73,8 +74,9 @@ class TestRAHasherService:
             "asyncio.create_subprocess_exec",
             side_effect=FileNotFoundError("RAHasher not found"),
         ):
-            with patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {7: "nes"}):
-                result = await service.calculate_hash(7, "/path/to/game.nes")
+            result = await service.calculate_hash(
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+            )
 
         assert result == ""
 
@@ -86,8 +88,9 @@ class TestRAHasherService:
         mock_proc.stderr.read.return_value = b"Error processing file"
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            with patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {7: "nes"}):
-                result = await service.calculate_hash(7, "/path/to/game.nes")
+            result = await service.calculate_hash(
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+            )
 
         assert result == ""
         mock_proc.wait.assert_called_once()
@@ -102,8 +105,9 @@ class TestRAHasherService:
         mock_proc.stderr = None
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            with patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {7: "nes"}):
-                result = await service.calculate_hash(7, "/path/to/game.nes")
+            result = await service.calculate_hash(
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+            )
 
         assert result == ""
 
@@ -116,8 +120,9 @@ class TestRAHasherService:
         mock_proc.stderr = None
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            with patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {7: "nes"}):
-                result = await service.calculate_hash(7, "/path/to/game.nes")
+            result = await service.calculate_hash(
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+            )
 
         assert result == ""
 
@@ -130,8 +135,9 @@ class TestRAHasherService:
         mock_proc.stderr = None
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            with patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {7: "nes"}):
-                result = await service.calculate_hash(7, "/path/to/game.nes")
+            result = await service.calculate_hash(
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+            )
 
         assert result == ""
 
@@ -146,8 +152,9 @@ class TestRAHasherService:
         mock_proc.stderr = None
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            with patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {7: "nes"}):
-                result = await service.calculate_hash(7, "/path/to/game.nes")
+            result = await service.calculate_hash(
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+            )
 
         assert result == "a1b2c3d4e5f6789012345678901234ab"
 
@@ -162,8 +169,9 @@ class TestRAHasherService:
         with patch(
             "asyncio.create_subprocess_exec", return_value=mock_proc
         ) as mock_subprocess:
-            with patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {7: "nes"}):
-                await service.calculate_hash(7, "/path/to/game.nes")
+            await service.calculate_hash(
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+            )
 
         mock_subprocess.assert_called_once_with(
             "RAHasher",
@@ -177,12 +185,12 @@ class TestRAHasherService:
     async def test_calculate_hash_different_platforms(self, service):
         """Test hash calculation for different platforms."""
         test_cases = [
-            (3, "/path/to/game.smc", "snes"),
-            (1, "/path/to/game.md", "genesis"),
-            (4, "/path/to/game.gb", "gb"),
+            (3, "/path/to/game.smc", "snes", ".smc"),
+            (1, "/path/to/game.md", "genesis", ".md"),
+            (4, "/path/to/game.gb", "gb", ".gb"),
         ]
 
-        for platform_id, file_path, platform_slug in test_cases:
+        for platform_id, file_path, platform_slug, file_extension in test_cases:
             mock_proc = AsyncMock()
             mock_proc.wait.return_value = 0
             mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
@@ -191,11 +199,11 @@ class TestRAHasherService:
             with patch(
                 "asyncio.create_subprocess_exec", return_value=mock_proc
             ) as mock_subprocess:
-                with patch(
-                    "handler.metadata.ra_handler.RA_ID_TO_SLUG",
-                    {platform_id: platform_slug},
-                ):
-                    result = await service.calculate_hash(platform_id, file_path)
+                result = await service.calculate_hash(
+                    {"ra_id": platform_id, "slug": platform_slug},
+                    file_path,
+                    file_extension,
+                )
 
             assert result == "a1b2c3d4e5f6789012345678901234ab"
             mock_subprocess.assert_called_with(
@@ -214,8 +222,9 @@ class TestRAHasherService:
         mock_proc.stderr.read.return_value = b"File not supported"
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            with patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {7: "nes"}):
-                result = await service.calculate_hash(7, "/path/to/game.nes")
+            result = await service.calculate_hash(
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+            )
 
         assert result == ""
         mock_proc.stderr.read.assert_called_once()
@@ -228,8 +237,9 @@ class TestRAHasherService:
         mock_proc.stderr = None
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            with patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {7: "nes"}):
-                result = await service.calculate_hash(7, "/path/to/game.nes")
+            result = await service.calculate_hash(
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+            )
 
         assert result == ""
 
@@ -260,27 +270,31 @@ class TestRAHasherArchiveSkip:
         assert ups in RA_BUFFER_HASH_UNSUPPORTED
         platform_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[ups]
 
-        with (
-            patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch(
-                "handler.metadata.ra_handler.RA_ID_TO_SLUG",
-                {platform_id: "disc-platform"},
-            ),
-        ):
-            result = await service.calculate_hash(platform_id, f"/path/to/game{ext}")
+        with patch("asyncio.create_subprocess_exec") as mock_subprocess:
+            result = await service.calculate_hash(
+                {"ra_id": platform_id, "slug": "disc-platform"},
+                f"/path/to/game{ext}",
+                ext,
+            )
 
         assert result == ""
         mock_subprocess.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_skips_subprocess_case_insensitive_extension(self, service):
-        """Extension match is case-insensitive (.ZIP, .Zip, etc.)."""
+    @pytest.mark.parametrize(
+        "ext_input",
+        [".zip", "zip", ".ZIP", "ZIP", ".Zip", "Zip"],
+    )
+    async def test_extension_normalization_skips_subprocess(self, service, ext_input):
+        """Extension is normalized: leading dot optional, case-insensitive."""
         platform_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSP]
-        with (
-            patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {platform_id: "psp"}),
-        ):
-            result = await service.calculate_hash(platform_id, "/path/to/GAME.ZIP")
+
+        with patch("asyncio.create_subprocess_exec") as mock_subprocess:
+            result = await service.calculate_hash(
+                {"ra_id": platform_id, "slug": "psp"},
+                "/path/to/game.zip",
+                ext_input,
+            )
 
         assert result == ""
         mock_subprocess.assert_not_called()
@@ -296,13 +310,12 @@ class TestRAHasherArchiveSkip:
         mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
         mock_proc.stderr = None
 
-        with (
-            patch(
-                "asyncio.create_subprocess_exec", return_value=mock_proc
-            ) as mock_subprocess,
-            patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {nes_id: "nes"}),
-        ):
-            result = await service.calculate_hash(nes_id, "/path/to/game.zip")
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=mock_proc
+        ) as mock_subprocess:
+            result = await service.calculate_hash(
+                {"ra_id": nes_id, "slug": "nes"}, "/path/to/game.zip", ".zip"
+            )
 
         assert result == "a1b2c3d4e5f6789012345678901234ab"
         mock_subprocess.assert_called_once()
@@ -317,13 +330,12 @@ class TestRAHasherArchiveSkip:
         mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
         mock_proc.stderr = None
 
-        with (
-            patch(
-                "asyncio.create_subprocess_exec", return_value=mock_proc
-            ) as mock_subprocess,
-            patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {platform_id: "psp"}),
-        ):
-            result = await service.calculate_hash(platform_id, "/path/to/game.iso")
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=mock_proc
+        ) as mock_subprocess:
+            result = await service.calculate_hash(
+                {"ra_id": platform_id, "slug": "psp"}, "/path/to/game.iso", ".iso"
+            )
 
         assert result == "a1b2c3d4e5f6789012345678901234ab"
         mock_subprocess.assert_called_once()
@@ -369,7 +381,9 @@ class TestRAHasherServiceIntegration:
         # 3. Known expected hash for that ROM
 
         # Example (uncomment and modify for real testing):
-        # result = await service.calculate_hash(7, "/path/to/test.nes")
+        # result = await service.calculate_hash(
+        #     {"ra_id": 7, "slug": "nes"}, "/path/to/test.nes", ".nes"
+        # )
         # assert result == "expected_hash_value"
         pass
 
@@ -392,12 +406,14 @@ class TestRAHasherServicePerformance:
         mock_proc.stderr = None
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            with patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {7: "nes"}):
-                # Run 5 concurrent hash calculations
-                tasks = [
-                    service.calculate_hash(7, f"/path/to/game{i}.nes") for i in range(5)
-                ]
-                results = await asyncio.gather(*tasks)
+            # Run 5 concurrent hash calculations
+            tasks = [
+                service.calculate_hash(
+                    {"ra_id": 7, "slug": "nes"}, f"/path/to/game{i}.nes", ".nes"
+                )
+                for i in range(5)
+            ]
+            results = await asyncio.gather(*tasks)
 
         # All should succeed
         assert all(result == "a1b2c3d4e5f6789012345678901234ab" for result in results)

--- a/backend/tests/adapters/services/test_rahasher.py
+++ b/backend/tests/adapters/services/test_rahasher.py
@@ -4,10 +4,13 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from adapters.services.rahasher import (
+    PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID,
+    RA_BUFFER_HASH_UNSUPPORTED,
     RAHASHER_VALID_HASH_REGEX,
     RAHasherError,
     RAHasherService,
 )
+from handler.metadata.base_handler import UniversalPlatformSlug as UPS
 
 
 class TestRAHasherValidHashRegex:
@@ -229,6 +232,101 @@ class TestRAHasherService:
                 result = await service.calculate_hash(7, "/path/to/game.nes")
 
         assert result == ""
+
+
+class TestRAHasherArchiveSkip:
+    """Verify RAHasher is skipped when an archive is fed to a disc-based platform."""
+
+    @pytest.fixture
+    def service(self):
+        return RAHasherService()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "ups,ext",
+        [
+            (UPS.PSP, ".zip"),
+            (UPS.PS2, ".7z"),
+            (UPS.PSX, ".tar"),
+            (UPS.SATURN, ".gz"),
+            (UPS.DC, ".bz2"),
+            (UPS.WII, ".rar"),
+        ],
+    )
+    async def test_skips_subprocess_for_archive_on_disc_platform(
+        self, service, ups, ext
+    ):
+        """No subprocess should be spawned; calculate_hash returns '' immediately."""
+        assert ups in RA_BUFFER_HASH_UNSUPPORTED
+        platform_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[ups]
+
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch(
+                "handler.metadata.ra_handler.RA_ID_TO_SLUG",
+                {platform_id: "disc-platform"},
+            ),
+        ):
+            result = await service.calculate_hash(platform_id, f"/path/to/game{ext}")
+
+        assert result == ""
+        mock_subprocess.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_subprocess_case_insensitive_extension(self, service):
+        """Extension match is case-insensitive (.ZIP, .Zip, etc.)."""
+        platform_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSP]
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {platform_id: "psp"}),
+        ):
+            result = await service.calculate_hash(platform_id, "/path/to/GAME.ZIP")
+
+        assert result == ""
+        mock_subprocess.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_skip_archive_for_cartridge_platform(self, service):
+        """Cartridge platforms (e.g. NES) support buffer hash; don't skip."""
+        assert UPS.NES not in RA_BUFFER_HASH_UNSUPPORTED
+        nes_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.NES]
+
+        mock_proc = AsyncMock()
+        mock_proc.wait.return_value = 0
+        mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
+        mock_proc.stderr = None
+
+        with (
+            patch(
+                "asyncio.create_subprocess_exec", return_value=mock_proc
+            ) as mock_subprocess,
+            patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {nes_id: "nes"}),
+        ):
+            result = await service.calculate_hash(nes_id, "/path/to/game.zip")
+
+        assert result == "a1b2c3d4e5f6789012345678901234ab"
+        mock_subprocess.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_does_not_skip_raw_iso_for_disc_platform(self, service):
+        """Raw disc images must still go through RAHasher for disc platforms."""
+        platform_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSP]
+
+        mock_proc = AsyncMock()
+        mock_proc.wait.return_value = 0
+        mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
+        mock_proc.stderr = None
+
+        with (
+            patch(
+                "asyncio.create_subprocess_exec", return_value=mock_proc
+            ) as mock_subprocess,
+            patch("handler.metadata.ra_handler.RA_ID_TO_SLUG", {platform_id: "psp"}),
+        ):
+            result = await service.calculate_hash(platform_id, "/path/to/game.iso")
+
+        assert result == "a1b2c3d4e5f6789012345678901234ab"
+        mock_subprocess.assert_called_once()
 
 
 class TestRAHasherError:

--- a/backend/tests/adapters/services/test_rahasher.py
+++ b/backend/tests/adapters/services/test_rahasher.py
@@ -51,7 +51,7 @@ class TestRAHasherService:
         return RAHasherService()
 
     @pytest.mark.asyncio
-    async def test_calculate_hash_success(self, service):
+    async def test_calculate_hash_success(self, service: RAHasherService):
         """Test successful hash calculation."""
         mock_proc = AsyncMock()
         mock_proc.wait.return_value = 0  # RAHasher returns 0 on success
@@ -60,7 +60,7 @@ class TestRAHasherService:
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
             )
 
         assert result == "a1b2c3d4e5f6789012345678901234ab"
@@ -68,20 +68,20 @@ class TestRAHasherService:
         mock_proc.stdout.read.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_calculate_hash_rahasher_not_found(self, service):
+    async def test_calculate_hash_rahasher_not_found(self, service: RAHasherService):
         """Test when RAHasher executable is not found."""
         with patch(
             "asyncio.create_subprocess_exec",
             side_effect=FileNotFoundError("RAHasher not found"),
         ):
             result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
             )
 
         assert result == ""
 
     @pytest.mark.asyncio
-    async def test_calculate_hash_rahasher_failure(self, service):
+    async def test_calculate_hash_rahasher_failure(self, service: RAHasherService):
         """Test when RAHasher fails with non-1 return code."""
         mock_proc = AsyncMock()
         mock_proc.wait.return_value = 2  # Error return code
@@ -89,7 +89,7 @@ class TestRAHasherService:
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
             )
 
         assert result == ""
@@ -97,7 +97,7 @@ class TestRAHasherService:
         mock_proc.stderr.read.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_calculate_hash_no_stdout(self, service):
+    async def test_calculate_hash_no_stdout(self, service: RAHasherService):
         """Test when RAHasher has no stdout."""
         mock_proc = AsyncMock()
         mock_proc.wait.return_value = 1
@@ -106,13 +106,13 @@ class TestRAHasherService:
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
             )
 
         assert result == ""
 
     @pytest.mark.asyncio
-    async def test_calculate_hash_empty_output(self, service):
+    async def test_calculate_hash_empty_output(self, service: RAHasherService):
         """Test when RAHasher returns empty output."""
         mock_proc = AsyncMock()
         mock_proc.wait.return_value = 1
@@ -121,13 +121,13 @@ class TestRAHasherService:
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
             )
 
         assert result == ""
 
     @pytest.mark.asyncio
-    async def test_calculate_hash_invalid_hash_format(self, service):
+    async def test_calculate_hash_invalid_hash_format(self, service: RAHasherService):
         """Test when RAHasher returns invalid hash format."""
         mock_proc = AsyncMock()
         mock_proc.wait.return_value = 1
@@ -136,13 +136,13 @@ class TestRAHasherService:
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
             )
 
         assert result == ""
 
     @pytest.mark.asyncio
-    async def test_calculate_hash_with_extra_output(self, service):
+    async def test_calculate_hash_with_extra_output(self, service: RAHasherService):
         """Test when RAHasher returns hash with extra text."""
         mock_proc = AsyncMock()
         mock_proc.wait.return_value = 0
@@ -153,13 +153,13 @@ class TestRAHasherService:
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
             )
 
         assert result == "a1b2c3d4e5f6789012345678901234ab"
 
     @pytest.mark.asyncio
-    async def test_calculate_hash_subprocess_args(self, service):
+    async def test_calculate_hash_subprocess_args(self, service: RAHasherService):
         """Test that subprocess is called with correct arguments."""
         mock_proc = AsyncMock()
         mock_proc.wait.return_value = 1
@@ -170,7 +170,7 @@ class TestRAHasherService:
             "asyncio.create_subprocess_exec", return_value=mock_proc
         ) as mock_subprocess:
             await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
             )
 
         mock_subprocess.assert_called_once_with(
@@ -182,15 +182,15 @@ class TestRAHasherService:
         )
 
     @pytest.mark.asyncio
-    async def test_calculate_hash_different_platforms(self, service):
+    async def test_calculate_hash_different_platforms(self, service: RAHasherService):
         """Test hash calculation for different platforms."""
         test_cases = [
-            (3, "/path/to/game.smc", "snes", ".smc"),
-            (1, "/path/to/game.md", "genesis", ".md"),
-            (4, "/path/to/game.gb", "gb", ".gb"),
+            (3, "/path/to/game.smc", "snes"),
+            (1, "/path/to/game.md", "genesis"),
+            (4, "/path/to/game.gb", "gb"),
         ]
 
-        for platform_id, file_path, platform_slug, file_extension in test_cases:
+        for platform_id, file_path, platform_slug in test_cases:
             mock_proc = AsyncMock()
             mock_proc.wait.return_value = 0
             mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
@@ -202,7 +202,6 @@ class TestRAHasherService:
                 result = await service.calculate_hash(
                     {"ra_id": platform_id, "slug": platform_slug},
                     file_path,
-                    file_extension,
                 )
 
             assert result == "a1b2c3d4e5f6789012345678901234ab"
@@ -215,7 +214,7 @@ class TestRAHasherService:
             )
 
     @pytest.mark.asyncio
-    async def test_calculate_hash_stderr_handling(self, service):
+    async def test_calculate_hash_stderr_handling(self, service: RAHasherService):
         """Test proper handling of stderr when RAHasher fails."""
         mock_proc = AsyncMock()
         mock_proc.wait.return_value = 2
@@ -223,14 +222,14 @@ class TestRAHasherService:
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
             )
 
         assert result == ""
         mock_proc.stderr.read.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_calculate_hash_stderr_none(self, service):
+    async def test_calculate_hash_stderr_none(self, service: RAHasherService):
         """Test handling when stderr is None."""
         mock_proc = AsyncMock()
         mock_proc.wait.return_value = 2
@@ -238,7 +237,7 @@ class TestRAHasherService:
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes", ".nes"
+                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
             )
 
         assert result == ""
@@ -264,7 +263,7 @@ class TestRAHasherArchiveSkip:
         ],
     )
     async def test_skips_subprocess_for_archive_on_disc_platform(
-        self, service, ups, ext
+        self, service: RAHasherService, ups, ext
     ):
         """No subprocess should be spawned; calculate_hash returns '' immediately."""
         assert ups in RA_BUFFER_HASH_UNSUPPORTED
@@ -274,33 +273,15 @@ class TestRAHasherArchiveSkip:
             result = await service.calculate_hash(
                 {"ra_id": platform_id, "slug": "disc-platform"},
                 f"/path/to/game{ext}",
-                ext,
             )
 
         assert result == ""
         mock_subprocess.assert_not_called()
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "ext_input",
-        [".zip", "zip", ".ZIP", "ZIP", ".Zip", "Zip"],
-    )
-    async def test_extension_normalization_skips_subprocess(self, service, ext_input):
-        """Extension is normalized: leading dot optional, case-insensitive."""
-        platform_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSP]
-
-        with patch("asyncio.create_subprocess_exec") as mock_subprocess:
-            result = await service.calculate_hash(
-                {"ra_id": platform_id, "slug": "psp"},
-                "/path/to/game.zip",
-                ext_input,
-            )
-
-        assert result == ""
-        mock_subprocess.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_does_not_skip_archive_for_cartridge_platform(self, service):
+    async def test_does_not_skip_archive_for_cartridge_platform(
+        self, service: RAHasherService
+    ):
         """Cartridge platforms (e.g. NES) support buffer hash; don't skip."""
         assert UPS.NES not in RA_BUFFER_HASH_UNSUPPORTED
         nes_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.NES]
@@ -314,14 +295,16 @@ class TestRAHasherArchiveSkip:
             "asyncio.create_subprocess_exec", return_value=mock_proc
         ) as mock_subprocess:
             result = await service.calculate_hash(
-                {"ra_id": nes_id, "slug": "nes"}, "/path/to/game.zip", ".zip"
+                {"ra_id": nes_id, "slug": "nes"}, "/path/to/game.zip"
             )
 
         assert result == "a1b2c3d4e5f6789012345678901234ab"
         mock_subprocess.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_does_not_skip_raw_iso_for_disc_platform(self, service):
+    async def test_does_not_skip_raw_iso_for_disc_platform(
+        self, service: RAHasherService
+    ):
         """Raw disc images must still go through RAHasher for disc platforms."""
         platform_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSP]
 
@@ -334,7 +317,7 @@ class TestRAHasherArchiveSkip:
             "asyncio.create_subprocess_exec", return_value=mock_proc
         ) as mock_subprocess:
             result = await service.calculate_hash(
-                {"ra_id": platform_id, "slug": "psp"}, "/path/to/game.iso", ".iso"
+                {"ra_id": platform_id, "slug": "psp"}, "/path/to/game.iso"
             )
 
         assert result == "a1b2c3d4e5f6789012345678901234ab"
@@ -362,32 +345,6 @@ class TestRAHasherError:
             assert str(e) == message
 
 
-# Integration-style tests (these would use real RAHasher if available)
-class TestRAHasherServiceIntegration:
-    """Integration tests for RAHasher service (requires RAHasher executable)."""
-
-    @pytest.fixture
-    def service(self):
-        """Create a RAHasherService instance for integration testing."""
-        return RAHasherService()
-
-    @pytest.mark.asyncio
-    @pytest.mark.skipif(True, reason="Requires RAHasher executable and test ROM files")
-    async def test_calculate_hash_real_rahasher(self, service):
-        """Test with real RAHasher executable (skipped by default)."""
-        # This test would require:
-        # 1. RAHasher executable in PATH
-        # 2. A test ROM file
-        # 3. Known expected hash for that ROM
-
-        # Example (uncomment and modify for real testing):
-        # result = await service.calculate_hash(
-        #     {"ra_id": 7, "slug": "nes"}, "/path/to/test.nes", ".nes"
-        # )
-        # assert result == "expected_hash_value"
-        pass
-
-
 # Performance tests
 class TestRAHasherServicePerformance:
     """Performance tests for RAHasher service."""
@@ -398,7 +355,7 @@ class TestRAHasherServicePerformance:
         return RAHasherService()
 
     @pytest.mark.asyncio
-    async def test_concurrent_hash_calculations(self, service):
+    async def test_concurrent_hash_calculations(self, service: RAHasherService):
         """Test multiple concurrent hash calculations."""
         mock_proc = AsyncMock()
         mock_proc.wait.return_value = 0
@@ -409,7 +366,7 @@ class TestRAHasherServicePerformance:
             # Run 5 concurrent hash calculations
             tasks = [
                 service.calculate_hash(
-                    {"ra_id": 7, "slug": "nes"}, f"/path/to/game{i}.nes", ".nes"
+                    {"ra_id": 7, "slug": "nes"}, f"/path/to/game{i}.nes"
                 )
                 for i in range(5)
             ]

--- a/backend/tests/handler/filesystem/test_roms_handler.py
+++ b/backend/tests/handler/filesystem/test_roms_handler.py
@@ -48,6 +48,7 @@ class TestFSRomsHandler:
             id=1,
             fs_name="Paper Mario (USA).z64",
             fs_path="n64/roms",
+            fs_extension="z64",
             platform=platform,
             full_path="n64/roms/Paper Mario (USA).z64",
         )
@@ -58,6 +59,7 @@ class TestFSRomsHandler:
             id=3,
             fs_name="Sonic (EU) [T]",
             fs_path="n64/roms",
+            fs_extension="",
             platform=platform,
             full_path="n64/roms/Sonic (EU) [T]",
             files=[
@@ -80,6 +82,7 @@ class TestFSRomsHandler:
             id=2,
             fs_name="Super Mario 64 (J) (Rev A)",
             fs_path="n64/roms",
+            fs_extension="",
             platform=platform,
             files=[
                 RomFile(
@@ -687,6 +690,7 @@ class TestFSRomsHandler:
         rom = Rom(
             id=1,
             fs_name="test.chd",
+            fs_extension="chd",
             fs_path=str(roms_path.relative_to(tmp_path)),
             platform=platform,
         )
@@ -742,6 +746,7 @@ class TestFSRomsHandler:
         rom = Rom(
             id=1,
             fs_name="old_format.chd",
+            fs_extension="chd",
             fs_path=str(roms_path.relative_to(tmp_path)),
             platform=platform,
         )

--- a/backend/utils/filesystem.py
+++ b/backend/utils/filesystem.py
@@ -7,7 +7,7 @@ from pathlib import Path
 # (roms_handler for hashing decisions, rahasher for skipping disc-platform
 # buffer-hash attempts, feeds for PKGi passthrough).
 COMPRESSED_FILE_EXTENSIONS: frozenset[str] = frozenset(
-    ("7z", "bz2", "gz", "rar", "tar", "zip")
+    (".7z", ".bz2", ".gz", ".rar", ".tar", ".zip")
 )
 
 

--- a/backend/utils/filesystem.py
+++ b/backend/utils/filesystem.py
@@ -7,7 +7,7 @@ from pathlib import Path
 # (roms_handler for hashing decisions, rahasher for skipping disc-platform
 # buffer-hash attempts, feeds for PKGi passthrough).
 COMPRESSED_FILE_EXTENSIONS: frozenset[str] = frozenset(
-    (".7z", ".bz2", ".gz", ".rar", ".tar", ".zip")
+    ("7z", "bz2", "gz", "rar", "tar", "zip")
 )
 
 

--- a/backend/utils/filesystem.py
+++ b/backend/utils/filesystem.py
@@ -3,6 +3,13 @@ import re
 from collections.abc import Iterator
 from pathlib import Path
 
+# Container file extensions treated as compressed archives across modules
+# (roms_handler for hashing decisions, rahasher for skipping disc-platform
+# buffer-hash attempts, feeds for PKGi passthrough).
+COMPRESSED_FILE_EXTENSIONS: frozenset[str] = frozenset(
+    (".7z", ".bz2", ".gz", ".rar", ".tar", ".zip")
+)
+
 
 def iter_files(path: str, recursive: bool = False) -> Iterator[tuple[Path, str]]:
     """List files in a directory.


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>
RAHasher was being spawned for every hashable ROM regardless of file type. When the source file is a zip/7z/tar and the RA platform needs an on-disk disc image (PSX, PS2, PSP, Saturn, Dreamcast, Sega CD, 3DO, PC-FX, Neo Geo CD, TurboGrafx CD, Atari Jaguar CD, Wii), the subprocess fails with "Unsupported console for buffer hash: {id}" after paying full process-spawn overhead per ROM — a serious slowdown when indexing large zipped collections (e.g. myrient PS2/PSP sets).

calculate_hash now short-circuits those combinations with a debug log and no subprocess. Raw disc images (.iso, .chd, .cue/.bin) and archives on cartridge platforms still go through RAHasher as before.

Also centralize COMPRESSED_FILE_EXTENSIONS in utils/filesystem.py so roms_handler (is_compressed_file / hashing), rahasher (skip logic), and feeds (PKGi passthrough) share one source of truth. The shared set adds .rar, which is_compressed_file now recognizes too.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes