### PR TITLE
fix: re-parse tags from filename when renaming a rom

### DIFF
--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -1296,6 +1296,20 @@ async def update_rom(
         }
     )
 
+    # Re-parse tags from the filename so region/language/revision/version/tags
+    # stay in sync whenever the fs_name changes.
+    if new_fs_name != rom.fs_name:
+        parsed_tags = fs_rom_handler.parse_tags(new_fs_name)
+        cleaned_data.update(
+            {
+                "regions": parsed_tags.regions,
+                "languages": parsed_tags.languages,
+                "tags": parsed_tags.other_tags,
+                "revision": parsed_tags.revision,
+                "version": parsed_tags.version,
+            }
+        )
+
     if remove_cover:
         cleaned_data.update(await fs_resource_handler.remove_cover(rom))
         cleaned_data.update({"url_cover": ""})

--- a/backend/tests/endpoints/roms/test_rom.py
+++ b/backend/tests/endpoints/roms/test_rom.py
@@ -103,6 +103,30 @@ def test_update_rom(
     assert get_rom_by_id_mock.called
 
 
+@patch.object(FSRomsHandler, "rename_fs_rom")
+@patch.object(IGDBHandler, "get_rom_by_id", return_value=IGDBRom(igdb_id=None))
+def test_update_rom_reparses_tags_on_fs_name_change(
+    rename_fs_rom_mock: AsyncMock,
+    get_rom_by_id_mock: AsyncMock,
+    client: TestClient,
+    access_token: str,
+    rom: Rom,
+):
+    response = client.put(
+        f"/api/roms/{rom.id}",
+        headers={"Authorization": f"Bearer {access_token}"},
+        data={"fs_name": "Patapon (Fr, En) (Rev 1).iso"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    body = response.json()
+    assert body["fs_name"] == "Patapon (Fr, En) (Rev 1).iso"
+    assert body["languages"] == ["French", "English"]
+    assert body["regions"] == []
+    assert body["revision"] == "1"
+    assert body["tags"] == []
+
+
 def test_delete_roms(client: TestClient, access_token: str, rom: Rom):
     response = client.post(
         "/api/roms/delete",


### PR DESCRIPTION
## Summary
- `PUT /roms/{id}` previously only updated `fs_name`, `fs_name_no_tags`, and `fs_name_no_ext` on rename, leaving `regions`/`languages`/`tags`/`revision`/`version` stale against the new filename.
- Re-parse tags via `fs_rom_handler.parse_tags()` whenever `fs_name` changes so e.g. `patapon (Fr En)` → `Patapon (Fr, En)` now updates languages to `["French", "English"]`.

## Repro
1. Add a game with filename `patapon (Fr En).iso` (tags not recognized — single token).
2. Rename via UI to `Patapon (Fr, En).iso`.
3. Before: languages remain empty. After: languages = `["French", "English"]`.

## Test plan
- [x] Added `test_update_rom_reparses_tags_on_fs_name_change` covering languages + revision parsing on rename.
- [ ] Manual rename in UI and confirm region/language/tag chips refresh.

Closes #3292