### PR TITLE
fix(frontend): use static auth background on Firefox

### DIFF
--- a/frontend/src/layouts/Auth.vue
+++ b/frontend/src/layouts/Auth.vue
@@ -27,6 +27,11 @@ const heartbeatStore = storeHeartbeat();
   max-width: 100vw;
   /* align-items: unset !important; */
 }
+@-moz-document url-prefix() {
+  #container {
+    background-image: url("/assets/auth_background_static.svg");
+  }
+}
 #version {
   position: absolute !important;
   right: 15px !important;


### PR DESCRIPTION
## Summary
- The animated `auth_background.svg` is laggy on Firefox.
- Swap in the existing `auth_background_static.svg` for Firefox only via `@-moz-document url-prefix()`; other engines keep the animation.

## Test plan
- [x] Open the auth page in Firefox → static background, no animation, no lag.
- [x] Open the auth page in Chrome / Safari → animated background renders as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)