### PR TITLE
Defer optional handler initialization with lazy factories

### DIFF
--- a/backend/endpoints/device.py
+++ b/backend/endpoints/device.py
@@ -8,7 +8,7 @@ from decorators.auth import protected_route
 from endpoints.responses.device import DeviceCreateResponse, DeviceSchema
 from handler.auth.constants import Scope
 from handler.database import db_device_handler, db_device_save_sync_handler
-from handler.filesystem import fs_sync_handler
+from handler.filesystem import get_fs_sync_handler
 from logger.logger import log
 from models.device import Device, SyncMode
 from utils.router import APIRouter
@@ -123,7 +123,7 @@ def register_device(
     # Auto-create sync folders for file_transfer devices
     if payload.sync_mode == SyncMode.FILE_TRANSFER:
         try:
-            fs_sync_handler.ensure_device_directories(device_id)
+            get_fs_sync_handler().ensure_device_directories(device_id)
         except Exception:
             log.warning(f"Failed to create sync directories for device {device_id}")
 

--- a/backend/handler/filesystem/__init__.py
+++ b/backend/handler/filesystem/__init__.py
@@ -1,15 +1,30 @@
 from .assets_handler import FSAssetsHandler
 from .firmware_handler import FSFirmwareHandler
-from .launchbox_handler import FSLaunchboxHandler
+from .launchbox_handler import FSLaunchboxHandler, get_fs_launchbox_handler
 from .platforms_handler import FSPlatformsHandler
 from .resources_handler import FSResourcesHandler
 from .roms_handler import FSRomsHandler
-from .sync_handler import FSSyncHandler
+from .sync_handler import FSSyncHandler, get_fs_sync_handler
 
 fs_asset_handler = FSAssetsHandler()
 fs_firmware_handler = FSFirmwareHandler()
 fs_platform_handler = FSPlatformsHandler()
 fs_rom_handler = FSRomsHandler()
 fs_resource_handler = FSResourcesHandler()
-fs_sync_handler = FSSyncHandler()
-fs_launchbox_handler = FSLaunchboxHandler()
+
+__all__ = [
+    "FSAssetsHandler",
+    "FSFirmwareHandler",
+    "FSLaunchboxHandler",
+    "FSPlatformsHandler",
+    "FSResourcesHandler",
+    "FSRomsHandler",
+    "FSSyncHandler",
+    "fs_asset_handler",
+    "fs_firmware_handler",
+    "fs_platform_handler",
+    "fs_resource_handler",
+    "fs_rom_handler",
+    "get_fs_launchbox_handler",
+    "get_fs_sync_handler",
+]

--- a/backend/handler/filesystem/base_handler.py
+++ b/backend/handler/filesystem/base_handler.py
@@ -16,7 +16,6 @@ from anyio import open_file
 from starlette.datastructures import UploadFile
 
 from config.config_manager import config_manager as cm
-from logger.logger import log
 from models.base import FILE_NAME_MAX_LENGTH
 from utils.filesystem import iter_directories, iter_files, link_or_copy_file
 
@@ -149,22 +148,11 @@ class Asset(Enum):
 
 
 class FSHandler:
-    def __init__(self, base_path: str, tolerate_missing_base: bool = False):
+    def __init__(self, base_path: str):
         self.base_path = Path(base_path).resolve()
         self._locks: dict[str, asyncio.Lock] = {}
         self._lock_mutex = asyncio.Lock()
-
-        # Create base directory synchronously during initialization.
-        try:
-            self.base_path.mkdir(parents=True, exist_ok=True)
-        except OSError:
-            if not tolerate_missing_base:
-                raise
-
-            log.warning(
-                f"Could not create or access {self.base_path}; "
-                "feature will be unavailable until the directory is writable."
-            )
+        self.base_path.mkdir(parents=True, exist_ok=True)
 
     async def _get_file_lock(self, file_path: str) -> asyncio.Lock:
         """Get or create a lock for a specific file path."""

--- a/backend/handler/filesystem/launchbox_handler.py
+++ b/backend/handler/filesystem/launchbox_handler.py
@@ -1,7 +1,19 @@
+import functools
+
 from config import LAUNCHBOX_BASE_PATH
 from handler.filesystem.base_handler import FSHandler
 
 
 class FSLaunchboxHandler(FSHandler):
     def __init__(self) -> None:
-        super().__init__(base_path=LAUNCHBOX_BASE_PATH, tolerate_missing_base=True)
+        super().__init__(base_path=LAUNCHBOX_BASE_PATH)
+
+
+@functools.cache
+def get_fs_launchbox_handler() -> FSLaunchboxHandler:
+    """Lazily instantiate the LaunchBox handler on first use.
+
+    Deferred so that startup doesn't fail when the LaunchBox feature is
+    unconfigured or its base path is not writable.
+    """
+    return FSLaunchboxHandler()

--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -29,11 +29,13 @@ def _resolve_local_file_uri(uri: str) -> Path | None:
     under the LaunchBox data root, since LaunchBox metadata produces paths
     relative to `/romm/launchbox`, which is not the same as the library root.
     """
-    from handler.filesystem import fs_launchbox_handler, fs_rom_handler
+    from handler.filesystem import fs_rom_handler, get_fs_launchbox_handler
 
     if uri.startswith("launchbox-file://"):
         try:
-            return fs_launchbox_handler.validate_path(uri[len("launchbox-file://") :])
+            return get_fs_launchbox_handler().validate_path(
+                uri[len("launchbox-file://") :]
+            )
         except ValueError:
             return None
 

--- a/backend/handler/filesystem/sync_handler.py
+++ b/backend/handler/filesystem/sync_handler.py
@@ -1,3 +1,4 @@
+import functools
 import hashlib
 import os
 from pathlib import Path
@@ -12,7 +13,7 @@ class FSSyncHandler(FSHandler):
     """Filesystem handler for sync folder operations (File Transfer mode)."""
 
     def __init__(self) -> None:
-        super().__init__(base_path=SYNC_BASE_PATH, tolerate_missing_base=True)
+        super().__init__(base_path=SYNC_BASE_PATH)
 
     def build_incoming_path(
         self, device_id: str, platform_slug: str | None = None
@@ -110,3 +111,13 @@ class FSSyncHandler(FSHandler):
                     f"Path {full_path} is outside the sync base directory"
                 ) from e
             path.unlink()
+
+
+@functools.cache
+def get_fs_sync_handler() -> FSSyncHandler:
+    """Lazily instantiate the sync folder handler on first use.
+
+    Deferred so that startup doesn't fail when sync is unconfigured or its
+    base path is not writable.
+    """
+    return FSSyncHandler()

--- a/backend/handler/sync/ssh_handler.py
+++ b/backend/handler/sync/ssh_handler.py
@@ -11,6 +11,7 @@ device's sync_config.
 
 from __future__ import annotations
 
+import functools
 import hashlib
 import os
 import tempfile
@@ -51,12 +52,12 @@ class SSHSyncHandler:
         self.keys_path = Path(SYNC_SSH_KEYS_PATH)
         try:
             self.keys_path.mkdir(parents=True, exist_ok=True)
-        except OSError:
-            log.warning(
-                f"Could not create or access {self.keys_path}; "
-                "push-pull sync will be unavailable until the directory is writable "
-                "or keys are mounted at this path."
-            )
+        except OSError as e:
+            raise RuntimeError(
+                f"SSH keys directory {self.keys_path} is not writable ({e}). "
+                "Mount a writable volume at this path, or set SYNC_SSH_KEYS_PATH "
+                "to a writable location, to use push-pull sync."
+            ) from e
 
     def _resolve_key_path(self, device_id: str, sync_config: dict) -> str | None:
         """Resolve the SSH key path for a device.
@@ -231,4 +232,12 @@ class SSHSyncHandler:
             log.info(f"Deleted remote file: {remote_path}")
 
 
-ssh_sync_handler = SSHSyncHandler()
+@functools.cache
+def get_ssh_sync_handler() -> SSHSyncHandler:
+    """Lazily instantiate the SSH sync handler on first use.
+
+    Deferred so that startup doesn't fail when push-pull sync is unconfigured
+    or the keys directory is not writable. The handler raises a clear error
+    at call time if the directory cannot be created.
+    """
+    return SSHSyncHandler()

--- a/backend/handler/sync/ssh_handler.py
+++ b/backend/handler/sync/ssh_handler.py
@@ -49,7 +49,14 @@ class SSHSyncHandler:
 
     def __init__(self) -> None:
         self.keys_path = Path(SYNC_SSH_KEYS_PATH)
-        self.keys_path.mkdir(parents=True, exist_ok=True)
+        try:
+            self.keys_path.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            log.warning(
+                f"Could not create or access {self.keys_path}; "
+                "push-pull sync will be unavailable until the directory is writable "
+                "or keys are mounted at this path."
+            )
 
     def _resolve_key_path(self, device_id: str, sync_config: dict) -> str | None:
         """Resolve the SSH key path for a device.

--- a/backend/sync_watcher.py
+++ b/backend/sync_watcher.py
@@ -27,7 +27,7 @@ from handler.database import (
     db_save_handler,
     db_sync_session_handler,
 )
-from handler.filesystem import fs_asset_handler, fs_sync_handler
+from handler.filesystem import fs_asset_handler, get_fs_sync_handler
 from handler.sync.comparison import compare_save_state
 from logger.formatter import highlight as hl
 from logger.logger import log
@@ -48,6 +48,7 @@ def _extract_device_and_platform(path: str) -> tuple[str, str, str] | None:
 
     Expected path format: {ROMM_BASE_PATH}/sync/{device_id}/incoming/{platform_slug}/filename.ext
     """
+    fs_sync_handler = get_fs_sync_handler()
     try:
         rel_path = os.path.relpath(path, start=str(fs_sync_handler.base_path))
         parts = rel_path.split(os.sep)
@@ -62,6 +63,7 @@ def _extract_device_and_platform(path: str) -> tuple[str, str, str] | None:
 
 
 def _ensure_conflicts_dir(device_id: str, platform_slug: str) -> str:
+    fs_sync_handler = get_fs_sync_handler()
     conflicts_dir = str(
         fs_sync_handler.base_path
         / fs_sync_handler.build_conflicts_path(device_id, platform_slug)
@@ -206,6 +208,8 @@ def _process_incoming_file(
 ) -> None:
     """Process a single incoming file from a device's sync folder."""
     from endpoints.sockets.sync import emit_sync_conflict
+
+    fs_sync_handler = get_fs_sync_handler()
 
     # Look up platform
     platform = db_platform_handler.get_platform_by_fs_slug(platform_slug)

--- a/backend/tasks/manual/sync_folder_scan.py
+++ b/backend/tasks/manual/sync_folder_scan.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from config import ENABLE_SYNC_FOLDER_WATCHER
 from handler.database import db_device_handler
-from handler.filesystem import fs_sync_handler
+from handler.filesystem import get_fs_sync_handler
 from logger.logger import log
 from models.device import SyncMode
 from tasks.tasks import Task, TaskType
@@ -38,6 +38,7 @@ class SyncFolderScanTask(Task):
             log.info("No file_transfer devices found")
             return {"status": "no_devices"}
 
+        fs_sync_handler = get_fs_sync_handler()
         total_files = 0
         for device in devices:
             if not device.sync_enabled:

--- a/backend/tasks/sync_push_pull_task.py
+++ b/backend/tasks/sync_push_pull_task.py
@@ -65,7 +65,6 @@ async def run_push_pull_sync(
 
 async def _sync_device(device: Device, session_id: int | None = None) -> dict:
     """Perform push-pull sync for a single device."""
-    ssh_sync_handler = get_ssh_sync_handler()
     sync_config = device.sync_config or {}
     if not sync_config.get("ssh_host"):
         log.warning(f"Push-pull device {device.id} has no ssh_host configured")
@@ -103,6 +102,7 @@ async def _sync_device(device: Device, session_id: int | None = None) -> dict:
     )
 
     try:
+        ssh_sync_handler = get_ssh_sync_handler()
         conn = await ssh_sync_handler.connect(sync_config, device_id=device.id)
     except Exception as e:
         log.error(f"Push-pull: failed to connect to device {device.id}: {e}")

--- a/backend/tasks/sync_push_pull_task.py
+++ b/backend/tasks/sync_push_pull_task.py
@@ -21,7 +21,7 @@ from handler.database import (
 )
 from handler.filesystem import fs_asset_handler
 from handler.sync.comparison import compare_save_state
-from handler.sync.ssh_handler import ssh_sync_handler
+from handler.sync.ssh_handler import get_ssh_sync_handler
 from logger.formatter import highlight as hl
 from logger.logger import log
 from models.device import Device, SyncMode
@@ -65,6 +65,7 @@ async def run_push_pull_sync(
 
 async def _sync_device(device: Device, session_id: int | None = None) -> dict:
     """Perform push-pull sync for a single device."""
+    ssh_sync_handler = get_ssh_sync_handler()
     sync_config = device.sync_config or {}
     if not sync_config.get("ssh_host"):
         log.warning(f"Push-pull device {device.id} has no ssh_host configured")
@@ -227,6 +228,7 @@ async def _process_remote_save(
     remote_save,
 ) -> str:
     """Process a single remote save file. Returns action taken."""
+    ssh_sync_handler = get_ssh_sync_handler()
     # Look up platform
     platform = db_platform_handler.get_platform_by_fs_slug(remote_save.platform_slug)
     if not platform:
@@ -340,6 +342,7 @@ async def _push_missing_saves(
     save_directories: list[dict],
 ) -> int:
     """Push server saves that are missing from the device."""
+    ssh_sync_handler = get_ssh_sync_handler()
     pushed = 0
 
     # Build set of remote filenames per platform

--- a/backend/tests/handler/filesystem/test_base_handler.py
+++ b/backend/tests/handler/filesystem/test_base_handler.py
@@ -585,50 +585,13 @@ class TestFSHandler:
             await handler.copy_file(handler.base_path / "missing.bin", "dest.bin")
 
 
-class TestFSHandlerTolerateMissingBase:
-    """Tests for the tolerate_missing_base flag, which lets optional features
-    (like the sync folder) come up degraded instead of crashing the whole app
-    when the base path can't be created."""
-
-    def test_default_raises_on_mkdir_failure(self):
-        """Default behavior: an OSError from mkdir propagates, so misconfigured
-        critical paths (resources, library) still fail loudly at startup."""
+class TestFSHandlerInit:
+    def test_raises_on_mkdir_failure(self):
+        """OSError from mkdir propagates, so misconfigured paths fail loudly
+        at construction time. Optional features should defer construction
+        (e.g. via a lazy factory) rather than swallow the error."""
         with patch.object(
             Path, "mkdir", side_effect=PermissionError(errno.EACCES, "denied")
         ):
             with pytest.raises(PermissionError):
                 FSHandler("/some/unwritable/path")
-
-    def test_tolerate_missing_base_swallows_oserror(self, tmp_path, caplog):
-        """With tolerate_missing_base=True, mkdir failure is logged but does
-        not raise — the handler instance is still constructed so module-level
-        imports don't crash."""
-        target = tmp_path / "missing"
-
-        with patch.object(
-            Path, "mkdir", side_effect=PermissionError(errno.EACCES, "denied")
-        ):
-            handler = FSHandler(str(target), tolerate_missing_base=True)
-
-        # Handler exists and base_path is set, even though the directory
-        # could not be created.
-        assert handler.base_path == target.resolve()
-        assert not handler.base_path.exists()
-
-    def test_tolerate_missing_base_still_creates_when_possible(self, tmp_path):
-        """tolerate_missing_base=True should not change behavior when mkdir
-        succeeds — the directory must still be created normally."""
-        target = tmp_path / "new_dir"
-        assert not target.exists()
-
-        handler = FSHandler(str(target), tolerate_missing_base=True)
-
-        assert handler.base_path.exists()
-        assert handler.base_path.is_dir()
-
-    def test_tolerate_missing_base_reraises_non_oserror(self, tmp_path):
-        """Only OSError gets swallowed; programming errors (e.g. a RuntimeError
-        from corrupted state) must still surface."""
-        with patch.object(Path, "mkdir", side_effect=RuntimeError("unexpected")):
-            with pytest.raises(RuntimeError, match="unexpected"):
-                FSHandler(str(tmp_path / "x"), tolerate_missing_base=True)

--- a/backend/tests/handler/filesystem/test_sync_handler.py
+++ b/backend/tests/handler/filesystem/test_sync_handler.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
-from handler.filesystem.sync_handler import FSSyncHandler
+from handler.filesystem.sync_handler import FSSyncHandler, get_fs_sync_handler
 
 
 class TestFSSyncHandler:
@@ -137,19 +137,20 @@ class TestFSSyncHandler:
         handler.remove_incoming_file("/nonexistent/path/file.sav")
 
 
-class TestFSSyncHandlerStartup:
+class TestFSSyncHandlerLazyFactory:
     """Sync is an optional feature: if /romm/sync isn't writable (bad mount,
-    wrong ownership), the app must still boot. Failures should surface when
-    sync is actually used, not at module-import time."""
+    wrong ownership), the app must still boot. The factory defers construction
+    until first use so the error surfaces at the call site, not at startup."""
 
-    def test_init_does_not_raise_when_base_path_unwritable(self):
-        """Regression test for the PermissionError on /romm/sync at boot.
-        FSSyncHandler must construct successfully even when mkdir fails."""
-        with patch.object(
-            Path, "mkdir", side_effect=PermissionError(errno.EACCES, "denied")
-        ):
-            handler = FSSyncHandler()
-
-        assert handler is not None
-        # base_path is set even though the directory wasn't created.
-        assert isinstance(handler.base_path, Path)
+    def test_factory_raises_at_call_time_when_unwritable(self):
+        """Regression for the PermissionError on /romm/sync at boot: the
+        failure must surface from the factory call, not from module import."""
+        get_fs_sync_handler.cache_clear()
+        try:
+            with patch.object(
+                Path, "mkdir", side_effect=PermissionError(errno.EACCES, "denied")
+            ):
+                with pytest.raises(PermissionError):
+                    get_fs_sync_handler()
+        finally:
+            get_fs_sync_handler.cache_clear()

--- a/backend/tests/test_sync_watcher.py
+++ b/backend/tests/test_sync_watcher.py
@@ -23,7 +23,7 @@ class TestExtractDeviceAndPlatform:
     @pytest.fixture(autouse=True)
     def patch_base_path(self, handler: FSSyncHandler, temp_dir):
         handler.base_path = Path(temp_dir)
-        with patch("sync_watcher.fs_sync_handler", handler):
+        with patch("sync_watcher.get_fs_sync_handler", return_value=handler):
             yield
 
     def test_extract_valid_incoming_path(self, temp_dir):
@@ -77,7 +77,7 @@ class TestEnsureConflictsDir:
     @pytest.fixture(autouse=True)
     def patch_base_path(self, handler: FSSyncHandler, temp_dir):
         handler.base_path = Path(temp_dir)
-        with patch("sync_watcher.fs_sync_handler", handler):
+        with patch("sync_watcher.get_fs_sync_handler", return_value=handler):
             yield
 
     def test_creates_directory_and_returns_path(self, temp_dir):

--- a/env.template
+++ b/env.template
@@ -87,8 +87,7 @@ SCHEDULED_CONVERT_IMAGES_TO_WEBP_CRON=0 4 * * *  # Cron expression for scheduled
 ENABLE_SCHEDULED_RETROACHIEVEMENTS_PROGRESS_SYNC=false  # Enable scheduled RetroAchievements progress sync
 SCHEDULED_RETROACHIEVEMENTS_PROGRESS_SYNC_CRON=0 4 * * *  # Cron expression for scheduled RetroAchievements sync
 
-# Sync — both modes use $ROMM_BASE_PATH/sync by default. Mount a writable
-# volume at that path when enabling either feature.
+# Sync
 ENABLE_SYNC_FOLDER_WATCHER=false  # Watch the sync folder and trigger scans on change
 SYNC_FOLDER_SCAN_DELAY=2  # Delay in minutes before scanning after a sync folder change
 ENABLE_SYNC_PUSH_PULL=false  # Enable scheduled sync push/pull

--- a/env.template
+++ b/env.template
@@ -87,7 +87,8 @@ SCHEDULED_CONVERT_IMAGES_TO_WEBP_CRON=0 4 * * *  # Cron expression for scheduled
 ENABLE_SCHEDULED_RETROACHIEVEMENTS_PROGRESS_SYNC=false  # Enable scheduled RetroAchievements progress sync
 SCHEDULED_RETROACHIEVEMENTS_PROGRESS_SYNC_CRON=0 4 * * *  # Cron expression for scheduled RetroAchievements sync
 
-# Sync
+# Sync — both modes use $ROMM_BASE_PATH/sync by default. Mount a writable
+# volume at that path when enabling either feature.
 ENABLE_SYNC_FOLDER_WATCHER=false  # Watch the sync folder and trigger scans on change
 SYNC_FOLDER_SCAN_DELAY=2  # Delay in minutes before scanning after a sync folder change
 ENABLE_SYNC_PUSH_PULL=false  # Enable scheduled sync push/pull


### PR DESCRIPTION
**Description**

This PR refactors optional filesystem and sync handlers to use lazy factory functions instead of eager module-level instantiation. This prevents startup failures when optional features (sync folder, push-pull sync, LaunchBox) have misconfigured or unwritable base paths.

**Key Changes**

1. **Removed `tolerate_missing_base` parameter** from `FSHandler.__init__()`. The base class now always raises on mkdir failures, which is appropriate for critical paths (resources, library, etc.).

2. **Added lazy factory functions** for optional features:
   - `get_fs_sync_handler()` — defers sync folder handler creation
   - `get_fs_launchbox_handler()` — defers LaunchBox handler creation
   - `get_ssh_sync_handler()` — defers SSH sync handler creation
   
   Each factory is decorated with `@functools.cache` to ensure a single instance per process.

3. **Updated all call sites** to invoke the factory functions instead of using module-level instances:
   - `sync_watcher.py` — calls factory in functions that use the handler
   - `tasks/sync_push_pull_task.py` — calls factory in async functions
   - `endpoints/device.py` — calls factory when creating sync directories
   - `resources_handler.py` — calls factory when resolving LaunchBox URIs
   - `tasks/manual/sync_folder_scan.py` — calls factory in task execution

4. **Improved error handling** in `SSHSyncHandler.__init__()` to wrap OSError in a clear RuntimeError with actionable guidance.

5. **Updated tests** to reflect the new lazy initialization pattern:
   - Removed tests for `tolerate_missing_base` behavior
   - Added test verifying factory raises at call time, not at import time
   - Updated mocks to patch factory functions instead of module-level instances

6. **Updated `__init__.py`** to export factory functions and added `__all__` for clarity.

**Rationale**

Optional features should not prevent application startup. By deferring handler construction to first use via cached factories, errors surface at the call site (where they can be handled) rather than at module import time (where they crash the entire app). Critical paths continue to fail fast at construction time, maintaining safety for essential features.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've added unit tests that cover the changes

https://claude.ai/code/session_01SoE8ZS7hNqiLu6LYKUuk41