### PR TITLE
feat(playmatch): add SteamGridDB, ScreenScraper, MobyGames & Launchbox hash support

### DIFF
--- a/backend/handler/metadata/playmatch_handler.py
+++ b/backend/handler/metadata/playmatch_handler.py
@@ -16,12 +16,23 @@ from utils.context import ctx_httpx_client
 
 class PlaymatchProvider(str, Enum):
     IGDB = "IGDB"
+    SteamGridDB = "SteamGridDB"
+    ScreenScraper = "ScreenScraper"
+    MobyGames = "MobyGames"
+    LaunchBox = "LaunchBox"
+    EmuReady = "EmuReady"
+    OpenVGDB = "OpenVGDB"
 
 
-# (rom attribute, provider tag). Playmatch drops unknown tags server-side.
+# (rom attribute, provider tag). Tag casing matches Playmatch's MetadataProvider
+# enum names (uppercased; Playmatch parses case-insensitively but spacing and
+# underscores must match). Entries for providers Playmatch doesn't currently
+# recognize are kept on purpose: Playmatch drops unknown tags server-side, and
+# preserving them means older RomM clients keep submitting correct tags when
+# Playmatch adds support for more providers.
 _PLAYMATCH_PROVIDER_TAGS: tuple[tuple[str, str], ...] = (
     ("igdb_id", "IGDB"),
-    ("moby_id", "MOBY_GAMES"),
+    ("moby_id", "MOBYGAMES"),
     ("ss_id", "SCREENSCRAPER"),
     ("ra_id", "RETRO_ACHIEVEMENTS"),
     ("launchbox_id", "LAUNCHBOX"),
@@ -32,6 +43,18 @@ _PLAYMATCH_PROVIDER_TAGS: tuple[tuple[str, str], ...] = (
     ("libretro_id", "LIBRETRO"),
     ("sgdb_id", "STEAMGRIDDB"),
     ("gamelist_id", "GAMELIST"),
+)
+
+
+# Inbound providerName -> rom attribute, derived from _PLAYMATCH_PROVIDER_TAGS.
+# Keyed on the uppercased tag so we can match against Playmatch's CamelCase
+# MetadataProvider values (`"MobyGames"` -> `"MOBYGAMES"` -> `"moby_id"`).
+_TAG_TO_ATTR: dict[str, str] = {tag: attr for attr, tag in _PLAYMATCH_PROVIDER_TAGS}
+
+# Subset of attrs the scan handler consumes from a Playmatch lookup. Other
+# entries in _PLAYMATCH_PROVIDER_TAGS are used only for outbound suggestions.
+_LOOKUP_ROM_ATTRS: frozenset[str] = frozenset(
+    {"igdb_id", "moby_id", "ss_id", "launchbox_id", "sgdb_id"}
 )
 
 
@@ -55,6 +78,20 @@ class PlaymatchExternalMetadata(TypedDict):
 
 class PlaymatchRomMatch(TypedDict):
     igdb_id: int | None
+    moby_id: int | None
+    ss_id: int | None
+    launchbox_id: int | None
+    sgdb_id: int | None
+
+
+def _empty_playmatch_rom_match() -> PlaymatchRomMatch:
+    return PlaymatchRomMatch(
+        igdb_id=None,
+        moby_id=None,
+        ss_id=None,
+        launchbox_id=None,
+        sgdb_id=None,
+    )
 
 
 class PlaymatchHandler(MetadataHandler):
@@ -124,7 +161,7 @@ class PlaymatchHandler(MetadataHandler):
                 detail="Can't connect to Playmatch, check your internet connection",
             ) from exc
         except json.JSONDecodeError as exc:
-            log.error("Error decoding JSON response from ScreenScraper: %s", exc)
+            log.error("Error decoding JSON response from Playmatch: %s", exc)
             return {}
 
     async def lookup_rom(self, files: list[RomFile]) -> PlaymatchRomMatch:
@@ -136,14 +173,14 @@ class PlaymatchHandler(MetadataHandler):
         :raises HTTPException: If the request fails or the service is unavailable.
         """
         if not self.is_enabled():
-            return PlaymatchRomMatch(igdb_id=None)
+            return _empty_playmatch_rom_match()
 
         first_file = next(
             (file for file in files if file.file_size_bytes > 0),
             None,
         )
         if first_file is None:
-            return PlaymatchRomMatch(igdb_id=None)
+            return _empty_playmatch_rom_match()
 
         try:
             response = await self._request(
@@ -157,30 +194,43 @@ class PlaymatchHandler(MetadataHandler):
             )
         except httpx.HTTPStatusError:
             # We silently fail if the service is unavailable as this should not block the rest of RomM.
-            return PlaymatchRomMatch(igdb_id=None)
+            return _empty_playmatch_rom_match()
 
         game_match_type = response.get("gameMatchType", None)
         if game_match_type == GameMatchType.NoMatch:
             log.debug("No match found for the provided ROM file.")
-            return PlaymatchRomMatch(igdb_id=None)
+            return _empty_playmatch_rom_match()
 
         externalMetadata = response.get("externalMetadata", [])
         if len(externalMetadata) == 0:
             log.debug("No external metadata found for the matched ROM file.")
-            return PlaymatchRomMatch(igdb_id=None)
+            return _empty_playmatch_rom_match()
 
-        igdb_id = None
-
+        result = _empty_playmatch_rom_match()
         for metadata in externalMetadata:
             provider_name = metadata.get("providerName", None)
             provider_game_id = metadata.get("providerId", None)
-            if provider_name == PlaymatchProvider.IGDB and provider_game_id is not None:
-                log.debug(
-                    "Playmatch found IGDB match with IGDB ID: %s", provider_game_id
-                )
-                igdb_id = int(provider_game_id)
+            if not provider_name or provider_game_id is None:
+                continue
 
-        return PlaymatchRomMatch(igdb_id=igdb_id)
+            attr = _TAG_TO_ATTR.get(provider_name.upper())
+            if not attr or attr not in _LOOKUP_ROM_ATTRS:
+                continue
+
+            try:
+                parsed_id = int(provider_game_id)
+            except (TypeError, ValueError):
+                log.debug(
+                    "Playmatch returned non-int id for %s: %r",
+                    provider_name,
+                    provider_game_id,
+                )
+                continue
+
+            log.debug("Playmatch found %s match with id: %s", provider_name, parsed_id)
+            result[attr] = parsed_id  # type: ignore[literal-required]
+
+        return result
 
     @staticmethod
     def is_manual_match(form_fields_set: set[str]) -> bool:

--- a/backend/handler/metadata/playmatch_handler.py
+++ b/backend/handler/metadata/playmatch_handler.py
@@ -1,6 +1,6 @@
 import json
 from enum import Enum
-from typing import NotRequired, TypedDict
+from typing import Final, NotRequired, TypedDict
 
 import httpx
 import yarl
@@ -16,39 +16,36 @@ from utils.context import ctx_httpx_client
 
 class PlaymatchProvider(str, Enum):
     IGDB = "IGDB"
-    SteamGridDB = "SteamGridDB"
-    ScreenScraper = "ScreenScraper"
-    MobyGames = "MobyGames"
-    LaunchBox = "LaunchBox"
-    EmuReady = "EmuReady"
-    OpenVGDB = "OpenVGDB"
+    STEAM_GRID_DB = "SteamGridDB"
+    SCREEN_SCRAPER = "ScreenScraper"
+    MOBY_GAMES = "MobyGames"
+    LAUNCH_BOX = "LaunchBox"
+    EMU_READY = "EmuReady"
+    OPEN_VGDB = "OpenVGDB"
 
 
-# Tag is the uppercased Playmatch MetadataProvider name. Playmatch parses it
-# case-insensitively but spacing must match. Tags Playmatch doesn't yet know
-# are kept so older RomM clients keep submitting the right tag once Playmatch
-# adds support.
-_PLAYMATCH_PROVIDER_TAGS: tuple[tuple[str, str], ...] = (
-    ("igdb_id", "IGDB"),
-    ("moby_id", "MOBYGAMES"),
-    ("ss_id", "SCREENSCRAPER"),
-    ("ra_id", "RETRO_ACHIEVEMENTS"),
-    ("launchbox_id", "LAUNCHBOX"),
-    ("hasheous_id", "HASHEOUS"),
-    ("tgdb_id", "TGDB"),
-    ("flashpoint_id", "FLASHPOINT"),
-    ("hltb_id", "HOWLONGTOBEAT"),
-    ("libretro_id", "LIBRETRO"),
-    ("sgdb_id", "STEAMGRIDDB"),
-    ("gamelist_id", "GAMELIST"),
-)
+# Tag is the uppercased Playmatch MetadataProvider name.
+# Playmatch parses it case-insensitively but spacing must match.
+# Tags Playmatch doesn't yet know are kept so older RomM clients keep
+# submitting the right tag once Playmatch adds support.
+PLAYMATCH_TAG_TO_ATTR: Final[dict[str, str]] = {
+    "IGDB": "igdb_id",
+    "MOBYGAMES": "moby_id",
+    "SCREENSCRAPER": "ss_id",
+    "RETRO_ACHIEVEMENTS": "ra_id",
+    "LAUNCHBOX": "launchbox_id",
+    "HASHEOUS": "hasheous_id",
+    "TGDB": "tgdb_id",
+    "FLASHPOINT": "flashpoint_id",
+    "HOWLONGTOBEAT": "hltb_id",
+    "LIBRETRO": "libretro_id",
+    "STEAMGRIDDB": "sgdb_id",
+    "GAMELIST": "gamelist_id",
+}
 
-
-_TAG_TO_ATTR: dict[str, str] = {tag: attr for attr, tag in _PLAYMATCH_PROVIDER_TAGS}
-
-# Rom attrs the scan handler actually consumes from a Playmatch lookup. Other
-# tags exist only for outbound suggestions.
-_LOOKUP_ROM_ATTRS: frozenset[str] = frozenset(
+# Rom attrs the scan handler actually consumes from a Playmatch lookup.
+# Other tags exist only for outbound suggestions.
+PLAYMATCH_LOOKUP_ROM_ATTRS: frozenset[str] = frozenset(
     {"igdb_id", "moby_id", "ss_id", "launchbox_id", "sgdb_id"}
 )
 
@@ -64,8 +61,8 @@ class GameMatchType(str, Enum):
     SHA256 = "SHA256"
     SHA1 = "SHA1"
     MD5 = "MD5"
-    FileNameAndSize = "FileNameAndSize"
-    NoMatch = "NoMatch"
+    FILE_NAME_AND_SIZE = "FileNameAndSize"
+    NO_MATCH = "NoMatch"
 
 
 class PlaymatchExternalMetadata(TypedDict):
@@ -84,16 +81,13 @@ class PlaymatchRomMatch(TypedDict):
     ss_id: int | None
     launchbox_id: int | None
     sgdb_id: int | None
-
-
-def _empty_playmatch_rom_match() -> PlaymatchRomMatch:
-    return PlaymatchRomMatch(
-        igdb_id=None,
-        moby_id=None,
-        ss_id=None,
-        launchbox_id=None,
-        sgdb_id=None,
-    )
+    ra_id: int | None
+    hasheous_id: int | None
+    tgdb_id: int | None
+    flashpoint_id: str | None
+    hltb_id: int | None
+    gamelist_id: str | None
+    libretro_id: str | None
 
 
 class PlaymatchHandler(MetadataHandler):
@@ -174,15 +168,30 @@ class PlaymatchHandler(MetadataHandler):
         :return: A PlaymatchRomMatch objects containing the matched ROM information.
         :raises HTTPException: If the request fails or the service is unavailable.
         """
+        fallback_rom = PlaymatchRomMatch(
+            igdb_id=None,
+            moby_id=None,
+            ss_id=None,
+            launchbox_id=None,
+            sgdb_id=None,
+            ra_id=None,
+            hasheous_id=None,
+            tgdb_id=None,
+            flashpoint_id=None,
+            hltb_id=None,
+            gamelist_id=None,
+            libretro_id=None,
+        )
+
         if not self.is_enabled():
-            return _empty_playmatch_rom_match()
+            return fallback_rom
 
         first_file = next(
             (file for file in files if file.file_size_bytes > 0),
             None,
         )
         if first_file is None:
-            return _empty_playmatch_rom_match()
+            return fallback_rom
 
         try:
             response = await self._request(
@@ -196,58 +205,61 @@ class PlaymatchHandler(MetadataHandler):
             )
         except httpx.HTTPStatusError:
             # We silently fail if the service is unavailable as this should not block the rest of RomM.
-            return _empty_playmatch_rom_match()
+            return fallback_rom
 
         game_match_type = response.get("gameMatchType", None)
-        if game_match_type == GameMatchType.NoMatch:
+        if game_match_type == GameMatchType.NO_MATCH:
             log.debug("No match found for the provided ROM file.")
-            return _empty_playmatch_rom_match()
+            return fallback_rom
 
         externalMetadata = response.get("externalMetadata", [])
         if len(externalMetadata) == 0:
             log.debug("No external metadata found for the matched ROM file.")
-            return _empty_playmatch_rom_match()
+            return fallback_rom
 
-        result = _empty_playmatch_rom_match()
+        result = fallback_rom
         for metadata in externalMetadata:
             provider_name = metadata.get("providerName", None)
             provider_game_id = metadata.get("providerId", None)
             if not provider_name or provider_game_id is None:
                 continue
 
-            attr = _TAG_TO_ATTR.get(provider_name.upper())
-            if not attr or attr not in _LOOKUP_ROM_ATTRS:
+            attr = PLAYMATCH_TAG_TO_ATTR.get(provider_name.upper())
+            if not attr or attr not in PLAYMATCH_LOOKUP_ROM_ATTRS:
                 continue
 
             try:
                 parsed_id = int(provider_game_id)
             except (TypeError, ValueError):
                 log.debug(
-                    "Playmatch returned non-int id for %s: %r",
+                    "Playmatch returned non-int ID for %s: %r",
                     provider_name,
                     provider_game_id,
                 )
                 continue
 
             log.debug("Playmatch found %s match with id: %s", provider_name, parsed_id)
-            result[attr] = parsed_id  # type: ignore[literal-required]
+            result[attr] = parsed_id  # trunk-ignore(mypy/literal-required)
 
         return result
 
     @staticmethod
     def is_manual_match(form_fields_set: set[str]) -> bool:
         """True if the submitted form contains any Playmatch-tracked provider id field."""
-        return any(attr in form_fields_set for attr, _ in _PLAYMATCH_PROVIDER_TAGS)
+        return any(attr in form_fields_set for attr in PLAYMATCH_TAG_TO_ATTR.values())
 
     async def submit_manual_match_suggestion(self, rom: Rom) -> None:
-        """Fire-and-forget suggestion POST. No-ops if disabled or no provider IDs are set; never raises."""
+        """
+        Fire-and-forget suggestion POST.
+        No-ops if disabled or no provider IDs are set.
+        """
         try:
             if not self.is_enabled():
                 return
 
             mappings = [
                 {"provider": tag, "providerId": str(getattr(rom, attr))}
-                for attr, tag in _PLAYMATCH_PROVIDER_TAGS
+                for tag, attr in PLAYMATCH_TAG_TO_ATTR.items()
                 if getattr(rom, attr, None)
             ]
             if not mappings:

--- a/backend/handler/metadata/playmatch_handler.py
+++ b/backend/handler/metadata/playmatch_handler.py
@@ -24,12 +24,10 @@ class PlaymatchProvider(str, Enum):
     OpenVGDB = "OpenVGDB"
 
 
-# (rom attribute, provider tag). Tag casing matches Playmatch's MetadataProvider
-# enum names (uppercased; Playmatch parses case-insensitively but spacing and
-# underscores must match). Entries for providers Playmatch doesn't currently
-# recognize are kept on purpose: Playmatch drops unknown tags server-side, and
-# preserving them means older RomM clients keep submitting correct tags when
-# Playmatch adds support for more providers.
+# Tag is the uppercased Playmatch MetadataProvider name. Playmatch parses it
+# case-insensitively but spacing must match. Tags Playmatch doesn't yet know
+# are kept so older RomM clients keep submitting the right tag once Playmatch
+# adds support.
 _PLAYMATCH_PROVIDER_TAGS: tuple[tuple[str, str], ...] = (
     ("igdb_id", "IGDB"),
     ("moby_id", "MOBYGAMES"),
@@ -46,13 +44,10 @@ _PLAYMATCH_PROVIDER_TAGS: tuple[tuple[str, str], ...] = (
 )
 
 
-# Inbound providerName -> rom attribute, derived from _PLAYMATCH_PROVIDER_TAGS.
-# Keyed on the uppercased tag so we can match against Playmatch's CamelCase
-# MetadataProvider values (`"MobyGames"` -> `"MOBYGAMES"` -> `"moby_id"`).
 _TAG_TO_ATTR: dict[str, str] = {tag: attr for attr, tag in _PLAYMATCH_PROVIDER_TAGS}
 
-# Subset of attrs the scan handler consumes from a Playmatch lookup. Other
-# entries in _PLAYMATCH_PROVIDER_TAGS are used only for outbound suggestions.
+# Rom attrs the scan handler actually consumes from a Playmatch lookup. Other
+# tags exist only for outbound suggestions.
 _LOOKUP_ROM_ATTRS: frozenset[str] = frozenset(
     {"igdb_id", "moby_id", "ss_id", "launchbox_id", "sgdb_id"}
 )

--- a/backend/handler/metadata/playmatch_handler.py
+++ b/backend/handler/metadata/playmatch_handler.py
@@ -52,6 +52,13 @@ _LOOKUP_ROM_ATTRS: frozenset[str] = frozenset(
     {"igdb_id", "moby_id", "ss_id", "launchbox_id", "sgdb_id"}
 )
 
+# MetadataSource values (StrEnum) for which Playmatch can return ids. Typed as
+# strings so this module stays free of scan_handler imports. EmuReady and
+# OpenVGDB are in Playmatch's enum but have no RomM counterpart yet.
+PLAYMATCH_SUPPORTED_SOURCES: frozenset[str] = frozenset(
+    {"igdb", "moby", "ss", "launchbox", "sgdb"}
+)
+
 
 class GameMatchType(str, Enum):
     SHA256 = "SHA256"

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -77,6 +77,20 @@ class MetadataSource(enum.StrEnum):
     LIBRETRO = "libretro"  # Libretro thumbnails
 
 
+# RomM-side counterparts to the providers Playmatch can return ids for via
+# /api/identify/ids. EmuReady and OpenVGDB are also in Playmatch's enum but
+# have no corresponding RomM source today.
+PLAYMATCH_SUPPORTED_SOURCES: frozenset[MetadataSource] = frozenset(
+    {
+        MetadataSource.IGDB,
+        MetadataSource.MOBY,
+        MetadataSource.SS,
+        MetadataSource.LAUNCHBOX,
+        MetadataSource.SGDB,
+    }
+)
+
+
 def get_main_platform_igdb_id(platform: Platform):
     cnfg = cm.get_config()
 
@@ -370,19 +384,31 @@ async def scan_rom(
         )
 
     async def fetch_playmatch_hash_match() -> PlaymatchRomMatch:
+        # Playmatch matches by file hash, so it doesn't need any platform-level
+        # external id and isn't tied to any single provider. Run it whenever
+        # Playmatch is enabled and at least one provider Playmatch can return
+        # is configured for this scan (otherwise the hash lookup is wasted).
         if (
-            MetadataSource.IGDB in metadata_sources
-            and platform.igdb_id
+            meta_playmatch_handler.is_enabled()
+            and any(
+                source in metadata_sources for source in PLAYMATCH_SUPPORTED_SOURCES
+            )
             and (
                 newly_added
                 or scan_type == ScanType.COMPLETE
-                or (scan_type == ScanType.UPDATE and rom.igdb_id)
-                or (scan_type == ScanType.UNMATCHED and not rom.igdb_id)
+                or scan_type == ScanType.UPDATE
+                or scan_type == ScanType.UNMATCHED
             )
         ):
             return await meta_playmatch_handler.lookup_rom(fs_rom["files"])
 
-        return PlaymatchRomMatch(igdb_id=None)
+        return PlaymatchRomMatch(
+            igdb_id=None,
+            moby_id=None,
+            ss_id=None,
+            launchbox_id=None,
+            sgdb_id=None,
+        )
 
     async def fetch_hasheous_hash_match() -> HasheousRom:
         if (
@@ -555,7 +581,7 @@ async def scan_rom(
 
         return HLTBRom(hltb_id=None)
 
-    async def fetch_moby_rom() -> MobyGamesRom:
+    async def fetch_moby_rom(playmatch_rom: PlaymatchRomMatch) -> MobyGamesRom:
         if (
             MetadataSource.MOBY in metadata_sources
             and platform.moby_id
@@ -572,14 +598,22 @@ async def scan_rom(
         ):
             if scan_type == ScanType.UPDATE and rom.moby_id:
                 return await meta_moby_handler.get_rom_by_id(rom.moby_id)
-            else:
-                return await meta_moby_handler.get_rom(
-                    rom_attrs["fs_name"], platform_moby_id=platform.moby_id
+
+            if playmatch_rom["moby_id"] is not None:
+                log.debug(
+                    f"{hl(rom_attrs['fs_name'])} identified by Playmatch as MobyGames "
+                    f"{hl(str(playmatch_rom['moby_id']), color=BLUE)} {emoji.EMOJI_ALIEN_MONSTER}",
+                    extra=LOGGER_MODULE_NAME,
                 )
+                return await meta_moby_handler.get_rom_by_id(playmatch_rom["moby_id"])
+
+            return await meta_moby_handler.get_rom(
+                rom_attrs["fs_name"], platform_moby_id=platform.moby_id
+            )
 
         return MobyGamesRom(moby_id=None)
 
-    async def fetch_ss_rom() -> SSRom:
+    async def fetch_ss_rom(playmatch_rom: PlaymatchRomMatch) -> SSRom:
         if (
             MetadataSource.SS in metadata_sources
             and platform.ss_id
@@ -598,6 +632,15 @@ async def scan_rom(
             if scan_type == ScanType.UPDATE and rom.ss_id:
                 return await meta_ss_handler.get_rom_by_id(rom, rom.ss_id)
 
+            # Use Playmatch's hash-based id when available
+            if playmatch_rom["ss_id"] is not None:
+                log.debug(
+                    f"{hl(rom_attrs['fs_name'])} identified by Playmatch as ScreenScraper "
+                    f"{hl(str(playmatch_rom['ss_id']), color=BLUE)} {emoji.EMOJI_ALIEN_MONSTER}",
+                    extra=LOGGER_MODULE_NAME,
+                )
+                return await meta_ss_handler.get_rom_by_id(rom, playmatch_rom["ss_id"])
+
             # Use the file hashes for lookup
             game_by_hash = await meta_ss_handler.lookup_rom(
                 rom, platform.ss_id, fs_rom["files"]
@@ -612,7 +655,9 @@ async def scan_rom(
 
         return SSRom(ss_id=None)
 
-    async def fetch_launchbox_rom(platform_slug: str) -> LaunchboxRom:
+    async def fetch_launchbox_rom(
+        platform_slug: str, playmatch_rom: PlaymatchRomMatch
+    ) -> LaunchboxRom:
         if MetadataSource.LAUNCHBOX in metadata_sources and (
             newly_added
             or scan_type == ScanType.COMPLETE
@@ -630,6 +675,18 @@ async def scan_rom(
             ):
                 launchbox_rom = await meta_launchbox_handler.get_rom_by_id(
                     rom.launchbox_id,
+                    remote_enabled=True,
+                    fs_name=rom_attrs["fs_name"],
+                    platform_slug=platform_slug,
+                )
+            elif playmatch_rom["launchbox_id"] is not None and launchbox_remote_enabled:
+                log.debug(
+                    f"{hl(rom_attrs['fs_name'])} identified by Playmatch as LaunchBox "
+                    f"{hl(str(playmatch_rom['launchbox_id']), color=BLUE)} {emoji.EMOJI_ALIEN_MONSTER}",
+                    extra=LOGGER_MODULE_NAME,
+                )
+                launchbox_rom = await meta_launchbox_handler.get_rom_by_id(
+                    playmatch_rom["launchbox_id"],
                     remote_enabled=True,
                     fs_name=rom_attrs["fs_name"],
                     platform_slug=platform_slug,
@@ -731,10 +788,10 @@ async def scan_rom(
         libretro_handler_rom,
     ) = await asyncio.gather(
         fetch_igdb_rom(playmatch_hash_match, hasheous_hash_match),
-        fetch_moby_rom(),
-        fetch_ss_rom(),
+        fetch_moby_rom(playmatch_hash_match),
+        fetch_ss_rom(playmatch_hash_match),
         fetch_ra_rom(hasheous_hash_match),
-        fetch_launchbox_rom(platform.slug),
+        fetch_launchbox_rom(platform.slug, playmatch_hash_match),
         fetch_hasheous_rom(hasheous_hash_match),
         fetch_flashpoint_rom(),
         fetch_hltb_rom(),
@@ -834,7 +891,7 @@ async def scan_rom(
         )
         return Rom(**rom_attrs)
 
-    async def fetch_sgdb_details() -> SGDBRom:
+    async def fetch_sgdb_details(playmatch_rom: PlaymatchRomMatch) -> SGDBRom:
         """Fetch SteamGridDB details for the ROM."""
         if MetadataSource.SGDB in metadata_sources and (
             newly_added
@@ -844,22 +901,30 @@ async def scan_rom(
         ):
             if scan_type == ScanType.UPDATE and rom.sgdb_id:
                 return await meta_sgdb_handler.get_rom_by_id(rom.sgdb_id)
-            else:
-                game_names = [
-                    igdb_handler_rom.get("name", None),
-                    hasheous_handler_rom.get("name", None),
-                    ss_handler_rom.get("name", None),
-                    moby_handler_rom.get("name", None),
-                    launchbox_handler_rom.get("name", None),
-                    gamelist_handler_rom.get("name", None),
-                    rom_attrs["fs_name_no_tags"],
-                ]
-                game_names = [name for name in game_names if name]
-                return await meta_sgdb_handler.get_details_by_names(game_names)
+
+            if playmatch_rom["sgdb_id"] is not None:
+                log.debug(
+                    f"{hl(rom_attrs['fs_name'])} identified by Playmatch as SteamGridDB "
+                    f"{hl(str(playmatch_rom['sgdb_id']), color=BLUE)} {emoji.EMOJI_ALIEN_MONSTER}",
+                    extra=LOGGER_MODULE_NAME,
+                )
+                return await meta_sgdb_handler.get_rom_by_id(playmatch_rom["sgdb_id"])
+
+            game_names = [
+                igdb_handler_rom.get("name", None),
+                hasheous_handler_rom.get("name", None),
+                ss_handler_rom.get("name", None),
+                moby_handler_rom.get("name", None),
+                launchbox_handler_rom.get("name", None),
+                gamelist_handler_rom.get("name", None),
+                rom_attrs["fs_name_no_tags"],
+            ]
+            game_names = [name for name in game_names if name]
+            return await meta_sgdb_handler.get_details_by_names(game_names)
 
         return SGDBRom(sgdb_id=None)
 
-    sgdb_hander_rom = await fetch_sgdb_details()
+    sgdb_hander_rom = await fetch_sgdb_details(playmatch_hash_match)
     if sgdb_hander_rom.get("sgdb_id"):
         rom_attrs["sgdb_id"] = sgdb_hander_rom["sgdb_id"]
 

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -77,9 +77,8 @@ class MetadataSource(enum.StrEnum):
     LIBRETRO = "libretro"  # Libretro thumbnails
 
 
-# RomM-side counterparts to the providers Playmatch can return ids for via
-# /api/identify/ids. EmuReady and OpenVGDB are also in Playmatch's enum but
-# have no corresponding RomM source today.
+# RomM sources for which Playmatch can return ids. EmuReady and OpenVGDB are
+# in Playmatch's enum but have no RomM counterpart yet.
 PLAYMATCH_SUPPORTED_SOURCES: frozenset[MetadataSource] = frozenset(
     {
         MetadataSource.IGDB,
@@ -384,10 +383,6 @@ async def scan_rom(
         )
 
     async def fetch_playmatch_hash_match() -> PlaymatchRomMatch:
-        # Playmatch matches by file hash, so it doesn't need any platform-level
-        # external id and isn't tied to any single provider. Run it whenever
-        # Playmatch is enabled and at least one provider Playmatch can return
-        # is configured for this scan (otherwise the hash lookup is wasted).
         if (
             meta_playmatch_handler.is_enabled()
             and any(

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -393,6 +393,13 @@ async def scan_rom(
             ss_id=None,
             launchbox_id=None,
             sgdb_id=None,
+            ra_id=None,
+            hasheous_id=None,
+            tgdb_id=None,
+            flashpoint_id=None,
+            hltb_id=None,
+            libretro_id=None,
+            gamelist_id=None,
         )
 
     async def fetch_hasheous_hash_match() -> HasheousRom:

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -34,7 +34,10 @@ from handler.metadata.launchbox_handler.platforms import LAUNCHBOX_PLATFORM_LIST
 from handler.metadata.launchbox_handler.types import LaunchboxRom
 from handler.metadata.libretro_handler import LIBRETRO_PLATFORM_LIST, LibretroRom
 from handler.metadata.moby_handler import MOBYGAMES_PLATFORM_LIST, MobyGamesRom
-from handler.metadata.playmatch_handler import PlaymatchRomMatch
+from handler.metadata.playmatch_handler import (
+    PLAYMATCH_SUPPORTED_SOURCES,
+    PlaymatchRomMatch,
+)
 from handler.metadata.ra_handler import RA_PLATFORM_LIST, RAGameRom
 from handler.metadata.sgdb_handler import SGDBRom
 from handler.metadata.ss_handler import SCREENSAVER_PLATFORM_LIST, SSRom
@@ -75,19 +78,6 @@ class MetadataSource(enum.StrEnum):
     HLTB = "hltb"  # HowLongToBeat
     GAMELIST = "gamelist"  # ES-DE gamelist.xml
     LIBRETRO = "libretro"  # Libretro thumbnails
-
-
-# RomM sources for which Playmatch can return ids. EmuReady and OpenVGDB are
-# in Playmatch's enum but have no RomM counterpart yet.
-PLAYMATCH_SUPPORTED_SOURCES: frozenset[MetadataSource] = frozenset(
-    {
-        MetadataSource.IGDB,
-        MetadataSource.MOBY,
-        MetadataSource.SS,
-        MetadataSource.LAUNCHBOX,
-        MetadataSource.SGDB,
-    }
-)
 
 
 def get_main_platform_igdb_id(platform: Platform):


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Playmatch recently expanded its supported `MetadataProvider` to `IGDB, SteamGridDB, ScreenScraper, MobyGames, LaunchBox, EmuReady, OpenVGDB`. This PR removes the`IGDB` gate and forwards every provider id Playmatch returns into the matching fetch function, the same way `igdb_id` was already used.

When `PLAYMATCH_API_ENABLED=true` and at least one Playmatch-supported source (IGDB, MobyGames, ScreenScraper, LaunchBox, SteamGridDB) is enabled, the scan handler now runs Playmatch on hash and uses each returned id as a direct lookup hint for the corresponding metadata source. No platform-level external id is required, since Playmatch matches by file hash.

**Disclosure**
I am not a Python developer and am not very familiar with the RomM codebase. I used Claude to analyze the existing Playmatch integration and to help write the extension of playmatch to other metadata providers. I reviewed the result before submitting.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)
