### PR TITLE
Fix download failing when hash has not been computed

### DIFF
--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -206,12 +206,6 @@ def _should_get_rom_files(
         newly_added (bool): Whether the rom is newly added.
         roms_ids (list[int]): List of selected roms to be scanned.
     """
-    # Get hash calculation setting from config
-    calculate_hashes = not cm.get_config().SKIP_HASH_CALCULATION
-
-    # Skip file processing entirely if hashes are disabled (except for HASHES scan type)
-    if not calculate_hashes and scan_type != ScanType.HASHES:
-        return False
 
     return bool(
         newly_added


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

When hash calculation is disabled, the size of each file isn't retrieved at all, which seems to cause downloads to fail with an internal server error. This PR make the skip mechanism a bit less aggressive by allowing file size to be stored. IMO This is nice to still have the file size displayed in the UI in this situation, and doesn't cost much in terms of resources. `SKIP_HASH_CALCULATION` is still checked and hash is still properly skipped right after `_should_get_rom_files` has been called anyway.

This issue should be fairly easy to reproduce, as I could by only following the development setup doc on a fresh repository. Just add any game, set `skip_hash_calculation: true` in the config, start a library scan and try to download or play the game. 

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)
N/A