### PR TITLE
fix(nginx): use Buffer for binary-safe base64 decode in m3u endpoint

### DIFF
--- a/docker/nginx/js/decode.js
+++ b/docker/nginx/js/decode.js
@@ -9,8 +9,10 @@ function decodeBase64(r) {
   }
 
   try {
-    var decodedValue = atob(encodedValue);
-    r.return(200, decodedValue);
+    // Use Buffer to return raw bytes — atob() returns a JS string which r.return()
+    // would re-encode as UTF-8, corrupting any non-ASCII bytes (e.g. in filenames
+    // like "Pokémon") and causing CRC mismatches in the mod_zip manifest.
+    r.return(200, Buffer.from(encodedValue, 'base64'));
   } catch (e) {
     r.return(400, "Invalid Base64 encoding");
   }


### PR DESCRIPTION
**Description**
Fixes #3427.

The internal `/decode` nginx endpoint decodes a base64-encoded `.m3u` payload for inclusion in `mod_zip` archives. It previously used `atob()` which returns a JS string — when passed to `r.return()`, njs re-encodes that string as UTF-8, double-encoding any bytes above `0x7F`. This causes the bytes served to differ from what the Python backend computed the CRC32 over, resulting in a CRC failure on the `.m3u` file for any ROM whose filenames contain non-ASCII characters (e.g. Pokémon).

`Buffer.from(value, 'base64')` decodes directly to a byte array and `r.return()` sends it verbatim with no re-encoding, so the CRC matches exactly.

Verified by downloading Pokémon Violet (US) (3 `.nsp` files with non-ASCII names) as a ZIP before and after the fix.

> [!IMPORTANT]
> **AI Assistance Disclosure:** The root cause analysis, fix, and PR description were generated with Claude Code (Anthropic). The fix was verified manually by the contributor on a self-hosted Unraid instance.

**Checklist**
- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes