### PR TITLE
chore: remove obsolete 'version' attribute

### DIFF
--- a/examples/docker-compose.example.yml
+++ b/examples/docker-compose.example.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 volumes:
   mysql_data:
   romm_resources:


### PR DESCRIPTION
Remove the now obsolete 'version' attribute in the example docker compose file.