### PR TITLE
fix: wipe downloaded resources on COMPLETE rescan

### DIFF
--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -301,15 +301,30 @@ async def _identify_rom(
     # post-scan download steps below skip downloads when a file already exists or
     # when the source URL is unchanged, so the on-disk files must be removed here.
     if not newly_added and scan_type == ScanType.COMPLETE:
-        await fs_resource_handler.remove_cover(rom)
-        await fs_resource_handler.remove_manual(rom)
-        await fs_resource_handler.remove_directory(
-            f"{rom.fs_resources_path}/screenshots"
-        )
-        for media_type in MetadataMediaType:
-            await fs_resource_handler.remove_media_resources_path(
-                platform.id, rom.id, media_type
+        try:
+            await fs_resource_handler.remove_cover(rom)
+        except FileNotFoundError:
+            pass
+
+        try:
+            await fs_resource_handler.remove_manual(rom)
+        except FileNotFoundError:
+            pass
+
+        try:
+            await fs_resource_handler.remove_directory(
+                f"{rom.fs_resources_path}/screenshots"
             )
+        except FileNotFoundError:
+            pass
+
+        for media_type in MetadataMediaType:
+            try:
+                await fs_resource_handler.remove_media_resources_path(
+                    platform.id, rom.id, media_type
+                )
+            except FileNotFoundError:
+                pass
 
     log.debug(f"Scanning {rom.fs_name}...")
     scanned_rom = await scan_rom(

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -11,6 +11,7 @@ from rq import Worker
 from rq.job import Job
 
 from config import DEV_MODE, REDIS_URL, SCAN_TIMEOUT, SCAN_WORKERS, TASK_RESULT_TTL
+from config.config_manager import MetadataMediaType
 from config.config_manager import config_manager as cm
 from endpoints.responses import TaskType
 from endpoints.responses.platform import PlatformSchema
@@ -294,6 +295,21 @@ async def _identify_rom(
                 "ra_hash": parsed_rom_files.ra_hash,
             }
         )
+
+    # For a COMPLETE rescan, wipe all downloaded resources before re-fetching so
+    # stale files (e.g. a cover from the wrong region) can't be reused. The
+    # post-scan download steps below skip downloads when a file already exists or
+    # when the source URL is unchanged, so the on-disk files must be removed here.
+    if not newly_added and scan_type == ScanType.COMPLETE:
+        await fs_resource_handler.remove_cover(rom)
+        await fs_resource_handler.remove_manual(rom)
+        await fs_resource_handler.remove_directory(
+            f"{rom.fs_resources_path}/screenshots"
+        )
+        for media_type in MetadataMediaType:
+            await fs_resource_handler.remove_media_resources_path(
+                platform.id, rom.id, media_type
+            )
 
     log.debug(f"Scanning {rom.fs_name}...")
     scanned_rom = await scan_rom(

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -888,6 +888,19 @@ async def scan_rom(
                 if fields["metadata_field"]:
                     rom_attrs[fields["metadata_field"]] = {}
 
+        # Reset artwork fields so stale values are nulled when no source supplies them
+        rom_attrs.update(
+            {
+                "url_cover": None,
+                "url_screenshots": [],
+                "url_manual": None,
+                "path_cover_s": None,
+                "path_cover_l": None,
+                "path_screenshots": [],
+                "path_manual": None,
+            }
+        )
+
     # Determine which metadata sources are available
     available_sources = [
         name

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -888,16 +888,16 @@ async def scan_rom(
                 if fields["metadata_field"]:
                     rom_attrs[fields["metadata_field"]] = {}
 
-        # Reset artwork fields so stale values are nulled when no source supplies them
+        # Reset artwork fields so stale values are cleared when no source supplies them
         rom_attrs.update(
             {
-                "url_cover": None,
+                "url_cover": "",
                 "url_screenshots": [],
-                "url_manual": None,
-                "path_cover_s": None,
-                "path_cover_l": None,
+                "url_manual": "",
+                "path_cover_s": "",
+                "path_cover_l": "",
                 "path_screenshots": [],
-                "path_manual": None,
+                "path_manual": "",
             }
         )
 


### PR DESCRIPTION
## Problem

A **COMPLETE rescan** never deleted previously downloaded asset files, and the post-scan download steps short-circuit when work appears already done:

- `store_media_file` always skips when the destination file exists (no overwrite param)
- `get_cover` / `get_manual` / `get_rom_screenshots` only re-download when the source URL changed

So covers, screenshots, manuals, and SS/gamelist/LaunchBox extended media (miximage, bezel, box3d, logo, fanart, video, …) were reused even when a fresh fetch returned a different URL. This defeated the region-priority fix in #3396: the correct region couldn't replace an already-downloaded wrong-region cover/media because the old file was still on disk and `path_cover_s` still pointed at it.

Separately, when the sole provider of an artwork field was **deselected**, the on-disk file lingered and the `url_*` DB columns kept stale values (they're never seeded for COMPLETE, and the priority loops only *set* fields, never clear them).

## Fix

- **`endpoints/sockets/scan.py`** — for a COMPLETE rescan of an existing ROM, remove the cover, manual, screenshots, and every extended-media directory *before* re-fetching, so `get_cover`/`store_media_file` pull fresh files.
- **`handler/scan_handler.py`** — reset `url_cover`/`url_screenshots`/`url_manual` and the matching `path_*` fields for COMPLETE rescans before the priority loops run. Stale DB values are now explicitly nulled when no selected source supplies them, rather than relying on `session.merge` semantics. Clearing for deselected sources falls out as a subset of this behavior.

## Testing

`DB_HOST=127.0.0.1 uv run pytest tests/endpoints/sockets/test_scan.py tests/handler/filesystem/test_resources_handler.py tests/handler/test_fastapi.py` — 102 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)