### PR TITLE
ES-DE: Use original media location instead of copying

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -37,6 +37,7 @@ LIBRARY_BASE_PATH: Final[str] = f"{ROMM_BASE_PATH}/library"
 RESOURCES_BASE_PATH: Final[str] = f"{ROMM_BASE_PATH}/resources"
 ASSETS_BASE_PATH: Final[str] = f"{ROMM_BASE_PATH}/assets"
 FRONTEND_RESOURCES_PATH: Final[str] = "/assets/romm/resources"
+FRONTEND_LIBRARY_PATH: Final[str] = "/api/raw/library"
 
 # SEVEN ZIP
 SEVEN_ZIP_TIMEOUT: Final[int] = safe_int(_get_env("SEVEN_ZIP_TIMEOUT"), 60)

--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -108,6 +108,7 @@ class Config:
     EXCLUDED_MULTI_PARTS_EXT: list[str]
     EXCLUDED_MULTI_PARTS_FILES: list[str]
     GAMELIST_AUTO_EXPORT_ON_SCAN: bool
+    GAMELIST_USE_ORIGINAL_MEDIA: bool
     PEGASUS_AUTO_EXPORT_ON_SCAN: bool
     PLATFORMS_BINDING: dict[str, str]
     PLATFORMS_VERSIONS: dict[str, str]
@@ -374,6 +375,9 @@ class ConfigManager:
             ),
             GAMELIST_AUTO_EXPORT_ON_SCAN=pydash.get(
                 self._raw_config, "scan.gamelist.export", False
+            ),
+            GAMELIST_USE_ORIGINAL_MEDIA=pydash.get(
+                self._raw_config, "scan.gamelist.use_original_media", False
             ),
             GAMELIST_MEDIA_THUMBNAIL=pydash.get(
                 self._raw_config,
@@ -710,6 +714,7 @@ class ConfigManager:
                 "media": self.config.SCAN_MEDIA,
                 "gamelist": {
                     "export": self.config.GAMELIST_AUTO_EXPORT_ON_SCAN,
+                    "use_original_media": self.config.GAMELIST_USE_ORIGINAL_MEDIA,
                     "media": {
                         "thumbnail": self.config.GAMELIST_MEDIA_THUMBNAIL,
                         "image": self.config.GAMELIST_MEDIA_IMAGE,

--- a/backend/endpoints/raw.py
+++ b/backend/endpoints/raw.py
@@ -3,7 +3,7 @@ from fastapi.responses import FileResponse
 
 from decorators.auth import protected_route
 from handler.auth.constants import Scope
-from handler.filesystem import fs_asset_handler
+from handler.filesystem import fs_asset_handler, fs_platform_handler
 from utils.router import APIRouter
 
 router = APIRouter(
@@ -51,5 +51,31 @@ def get_raw_asset(request: Request, path: str):
 
     if not resolved_path:
         raise HTTPException(status_code=404, detail="Asset not found")
+
+    return FileResponse(path=str(resolved_path), filename=resolved_path.name)
+
+
+@protected_route(router.head, "/library/{path:path}", [Scope.ASSETS_READ])
+def head_raw_library(request: Request, path: str):
+    try:
+        resolved_path = fs_platform_handler.validate_path(path)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="Library file not found") from exc
+
+    if not resolved_path.exists() or not resolved_path.is_file():
+        return HTTPException(status_code=404, detail="Library file not found")
+
+    return FileResponse(path=str(resolved_path), filename=resolved_path.name)
+
+
+@protected_route(router.get, "/library/{path:path}", [Scope.ASSETS_READ])
+def get_raw_library(request: Request, path: str):
+    try:
+        resolved_path = fs_platform_handler.validate_path(path)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="Library file not found") from exc
+
+    if not resolved_path.exists() or not resolved_path.is_file():
+        return HTTPException(status_code=404, detail="Library file not found")
 
     return FileResponse(path=str(resolved_path), filename=resolved_path.name)

--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -196,6 +196,9 @@ class FSResourcesHandler(FSHandler):
         if not entity:
             return None, None
 
+        if url_cover and url_cover.startswith("library://"):
+            return url_cover, url_cover
+
         # Download covers if URL provided and (overwriting or covers don't exist)
         if url_cover:
             if overwrite or not self.cover_exists(entity, CoverSize.SMALL):
@@ -372,6 +375,9 @@ class FSResourcesHandler(FSHandler):
         # Download and store new screenshots
         path_screenshots: list[str] = []
         for idx, url_screenshot in enumerate(url_screenshots):
+            if url_screenshot.startswith("library://"):
+                path_screenshots.append(url_screenshot)
+                continue
             await self._store_screenshot(rom, url_screenshot, idx)
             path_screenshots.append(self._get_screenshot_path(rom, str(idx)))
 
@@ -476,6 +482,9 @@ class FSResourcesHandler(FSHandler):
         if not url_manual or (not overwrite and self.manual_exists(rom)):
             return rom.path_manual or None
 
+        if url_manual.startswith("library://"):
+            return url_manual
+
         # Download and store new manual
         await self._store_manual(rom, url_manual)
         return self._get_manual_path(rom)
@@ -532,6 +541,9 @@ class FSResourcesHandler(FSHandler):
         return os.path.join("roms", str(platform_id), str(rom_id), media_type.value)
 
     async def store_media_file(self, url_media: str, dest_path: str) -> None:
+        if url_media.startswith("library://") or dest_path.startswith("library://"):
+            return
+
         httpx_client = ctx_httpx_client.get()
         directory, filename = os.path.split(dest_path)
 

--- a/backend/handler/metadata/gamelist_handler.py
+++ b/backend/handler/metadata/gamelist_handler.py
@@ -96,12 +96,14 @@ XML_TAG_MAP: Final = {
     "video_url": "video",
 }
 
+def _scheme() -> str:
+    return "library" if cm.get_config().GAMELIST_USE_ORIGINAL_MEDIA else "file"
 
 def _make_file_uri(platform_dir: str, raw_text: str) -> str:
     cleaned_text = raw_text.replace("./", "")
     joined_path = Path(platform_dir, cleaned_text)
     fs_platform_handler.validate_path(str(joined_path))
-    return f"file://{joined_path.as_posix()}"
+    return f"{_scheme()}://{joined_path.as_posix()}"
 
 
 def extract_media_from_gamelist_rom(
@@ -148,7 +150,7 @@ def extract_media_from_gamelist_rom(
             if found_files:
                 # trunk-ignore(mypy/literal-required)
                 gamelist_media[media_key] = (
-                    f"file://{str(Path(found_files[0]).relative_to(fs_platform_handler.base_path))}"
+                    f"{_scheme()}://{str(Path(found_files[0]).relative_to(fs_platform_handler.base_path))}"
                 )
 
     return gamelist_media
@@ -210,6 +212,12 @@ def extract_metadata_from_gamelist_rom(
     )
 
 
+def _media_path(rom: Rom, url: str | None, media_type: MetadataMediaType, filename: str) -> str:
+    if url and url.startswith("library://"):
+        return url
+    return f"{fs_resource_handler.get_media_resources_path(rom.platform_id, rom.id, media_type)}/{filename}"
+
+
 def populate_rom_specific_paths(
     rom_metadata: GamelistMetadata, rom: Rom
 ) -> dict[str, str]:
@@ -223,38 +231,38 @@ def populate_rom_specific_paths(
     if MetadataMediaType.BOX3D in preferred_media_types and rom_metadata.get(
         "box3d_url"
     ):
-        updated_metadata["box3d_path"] = (
-            f"{fs_resource_handler.get_media_resources_path(rom.platform_id, rom.id, MetadataMediaType.BOX3D)}/box3d.png"
+        updated_metadata["box3d_path"] = _media_path(
+            rom, rom_metadata.get("box3d_url"), MetadataMediaType.BOX3D, "box3d.png"
         )
     if MetadataMediaType.MARQUEE in preferred_media_types and rom_metadata.get(
         "marquee_url"
     ):
-        updated_metadata["marquee_path"] = (
-            f"{fs_resource_handler.get_media_resources_path(rom.platform_id, rom.id, MetadataMediaType.MARQUEE)}/marquee.png"
+        updated_metadata["marquee_path"] = _media_path(
+            rom, rom_metadata.get("marquee_url"), MetadataMediaType.MARQUEE, "marquee.png"
         )
     if MetadataMediaType.MIXIMAGE in preferred_media_types and rom_metadata.get(
         "miximage_url"
     ):
-        updated_metadata["miximage_path"] = (
-            f"{fs_resource_handler.get_media_resources_path(rom.platform_id, rom.id, MetadataMediaType.MIXIMAGE)}/miximage.png"
+        updated_metadata["miximage_path"] = _media_path(
+            rom, rom_metadata.get("miximage_url"), MetadataMediaType.MIXIMAGE, "miximage.png"
         )
     if MetadataMediaType.PHYSICAL in preferred_media_types and rom_metadata.get(
         "physical_url"
     ):
-        updated_metadata["physical_path"] = (
-            f"{fs_resource_handler.get_media_resources_path(rom.platform_id, rom.id, MetadataMediaType.PHYSICAL)}/physical.png"
+        updated_metadata["physical_path"] = _media_path(
+            rom, rom_metadata.get("physical_url"), MetadataMediaType.PHYSICAL, "physical.png"
         )
     if MetadataMediaType.TITLE_SCREEN in preferred_media_types and rom_metadata.get(
         "title_screen_url"
     ):
-        updated_metadata["title_screen_path"] = (
-            f"{fs_resource_handler.get_media_resources_path(rom.platform_id, rom.id, MetadataMediaType.TITLE_SCREEN)}/title_screen.png"
+        updated_metadata["title_screen_path"] = _media_path(
+            rom, rom_metadata.get("title_screen_url"), MetadataMediaType.TITLE_SCREEN, "title_screen.png",
         )
     if MetadataMediaType.VIDEO in preferred_media_types and rom_metadata.get(
         "video_url"
     ):
-        updated_metadata["video_path"] = (
-            f"{fs_resource_handler.get_media_resources_path(rom.platform_id, rom.id, MetadataMediaType.VIDEO)}/video.mp4"
+        updated_metadata["video_path"] = _media_path(
+            rom, rom_metadata.get("video_url"), MetadataMediaType.VIDEO, "video.mp4"
         )
 
     return updated_metadata

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from config import FRONTEND_RESOURCES_PATH
+from config import FRONTEND_RESOURCES_PATH, FRONTEND_LIBRARY_PATH
 from models.base import (
     FILE_EXTENSION_MAX_LENGTH,
     FILE_NAME_MAX_LENGTH,
@@ -35,6 +35,10 @@ if TYPE_CHECKING:
     from models.platform import Platform
     from models.user import User
 
+def _media_url(path: str) -> str:
+    if path.startswith("library://"):
+        return f"{FRONTEND_LIBRARY_PATH}/{path[len('library://'):]}"
+    return f"{FRONTEND_RESOURCES_PATH}/{path}"
 
 class RomFileCategory(enum.StrEnum):
     GAME = "game"
@@ -311,7 +315,7 @@ class Rom(BaseModel):
     @cached_property
     def merged_screenshots(self) -> list[str]:
         if self.path_screenshots:
-            return [f"{FRONTEND_RESOURCES_PATH}/{s}" for s in self.path_screenshots]
+            return [_media_url(s) for s in self.path_screenshots]
 
         return []
 
@@ -338,7 +342,7 @@ class Rom(BaseModel):
     @property
     def path_cover_small(self) -> str:
         return (
-            f"{FRONTEND_RESOURCES_PATH}/{self.path_cover_s}?ts={self.updated_at}"
+            f"{_media_url(self.path_cover_s)}?ts={self.updated_at}"
             if self.path_cover_s
             else ""
         )
@@ -346,7 +350,7 @@ class Rom(BaseModel):
     @property
     def path_cover_large(self) -> str:
         return (
-            f"{FRONTEND_RESOURCES_PATH}/{self.path_cover_l}?ts={self.updated_at}"
+            f"{_media_url(self.path_cover_l)}?ts={self.updated_at}"
             if self.path_cover_l
             else ""
         )

--- a/frontend/src/components/Details/Info/MediaCarousel.vue
+++ b/frontend/src/components/Details/Info/MediaCarousel.vue
@@ -4,7 +4,7 @@ import { computed } from "vue";
 import { useDisplay } from "vuetify";
 import storeHeartbeat from "@/stores/heartbeat";
 import type { DetailedRom } from "@/stores/roms";
-import { FRONTEND_RESOURCES_PATH } from "@/utils";
+import { mediaUrl } from "@/utils";
 
 interface Props {
   rom: DetailedRom;
@@ -101,7 +101,7 @@ const carouselHeight = computed(() => {
       content-class="d-flex justify-center align-center"
     >
       <video
-        :src="`${FRONTEND_RESOURCES_PATH}/${rom.path_video}`"
+        :src="mediaUrl(rom.path_video)"
         class="h-full object-contain"
         controls
       />
@@ -117,7 +117,7 @@ const carouselHeight = computed(() => {
       <v-carousel-item
         v-if="path"
         :key="key"
-        :src="`${FRONTEND_RESOURCES_PATH}/${path}`"
+        :src="mediaUrl(path)"
         :class="{ pointer: enableClick }"
         @click="enableClick && emit('click')"
       />

--- a/frontend/src/components/Details/PDFViewer.vue
+++ b/frontend/src/components/Details/PDFViewer.vue
@@ -2,7 +2,7 @@
 import VuePdfApp from "vue3-pdf-app";
 import { useTheme, useDisplay } from "vuetify";
 import type { DetailedRom } from "@/stores/roms";
-import { FRONTEND_RESOURCES_PATH } from "@/utils";
+import { mediaUrl } from "@/utils";
 
 defineProps<{ rom: DetailedRom }>();
 const { xs } = useDisplay();
@@ -101,7 +101,7 @@ const pdfViewerConfig = {
     :config="{ toolbar: false }"
     :theme="theme.name.value == 'dark' ? 'dark' : 'light'"
     style="height: 100dvh"
-    :pdf="`${FRONTEND_RESOURCES_PATH}/${rom.path_manual}`"
+    :pdf="mediaUrl(rom.path_manual)"
   />
 </template>
 

--- a/frontend/src/components/common/Game/Card/Base.vue
+++ b/frontend/src/components/common/Game/Card/Base.vue
@@ -28,7 +28,7 @@ import storeHeartbeat from "@/stores/heartbeat";
 import storeRoms from "@/stores/roms";
 import type { SimpleRom, SearchRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
-import { FRONTEND_RESOURCES_PATH } from "@/utils";
+import { mediaUrl } from "@/utils";
 import {
   getMissingCoverImage,
   getUnmatchedCoverImage,
@@ -176,8 +176,7 @@ const isWebpEnabled = computed(
 
 const largeCover = computed(() => {
   if (props.coverSrc) return props.coverSrc;
-  if (boxartStyleCover.value)
-    return `${FRONTEND_RESOURCES_PATH}/${boxartStyleCover.value}`;
+  if (boxartStyleCover.value) return mediaUrl(boxartStyleCover.value);
   if (!romsStore.isSimpleRom(props.rom)) {
     return (
       props.rom.igdb_url_cover ||
@@ -195,8 +194,7 @@ const largeCover = computed(() => {
 
 const smallCover = computed(() => {
   if (props.coverSrc) return props.coverSrc;
-  if (boxartStyleCover.value)
-    return `${FRONTEND_RESOURCES_PATH}/${boxartStyleCover.value}`;
+  if (boxartStyleCover.value) return mediaUrl(boxartStyleCover.value);
   if (!romsStore.isSimpleRom(props.rom)) return "";
   const pathCoverSmall = isWebpEnabled.value
     ? props.rom.path_cover_small?.replace(EXTENSION_REGEX, ".webp")
@@ -464,7 +462,7 @@ onBeforeUnmount(() => {
             <div class="position-relative max-h-full" style="margin-top: -40px">
               <video
                 ref="hover-video-ref"
-                :src="`${FRONTEND_RESOURCES_PATH}/${localVideoPath}`"
+                :src="mediaUrl(localVideoPath)"
                 class="hover-video position-absolute"
                 loop
                 playsinline

--- a/frontend/src/components/common/Game/RAvatar.vue
+++ b/frontend/src/components/common/Game/RAvatar.vue
@@ -4,7 +4,7 @@ import type { VImg } from "vuetify/lib/components/VImg/VImg.js";
 import { useGameAnimation } from "@/composables/useGameAnimation";
 import storeHeartbeat from "@/stores/heartbeat";
 import type { SimpleRom } from "@/stores/roms";
-import { FRONTEND_RESOURCES_PATH } from "@/utils";
+import { mediaUrl } from "@/utils";
 import {
   EXTENSION_REGEX,
   getMissingCoverImage,
@@ -29,8 +29,7 @@ const { boxartStyleCover } = useGameAnimation({
 });
 
 const smallCover = computed(() => {
-  if (boxartStyleCover.value)
-    return `${FRONTEND_RESOURCES_PATH}/${boxartStyleCover.value}`;
+  if (boxartStyleCover.value) return mediaUrl(boxartStyleCover.value);
   const pathCoverSmall = isWebpEnabled.value
     ? props.rom.path_cover_small?.replace(EXTENSION_REGEX, ".webp")
     : props.rom.path_cover_small;

--- a/frontend/src/console/components/GameCard.vue
+++ b/frontend/src/console/components/GameCard.vue
@@ -16,7 +16,7 @@ import {
 import storeCollections from "@/stores/collections";
 import storeHeartbeat from "@/stores/heartbeat";
 import { type SimpleRom } from "@/stores/roms";
-import { FRONTEND_RESOURCES_PATH } from "@/utils";
+import { mediaUrl } from "@/utils";
 import {
   EXTENSION_REGEX,
   getMissingCoverImage,
@@ -55,8 +55,7 @@ const {
 });
 
 const largeCover = computed(() => {
-  if (boxartStyleCover.value)
-    return `${FRONTEND_RESOURCES_PATH}/${boxartStyleCover.value}`;
+  if (boxartStyleCover.value) return mediaUrl(boxartStyleCover.value);
   const pathCoverLarge = isWebpEnabled.value
     ? props.rom.path_cover_large?.replace(EXTENSION_REGEX, ".webp")
     : props.rom.path_cover_large;
@@ -64,8 +63,7 @@ const largeCover = computed(() => {
 });
 
 const smallCover = computed(() => {
-  if (boxartStyleCover.value)
-    return `${FRONTEND_RESOURCES_PATH}/${boxartStyleCover.value}`;
+  if (boxartStyleCover.value) return mediaUrl(boxartStyleCover.value);
   const pathCoverSmall = isWebpEnabled.value
     ? props.rom.path_cover_small?.replace(EXTENSION_REGEX, ".webp")
     : props.rom.path_cover_small;
@@ -182,7 +180,7 @@ onBeforeUnmount(() => {
         <div class="relative max-h-full" style="margin-top: -40px">
           <video
             ref="hover-video-ref"
-            :src="`${FRONTEND_RESOURCES_PATH}/${localVideoPath}`"
+            :src="mediaUrl(localVideoPath)"
             class="hover-video absolute"
             loop
             playsinline

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -785,6 +785,7 @@ export function platformCategoryToIcon(category: string) {
 }
 
 export const FRONTEND_RESOURCES_PATH = "/assets/romm/resources";
+export const FRONTEND_LIBRARY_PATH = "/api/raw/library";
 
 export const CD_BASED_SYSTEMS = new Set([
   "3do", // 3DO
@@ -821,4 +822,10 @@ export const CD_BASED_SYSTEMS = new Set([
 
 export function isCDBasedSystem(platformSlug: string): boolean {
   return CD_BASED_SYSTEMS.has(platformSlug.toLowerCase());
+}
+
+export function mediaUrl(path: string): string {
+  return path.startsWith("library://")
+    ? `${FRONTEND_LIBRARY_PATH}/${path.slice("library://".length)}`
+    : `${FRONTEND_RESOURCES_PATH}/${path}`;
 }


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

I kinda bigger feature, that I'll continue to test on my own instance.

Add an opt-in configuration entry to disable media copy to RomM resource directory. With huge libraries, this saves a lot a space on files that would otherwise be duplicated. The downside of this mode is that no media is processed anymore, e.g. no small and big images variants.  

AI Disclaimer: I used Claude to figure out quicker where to look as I'm quite new to this project, and asked it an initial implementation. All the code that is proposed here has been reviewed, understood, cleaned and tested.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A.