### PR TITLE
fix(docker): generate gunicorn logging config to writable /tmp path

### DIFF
--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -88,14 +88,18 @@ wait_for_gunicorn_socket() {
 	fi
 }
 
-# function that runs or main process and creates a corresponding PID file,
+# Function that runs our main process and creates a corresponding PID file
 start_bin_gunicorn() {
 	# cleanup potentially leftover socket
 	rm /tmp/gunicorn.sock -f
 
-	# Wire LOGLEVEL into Gunicorn's logging config so it respects the env var
+	# Wire LOGLEVEL into Gunicorn's logging config so it respects the env var.
 	local gunicorn_level="${LOGLEVEL^^}"
-	sed -i '/\[logger_gunicorn\]/,/^\[/ s/^level=.*/level='"${gunicorn_level}"'/' /etc/gunicorn/logging.conf
+	local gunicorn_log_config="/tmp/gunicorn/logging.conf"
+	# Copy the config to a writable runtime path so this works on read-only root filesystems.
+	mkdir -p /tmp/gunicorn
+	cp /etc/gunicorn/logging.conf "${gunicorn_log_config}"
+	sed -i '/\[logger_gunicorn\]/,/^\[/ s/^level=.*/level='"${gunicorn_level}"'/' "${gunicorn_log_config}"
 
 	# commands to start our main application and store its PID to check for crashes
 	info_log "Starting backend"
@@ -118,7 +122,7 @@ start_bin_gunicorn() {
 		--max-requests-jitter "${WEB_SERVER_MAX_REQUESTS_JITTER:-100}" \
 		--worker-connections "${WEB_SERVER_WORKER_CONNECTIONS:-1000}" \
 		--error-logfile - \
-		--log-config /etc/gunicorn/logging.conf \
+		--log-config "${gunicorn_log_config}" \
 		main:app &
 }
 


### PR DESCRIPTION
## Summary
- The init script runs `sed -i` against `/etc/gunicorn/logging.conf` to wire `LOGLEVEL` into Gunicorn's logging config. This fails in two common Kubernetes deployment modes:
  - `securityContext.readOnlyRootFilesystem: true` — `/etc` is read-only.
  - Non-root UID — `/etc/gunicorn` is not made writable in the Dockerfile (unlike `/etc/nginx/conf.d`), so `sed` errors with `can't create temp file '/etc/gunicorn/logging.confXXXXXX': Permission denied`.
- Fix: at startup, copy `/etc/gunicorn/logging.conf` to `/tmp/gunicorn/logging.conf`, run `sed` on the copy, and pass that copy to `gunicorn --log-config`. The image file under `/etc` is no longer mutated. `/tmp` is writable in all deployment modes, so this resolves both cases without Dockerfile changes.

Fixes the issue reported where RomM cannot start under `readOnlyRootFilesystem: true` or as a non-root UID in Kubernetes.

## Test plan
- [ ] Container starts normally with default config (root UID, writable rootfs).
- [ ] Container starts with `securityContext.readOnlyRootFilesystem: true`.
- [ ] Container starts when running as a non-root UID without `/etc/gunicorn` being writable.
- [ ] `LOGLEVEL=DEBUG` is correctly reflected in the generated `/tmp/gunicorn/logging.conf` and in Gunicorn's output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)