### PR TITLE
Update config.batocera-retrobat.yml

### DIFF
--- a/examples/config.batocera-retrobat.yml
+++ b/examples/config.batocera-retrobat.yml
@@ -10,8 +10,9 @@ exclude:
         extensions: []
         names: []
     single_file:
-      extensions: []
-      names: []
+      extensions:
+        - "xml"
+        - "txt"
 filesystem: {}
 system:
   platforms:
@@ -88,6 +89,7 @@ system:
     macintosh: mac
     mame: arcade
     mastersystem: sms
+    megacd: segacd
     megadrive: genesis
     megadrive-msu: genesis
     megaduck: mega-duck-slash-cougar-boy


### PR DESCRIPTION
**Description**
Segacd became megacd with version 42 of batocera (see https://github.com/batocera-linux/batocera.linux/blob/master/batocera-Changelog.md#20251012---batoceralinux-42---papilio-ulysses).  Also don't scan txt files or xml (batocera leaves txt with initial directory and gamelist.xml after a scan)

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally



