### PR TITLE
fix(screenscraper): re-add user credentials to media file downloads

### DIFF
--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -59,7 +59,7 @@ from handler.metadata import (
     meta_ra_handler,
     meta_ss_handler,
 )
-from handler.metadata.ss_handler import get_preferred_media_types
+from handler.metadata.ss_handler import add_ss_auth_to_url, get_preferred_media_types
 from logger.formatter import BLUE
 from logger.formatter import highlight as hl
 from logger.logger import log
@@ -1402,7 +1402,9 @@ async def update_rom(
 
             if cleaned_data.get("ss_metadata", {}).get(f"{media_type.value}_path"):
                 await fs_resource_handler.store_media_file(
-                    cleaned_data["ss_metadata"][f"{media_type.value}_url"],
+                    add_ss_auth_to_url(
+                        cleaned_data["ss_metadata"][f"{media_type.value}_url"]
+                    ),
                     cleaned_data["ss_metadata"][f"{media_type.value}_path"],
                 )
 

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -31,7 +31,7 @@ from handler.filesystem import (
 )
 from handler.filesystem.roms_handler import FSRom
 from handler.metadata import meta_gamelist_handler, meta_hltb_handler
-from handler.metadata.ss_handler import get_preferred_media_types
+from handler.metadata.ss_handler import add_ss_auth_to_url, get_preferred_media_types
 from handler.redis_handler import get_job_func_name, high_prio_queue, redis_client
 from handler.scan_handler import (
     MetadataSource,
@@ -401,7 +401,9 @@ async def _identify_rom(
         for media_type in preferred_media_types:
             if _added_rom.ss_metadata.get(f"{media_type.value}_path"):
                 await fs_resource_handler.store_media_file(
-                    _added_rom.ss_metadata[f"{media_type.value}_url"],
+                    add_ss_auth_to_url(
+                        _added_rom.ss_metadata[f"{media_type.value}_url"]
+                    ),
                     _added_rom.ss_metadata[f"{media_type.value}_path"],
                 )
 

--- a/backend/handler/metadata/base_handler.py
+++ b/backend/handler/metadata/base_handler.py
@@ -116,6 +116,16 @@ def strip_sensitive_query_params(
     return urlunparse(parsed._replace(query=new_query))
 
 
+def restore_sensitive_query_params(url: str, params: dict[str, str]) -> str:
+    """Add back key/value pairs previously stripped by strip_sensitive_query_params."""
+    parsed = urlparse(url)
+    qsl = parse_qsl(parsed.query, keep_blank_values=True)
+    existing = {k.lower() for k in params}
+    filtered = [(k, v) for k, v in qsl if k.lower() not in existing]
+    new_query = urlencode(filtered + list(params.items()))
+    return urlunparse(parsed._replace(query=new_query))
+
+
 class MetadataHandler(abc.ABC):
     SEARCH_TERM_SPLIT_PATTERN = re.compile(r"[\:\-\/]")
     SEARCH_TERM_NORMALIZER = re.compile(r"\s*[:-]\s+")

--- a/backend/handler/metadata/base_handler.py
+++ b/backend/handler/metadata/base_handler.py
@@ -106,6 +106,7 @@ def _normalize_search_term(
 def strip_sensitive_query_params(
     url: str, sensitive_keys: set[str] = SENSITIVE_KEYS
 ) -> str:
+    """Remove sensitive query parameters from a URL."""
     parsed = urlparse(url)
     qsl = parse_qsl(parsed.query, keep_blank_values=True)
 
@@ -120,8 +121,10 @@ def restore_sensitive_query_params(url: str, params: dict[str, str]) -> str:
     """Add back key/value pairs previously stripped by strip_sensitive_query_params."""
     parsed = urlparse(url)
     qsl = parse_qsl(parsed.query, keep_blank_values=True)
+
     existing = {k.lower() for k in params}
     filtered = [(k, v) for k, v in qsl if k.lower() not in existing]
+
     new_query = urlencode(filtered + list(params.items()))
     return urlunparse(parsed._replace(query=new_query))
 

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -36,17 +36,16 @@ SENSITIVE_KEYS = {"ssid", "sspassword"}
 
 def add_ss_auth_to_url(url: str) -> str:
     """Re-add SS user credentials to a media URL at download time (never stored)."""
-    creds = {
-        k: v
-        for k, v in {
+    if not SCREENSCRAPER_USER or not SCREENSCRAPER_PASSWORD:
+        return url
+
+    return restore_sensitive_query_params(
+        url,
+        {
             "ssid": SCREENSCRAPER_USER,
             "sspassword": SCREENSCRAPER_PASSWORD,
-        }.items()
-        if v
-    }
-    if not creds:
-        return url
-    return restore_sensitive_query_params(url, creds)
+        },
+    )
 
 
 def get_preferred_regions(rom: Rom | None = None) -> list[str]:

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -27,10 +27,26 @@ from .base_handler import (
 )
 from .base_handler import UniversalPlatformSlug as UPS
 from .base_handler import (
+    restore_sensitive_query_params,
     strip_sensitive_query_params,
 )
 
 SENSITIVE_KEYS = {"ssid", "sspassword"}
+
+
+def add_ss_auth_to_url(url: str) -> str:
+    """Re-add SS user credentials to a media URL at download time (never stored)."""
+    creds = {
+        k: v
+        for k, v in {
+            "ssid": SCREENSCRAPER_USER,
+            "sspassword": SCREENSCRAPER_PASSWORD,
+        }.items()
+        if v
+    }
+    if not creds:
+        return url
+    return restore_sensitive_query_params(url, creds)
 
 
 def get_preferred_regions(rom: Rom | None = None) -> list[str]:

--- a/backend/tests/handler/metadata/test_base_handler.py
+++ b/backend/tests/handler/metadata/test_base_handler.py
@@ -1,6 +1,7 @@
 import json
 import re
 from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qsl, urlparse
 
 import pytest
 
@@ -21,6 +22,8 @@ from handler.metadata.base_handler import (
     MetadataHandler,
     UniversalPlatformSlug,
     _normalize_search_term,
+    restore_sensitive_query_params,
+    strip_sensitive_query_params,
 )
 from handler.redis_handler import async_cache
 
@@ -398,6 +401,152 @@ class TestMetadataHandlerMethods:
         values = {"api_key": "ab"}
         result = handler._mask_sensitive_values(values)
         assert result["api_key"] == "ab***ab"  # Shows first 2 and last 2
+
+
+class TestStripSensitiveQueryParams:
+    """Test the strip_sensitive_query_params function."""
+
+    def test_removes_known_sensitive_keys(self):
+        """ssid and sspassword should be stripped from the query string."""
+        url = "https://api.example.com/media?ssid=user&sspassword=secret&crc=abc"
+        result = strip_sensitive_query_params(url)
+        assert "ssid=" not in result
+        assert "sspassword=" not in result
+        assert "crc=abc" in result
+
+    def test_preserves_non_sensitive_params(self):
+        """Non-sensitive params should keep their values and ordering."""
+        url = "https://api.example.com/media?systemeid=1&ssid=user&romnom=Game.zip"
+        result = strip_sensitive_query_params(url)
+        # parse rather than rely on a literal — urlencode may reorder identically-named keys
+        parsed = parse_qsl(urlparse(result).query, keep_blank_values=True)
+        assert ("systemeid", "1") in parsed
+        assert ("romnom", "Game.zip") in parsed
+        assert all(k != "ssid" for k, _ in parsed)
+
+    def test_case_insensitive_key_matching(self):
+        """Keys should match regardless of case (SSID, SsId, etc.)."""
+        url = "https://api.example.com/media?SSID=user&SSPassword=secret&crc=abc"
+        result = strip_sensitive_query_params(url)
+        assert "SSID=" not in result
+        assert "SSPassword=" not in result
+        assert "crc=abc" in result
+
+    def test_url_with_no_query(self):
+        """URLs without a query string should pass through unchanged in shape."""
+        url = "https://api.example.com/media"
+        result = strip_sensitive_query_params(url)
+        assert result == "https://api.example.com/media"
+
+    def test_url_with_no_sensitive_params(self):
+        """URLs whose params are all non-sensitive should be preserved."""
+        url = "https://api.example.com/media?systemeid=1&romnom=Game.zip"
+        result = strip_sensitive_query_params(url)
+        parsed = parse_qsl(urlparse(result).query, keep_blank_values=True)
+        assert ("systemeid", "1") in parsed
+        assert ("romnom", "Game.zip") in parsed
+
+    def test_preserves_other_url_components(self):
+        """Scheme, host, path, and fragment should be preserved."""
+        url = "https://api.example.com:8080/path/to/media?ssid=u&keep=1#frag"
+        result = strip_sensitive_query_params(url)
+        parsed = urlparse(result)
+        assert parsed.scheme == "https"
+        assert parsed.netloc == "api.example.com:8080"
+        assert parsed.path == "/path/to/media"
+        assert parsed.fragment == "frag"
+        assert "ssid" not in parsed.query
+
+    def test_custom_sensitive_keys_override(self):
+        """A caller-supplied sensitive_keys set should override the default."""
+        url = "https://api.example.com/m?ssid=user&token=tk&keep=1"
+        result = strip_sensitive_query_params(url, sensitive_keys={"token"})
+        parsed = parse_qsl(urlparse(result).query, keep_blank_values=True)
+        # ssid is not in the custom set so it stays; token is stripped
+        assert ("ssid", "user") in parsed
+        assert ("keep", "1") in parsed
+        assert all(k != "token" for k, _ in parsed)
+
+    def test_blank_values_preserved(self):
+        """Blank values for non-sensitive keys should not be dropped."""
+        url = "https://api.example.com/m?empty=&keep=1&ssid=user"
+        result = strip_sensitive_query_params(url)
+        parsed = parse_qsl(urlparse(result).query, keep_blank_values=True)
+        assert ("empty", "") in parsed
+        assert ("keep", "1") in parsed
+
+
+class TestRestoreSensitiveQueryParams:
+    """Test the restore_sensitive_query_params function."""
+
+    def test_appends_to_url_with_no_query(self):
+        """Restoring onto a URL with no query should produce a valid query."""
+        url = "https://api.example.com/media"
+        result = restore_sensitive_query_params(
+            url, {"ssid": "user", "sspassword": "secret"}
+        )
+        parsed = parse_qsl(urlparse(result).query, keep_blank_values=True)
+        assert ("ssid", "user") in parsed
+        assert ("sspassword", "secret") in parsed
+
+    def test_preserves_existing_non_conflicting_params(self):
+        """Other params present on the URL must be kept alongside restored ones."""
+        url = "https://api.example.com/m?systemeid=1&romnom=Game.zip"
+        result = restore_sensitive_query_params(url, {"ssid": "user"})
+        parsed = parse_qsl(urlparse(result).query, keep_blank_values=True)
+        assert ("systemeid", "1") in parsed
+        assert ("romnom", "Game.zip") in parsed
+        assert ("ssid", "user") in parsed
+
+    def test_overwrites_existing_same_key_no_duplicates(self):
+        """If the URL already has the key, it should be replaced, not duplicated."""
+        url = "https://api.example.com/m?ssid=old&keep=1"
+        result = restore_sensitive_query_params(url, {"ssid": "new"})
+        parsed = parse_qsl(urlparse(result).query, keep_blank_values=True)
+        ssid_values = [v for k, v in parsed if k == "ssid"]
+        assert ssid_values == ["new"]
+        assert ("keep", "1") in parsed
+
+    def test_overwrite_is_case_insensitive(self):
+        """Existing keys differing only in case should still be replaced."""
+        url = "https://api.example.com/m?SSID=old&keep=1"
+        result = restore_sensitive_query_params(url, {"ssid": "new"})
+        parsed = parse_qsl(urlparse(result).query, keep_blank_values=True)
+        # No leftover SSID=old entry under any casing
+        ssid_values = [v for k, v in parsed if k.lower() == "ssid"]
+        assert ssid_values == ["new"]
+
+    def test_encodes_special_characters_in_values(self):
+        """Values with reserved URL characters must be percent-encoded."""
+        url = "https://api.example.com/m"
+        result = restore_sensitive_query_params(url, {"sspassword": "p@ss w&rd=!"})
+        # The raw value must not appear unencoded in the query
+        assert "p@ss w&rd=!" not in result
+        # But round-tripping through parse_qsl recovers the original value
+        parsed = parse_qsl(urlparse(result).query, keep_blank_values=True)
+        assert ("sspassword", "p@ss w&rd=!") in parsed
+
+    def test_preserves_other_url_components(self):
+        """Scheme, host, path, and fragment should be preserved."""
+        url = "https://api.example.com:8080/path?keep=1#frag"
+        result = restore_sensitive_query_params(url, {"ssid": "u"})
+        parsed = urlparse(result)
+        assert parsed.scheme == "https"
+        assert parsed.netloc == "api.example.com:8080"
+        assert parsed.path == "/path"
+        assert parsed.fragment == "frag"
+
+    def test_strip_then_restore_roundtrip(self):
+        """strip → restore should recover an equivalent URL for the credential keys."""
+        original = "https://api.example.com/m?ssid=user&sspassword=secret&crc=abc"
+        stripped = strip_sensitive_query_params(original)
+        restored = restore_sensitive_query_params(
+            stripped, {"ssid": "user", "sspassword": "secret"}
+        )
+        parsed = parse_qsl(urlparse(restored).query, keep_blank_values=True)
+        assert ("ssid", "user") in parsed
+        assert ("sspassword", "secret") in parsed
+        assert ("crc", "abc") in parsed
 
 
 class TestRegexPatterns:

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -9,6 +9,7 @@ from config.config_manager import Config, MetadataMediaType
 from handler.metadata.ss_handler import (
     _get_rom_type,
     _is_notgame,
+    add_ss_auth_to_url,
     extract_media_from_ss_game,
     get_preferred_regions,
 )
@@ -314,6 +315,142 @@ class TestExtractMediaSensitiveKeyStripping:
             result = extract_media_from_ss_game(rom, game)
 
         assert result["box2d_url"] == clean_url
+
+
+class TestAddSsAuthToUrl:
+    """Tests for add_ss_auth_to_url — re-attaches user creds at download time."""
+
+    def test_appends_credentials_when_configured(self):
+        """With both user and password set, creds are appended to the URL."""
+        url = "https://screenscraper.fr/img.png?systemeid=1&romnom=Game.zip"
+        with (
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_USER", "user1"),
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_PASSWORD", "pw1"),
+        ):
+            result = add_ss_auth_to_url(url)
+
+        query = parse_qs(urlparse(result).query)
+        assert query.get("ssid") == ["user1"]
+        assert query.get("sspassword") == ["pw1"]
+        # Other params are preserved
+        assert query.get("systemeid") == ["1"]
+        assert query.get("romnom") == ["Game.zip"]
+
+    def test_no_op_when_user_missing(self):
+        """If SCREENSCRAPER_USER is unset, the URL is returned unchanged."""
+        url = "https://screenscraper.fr/img.png?systemeid=1"
+        with (
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_USER", ""),
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_PASSWORD", "pw1"),
+        ):
+            result = add_ss_auth_to_url(url)
+
+        assert result == url
+
+    def test_no_op_when_password_missing(self):
+        """If SCREENSCRAPER_PASSWORD is unset, the URL is returned unchanged."""
+        url = "https://screenscraper.fr/img.png?systemeid=1"
+        with (
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_USER", "user1"),
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_PASSWORD", ""),
+        ):
+            result = add_ss_auth_to_url(url)
+
+        assert result == url
+
+    def test_does_not_duplicate_existing_credentials(self):
+        """Pre-existing ssid/sspassword on the URL are replaced, not duplicated."""
+        url = "https://screenscraper.fr/img.png?ssid=old&sspassword=oldpw&keep=1"
+        with (
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_USER", "new"),
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_PASSWORD", "newpw"),
+        ):
+            result = add_ss_auth_to_url(url)
+
+        query = parse_qs(urlparse(result).query)
+        # Exactly one occurrence of each, with the new values
+        assert query.get("ssid") == ["new"]
+        assert query.get("sspassword") == ["newpw"]
+        assert query.get("keep") == ["1"]
+
+    def test_handles_stripped_url_from_extract_media(self):
+        """A URL that's already had ssid/sspassword stripped (the storage form)
+        gets credentials re-attached cleanly, with dev creds and other params
+        left intact."""
+        # Shape mirrors what extract_media_from_ss_game persists
+        stripped_url = (
+            "https://screenscraper.fr/img.png?devid=dev&devpassword=devpw&other=keep"
+        )
+        with (
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_USER", "user1"),
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_PASSWORD", "pw1"),
+        ):
+            result = add_ss_auth_to_url(stripped_url)
+
+        query = parse_qs(urlparse(result).query)
+        assert query.get("ssid") == ["user1"]
+        assert query.get("sspassword") == ["pw1"]
+        assert query.get("devid") == ["dev"]
+        assert query.get("devpassword") == ["devpw"]
+        assert query.get("other") == ["keep"]
+
+    def test_strip_then_reauth_roundtrip(self):
+        """End-to-end: storing media strips user creds; download-time auth
+        restores them without leaking creds into intermediate state."""
+        config = _make_config()
+        rom = MagicMock()
+        rom.platform_id = 1
+        rom.id = 100
+        original_url = (
+            "https://screenscraper.fr/img.png"
+            "?ssid=scanner-user&sspassword=scanner-pw&systemeid=1"
+        )
+        game = cast(
+            SSGame,
+            {
+                "medias": [
+                    {
+                        "type": "box-2D",
+                        "parent": "jeu",
+                        "region": "us",
+                        "url": original_url,
+                        "crc": "",
+                        "md5": "",
+                        "sha1": "",
+                        "size": "0",
+                        "format": "png",
+                    }
+                ]
+            },
+        )
+        with (
+            patch("handler.metadata.ss_handler.cm.get_config", return_value=config),
+            patch(
+                "handler.metadata.ss_handler.fs_resource_handler.get_media_resources_path",
+                return_value="roms/1/100/box2d",
+            ),
+        ):
+            extracted = extract_media_from_ss_game(rom, game)
+
+        stored_url = extracted["box2d_url"]
+        assert stored_url is not None
+
+        # Stored URL must not carry user creds
+        stored_query = parse_qs(urlparse(stored_url).query)
+        assert "ssid" not in stored_query
+        assert "sspassword" not in stored_query
+
+        # At download time, add_ss_auth_to_url re-attaches the *current* creds
+        with (
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_USER", "download-user"),
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_PASSWORD", "download-pw"),
+        ):
+            download_url = add_ss_auth_to_url(stored_url)
+
+        download_query = parse_qs(urlparse(download_url).query)
+        assert download_query.get("ssid") == ["download-user"]
+        assert download_query.get("sspassword") == ["download-pw"]
+        assert download_query.get("systemeid") == ["1"]
 
 
 class TestGetRomType:


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
When RomM downloads media files from ScreenScraper (cover art, screenshots, video, manual — all media types), `ssid`/`sspassword` were absent from the HTTP request. This caused every media download to count against the **anonymous IP quota** rather than the authenticated user's personal quota, which has a significantly lower daily limit.

**Root cause:**
`extract_media_from_ss_game()` correctly strips `ssid`/`sspassword` from every media URL before storing it in the database (so credentials are never persisted). However, at download time `store_media_file()` issues a plain `httpx` GET against the stripped URL with no credentials re-attached.

Note: All SS info/search API calls (`jeuInfos.php`, `jeuRecherche.php`, `ssinfraInfos.php`) already use the authenticated aiohttp client via `auth_middleware` and are not affected.

**Fix:**
#3413 
- Adds `restore_sensitive_query_params(url, params)` to `base_handler.py` as the principled complement to the existing `strip_sensitive_query_params()` — same `urllib.parse` plumbing, same key-set authority
- Adds `add_ss_auth_to_url(url)` to `ss_handler.py` which rebuilds credentials from config at download time using the same `SENSITIVE_KEYS` as the strip
- Wraps the SS media URL in the scan socket handler with `add_ss_auth_to_url()` before passing to `store_media_file()` — credentials are never stored, only injected ephemerally at download time

**Verified locally:**
- Stored URL in DB has no `ssid`/`sspassword` (unchanged behaviour)
- URL passed to `store_media_file` after the fix contains `ssid=<user>&sspassword=<pass>`
- Manual download returned HTTP 200 with the correct PDF payload

**Checklist**

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

> 🤖 Drafted with [Claude Code](https://claude.ai/code)