### PR TITLE
feat(hashing): compute raw CHD hashes and route disc-data SHA1 to Hasheous

### DIFF
--- a/backend/alembic/versions/0080_add_chd_sha1_hash.py
+++ b/backend/alembic/versions/0080_add_chd_sha1_hash.py
@@ -1,0 +1,28 @@
+"""Add chd_sha1_hash to rom_files
+
+Revision ID: 0080_add_chd_sha1_hash
+Revises: 0079_add_rom_files_rom_id_index
+Create Date: 2026-04-24 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0080_add_chd_sha1_hash"
+down_revision = "0079_add_rom_files_rom_id_index"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("rom_files", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("chd_sha1_hash", sa.String(length=100), nullable=True),
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("rom_files", schema=None) as batch_op:
+        batch_op.drop_column("chd_sha1_hash", if_exists=True)

--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -163,6 +163,7 @@ class RomFileSchema(BaseModel):
     md5_hash: str | None
     sha1_hash: str | None
     ra_hash: str | None
+    chd_sha1_hash: str | None
     category: RomFileCategory | None
 
 

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -347,6 +347,7 @@ async def _identify_rom(
                 md5_hash=file.md5_hash,
                 sha1_hash=file.sha1_hash,
                 ra_hash=file.ra_hash,
+                chd_sha1_hash=file.chd_sha1_hash,
             )
             for file in fs_rom["files"]
         ]

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -1,3 +1,4 @@
+import asyncio
 import binascii
 import bz2
 import fnmatch
@@ -10,7 +11,7 @@ import zlib
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import IO, Any, Final, Literal, TypedDict, cast
+from typing import IO, Any, Final, Literal, TypedDict
 
 import magic
 import zipfile_inflate64  # trunk-ignore(ruff/F401): Patches zipfile to support Enhanced Deflate
@@ -114,6 +115,7 @@ class FileHash(TypedDict):
     crc_hash: str
     md5_hash: str
     sha1_hash: str
+    chd_sha1_hash: str
 
 
 def is_compressed_file(file_path: str) -> bool:
@@ -245,34 +247,6 @@ def extract_chd_hash(file_path: Path) -> str | None:
             return sha1_bytes.hex()
     except OSError:
         return None
-
-
-class CHDHashWrapper:
-    """
-    Wrapper class that mimics hashlib hash objects but returns a pre-computed hash.
-
-    This class provides a hashlib-compatible interface for pre-computed hashes
-    extracted from CHD v5 file headers. It implements the same methods and attributes
-    as hashlib hash objects (digest(), hexdigest(), update(), and name).
-    """
-
-    def __init__(self, hash_hex: str, name: str):
-        self.hash_hex = hash_hex
-        self.name = name
-        # Store the digest as bytes
-        self._digest = bytes.fromhex(hash_hex)
-
-    def hexdigest(self) -> str:
-        """Return the hash as a hexadecimal string."""
-        return self.hash_hex
-
-    def digest(self) -> bytes:
-        """Return the hash as bytes."""
-        return self._digest
-
-    def update(self, data: bytes | bytearray) -> None:
-        """No-op update method for compatibility with hashlib interface."""
-        pass
 
 
 def category_matches(category: str, path_parts: list[str]):
@@ -414,6 +388,7 @@ class FSRomsHandler(FSHandler):
             crc_hash=file_hash["crc_hash"],
             md5_hash=file_hash["md5_hash"],
             sha1_hash=file_hash["sha1_hash"],
+            chd_sha1_hash=file_hash["chd_sha1_hash"] or None,
         )
 
     async def get_rom_files(
@@ -448,9 +423,28 @@ class FSRomsHandler(FSHandler):
             if calculate_hashes:
                 ra_platform = meta_ra_handler.get_platform(rom.platform_slug)
                 if ra_platform and ra_platform["ra_id"]:
+                    rom_dir = Path(abs_fs_path, rom.fs_name)
+                    # RAHasher can't process CHD files via the /* wildcard — it expects
+                    # track files (bin/cue/etc.). For CHD-only folders, find the largest
+                    # CHD and pass it directly, matching single-file CHD behaviour.
+
+                    def _list_chd_by_size() -> list[Path]:
+                        chds = [
+                            f for f in rom_dir.iterdir() if f.suffix.lower() == ".chd"
+                        ]
+                        return sorted(
+                            chds, key=lambda f: f.stat().st_size, reverse=True
+                        )
+
+                    chd_files = await asyncio.to_thread(_list_chd_by_size)
+                    ra_path = (
+                        str(chd_files[0])
+                        if chd_files
+                        else f"{abs_fs_path}/{rom.fs_name}/*"
+                    )
                     rom_ra_h = await RAHasherService().calculate_hash(
                         ra_platform,
-                        f"{abs_fs_path}/{rom.fs_name}/*",
+                        ra_path,
                     )
 
             for f_path, file_name in iter_files(
@@ -478,7 +472,8 @@ class FSRomsHandler(FSHandler):
                         if is_top_level:
                             # Include this file in the main ROM hash calculation
                             crc_c, rom_crc_c, md5_h, rom_md5_h, sha1_h, rom_sha1_h = (
-                                self._calculate_rom_hashes(
+                                await asyncio.to_thread(
+                                    self._calculate_rom_hashes,
                                     Path(f_path, file_name),
                                     rom_crc_c,
                                     rom_md5_h,
@@ -487,7 +482,8 @@ class FSRomsHandler(FSHandler):
                             )
                         else:
                             # Calculate individual file hash only
-                            crc_c, _, md5_h, _, sha1_h, _ = self._calculate_rom_hashes(
+                            crc_c, _, md5_h, _, sha1_h, _ = await asyncio.to_thread(
+                                self._calculate_rom_hashes,
                                 Path(f_path, file_name),
                                 0,
                                 hashlib.md5(usedforsecurity=False),
@@ -498,6 +494,9 @@ class FSRomsHandler(FSHandler):
                         md5_h = hashlib.md5(usedforsecurity=False)
                         sha1_h = hashlib.sha1(usedforsecurity=False)
 
+                    chd_sha1 = ""
+                    if Path(file_name).suffix.lower() == ".chd":
+                        chd_sha1 = extract_chd_hash(Path(f_path, file_name)) or ""
                     file_hash = FileHash(
                         crc_hash=crc32_to_hex(crc_c) if crc_c != DEFAULT_CRC_C else "",
                         md5_hash=(
@@ -510,12 +509,14 @@ class FSRomsHandler(FSHandler):
                             if sha1_h.digest() != DEFAULT_SHA1_H_DIGEST
                             else ""
                         ),
+                        chd_sha1_hash=chd_sha1,
                     )
                 else:
                     file_hash = FileHash(
                         crc_hash="",
                         md5_hash="",
                         sha1_hash="",
+                        chd_sha1_hash="",
                     )
 
                 rom_files.append(
@@ -529,8 +530,12 @@ class FSRomsHandler(FSHandler):
         elif hashable_platform:
             try:
                 crc_c, rom_crc_c, md5_h, rom_md5_h, sha1_h, rom_sha1_h = (
-                    self._calculate_rom_hashes(
-                        Path(abs_fs_path, rom.fs_name), rom_crc_c, rom_md5_h, rom_sha1_h
+                    await asyncio.to_thread(
+                        self._calculate_rom_hashes,
+                        Path(abs_fs_path, rom.fs_name),
+                        rom_crc_c,
+                        rom_md5_h,
+                        rom_sha1_h,
                     )
                 )
             except zlib.error:
@@ -547,6 +552,9 @@ class FSRomsHandler(FSHandler):
                         f"{abs_fs_path}/{rom.fs_name}",
                     )
 
+            chd_sha1 = ""
+            if Path(rom.fs_name).suffix.lower() == ".chd":
+                chd_sha1 = extract_chd_hash(Path(abs_fs_path, rom.fs_name)) or ""
             file_hash = FileHash(
                 crc_hash=crc32_to_hex(crc_c) if crc_c != DEFAULT_CRC_C else "",
                 md5_hash=(
@@ -557,6 +565,7 @@ class FSRomsHandler(FSHandler):
                     if sha1_h.digest() != DEFAULT_SHA1_H_DIGEST
                     else ""
                 ),
+                chd_sha1_hash=chd_sha1,
             )
             rom_files.append(
                 self._build_rom_file(
@@ -571,6 +580,7 @@ class FSRomsHandler(FSHandler):
                 crc_hash="",
                 md5_hash="",
                 sha1_hash="",
+                chd_sha1_hash="",
             )
             rom_files.append(
                 self._build_rom_file(
@@ -646,17 +656,6 @@ class FSRomsHandler(FSHandler):
             elif extension == ".bz2" or file_type == "application/x-bzip2":
                 for chunk in read_bz2_file(file_path):
                     update_hashes(chunk)
-
-            elif extension == ".chd" or file_type == "application/x-mame-chd":
-                chd_hash = extract_chd_hash(file_path)
-                if chd_hash:
-                    sha1_h = cast(Any, CHDHashWrapper(chd_hash, name="sha1"))
-                    rom_sha1_h = cast(Any, CHDHashWrapper(chd_hash, name="sha1"))
-                else:
-                    # Not a valid v5 CHD, treat as basic file
-                    # This ensures CRC32 and MD5 are still calculated for non-v5 CHDs
-                    for chunk in read_basic_file(file_path):
-                        update_hashes(chunk)
 
             else:
                 for chunk in read_basic_file(file_path):

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import re
 import tarfile
+import threading
 import zipfile
 import zlib
 from collections.abc import Callable, Iterator
@@ -100,6 +101,7 @@ NON_HASHABLE_PLATFORMS = frozenset(
 
 FILE_READ_CHUNK_SIZE = 1024 * 8
 _MIME_DETECTOR = magic.Magic(mime=True)
+_MIME_DETECTOR_LOCK = threading.Lock()
 
 
 class FSRom(TypedDict):
@@ -122,7 +124,8 @@ class FileHash(TypedDict):
 
 def is_compressed_file(file_path: str) -> bool:
     try:
-        file_type = _MIME_DETECTOR.from_file(file_path)
+        with _MIME_DETECTOR_LOCK:
+            file_type = _MIME_DETECTOR.from_file(file_path)
     except magic.MagicException:
         file_type = ""
 
@@ -201,7 +204,8 @@ def is_chd_file(file_path: Path) -> bool:
         return True
 
     try:
-        return _MIME_DETECTOR.from_file(file_path) == CHD_MIME_TYPE
+        with _MIME_DETECTOR_LOCK:
+            return _MIME_DETECTOR.from_file(file_path) == CHD_MIME_TYPE
     except (OSError, magic.MagicException):
         return False
 
@@ -232,7 +236,9 @@ def extract_chd_hash(file_path: Path) -> str:
         file_path: Path to the CHD file
 
     Returns:
-        SHA1 hash as hex string if valid
+        The embedded SHA1 hash as a hex string for a valid CHD v5 file, or an
+        empty string if the file is invalid, uses an unsupported CHD version,
+        is truncated, or cannot be read due to an I/O error.
     """
     try:
         with open(file_path, "rb") as f:
@@ -465,6 +471,7 @@ class FSRomsHandler(FSHandler):
                 f"{abs_fs_path}/{rom.fs_name}", recursive=True
             ):
                 # Check if file is excluded by extension.
+                f_rom_dir = Path(f_path, rom.fs_name)
                 file_name_lower = file_name.lower()
                 if any(
                     file_name_lower.endswith("." + ext) for ext in excluded_file_exts
@@ -521,8 +528,8 @@ class FSRomsHandler(FSHandler):
                             else ""
                         ),
                         chd_sha1_hash=(
-                            extract_chd_hash(rom_dir)
-                            if is_chd_file(Path(f_path, file_name))
+                            extract_chd_hash(f_rom_dir)
+                            if is_chd_file(f_rom_dir)
                             else ""
                         ),
                     )
@@ -578,9 +585,7 @@ class FSRomsHandler(FSHandler):
                     else ""
                 ),
                 chd_sha1_hash=(
-                    extract_chd_hash(rom_dir)
-                    if is_chd_file(Path(abs_fs_path, rom.fs_name))
-                    else ""
+                    extract_chd_hash(rom_dir) if is_chd_file(rom_dir) else ""
                 ),
             )
             rom_files.append(
@@ -631,10 +636,10 @@ class FSRomsHandler(FSHandler):
         rom_sha1_h: Any,
     ) -> tuple[int, int, Any, Any, Any, Any]:
         extension = Path(file_path).suffix.lower()
-        mime = magic.Magic(mime=True)
         try:
             try:
-                file_type = mime.from_file(file_path)
+                with _MIME_DETECTOR_LOCK:
+                    file_type = _MIME_DETECTOR.from_file(file_path)
             except magic.MagicException:
                 file_type = ""
 

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -65,6 +65,7 @@ CHD_VERSION_LENGTH: Final = 4  # Version is a uint32
 CHD_V5_SHA1_OFFSET: Final = 84  # Combined raw+meta SHA1 offset in v5
 CHD_V5_SHA1_LENGTH: Final = 20  # SHA1 is 20 bytes
 CHD_V5_VERSION: Final = 5  # CHD v5 identifier
+CHD_MIME_TYPE: Final = "application/x-mame-chd"
 
 NON_HASHABLE_PLATFORMS = frozenset(
     (
@@ -98,6 +99,7 @@ NON_HASHABLE_PLATFORMS = frozenset(
 )
 
 FILE_READ_CHUNK_SIZE = 1024 * 8
+_MIME_DETECTOR = magic.Magic(mime=True)
 
 
 class FSRom(TypedDict):
@@ -119,8 +121,10 @@ class FileHash(TypedDict):
 
 
 def is_compressed_file(file_path: str) -> bool:
-    mime = magic.Magic(mime=True)
-    file_type = mime.from_file(file_path)
+    try:
+        file_type = _MIME_DETECTOR.from_file(file_path)
+    except magic.MagicException:
+        file_type = ""
 
     return file_type in COMPRESSED_MIME_TYPES or file_path.lower().endswith(
         tuple(COMPRESSED_FILE_EXTENSIONS)
@@ -191,7 +195,18 @@ def read_bz2_file(file_path: Path) -> Iterator[bytes]:
             yield chunk
 
 
-def extract_chd_hash(file_path: Path) -> str | None:
+def is_chd_file(file_path: Path) -> bool:
+    """Return True if the file is a CHD by extension or libmagic-detected MIME type."""
+    if file_path.suffix.lower() == ".chd":
+        return True
+
+    try:
+        return _MIME_DETECTOR.from_file(file_path) == CHD_MIME_TYPE
+    except (OSError, magic.MagicException):
+        return False
+
+
+def extract_chd_hash(file_path: Path) -> str:
     """
     Extract the embedded SHA1 hash from a CHD (Compressed Hunks of Data) v5 file header.
 
@@ -217,7 +232,7 @@ def extract_chd_hash(file_path: Path) -> str | None:
         file_path: Path to the CHD file
 
     Returns:
-        SHA1 hash as hex string, or None if file is not a valid CHD v5 file or parsing fails
+        SHA1 hash as hex string if valid
     """
     try:
         with open(file_path, "rb") as f:
@@ -229,7 +244,7 @@ def extract_chd_hash(file_path: Path) -> str | None:
                 len(header) < CHD_MIN_HEADER_LENGTH
                 or header[:CHD_SIGNATURE_LENGTH] != CHD_SIGNATURE
             ):
-                return None
+                return ""
 
             # Extract and verify version (big-endian uint32)
             version_end = CHD_VERSION_OFFSET + CHD_VERSION_LENGTH
@@ -237,16 +252,16 @@ def extract_chd_hash(file_path: Path) -> str | None:
 
             # Only support v5 CHD files
             if version != CHD_V5_VERSION:
-                return None
+                return ""
 
             # Extract combined raw+meta SHA1 from v5 header
             sha1_end = CHD_V5_SHA1_OFFSET + CHD_V5_SHA1_LENGTH
             if len(header) < sha1_end:
-                return None
+                return ""
             sha1_bytes = header[CHD_V5_SHA1_OFFSET:sha1_end]
             return sha1_bytes.hex()
     except OSError:
-        return None
+        return ""
 
 
 def category_matches(category: str, path_parts: list[str]):
@@ -388,7 +403,7 @@ class FSRomsHandler(FSHandler):
             crc_hash=file_hash["crc_hash"],
             md5_hash=file_hash["md5_hash"],
             sha1_hash=file_hash["sha1_hash"],
-            chd_sha1_hash=file_hash["chd_sha1_hash"] or None,
+            chd_sha1_hash=file_hash["chd_sha1_hash"],
         )
 
     async def get_rom_files(
@@ -417,29 +432,28 @@ class FSRomsHandler(FSHandler):
         rom_sha1_h = hashlib.sha1(usedforsecurity=False) if calculate_hashes else None
         rom_ra_h = ""
 
+        rom_dir = Path(abs_fs_path, rom.fs_name)
         # Check if rom is a multi-part rom
         if await AnyioPath(f"{abs_fs_path}/{rom.fs_name}").is_dir():
             # Calculate the RA hash if the platform has a slug that matches a known RA slug
             if calculate_hashes:
                 ra_platform = meta_ra_handler.get_platform(rom.platform_slug)
                 if ra_platform and ra_platform["ra_id"]:
-                    rom_dir = Path(abs_fs_path, rom.fs_name)
-                    # RAHasher can't process CHD files via the /* wildcard — it expects
+                    # RAHasher can't process CHD files via the /* wildcard and instead expects
                     # track files (bin/cue/etc.). For CHD-only folders, find the largest
                     # CHD and pass it directly, matching single-file CHD behaviour.
 
-                    def _list_chd_by_size() -> list[Path]:
-                        chds = [
-                            f for f in rom_dir.iterdir() if f.suffix.lower() == ".chd"
-                        ]
-                        return sorted(
+                    def _largest_chd_file() -> Path | None:
+                        chds = [f for f in rom_dir.iterdir() if is_chd_file(f)]
+                        sorted_chds = sorted(
                             chds, key=lambda f: f.stat().st_size, reverse=True
                         )
+                        return sorted_chds[0] if sorted_chds else None
 
-                    chd_files = await asyncio.to_thread(_list_chd_by_size)
+                    chd_file = await asyncio.to_thread(_largest_chd_file)
                     ra_path = (
-                        str(chd_files[0])
-                        if chd_files
+                        str(chd_file)
+                        if chd_file and chd_file.is_file()
                         else f"{abs_fs_path}/{rom.fs_name}/*"
                     )
                     rom_ra_h = await RAHasherService().calculate_hash(
@@ -494,9 +508,6 @@ class FSRomsHandler(FSHandler):
                         md5_h = hashlib.md5(usedforsecurity=False)
                         sha1_h = hashlib.sha1(usedforsecurity=False)
 
-                    chd_sha1 = ""
-                    if Path(file_name).suffix.lower() == ".chd":
-                        chd_sha1 = extract_chd_hash(Path(f_path, file_name)) or ""
                     file_hash = FileHash(
                         crc_hash=crc32_to_hex(crc_c) if crc_c != DEFAULT_CRC_C else "",
                         md5_hash=(
@@ -509,7 +520,11 @@ class FSRomsHandler(FSHandler):
                             if sha1_h.digest() != DEFAULT_SHA1_H_DIGEST
                             else ""
                         ),
-                        chd_sha1_hash=chd_sha1,
+                        chd_sha1_hash=(
+                            extract_chd_hash(rom_dir)
+                            if is_chd_file(Path(f_path, file_name))
+                            else ""
+                        ),
                     )
                 else:
                     file_hash = FileHash(
@@ -552,9 +567,6 @@ class FSRomsHandler(FSHandler):
                         f"{abs_fs_path}/{rom.fs_name}",
                     )
 
-            chd_sha1 = ""
-            if Path(rom.fs_name).suffix.lower() == ".chd":
-                chd_sha1 = extract_chd_hash(Path(abs_fs_path, rom.fs_name)) or ""
             file_hash = FileHash(
                 crc_hash=crc32_to_hex(crc_c) if crc_c != DEFAULT_CRC_C else "",
                 md5_hash=(
@@ -565,7 +577,11 @@ class FSRomsHandler(FSHandler):
                     if sha1_h.digest() != DEFAULT_SHA1_H_DIGEST
                     else ""
                 ),
-                chd_sha1_hash=chd_sha1,
+                chd_sha1_hash=(
+                    extract_chd_hash(rom_dir)
+                    if is_chd_file(Path(abs_fs_path, rom.fs_name))
+                    else ""
+                ),
             )
             rom_files.append(
                 self._build_rom_file(
@@ -617,7 +633,10 @@ class FSRomsHandler(FSHandler):
         extension = Path(file_path).suffix.lower()
         mime = magic.Magic(mime=True)
         try:
-            file_type = mime.from_file(file_path)
+            try:
+                file_type = mime.from_file(file_path)
+            except magic.MagicException:
+                file_type = ""
 
             crc_c = 0
             md5_h = hashlib.md5(usedforsecurity=False)

--- a/backend/handler/metadata/hasheous_handler.py
+++ b/backend/handler/metadata/hasheous_handler.py
@@ -258,9 +258,16 @@ class HasheousHandler(MetadataHandler):
         if first_file is None:
             return fallback_rom
 
-        md5_hash = first_file.md5_hash
-        sha1_hash = first_file.sha1_hash
-        crc_hash = first_file.crc_hash
+        if first_file.chd_sha1_hash:
+            # For CHD files, Hasheous indexes by disc-data SHA1 only.
+            # Raw file MD5/CRC are hashes of the container and won't match.
+            md5_hash = None
+            sha1_hash = first_file.chd_sha1_hash
+            crc_hash = None
+        else:
+            md5_hash = first_file.md5_hash
+            sha1_hash = first_file.sha1_hash
+            crc_hash = first_file.crc_hash
 
         if not (md5_hash or sha1_hash or crc_hash):
             log.warning(

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -385,7 +385,7 @@ async def scan_rom(
                 or scan_type == ScanType.UNMATCHED
             )
         ):
-            return await meta_playmatch_handler.lookup_rom(fs_rom["files"])
+            return await meta_playmatch_handler.lookup_rom(fs_rom["files"] or rom.files)
 
         return PlaymatchRomMatch(
             igdb_id=None,
@@ -418,7 +418,7 @@ async def scan_rom(
             )
         ):
             return await meta_hasheous_handler.lookup_rom(
-                platform.slug, fs_rom["files"]
+                platform.slug, fs_rom["files"] or rom.files
             )
 
         return HasheousRom(hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None)
@@ -635,7 +635,7 @@ async def scan_rom(
 
             # Use the file hashes for lookup
             game_by_hash = await meta_ss_handler.lookup_rom(
-                rom, platform.ss_id, fs_rom["files"]
+                rom, platform.ss_id, fs_rom["files"] or rom.files
             )
             if game_by_hash.get("ss_id"):
                 return game_by_hash

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -76,6 +76,7 @@ class RomFile(BaseModel):
     md5_hash: Mapped[str | None] = mapped_column(String(100))
     sha1_hash: Mapped[str | None] = mapped_column(String(100))
     ra_hash: Mapped[str | None] = mapped_column(String(100))
+    chd_sha1_hash: Mapped[str | None] = mapped_column(String(100))
     category: Mapped[RomFileCategory | None] = mapped_column(
         Enum(RomFileCategory), default=None
     )

--- a/backend/tests/handler/filesystem/test_roms_handler.py
+++ b/backend/tests/handler/filesystem/test_roms_handler.py
@@ -7,7 +7,6 @@ import pytest
 
 from config.config_manager import LIBRARY_BASE_PATH, Config
 from handler.filesystem.roms_handler import (
-    CHDHashWrapper,
     FileHash,
     FSRomsHandler,
     extract_chd_hash,
@@ -259,6 +258,7 @@ class TestFSRomsHandler:
                 "crc_hash": "ABCD1234",
                 "md5_hash": "def456",
                 "sha1_hash": "789ghi",
+                "chd_sha1_hash": "",
             }
         )
 
@@ -284,6 +284,7 @@ class TestFSRomsHandler:
                 "crc_hash": "12345678",
                 "md5_hash": "abcdef",
                 "sha1_hash": "123456",
+                "chd_sha1_hash": "",
             }
         )
 
@@ -712,13 +713,11 @@ class TestFSRomsHandler:
     async def test_get_rom_files_with_chd_v5_uses_internal_hash(
         self, handler: FSRomsHandler, platform, tmp_path
     ):
-        """Test that a CHD v5 file uses its internal hash and skips other hashing.
+        """Test that a CHD v5 file stores the header SHA1 in chd_sha1_hash.
 
-        This integration test verifies the complete CHD v5 hashing logic:
-        1. For valid CHD v5 files, the embedded SHA1 hash from the file header is used
-        2. CRC32 and MD5 hashes are NOT calculated from file contents
-        3. The file is not double-processed by read_basic_file
-        4. This prevents regressions in the if/elif archive type chain
+        CHD files are hashed like any other file type (CRC32, MD5, SHA1 from
+        raw bytes). The embedded disc-data SHA1 from the CHD v5 header is
+        separately stored in chd_sha1_hash for metadata providers that need it.
         """
         # Create a mock CHD v5 file in a temporary directory
         chd_file = tmp_path / "test.chd"
@@ -751,22 +750,19 @@ class TestFSRomsHandler:
         # Run the hashing process
         parsed_rom_files = await test_handler.get_rom_files(rom)
 
-        # Assert that only SHA1 is populated, and it's from the header
+        # All three raw-file hashes should be populated
         assert len(parsed_rom_files.rom_files) == 1
+        assert parsed_rom_files.crc_hash != "", "CRC should be computed from raw bytes"
+        assert parsed_rom_files.md5_hash != "", "MD5 should be computed from raw bytes"
         assert (
-            parsed_rom_files.sha1_hash == internal_sha1
-        ), "SHA1 should be from CHD v5 header"
-        assert parsed_rom_files.rom_files[0].sha1_hash == internal_sha1
+            parsed_rom_files.sha1_hash != ""
+        ), "SHA1 should be computed from raw bytes"
 
-        # CRC32 and MD5 should be empty/zero (not calculated)
-        assert (
-            parsed_rom_files.crc_hash == ""
-        ), f"CRC hash should be empty, got: {parsed_rom_files.crc_hash}"
-        assert (
-            parsed_rom_files.md5_hash == ""
-        ), f"MD5 hash should be empty, got: {parsed_rom_files.md5_hash}"
-        assert parsed_rom_files.rom_files[0].crc_hash == ""
-        assert parsed_rom_files.rom_files[0].md5_hash == ""
+        # Raw file SHA1 is NOT the header SHA1
+        assert parsed_rom_files.sha1_hash != internal_sha1
+
+        # Header SHA1 stored separately in chd_sha1_hash
+        assert parsed_rom_files.rom_files[0].chd_sha1_hash == internal_sha1
 
     @pytest.mark.asyncio
     async def test_get_rom_files_with_non_v5_chd_fallback_to_std_hashing(
@@ -974,28 +970,6 @@ class TestExtractCHDHash:
         assert result == result.lower()
         # Verify it's 40 characters (SHA1 is 20 bytes = 40 hex chars)
         assert len(result) == 40
-
-    def test_extract_chd_hash_with_wrapper(self, tmp_path):
-        """Test that extracted hash integrates properly with CHDHashWrapper"""
-        chd_file = tmp_path / "test_wrapper.chd"
-
-        header = bytearray(124)
-        header[0:8] = b"MComprHD"
-        header[12:16] = int(5).to_bytes(4, "big")
-        test_sha1 = bytes.fromhex("0123456789abcdef0123456789abcdef01234567")
-        header[84:104] = test_sha1
-
-        chd_file.write_bytes(header)
-
-        extracted_hash = extract_chd_hash(chd_file)
-        assert extracted_hash is not None
-
-        # Should be usable with CHDHashWrapper
-        wrapper = CHDHashWrapper(extracted_hash, "sha1")
-        assert wrapper.hexdigest() == extracted_hash
-        assert len(wrapper.digest()) == 20
-        # Verify digest bytes match the original
-        assert wrapper.digest() == test_sha1
 
     def test_extract_chd_hash_unknown_version(self, tmp_path):
         """Test that unknown CHD versions are rejected"""

--- a/backend/tests/handler/filesystem/test_roms_handler.py
+++ b/backend/tests/handler/filesystem/test_roms_handler.py
@@ -258,7 +258,7 @@ class TestFSRomsHandler:
                 "crc_hash": "ABCD1234",
                 "md5_hash": "def456",
                 "sha1_hash": "789ghi",
-                "chd_sha1_hash": "",
+                "chd_sha1_hash": "654321",
             }
         )
 
@@ -284,7 +284,7 @@ class TestFSRomsHandler:
                 "crc_hash": "12345678",
                 "md5_hash": "abcdef",
                 "sha1_hash": "123456",
-                "chd_sha1_hash": "",
+                "chd_sha1_hash": "654321",
             }
         )
 
@@ -842,7 +842,7 @@ class TestExtractCHDHash:
 
         result = extract_chd_hash(chd_file)
 
-        assert result is not None
+        assert result
         assert isinstance(result, str)
         assert len(result) == 40  # SHA1 hex is 40 characters
         assert result == "0123456789abcdef0123456789abcdef01234567"
@@ -859,7 +859,7 @@ class TestExtractCHDHash:
 
         result = extract_chd_hash(chd_file)
 
-        assert result is None
+        assert result == ""
 
     def test_extract_chd_hash_v2_rejected(self, tmp_path):
         """Test that CHD v2 files are rejected"""
@@ -873,7 +873,7 @@ class TestExtractCHDHash:
 
         result = extract_chd_hash(chd_file)
 
-        assert result is None
+        assert result == ""
 
     def test_extract_chd_hash_v3_rejected(self, tmp_path):
         """Test that CHD v3 files are rejected"""
@@ -887,7 +887,7 @@ class TestExtractCHDHash:
 
         result = extract_chd_hash(chd_file)
 
-        assert result is None
+        assert result == ""
 
     def test_extract_chd_hash_v4_rejected(self, tmp_path):
         """Test that CHD v4 files are rejected"""
@@ -901,7 +901,7 @@ class TestExtractCHDHash:
 
         result = extract_chd_hash(chd_file)
 
-        assert result is None
+        assert result == ""
 
     def test_extract_chd_hash_invalid_magic(self, tmp_path):
         """Test that files without CHD magic signature are rejected"""
@@ -915,7 +915,7 @@ class TestExtractCHDHash:
 
         result = extract_chd_hash(chd_file)
 
-        assert result is None
+        assert result == ""
 
     def test_extract_chd_hash_truncated_header(self, tmp_path):
         """Test that CHD v5 file with truncated header is rejected"""
@@ -930,7 +930,7 @@ class TestExtractCHDHash:
 
         result = extract_chd_hash(chd_file)
 
-        assert result is None
+        assert result == ""
 
     def test_extract_chd_hash_nonexistent_file(self, tmp_path):
         """Test that non-existent files are handled gracefully"""
@@ -938,7 +938,7 @@ class TestExtractCHDHash:
 
         result = extract_chd_hash(nonexistent)
 
-        assert result is None
+        assert result == ""
 
     def test_extract_chd_hash_empty_file(self, tmp_path):
         """Test that empty files are rejected"""
@@ -947,7 +947,7 @@ class TestExtractCHDHash:
 
         result = extract_chd_hash(chd_file)
 
-        assert result is None
+        assert result == ""
 
     def test_extract_chd_hash_sha1_format(self, tmp_path):
         """Test that SHA1 hash is correctly formatted as hex"""
@@ -983,7 +983,7 @@ class TestExtractCHDHash:
 
         result = extract_chd_hash(chd_file)
 
-        assert result is None
+        assert result == ""
 
     def test_extract_chd_hash_multiple_different_hashes(self, tmp_path):
         """Test that different SHA1 hashes are correctly extracted"""
@@ -1011,11 +1011,11 @@ class TestExtractCHDHash:
     def test_extract_chd_hash_version_boundary_cases(self, tmp_path):
         """Test version checking at boundaries (0, 1, 4, 5, 6)"""
         test_versions = [
-            (0, None),  # Version 0 should return None
-            (1, None),  # Version 1 should return None
-            (4, None),  # Version 4 should return None
+            (0, ""),  # Version 0 should return ""
+            (1, ""),  # Version 1 should return ""
+            (4, ""),  # Version 4 should return ""
             (5, "0123456789abcdef0123456789abcdef01234567"),  # Version 5 should work
-            (6, None),  # Version 6 should return None
+            (6, ""),  # Version 6 should return ""
         ]
 
         for version, expected in test_versions:
@@ -1030,10 +1030,7 @@ class TestExtractCHDHash:
 
             result = extract_chd_hash(chd_file)
 
-            if expected is None:
-                assert result is None, f"Version {version} should return None"
-            else:
-                assert result == expected, f"Version {version} should return {expected}"
+            assert result == expected, f"Version {version} should return {expected!r}"
 
     def test_extract_chd_hash_file_too_short_for_magic(self, tmp_path):
         """Test file that's too short to even contain magic + version"""
@@ -1047,7 +1044,7 @@ class TestExtractCHDHash:
 
         result = extract_chd_hash(chd_file)
 
-        assert result is None
+        assert result == ""
 
     def test_extract_chd_hash_permission_error(self, tmp_path):
         """Test graceful handling of permission errors"""
@@ -1064,7 +1061,7 @@ class TestExtractCHDHash:
 
         try:
             result = extract_chd_hash(chd_file)
-            assert result is None
+            assert result == ""
         finally:
             # Restore permissions for cleanup
             chd_file.chmod(0o644)
@@ -1109,7 +1106,7 @@ class TestExtractCHDHash:
         # Expected SHA1 from the header at bytes 84-103 (20 bytes, as per chd.h)
         expected_sha1 = "0167fc76f9e4312e6ab48fe980d2ce5b23f775c2"
 
-        assert result is not None
+        assert result
         assert result == expected_sha1
         assert len(result) == 40
         # Verify it matches what's in the header
@@ -1136,14 +1133,14 @@ class TestExtractCHDHash:
 
         result = extract_chd_hash(chd_file)
 
-        assert result is not None
+        assert result
         assert result == "0167fc76f9e4312e6ab48fe980d2ce5b23f775c2"
         assert bytes.fromhex(result) == test_sha1
 
     def test_extract_chd_hash_off_by_one_header_sizes(self, tmp_path):
         """Test boundary conditions around minimum required header size (104 bytes)"""
         test_cases = [
-            (103, None),  # 103 bytes - not enough for SHA1 region
+            (103, ""),  # 103 bytes - not enough for SHA1 region
             (
                 104,
                 "0167fc76f9e4312e6ab48fe980d2ce5b23f775c2",
@@ -1186,7 +1183,7 @@ class TestExtractCHDHash:
         result = extract_chd_hash(chd_file)
 
         # Should return None because version is not 5
-        assert result is None
+        assert result == ""
 
     def test_extract_chd_hash_zero_sha1(self, tmp_path):
         """Test handling of all-zero SHA1 hash (edge case but valid)"""

--- a/backend/tests/handler/filesystem/test_roms_handler.py
+++ b/backend/tests/handler/filesystem/test_roms_handler.py
@@ -1182,7 +1182,7 @@ class TestExtractCHDHash:
 
         result = extract_chd_hash(chd_file)
 
-        # Should return None because version is not 5
+        # Should return empty string because version is not 5
         assert result == ""
 
     def test_extract_chd_hash_zero_sha1(self, tmp_path):

--- a/frontend/src/__generated__/models/RomFileSchema.ts
+++ b/frontend/src/__generated__/models/RomFileSchema.ts
@@ -17,6 +17,7 @@ export type RomFileSchema = {
     md5_hash: (string | null);
     sha1_hash: (string | null);
     ra_hash: (string | null);
+    chd_sha1_hash: (string | null);
     category: (RomFileCategory | null);
 };
 

--- a/frontend/src/components/Details/Info/FileInfo.vue
+++ b/frontend/src/components/Details/Info/FileInfo.vue
@@ -20,7 +20,7 @@ const romInfo = ref([
   { label: "Size", value: formatBytes(props.rom.fs_size_bytes) },
   { label: "SHA-1", value: props.rom.sha1_hash },
   {
-    label: "Disc SHA-1",
+    label: "CHD SHA-1",
     value: props.rom.has_simple_single_file
       ? (props.rom.files[0]?.chd_sha1_hash ?? null)
       : null,

--- a/frontend/src/components/Details/Info/FileInfo.vue
+++ b/frontend/src/components/Details/Info/FileInfo.vue
@@ -19,6 +19,12 @@ const romUser = ref(props.rom.rom_user);
 const romInfo = ref([
   { label: "Size", value: formatBytes(props.rom.fs_size_bytes) },
   { label: "SHA-1", value: props.rom.sha1_hash },
+  {
+    label: "Disc SHA-1",
+    value: props.rom.has_simple_single_file
+      ? (props.rom.files[0]?.chd_sha1_hash ?? null)
+      : null,
+  },
   { label: "MD5", value: props.rom.md5_hash },
   { label: "CRC", value: props.rom.crc_hash },
   { label: "Revision", value: props.rom.revision },

--- a/frontend/src/components/Details/Info/FileSelectItem.vue
+++ b/frontend/src/components/Details/Info/FileSelectItem.vue
@@ -21,6 +21,14 @@ const fileInfo = ref([
       : null,
   },
   {
+    label: "Disc SHA-1",
+    value: props.item.chd_sha1_hash
+      ? props.item.chd_sha1_hash.substring(0, 6) +
+        "..." +
+        props.item.chd_sha1_hash.substring(props.item.chd_sha1_hash.length - 6)
+      : null,
+  },
+  {
     label: "MD5",
     value: props.item.md5_hash
       ? props.item.md5_hash.substring(0, 6) +

--- a/frontend/src/components/Details/Info/FileSelectItem.vue
+++ b/frontend/src/components/Details/Info/FileSelectItem.vue
@@ -21,7 +21,7 @@ const fileInfo = ref([
       : null,
   },
   {
-    label: "Disc SHA-1",
+    label: "CHD SHA-1",
     value: props.item.chd_sha1_hash
       ? props.item.chd_sha1_hash.substring(0, 6) +
         "..." +


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

### The problem

CHD files were being treated as a special case in RomM's hashing pipeline. Instead of computing CRC32 / MD5 / SHA1 from the raw container bytes the way every other file type does, only the disc-data SHA1 from the CHD v5 header was extracted. That value was then injected into the regular `sha1_hash` field via a `CHDHashWrapper` shim that mimicked the hashlib interface.

This caused two concrete downstream problems:

1. **ScreenScraper KO scrapes for CHD files were useless to SS.** When SS doesn't recognise a hash, it logs a "KO" entry to help build its database. RomM was sending it the disc-data SHA1 in the `sha1` field — a value SS doesn't index by — so SS would log a KO entry against a hash that could never match anything in their pipeline. The companion PR ([#XXXX](#)) ensures KO scrapes carry `romnom`/`romtype`, but that fix is moot for CHDs unless we send the actual file hashes.
2. **The raw container hashes were never available**, so anything that legitimately wanted the file's CRC32 / MD5 / SHA1 (UI display, comparison against external DAT files, future integrations) had no value to use.

### The fix

CHD files now follow the same hash path as every other file type — `_calculate_rom_hashes()` runs CRC32 / MD5 / SHA1 over the raw container bytes. The disc-data SHA1 (extracted from the CHD v5 header) is kept, but stored in a **new dedicated field** so it doesn't collide with the raw SHA1.

Specifically:

- **New `rom_files.chd_sha1_hash` column** (alembic migration `0080`). Nullable, defaults to NULL. Only populated for `.chd` files.
- **`CHDHashWrapper` removed.** No longer needed — disc-data SHA1 is extracted separately via `extract_chd_hash()` instead of being smuggled through the hashlib pipeline.
- **CHD-specific branch in `extract_chd_hash` removed from `_calculate_rom_hashes()`** — CHDs now fall through to the standard raw-byte read.
- **`FileHash` TypedDict gains `chd_sha1_hash`** so it flows through `_build_rom_file()` into `RomFile`.

### Hasheous routing

Hasheous indexes disc-based games by disc-data SHA1 only — raw file hashes won't match. The `HasheousHandler.lookup_rom()` is updated so that for CHD files (`first_file.chd_sha1_hash` populated), only the disc-data SHA1 is sent and MD5/CRC are left empty. For all other files, behaviour is unchanged.

### RAHasher multi-file fix

For multi-file ROM directories, RomM was calling RAHasher with a `/*` wildcard path. RAHasher can't expand wildcards, so it would silently produce no hash for any folder-based ROM. For dirs that contain CHDs, the code now finds the largest CHD and passes it directly — matching the single-file CHD behaviour and aligning with how RAHasher expects multi-disc games to be addressed.

### Async-safe hash computation

Hash calculations on large files (multi-GB ISOs/CHDs) were blocking the asyncio event loop. `_calculate_rom_hashes()` calls are now wrapped in `asyncio.to_thread(...)` so the scan doesn't stall other operations while a big file is being read.

### `rom.files` fallback during UPDATE / UNMATCHED scans

When a scan doesn't rehash files (UPDATE and UNMATCHED scan types), `fs_rom["files"]` comes back empty, which meant the hash-lookup metadata handlers (Playmatch, Hasheous, ScreenScraper) had no hashes to send. Three call sites in `scan_handler.py` now fall back to `rom.files` (the DB-stored hashes from the last successful scan) when `fs_rom["files"]` is empty:

```python
fs_rom["files"] or rom.files
```

This restores hash-based matching for those scan types.

### Frontend: Disc SHA-1 display

The new disc-data SHA1 is surfaced in the ROM detail view:

- **[FileInfo.vue](frontend/src/components/Details/Info/FileInfo.vue)** — single-file CHDs show the full hash in the ROM info panel.
- **[FileSelectItem.vue](frontend/src/components/Details/Info/FileSelectItem.vue)** — multi-file CHD sets (e.g. multi-disc games) show a truncated `first6…last6` hash per file in the file selector.

### Files

- [backend/alembic/versions/0080_add_chd_sha1_hash.py](backend/alembic/versions/0080_add_chd_sha1_hash.py) — new column
- [backend/models/rom.py](backend/models/rom.py) — `RomFile.chd_sha1_hash` field
- [backend/endpoints/responses/rom.py](backend/endpoints/responses/rom.py) — schema exposes field
- [backend/endpoints/sockets/scan.py](backend/endpoints/sockets/scan.py) — socket payload includes field
- [backend/handler/filesystem/roms_handler.py](backend/handler/filesystem/roms_handler.py) — raw-hash path, RAHasher fix, asyncio.to_thread, CHDHashWrapper removal
- [backend/handler/metadata/hasheous_handler.py](backend/handler/metadata/hasheous_handler.py) — disc-data SHA1 routing for CHDs
- [backend/handler/scan_handler.py](backend/handler/scan_handler.py) — `rom.files` fallback for UPDATE / UNMATCHED scans
- Two Vue components + the generated TS schema for the new field

### Test coverage

`tests/handler/filesystem/test_roms_handler.py` was updated to reflect the new behaviour:

- `test_get_rom_files_with_chd_v5_uses_internal_hash` — confirms disc-data SHA1 ends up in `chd_sha1_hash` (not in `sha1_hash`).
- `test_get_rom_files_with_non_v5_chd_fallback_to_std_hashing` — confirms non-v5 CHDs fall through to standard raw hashing.
- The full `TestExtractCHDHash` class (21 tests) covers header parsing edge cases — version boundaries, truncated headers, permission errors, zero/max SHA1, etc.
- Stale tests for the removed `CHDHashWrapper` were deleted.

> [!NOTE]
> This PR is one half of an earlier combined PR that was split per maintainer feedback. The companion PR ([#3384](#)) covers ScreenScraper API handling improvements and touches a disjoint set of files, so the two can be reviewed in parallel.

> [!NOTE]
> **AI assistance disclosure**: This PR was developed with assistance from Claude (Anthropic). Claude contributed to authoring portions of the original code (the squashed commit retains `Co-Authored-By: Claude Sonnet 4.6`), and was used to split the original combined branch into smaller per-feature PRs, draft this description, and verify tests / lint / migration round-trip / frontend rendering locally. All code was reviewed and is endorsed by me before submission.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

<!-- Suggest adding screenshots of the new "Disc SHA-1" rows in:
     1. A single-file CHD's detail view (FileInfo.vue)
     2. A multi-file CHD set's file selector (FileSelectItem.vue)
     since you just confirmed the rendering works. -->
