### PR TITLE
fix(git): enforce LF line endings for shell scripts via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,9 @@
 **/tests/cassettes/*.yaml linguist-generated
+
+# Ensure shell scripts always use LF line endings in the repository,
+# regardless of the developer's OS or core.autocrlf setting.
+# Without this, Windows checkouts produce CRLF scripts that fail to
+# execute inside Linux containers with "no such file or directory".
+*.sh text eol=lf
+entrypoint.sh text eol=lf
+docker/init_scripts/init text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 **/tests/cassettes/*.yaml linguist-generated
 
+# Keep this file itself in LF so git can parse it reliably on all platforms.
+.gitattributes text eol=lf
+
 # Ensure shell scripts always use LF line endings in the repository,
 # regardless of the developer's OS or core.autocrlf setting.
 # Without this, Windows checkouts produce CRLF scripts that fail to


### PR DESCRIPTION
**Summary**
- Fixes #3265
- Adds `eol=lf` attributes to `.gitattributes` for `*.sh`, `entrypoint.sh`, and `docker/init_scripts/init`.
- Prevents git from converting shell script line endings to CRLF on Windows checkouts

**Problem**
On Windows, the default `core.autocrlf=true` git setting converts LF to CRLF on checkout. The repository's `.gitattributes` did not specify line ending behavior for shell scripts, so git deferred to this setting. When Docker copies CRLF scripts into a Linux container, the kernel rejects them:


`exec /entrypoint.sh: no such file or directory`


Adding `eol=lf` at the repository level overrides `core.autocrlf` for these files, ensuring consistent LF endings regardless of the developer's platform or local git configuration.

**Test plan**
 Verified git ls-files `--eol` reports `i/lf w/lf` for all affected scripts after applying the change
 Confirmed Docker container starts successfully on Windows after clean checkout
 
**AI Disclosure**
This PR was written with Claude Code (Claude Sonnet 4.6). The fix was identified during a separate contribution ([#3263](https://github.com/rommapp/romm/pull/3263)), analyzed and implemented with AI assistance, and verified locally by the human contributor.