### PR TITLE
fix: RAHasher silently failing on multi-part ROMs and poisoned cache

### DIFF
--- a/backend/adapters/services/rahasher.py
+++ b/backend/adapters/services/rahasher.py
@@ -106,6 +106,14 @@ class RAHasherService:
     """Service to calculate RetroAchievements hashes using RAHasher."""
 
     async def calculate_hash(self, platform: RAGamesPlatform, file_path: str) -> str:
+        """Return the RA hash for ``file_path`` on ``platform``.
+
+        Returns an empty string when the combination is unsupported by design
+        (e.g. an archived ROM on a disc-based platform that only does on-disk
+        hashing). Raises :class:`RAHasherError` for any actual failure — binary
+        missing, non-zero exit, empty stdout, malformed hash — so callers can
+        surface the problem instead of silently treating it as "no match".
+        """
         # Skip the subprocess entirely when the file is an archive and the
         # RA platform needs an on-disk disc image. RAHasher would just spawn,
         # fail with "Unsupported console for buffer hash: {id}", and return
@@ -138,28 +146,32 @@ class RAHasherService:
         return_code = await proc.wait()
         if return_code != 0:
             if proc.stderr is not None:
-                stderr = (await proc.stderr.read()).decode("utf-8")
+                stderr = (await proc.stderr.read()).decode("utf-8").strip()
             else:
-                stderr = None
-            log.error(f"RAHasher failed with code {return_code}. {stderr=}")
-            return ""
+                stderr = ""
+            raise RAHasherError(
+                f"RAHasher exited {return_code} for {file_path} "
+                f"(platform ID: {platform['ra_id']}): {stderr or '<no stderr>'}"
+            )
 
         if proc.stdout is None:
-            log.error("RAHasher did not return a hash.")
-            return ""
+            raise RAHasherError(
+                f"RAHasher produced no stdout for {file_path} "
+                f"(platform ID: {platform['ra_id']})"
+            )
 
         file_hash = (await proc.stdout.read()).decode("utf-8").strip()
         if not file_hash:
-            log.error(
-                f"RAHasher returned an empty hash for file {file_path} (platform ID: {platform['ra_id']})"
+            raise RAHasherError(
+                f"RAHasher returned an empty hash for {file_path} "
+                f"(platform ID: {platform['ra_id']})"
             )
-            return ""
 
         match = RAHASHER_VALID_HASH_REGEX.search(file_hash)
         if not match:
-            log.error(
-                f"RAHasher returned invalid hash {file_hash} for file {file_path} (platform ID: {platform['ra_id']})"
+            raise RAHasherError(
+                f"RAHasher returned invalid hash {file_hash!r} for {file_path} "
+                f"(platform ID: {platform['ra_id']})"
             )
-            return ""
 
         return match.group(0)

--- a/backend/adapters/services/retroachievements.py
+++ b/backend/adapters/services/retroachievements.py
@@ -156,6 +156,12 @@ class RetroAchievementsService:
 
         url = self.url.joinpath("API_GetGameList.php").with_query(**params)
         response = await self._request(str(url))
+        # _request() returns {} on HTTP / auth / JSON-decode errors. Casting that
+        # to list[RAGameListItem] lies to both the type checker and downstream
+        # callers that cache the "list" to disk — poisoning the RA hashes cache
+        # for REFRESH_RETROACHIEVEMENTS_CACHE_DAYS. Refuse to pretend.
+        if not isinstance(response, list):
+            return []
         return cast(list[RAGameListItem], response)
 
     async def get_user_completion_progress(

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -23,6 +23,7 @@ from exceptions.fs_exceptions import (
     RomsNotFoundException,
 )
 from handler.metadata.base_handler import UniversalPlatformSlug as UPS
+from logger.logger import log
 from models.platform import Platform
 from models.rom import Rom, RomFile, RomFileCategory
 from utils.archive_7zip import process_file_7z
@@ -419,7 +420,7 @@ class FSRomsHandler(FSHandler):
     async def get_rom_files(
         self, rom: Rom, calculate_hashes: bool = True
     ) -> ParsedRomFiles:
-        from adapters.services.rahasher import RAHasherService
+        from adapters.services.rahasher import RAHasherError, RAHasherService
         from handler.metadata import meta_ra_handler
 
         rel_roms_path = self.get_roms_fs_structure(
@@ -447,10 +448,26 @@ class FSRomsHandler(FSHandler):
             if calculate_hashes:
                 ra_platform = meta_ra_handler.get_platform(rom.platform_slug)
                 if ra_platform and ra_platform["ra_id"]:
-                    rom_ra_h = await RAHasherService().calculate_hash(
-                        ra_platform,
-                        f"{abs_fs_path}/{rom.fs_name}/*",
+                    # RAHasher takes a single file, not a glob or directory.
+                    # Previously this passed "<dir>/*" via create_subprocess_exec,
+                    # which doesn't expand globs — the literal "*" reached RAHasher
+                    # and every multi-part ROM silently failed to hash. Pick the
+                    # primary disc/cartridge file from the directory instead.
+                    primary_file = self._find_primary_ra_file(
+                        f"{abs_fs_path}/{rom.fs_name}"
                     )
+                    if primary_file is not None:
+                        try:
+                            rom_ra_h = await RAHasherService().calculate_hash(
+                                ra_platform,
+                                str(primary_file),
+                            )
+                        except RAHasherError as exc:
+                            log.error(
+                                "RAHasher failed for multi-part ROM %s: %s",
+                                rom.fs_name,
+                                exc,
+                            )
 
             for f_path, file_name in iter_files(
                 f"{abs_fs_path}/{rom.fs_name}", recursive=True
@@ -538,10 +555,13 @@ class FSRomsHandler(FSHandler):
             if calculate_hashes:
                 ra_platform = meta_ra_handler.get_platform(rom.platform_slug)
                 if ra_platform and ra_platform["ra_id"]:
-                    rom_ra_h = await RAHasherService().calculate_hash(
-                        ra_platform,
-                        f"{abs_fs_path}/{rom.fs_name}",
-                    )
+                    try:
+                        rom_ra_h = await RAHasherService().calculate_hash(
+                            ra_platform,
+                            f"{abs_fs_path}/{rom.fs_name}",
+                        )
+                    except RAHasherError as exc:
+                        log.error("RAHasher failed for %s: %s", rom.fs_name, exc)
 
             file_hash = FileHash(
                 crc_hash=crc32_to_hex(crc_c) if crc_c != DEFAULT_CRC_C else "",
@@ -592,6 +612,41 @@ class FSRomsHandler(FSHandler):
             ),
             ra_hash=rom_ra_h,
         )
+
+    # File extensions RAHasher understands for a multi-part ROM, in the order
+    # we prefer them (RA matches sets by the "primary" file, not the pieces).
+    _RA_PRIMARY_FILE_EXTS: Final = (
+        ".m3u",  # multi-disc playlist — whole-set match
+        ".cue",  # CD TOC
+        ".gdi",  # Dreamcast
+        ".chd",  # compressed disc image
+        ".iso",  # raw disc image
+        ".nrg",  # Nero disc image
+        ".pbp",  # PSP/PSX EBOOT
+    )
+
+    def _find_primary_ra_file(self, directory: str) -> Path | None:
+        """Pick the single file inside ``directory`` that RAHasher should hash.
+
+        Walks the directory top-level-first, preferring disc-image / playlist
+        extensions in the order RA cares about. Returns ``None`` if nothing
+        suitable is found, in which case the caller should skip hashing rather
+        than pass a directory (RAHasher expects a file) or a glob pattern
+        (``create_subprocess_exec`` doesn't expand globs).
+        """
+        best_match: Path | None = None
+        best_rank = len(self._RA_PRIMARY_FILE_EXTS)
+        for root, file_name in iter_files(directory, recursive=True):
+            ext = Path(file_name).suffix.lower()
+            if ext not in self._RA_PRIMARY_FILE_EXTS:
+                continue
+            rank = self._RA_PRIMARY_FILE_EXTS.index(ext)
+            if rank < best_rank:
+                best_rank = rank
+                best_match = root / file_name
+                if rank == 0:
+                    break
+        return best_match
 
     def _calculate_rom_hashes(
         self,

--- a/backend/handler/metadata/ra_handler.py
+++ b/backend/handler/metadata/ra_handler.py
@@ -178,36 +178,7 @@ class RAHandler(MetadataHandler):
         if not rom.platform.ra_id:
             return None
 
-        # Fetch all hashes for specific platform
-        roms: list[RAGameListItem]
-        if (
-            REFRESH_RETROACHIEVEMENTS_CACHE_DAYS
-            <= await self._days_since_last_cache_file_update(rom.platform.id)
-            or not await self._exists_cache_file(rom.platform.id)
-        ):
-            # Write the roms result to a JSON file if older than REFRESH_RETROACHIEVEMENTS_CACHE_DAYS days
-            roms = await self.ra_service.get_game_list(
-                system_id=rom.platform.ra_id,
-                only_games_with_achievements=True,
-                include_hashes=True,
-            )
-
-            platform_resources_path = fs_resource_handler.get_platform_resources_path(
-                rom.platform.id
-            )
-
-            json_file = json.dumps(roms, indent=4)
-            await fs_resource_handler.write_file(
-                json_file.encode("utf-8"),
-                platform_resources_path,
-                self.HASHES_FILE_NAME,
-            )
-        else:
-            # Read the roms result from the JSON file
-            json_file_bytes = await fs_resource_handler.read_file(
-                self._get_hashes_file_path(rom.platform.id)
-            )
-            roms = json.loads(json_file_bytes.decode("utf-8"))
+        roms = await self._get_platform_game_list(rom.platform.id, rom.platform.ra_id)
 
         ra_hash_lower = ra_hash.lower()
         for r in roms:
@@ -215,6 +186,63 @@ class RAHandler(MetadataHandler):
                 return r
 
         return None
+
+    async def _get_platform_game_list(
+        self, platform_id: int, ra_platform_id: int
+    ) -> list[RAGameListItem]:
+        """Return the cached game list for a platform, refetching if the cache
+        is expired, missing, or poisoned (not a list — e.g. a prior RA API
+        error wrote ``{}`` to disk, which would later raise AttributeError on
+        the ``r.get("Hashes", ...)`` lookup).
+        """
+        cache_fresh = (
+            await self._exists_cache_file(platform_id)
+            and await self._days_since_last_cache_file_update(platform_id)
+            < REFRESH_RETROACHIEVEMENTS_CACHE_DAYS
+        )
+
+        if cache_fresh:
+            try:
+                json_file_bytes = await fs_resource_handler.read_file(
+                    self._get_hashes_file_path(platform_id)
+                )
+                cached = json.loads(json_file_bytes.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                log.warning(
+                    "RA hashes cache for platform %s is corrupt, refetching: %s",
+                    platform_id,
+                    exc,
+                )
+            else:
+                if isinstance(cached, list):
+                    return cast(list[RAGameListItem], cached)
+                log.warning(
+                    "RA hashes cache for platform %s has wrong shape (%s), refetching",
+                    platform_id,
+                    type(cached).__name__,
+                )
+
+        roms = await self.ra_service.get_game_list(
+            system_id=ra_platform_id,
+            only_games_with_achievements=True,
+            include_hashes=True,
+        )
+
+        # Only persist a response we trust. An empty list (or anything that
+        # fell through get_game_list's type guard) is almost always an API
+        # error, and caching it would block matching for the full refresh
+        # window — which is how RA scanning silently breaks without Hasheous.
+        if roms:
+            platform_resources_path = fs_resource_handler.get_platform_resources_path(
+                platform_id
+            )
+            await fs_resource_handler.write_file(
+                json.dumps(roms, indent=4).encode("utf-8"),
+                platform_resources_path,
+                self.HASHES_FILE_NAME,
+            )
+
+        return roms
 
     def get_platform(self, slug: str) -> RAGamesPlatform:
         if slug not in RA_PLATFORM_LIST:

--- a/backend/tests/adapters/services/test_rahasher.py
+++ b/backend/tests/adapters/services/test_rahasher.py
@@ -69,77 +69,73 @@ class TestRAHasherService:
 
     @pytest.mark.asyncio
     async def test_calculate_hash_rahasher_not_found(self, service: RAHasherService):
-        """Test when RAHasher executable is not found."""
+        """Missing binary raises RAHasherError so scans don't silently skip RA."""
         with patch(
             "asyncio.create_subprocess_exec",
             side_effect=FileNotFoundError("RAHasher not found"),
         ):
-            result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
-            )
-
-        assert result == ""
+            with pytest.raises(RAHasherError, match="not found in PATH"):
+                await service.calculate_hash(
+                    {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
+                )
 
     @pytest.mark.asyncio
     async def test_calculate_hash_rahasher_failure(self, service: RAHasherService):
-        """Test when RAHasher fails with non-1 return code."""
+        """Non-zero exit code raises RAHasherError carrying stderr."""
         mock_proc = AsyncMock()
-        mock_proc.wait.return_value = 2  # Error return code
+        mock_proc.wait.return_value = 2
         mock_proc.stderr.read.return_value = b"Error processing file"
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
-            )
+            with pytest.raises(RAHasherError, match="exited 2"):
+                await service.calculate_hash(
+                    {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
+                )
 
-        assert result == ""
         mock_proc.wait.assert_called_once()
         mock_proc.stderr.read.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_calculate_hash_no_stdout(self, service: RAHasherService):
-        """Test when RAHasher has no stdout."""
+        """Zero exit with no stdout raises — that's a bug, not a clean miss."""
         mock_proc = AsyncMock()
-        mock_proc.wait.return_value = 1
+        mock_proc.wait.return_value = 0
         mock_proc.stdout = None
         mock_proc.stderr = None
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
-            )
-
-        assert result == ""
+            with pytest.raises(RAHasherError, match="no stdout"):
+                await service.calculate_hash(
+                    {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
+                )
 
     @pytest.mark.asyncio
     async def test_calculate_hash_empty_output(self, service: RAHasherService):
-        """Test when RAHasher returns empty output."""
+        """Empty stdout raises RAHasherError."""
         mock_proc = AsyncMock()
-        mock_proc.wait.return_value = 1
+        mock_proc.wait.return_value = 0
         mock_proc.stdout.read.return_value = b""
         mock_proc.stderr = None
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
-            )
-
-        assert result == ""
+            with pytest.raises(RAHasherError, match="empty hash"):
+                await service.calculate_hash(
+                    {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
+                )
 
     @pytest.mark.asyncio
     async def test_calculate_hash_invalid_hash_format(self, service: RAHasherService):
-        """Test when RAHasher returns invalid hash format."""
+        """Malformed hash output raises RAHasherError."""
         mock_proc = AsyncMock()
-        mock_proc.wait.return_value = 1
+        mock_proc.wait.return_value = 0
         mock_proc.stdout.read.return_value = b"invalid-hash-format\n"
         mock_proc.stderr = None
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
-            )
-
-        assert result == ""
+            with pytest.raises(RAHasherError, match="invalid hash"):
+                await service.calculate_hash(
+                    {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
+                )
 
     @pytest.mark.asyncio
     async def test_calculate_hash_with_extra_output(self, service: RAHasherService):
@@ -162,7 +158,7 @@ class TestRAHasherService:
     async def test_calculate_hash_subprocess_args(self, service: RAHasherService):
         """Test that subprocess is called with correct arguments."""
         mock_proc = AsyncMock()
-        mock_proc.wait.return_value = 1
+        mock_proc.wait.return_value = 0
         mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
         mock_proc.stderr = None
 
@@ -215,32 +211,31 @@ class TestRAHasherService:
 
     @pytest.mark.asyncio
     async def test_calculate_hash_stderr_handling(self, service: RAHasherService):
-        """Test proper handling of stderr when RAHasher fails."""
+        """Stderr from a failing RAHasher invocation is attached to the error."""
         mock_proc = AsyncMock()
         mock_proc.wait.return_value = 2
         mock_proc.stderr.read.return_value = b"File not supported"
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
-            )
+            with pytest.raises(RAHasherError, match="File not supported"):
+                await service.calculate_hash(
+                    {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
+                )
 
-        assert result == ""
         mock_proc.stderr.read.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_calculate_hash_stderr_none(self, service: RAHasherService):
-        """Test handling when stderr is None."""
+        """Missing stderr stream still raises with a placeholder message."""
         mock_proc = AsyncMock()
         mock_proc.wait.return_value = 2
         mock_proc.stderr = None
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await service.calculate_hash(
-                {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
-            )
-
-        assert result == ""
+            with pytest.raises(RAHasherError, match="<no stderr>"):
+                await service.calculate_hash(
+                    {"ra_id": 7, "slug": "nes"}, "/path/to/game.nes"
+                )
 
 
 class TestRAHasherArchiveSkip:


### PR DESCRIPTION
## Summary

- **Multi-part ROM hashing**: `get_rom_files` was passing `"<dir>/*"` to `RAHasherService.calculate_hash`, but `asyncio.create_subprocess_exec` doesn't expand globs — the literal `*` reached RAHasher and every multi-file ROM silently failed to hash. Now walks the directory and picks the primary disc/cartridge file (`.m3u` > `.cue` > `.gdi` > `.chd` > `.iso` > `.nrg` > `.pbp`).
- **Error propagation**: `RAHasherService.calculate_hash` previously logged-and-returned `""` on every failure path (missing binary, non-zero exit, empty stdout, malformed hash), making scan failures invisible. It now raises `RAHasherError` for real failures while still returning `""` for the intentional archive-on-disc-platform skip. Callers catch and log with ROM context.
- **Cache poisoning**: `RetroAchievementsService.get_game_list` would cast the `{}` returned by `_request()` on HTTP/auth errors to `list[RAGameListItem]`, and `RAHandler` would then persist that bogus value to `hashes.json` for `REFRESH_RETROACHIEVEMENTS_CACHE_DAYS`. Now refuses non-list responses, and the handler validates cache shape on read + only persists non-empty lists.

## Test plan

- [x] `pytest backend/tests/adapters/services/test_rahasher.py` passes (tests updated to assert `RAHasherError` is raised)
- [ ] Scan a multi-disc PS1 game (`.cue`/`.bin` set) and confirm RA hash is calculated and matched
- [x] Scan a single-file ROM (e.g. NES) and confirm RA hash still works end-to-end
- [x] Trigger an RA API failure (invalid key) during a scan and verify `hashes.json` is not overwritten with `{}` / empty list
- [ ] Confirm an existing corrupt `hashes.json` on disk triggers a refetch with a warning log instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)