### PR TITLE
feat(playmatch): send a suggestion to playmatch on manual match when enabled

### DIFF
--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -1,3 +1,4 @@
+import asyncio
 import binascii
 import json
 from base64 import b64encode
@@ -54,6 +55,7 @@ from handler.metadata import (
     meta_igdb_handler,
     meta_launchbox_handler,
     meta_moby_handler,
+    meta_playmatch_handler,
     meta_ra_handler,
     meta_ss_handler,
 )
@@ -73,6 +75,16 @@ from .files import router as files_router
 from .manual import router as manual_router
 from .notes import router as notes_router
 from .upload import router as upload_router
+
+# The event loop only holds weak refs to tasks; hold strong refs until they finish.
+_background_tasks: set[asyncio.Task[Any]] = set()
+
+
+def _fire_and_forget(coro: Any) -> None:
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
 
 router = APIRouter(
     prefix="/roms",
@@ -1439,6 +1451,8 @@ async def update_rom(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
+    _fire_and_forget(meta_playmatch_handler.submit_manual_match_suggestion(rom))
 
     return DetailedRomSchema.from_orm_with_request(rom, request)
 

--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -1,4 +1,3 @@
-import asyncio
 import binascii
 import json
 from base64 import b64encode
@@ -64,6 +63,7 @@ from logger.formatter import BLUE
 from logger.formatter import highlight as hl
 from logger.logger import log
 from models.rom import Rom, RomUserStatus
+from utils.background_tasks import fire_and_forget
 from utils.database import safe_int, safe_str_to_bool
 from utils.filesystem import sanitize_filename
 from utils.hashing import crc32_to_hex
@@ -75,16 +75,6 @@ from .files import router as files_router
 from .manual import router as manual_router
 from .notes import router as notes_router
 from .upload import router as upload_router
-
-# The event loop only holds weak refs to tasks; hold strong refs until they finish.
-_background_tasks: set[asyncio.Task[Any]] = set()
-
-
-def _fire_and_forget(coro: Any) -> None:
-    task = asyncio.create_task(coro)
-    _background_tasks.add(task)
-    task.add_done_callback(_background_tasks.discard)
-
 
 router = APIRouter(
     prefix="/roms",
@@ -1453,7 +1443,7 @@ async def update_rom(
         raise RomNotFoundInDatabaseException(id)
 
     if meta_playmatch_handler.is_manual_match(form_data.model_fields_set):
-        _fire_and_forget(meta_playmatch_handler.submit_manual_match_suggestion(rom))
+        fire_and_forget(meta_playmatch_handler.submit_manual_match_suggestion(rom))
 
     return DetailedRomSchema.from_orm_with_request(rom, request)
 

--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -1452,7 +1452,8 @@ async def update_rom(
     if not rom:
         raise RomNotFoundInDatabaseException(id)
 
-    _fire_and_forget(meta_playmatch_handler.submit_manual_match_suggestion(rom))
+    if meta_playmatch_handler.is_manual_match(form_data.model_fields_set):
+        _fire_and_forget(meta_playmatch_handler.submit_manual_match_suggestion(rom))
 
     return DetailedRomSchema.from_orm_with_request(rom, request)
 

--- a/backend/handler/metadata/playmatch_handler.py
+++ b/backend/handler/metadata/playmatch_handler.py
@@ -9,13 +9,30 @@ from fastapi import HTTPException, status
 from config import PLAYMATCH_API_ENABLED
 from handler.metadata.base_handler import MetadataHandler
 from logger.logger import log
-from models.rom import RomFile
+from models.rom import Rom, RomFile
 from utils import get_version
 from utils.context import ctx_httpx_client
 
 
 class PlaymatchProvider(str, Enum):
     IGDB = "IGDB"
+
+
+# (rom attribute, provider tag). Playmatch drops unknown tags server-side.
+_PLAYMATCH_PROVIDER_TAGS: tuple[tuple[str, str], ...] = (
+    ("igdb_id", "IGDB"),
+    ("moby_id", "MOBY_GAMES"),
+    ("ss_id", "SCREENSCRAPER"),
+    ("ra_id", "RETRO_ACHIEVEMENTS"),
+    ("launchbox_id", "LAUNCHBOX"),
+    ("hasheous_id", "HASHEOUS"),
+    ("tgdb_id", "TGDB"),
+    ("flashpoint_id", "FLASHPOINT"),
+    ("hltb_id", "HOWLONGTOBEAT"),
+    ("libretro_id", "LIBRETRO"),
+    ("sgdb_id", "STEAMGRIDDB"),
+    ("gamelist_id", "GAMELIST"),
+)
 
 
 class GameMatchType(str, Enum):
@@ -49,6 +66,7 @@ class PlaymatchHandler(MetadataHandler):
         self.base_url = "https://playmatch.retrorealm.dev/api"
         self.identify_url = f"{self.base_url}/identify/ids"
         self.healthcheck_url = f"{self.base_url}/health"
+        self.suggestion_url = f"{self.base_url}/suggestion/external/game"
 
     @classmethod
     def is_enabled(cls) -> bool:
@@ -163,3 +181,51 @@ class PlaymatchHandler(MetadataHandler):
                 igdb_id = int(provider_game_id)
 
         return PlaymatchRomMatch(igdb_id=igdb_id)
+
+    async def submit_manual_match_suggestion(self, rom: Rom) -> None:
+        """Fire-and-forget suggestion POST. No-ops if disabled or unmatched; never raises."""
+        try:
+            if not self.is_enabled():
+                return
+
+            mappings = [
+                {"provider": tag, "providerId": str(getattr(rom, attr))}
+                for attr, tag in _PLAYMATCH_PROVIDER_TAGS
+                if getattr(rom, attr, None) not in (None, "")
+            ]
+            if not mappings:
+                return
+
+            first_file = next(
+                (f for f in rom.files if f.file_size_bytes > 0),
+                None,
+            )
+            if first_file is not None:
+                md5 = first_file.md5_hash
+                sha1 = first_file.sha1_hash
+                file_name = first_file.file_name
+                file_size: int | None = first_file.file_size_bytes
+            else:
+                md5 = rom.md5_hash
+                sha1 = rom.sha1_hash
+                file_name = rom.fs_name
+                file_size = rom.fs_size_bytes or None
+
+            payload = {
+                "md5": md5,
+                "sha1": sha1,
+                "sha256": None,
+                "fileName": file_name,
+                "fileSize": file_size,
+                "mappings": mappings,
+            }
+
+            httpx_client = ctx_httpx_client.get()
+            await httpx_client.post(
+                self.suggestion_url,
+                json=payload,
+                headers={"user-agent": f"RomM/{get_version()}"},
+                timeout=30,
+            )
+        except Exception:
+            log.debug("Playmatch match suggestion failed (ignored)", exc_info=True)

--- a/backend/handler/metadata/playmatch_handler.py
+++ b/backend/handler/metadata/playmatch_handler.py
@@ -182,6 +182,11 @@ class PlaymatchHandler(MetadataHandler):
 
         return PlaymatchRomMatch(igdb_id=igdb_id)
 
+    @staticmethod
+    def is_manual_match(form_fields_set: set[str]) -> bool:
+        """True if the submitted form contains any Playmatch-tracked provider id field."""
+        return any(attr in form_fields_set for attr, _ in _PLAYMATCH_PROVIDER_TAGS)
+
     async def submit_manual_match_suggestion(self, rom: Rom) -> None:
         """Fire-and-forget suggestion POST. No-ops if disabled or no provider IDs are set; never raises."""
         try:

--- a/backend/handler/metadata/playmatch_handler.py
+++ b/backend/handler/metadata/playmatch_handler.py
@@ -183,7 +183,7 @@ class PlaymatchHandler(MetadataHandler):
         return PlaymatchRomMatch(igdb_id=igdb_id)
 
     async def submit_manual_match_suggestion(self, rom: Rom) -> None:
-        """Fire-and-forget suggestion POST. No-ops if disabled or unmatched; never raises."""
+        """Fire-and-forget suggestion POST. No-ops if disabled or no provider IDs are set; never raises."""
         try:
             if not self.is_enabled():
                 return
@@ -191,7 +191,7 @@ class PlaymatchHandler(MetadataHandler):
             mappings = [
                 {"provider": tag, "providerId": str(getattr(rom, attr))}
                 for attr, tag in _PLAYMATCH_PROVIDER_TAGS
-                if getattr(rom, attr, None) not in (None, "")
+                if getattr(rom, attr, None)
             ]
             if not mappings:
                 return
@@ -221,11 +221,12 @@ class PlaymatchHandler(MetadataHandler):
             }
 
             httpx_client = ctx_httpx_client.get()
-            await httpx_client.post(
+            res = await httpx_client.post(
                 self.suggestion_url,
                 json=payload,
                 headers={"user-agent": f"RomM/{get_version()}"},
                 timeout=30,
             )
+            res.raise_for_status()
         except Exception:
             log.debug("Playmatch match suggestion failed (ignored)", exc_info=True)

--- a/backend/utils/background_tasks.py
+++ b/backend/utils/background_tasks.py
@@ -1,0 +1,13 @@
+import asyncio
+from collections.abc import Coroutine
+from typing import Any
+
+# The event loop only holds weak refs to tasks; hold strong refs until they finish.
+_background_tasks: set[asyncio.Task[Any]] = set()
+
+
+def fire_and_forget(coro: Coroutine[Any, Any, Any]) -> None:
+    """Schedule a coroutine without awaiting it."""
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>
 
Sends a fire-and-forget suggestion to Playmatch whenever a user updates a ROM through the edit/match endpoint. Its added as as suggestion which gets enqueued on playmatch side and then assuming its valid, the rom exitss on playmatch side and is unmatched will create a suggestion which will be manually reviewed on playmatch side before approving.

This helps in the long run to fill up playmatchs match database for all other RomM users when RomM users do manually matching and have playmatch enabled, arcaneasada agreed with me on Discord about it. Generally improving the Database for everybody.

When `PLAYMATCH_API_ENABLED=true` and a user calls `PUT /roms/{id}`, RomM posts the ROM's resolved provider IDs, hashes, filename, and filesize to `POST /api/suggestion/external/game`.

Payload details:

- `md5`, `sha1`, `fileName`, and `fileSize` come from the first ROM file with size > 0, falling back to ROM-level fields. `sha256` is always `null` since RomM does not compute it.
- `mappings` includes every provider id currently set on the ROM: IGDB, MobyGames, ScreenScraper, RetroAchievements, LaunchBox, Hasheous, TheGamesDB, Flashpoint, HowLongToBeat, Libretro, SteamGridDB, Gamelist. Only `IGDB` is consumed by Playmatch today. Unknown tags are dropped server-side, so future Playmatch providers will start working without a RomM change.

Behavior:

- Scheduled via `asyncio.create_task` and strong-referenced in a module-level set, so the PUT response is not delayed and the task is not garbage-collected before it runs. (Claude recommended this, i wasn't sure if it was needed, feel free to give feedback on this!)
- All exceptions are caught and logged at debug. A Playmatch outage should not interrupt RomM at all.
- No-ops when Playmatch is disabled, when the ROM has no provider IDs, or when the caller passes `unmatch_metadata=true` (the existing early return).

**Disclosure**
I am not a Python developer and am not very familiar with the RomM codebase. I used Claude to analyze the existing Playmatch integration and to help write the new handler method and endpoint hook. I reviewed the result before submitting.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes (should not be needed for this change)