### PR TITLE
Add credentialless attribute to YouTube iframe

### DIFF
--- a/frontend/src/components/Details/Info/MediaCarousel.vue
+++ b/frontend/src/components/Details/Info/MediaCarousel.vue
@@ -80,6 +80,7 @@ const carouselHeight = computed(() => {
         height="100%"
         width="100%"
         :src="`${heartbeat.FRONTEND.YOUTUBE_BASE_URL}/embed/${youtubeVideoId}`"
+        credentialless
         title="YouTube video player"
         frameborder="0"
         allow="


### PR DESCRIPTION
add credentialless attribute to YouTube iframe for COEP compatibility

<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>adds credentialless attribute for COEP compatibility.</sup>

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)
<img width="1587" height="859" alt="before" src="https://github.com/user-attachments/assets/26a5c200-122f-45bf-a511-195eb0d2efcb" />
<img width="1633" height="892" alt="after" src="https://github.com/user-attachments/assets/ebb2c097-ca53-4d73-9fb0-7065e1bb9ff5" />
