### PR TITLE
Fix save-sync hash drift, archival save leak, and dedupe scoping

### DIFF
--- a/backend/endpoints/saves.py
+++ b/backend/endpoints/saves.py
@@ -162,7 +162,7 @@ async def add_save(
         actual_filename = _apply_datetime_tag(sanitized_save_filename)
 
     db_save = db_save_handler.get_save_by_filename(
-        user_id=request.user.id, rom_id=rom.id, file_name=actual_filename
+        user_id=request.user.id, rom_id=rom.id, file_name=actual_filename, slot=slot
     )
 
     if device and slot and not overwrite:
@@ -222,6 +222,7 @@ async def add_save(
             user_id=request.user.id,
             rom_id=rom.id,
             content_hash=scanned_save.content_hash,
+            slot=slot,
         )
         if existing_by_hash:
             try:

--- a/backend/endpoints/sync.py
+++ b/backend/endpoints/sync.py
@@ -115,9 +115,15 @@ def negotiate_sync(
 
     operations: list[SyncOperationSchema] = []
 
-    # Build a set of server saves for this user, keyed by (rom_id, file_name)
-    # We'll also track which server saves were mentioned by the client
-    server_saves = db_save_handler.get_saves(user_id=request.user.id)
+    # Build a set of server saves for this user, keyed by (rom_id, file_name).
+    # Only slot-bound saves participate in sync; null-slot saves are web-UI or
+    # archival uploads and act as backups (clients can opt-in to import them
+    # outside the sync flow).
+    server_saves = [
+        s
+        for s in db_save_handler.get_saves(user_id=request.user.id)
+        if s.slot is not None
+    ]
     server_save_map: dict[tuple[int, str], Save] = {}
     for save in server_saves:
         server_save_map[(save.rom_id, save.file_name)] = save

--- a/backend/endpoints/sync.py
+++ b/backend/endpoints/sync.py
@@ -118,12 +118,11 @@ def negotiate_sync(
     # Build a set of server saves for this user, keyed by (rom_id, file_name).
     # Only slot-bound saves participate in sync; null-slot saves are web-UI or
     # archival uploads and act as backups (clients can opt-in to import them
-    # outside the sync flow).
-    server_saves = [
-        s
-        for s in db_save_handler.get_saves(user_id=request.user.id)
-        if s.slot is not None
-    ]
+    # outside the sync flow). Filtering in SQL avoids materializing archival
+    # rows we'd immediately discard.
+    server_saves = db_save_handler.get_saves(
+        user_id=request.user.id, slot_not_null=True
+    )
     server_save_map: dict[tuple[int, str], Save] = {}
     for save in server_saves:
         server_save_map[(save.rom_id, save.file_name)] = save

--- a/backend/endpoints/tasks.py
+++ b/backend/endpoints/tasks.py
@@ -36,6 +36,9 @@ from handler.redis_handler import (
 )
 from tasks.manual.cleanup_missing_roms import cleanup_missing_roms_task
 from tasks.manual.cleanup_orphaned_resources import cleanup_orphaned_resources_task
+from tasks.manual.recompute_save_content_hashes import (
+    recompute_save_content_hashes_task,
+)
 from tasks.manual.sync_folder_scan import sync_folder_scan_task
 from tasks.scheduled.convert_images_to_webp import convert_images_to_webp_task
 from tasks.scheduled.scan_library import scan_library_task
@@ -114,6 +117,13 @@ manual_tasks: list[ManualTask] = [
             "name": "sync_folder_scan",
             "type": TaskType.SYNC,
             "task": sync_folder_scan_task,
+        }
+    ),
+    ManualTask(
+        {
+            "name": "recompute_save_content_hashes",
+            "type": TaskType.CLEANUP,
+            "task": recompute_save_content_hashes_task,
         }
     ),
 ]

--- a/backend/handler/database/saves_handler.py
+++ b/backend/handler/database/saves_handler.py
@@ -68,6 +68,7 @@ class DBSavesHandler(DBBaseHandler):
         rom_id: int | None = None,
         platform_id: int | None = None,
         slot: str | None = None,
+        slot_not_null: bool = False,
         order_by: Literal["updated_at", "created_at"] | None = None,
         order_dir: Literal["asc", "desc"] = "desc",
         only_fields: Sequence[QueryableAttribute] | None = None,
@@ -85,6 +86,9 @@ class DBSavesHandler(DBBaseHandler):
 
         if slot is not None:
             query = query.filter(Save.slot == slot)
+
+        if slot_not_null:
+            query = query.filter(Save.slot.is_not(None))
 
         if order_by:
             order_col = getattr(Save, order_by)

--- a/backend/handler/database/saves_handler.py
+++ b/backend/handler/database/saves_handler.py
@@ -196,10 +196,18 @@ class DBSavesHandler(DBBaseHandler):
         )
 
     @begin_session
-    def get_all_saves(
+    def get_saves_after_id(
         self,
+        after_id: int,
+        limit: int,
         session: Session = None,  # type: ignore
     ) -> Sequence[Save]:
-        """Every Save row across all users, ordered by id. Used by the
-        recompute_save_content_hashes maintenance task."""
-        return session.scalars(select(Save).order_by(asc(Save.id))).all()
+        """Page Save rows by primary key. Returns up to ``limit`` rows with
+        ``id > after_id``, ordered by id. Used by the
+        recompute_save_content_hashes maintenance task to walk every row in
+        bounded-memory batches: streaming via ``yield_per`` is incompatible
+        with the per-call session lifetime that ``@begin_session`` enforces,
+        so the caller drives pagination with this method instead."""
+        return session.scalars(
+            select(Save).where(Save.id > after_id).order_by(asc(Save.id)).limit(limit)
+        ).all()

--- a/backend/handler/database/saves_handler.py
+++ b/backend/handler/database/saves_handler.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from typing import Literal
 
-from sqlalchemy import and_, asc, delete, desc, select, update
+from sqlalchemy import and_, asc, delete, desc, func, select, update
 from sqlalchemy.orm import QueryableAttribute, Session, load_only
 
 from decorators.database import begin_session
@@ -35,13 +35,15 @@ class DBSavesHandler(DBBaseHandler):
         user_id: int,
         rom_id: int,
         file_name: str,
+        slot: str | None = None,
         session: Session = None,  # type: ignore
     ) -> Save | None:
-        return session.scalars(
-            select(Save)
-            .filter_by(rom_id=rom_id, user_id=user_id, file_name=file_name)
-            .limit(1)
-        ).first()
+        query = select(Save).filter_by(
+            rom_id=rom_id, user_id=user_id, file_name=file_name
+        )
+        if slot is not None:
+            query = query.filter(Save.slot == slot)
+        return session.scalars(query.limit(1)).first()
 
     @begin_session
     def get_save_by_content_hash(
@@ -49,13 +51,15 @@ class DBSavesHandler(DBBaseHandler):
         user_id: int,
         rom_id: int,
         content_hash: str,
+        slot: str | None = None,
         session: Session = None,  # type: ignore
     ) -> Save | None:
-        return session.scalar(
-            select(Save)
-            .filter_by(rom_id=rom_id, user_id=user_id, content_hash=content_hash)
-            .limit(1)
+        query = select(Save).filter_by(
+            rom_id=rom_id, user_id=user_id, content_hash=content_hash
         )
+        if slot is not None:
+            query = query.filter(Save.slot == slot)
+        return session.scalar(query.limit(1))
 
     @begin_session
     def get_saves(
@@ -176,3 +180,26 @@ class DBSavesHandler(DBBaseHandler):
             "total_count": len(saves),
             "slots": list(slots_data.values()),
         }
+
+    @begin_session
+    def count_saves_missing_content_hash(
+        self,
+        session: Session = None,  # type: ignore
+    ) -> int:
+        """Number of Save rows whose content_hash is NULL. Used at startup to
+        decide whether the one-shot recompute task needs to be enqueued."""
+        return (
+            session.scalar(
+                select(func.count(Save.id)).where(Save.content_hash.is_(None))
+            )
+            or 0
+        )
+
+    @begin_session
+    def get_all_saves(
+        self,
+        session: Session = None,  # type: ignore
+    ) -> Sequence[Save]:
+        """Every Save row across all users, ordered by id. Used by the
+        recompute_save_content_hashes maintenance task."""
+        return session.scalars(select(Save).order_by(asc(Save.id))).all()

--- a/backend/handler/filesystem/assets_handler.py
+++ b/backend/handler/filesystem/assets_handler.py
@@ -132,7 +132,7 @@ class FSAssetsHandler(FSHandler):
         return hash_obj.hexdigest()
 
     async def _compute_zip_hash(self, zip_path: str) -> str:
-        with zipfile.ZipFile(f"{self.base_path}/{zip_path}", "r") as zf:
+        with zipfile.ZipFile(self.base_path / zip_path, "r") as zf:
             file_hashes = []
             for name in sorted(zf.namelist()):
                 if not name.endswith("/"):
@@ -144,7 +144,7 @@ class FSAssetsHandler(FSHandler):
 
     async def compute_content_hash(self, file_path: str) -> str | None:
         try:
-            full_path = f"{self.base_path}/{file_path}"
+            full_path = self.base_path / file_path
             if zipfile.is_zipfile(full_path):
                 return await self._compute_zip_hash(file_path)
             return await self._compute_file_hash(file_path)

--- a/backend/handler/filesystem/assets_handler.py
+++ b/backend/handler/filesystem/assets_handler.py
@@ -144,7 +144,8 @@ class FSAssetsHandler(FSHandler):
 
     async def compute_content_hash(self, file_path: str) -> str | None:
         try:
-            if zipfile.is_zipfile(file_path):
+            full_path = f"{self.base_path}/{file_path}"
+            if zipfile.is_zipfile(full_path):
                 return await self._compute_zip_hash(file_path)
             return await self._compute_file_hash(file_path)
         except Exception as e:

--- a/backend/startup.py
+++ b/backend/startup.py
@@ -13,7 +13,9 @@ from config import (
     ENABLE_SCHEDULED_UPDATE_SWITCH_TITLEDB,
     ENABLE_SYNC_PUSH_PULL,
     SENTRY_DSN,
+    TASK_TIMEOUT,
 )
+from handler.database import db_save_handler
 from handler.metadata.base_handler import (
     MAME_XML_KEY,
     METADATA_FIXTURES_DIR,
@@ -23,9 +25,12 @@ from handler.metadata.base_handler import (
     PSP_SERIAL_INDEX_KEY,
     SCUMMVM_INDEX_KEY,
 )
-from handler.redis_handler import async_cache
+from handler.redis_handler import async_cache, low_prio_queue
 from logger.logger import log
 from models.firmware import FIRMWARE_FIXTURES_DIR, KNOWN_BIOS_KEY
+from tasks.manual.recompute_save_content_hashes import (
+    recompute_save_content_hashes_task,
+)
 from tasks.scheduled.cleanup_netplay import cleanup_netplay_task
 from tasks.scheduled.cleanup_upload_tmp import cleanup_upload_tmp_task
 from tasks.scheduled.convert_images_to_webp import convert_images_to_webp_task
@@ -41,6 +46,45 @@ from utils.cache import conditionally_set_cache
 from utils.context import initialize_context
 
 tracer = trace.get_tracer(__name__)
+
+
+def _enqueue_recompute_save_hashes_if_needed() -> None:
+    """Backfill content_hash for saves uploaded before the path-resolution
+    fix. Non-blocking: a single COUNT query, then -- only if any Save rows
+    still have NULL content_hash -- enqueue the manual recompute task on
+    the low-priority RQ queue. The worker process picks it up; this
+    process moves on. Once the run completes, future restarts see 0 NULL
+    hashes and skip. Admins can still trigger the manual task explicitly."""
+    try:
+        missing = db_save_handler.count_saves_missing_content_hash()
+    except Exception:
+        log.exception(
+            "Failed to count saves with NULL content_hash; "
+            "skipping auto-enqueue of recompute_save_content_hashes (admins can run it manually)"
+        )
+        return
+
+    if missing == 0:
+        log.debug("All saves have content_hash; skipping recompute auto-enqueue")
+        return
+
+    try:
+        low_prio_queue.enqueue(
+            recompute_save_content_hashes_task.run,
+            job_timeout=TASK_TIMEOUT,
+            meta={
+                "task_name": recompute_save_content_hashes_task.title,
+                "task_type": recompute_save_content_hashes_task.task_type.value,
+            },
+        )
+        log.info(
+            f"Enqueued recompute_save_content_hashes ({missing} saves with NULL content_hash); "
+            "running on low-priority worker"
+        )
+    except Exception:
+        log.exception(
+            "Failed to enqueue recompute_save_content_hashes; admins can run it manually"
+        )
 
 
 @tracer.start_as_current_span("main")
@@ -72,6 +116,8 @@ async def main() -> None:
         if ENABLE_SYNC_PUSH_PULL:
             log.info("Starting scheduled push-pull sync")
             sync_push_pull_task.init()
+
+        _enqueue_recompute_save_hashes_if_needed()
 
         log.info("Initializing cache with fixtures data")
         await conditionally_set_cache(

--- a/backend/startup.py
+++ b/backend/startup.py
@@ -4,6 +4,7 @@ import asyncio
 
 import sentry_sdk
 from opentelemetry import trace
+from rq.exceptions import DuplicateJobError
 
 from config import (
     ENABLE_SCHEDULED_CONVERT_IMAGES_TO_WEBP,
@@ -47,6 +48,8 @@ from utils.context import initialize_context
 
 tracer = trace.get_tracer(__name__)
 
+RECOMPUTE_SAVE_HASHES_JOB_ID = "recompute_save_content_hashes:bootstrap"
+
 
 def _enqueue_recompute_save_hashes_if_needed() -> None:
     """Backfill content_hash for saves uploaded before the path-resolution
@@ -71,6 +74,8 @@ def _enqueue_recompute_save_hashes_if_needed() -> None:
     try:
         low_prio_queue.enqueue(
             recompute_save_content_hashes_task.run,
+            job_id=RECOMPUTE_SAVE_HASHES_JOB_ID,
+            unique=True,
             job_timeout=TASK_TIMEOUT,
             meta={
                 "task_name": recompute_save_content_hashes_task.title,
@@ -80,6 +85,11 @@ def _enqueue_recompute_save_hashes_if_needed() -> None:
         log.info(
             f"Enqueued recompute_save_content_hashes ({missing} saves with NULL content_hash); "
             "running on low-priority worker"
+        )
+    except DuplicateJobError:
+        log.info(
+            "recompute_save_content_hashes already queued or running from a "
+            "previous restart; skipping enqueue"
         )
     except Exception:
         log.exception(

--- a/backend/sync_watcher.py
+++ b/backend/sync_watcher.py
@@ -224,15 +224,13 @@ def _process_incoming_file(
 
     # Try to find matching saves on this platform for this user. Only
     # slot-bound saves participate in sync; null-slot saves are web-UI /
-    # archival uploads and must never be paired with a device push.
-    saves_on_platform = [
-        s
-        for s in db_save_handler.get_saves(
-            user_id=device.user_id,
-            platform_id=platform.id,
-        )
-        if s.slot is not None
-    ]
+    # archival uploads and must never be paired with a device push. Filter
+    # in SQL so archival rows never load.
+    saves_on_platform = db_save_handler.get_saves(
+        user_id=device.user_id,
+        platform_id=platform.id,
+        slot_not_null=True,
+    )
 
     matched_save = None
     for save in saves_on_platform:

--- a/backend/sync_watcher.py
+++ b/backend/sync_watcher.py
@@ -222,11 +222,17 @@ def _process_incoming_file(
     file_size = os.path.getsize(full_path)
     file_mtime = datetime.fromtimestamp(os.path.getmtime(full_path), tz=timezone.utc)
 
-    # Try to find matching saves on this platform for this user
-    saves_on_platform = db_save_handler.get_saves(
-        user_id=device.user_id,
-        platform_id=platform.id,
-    )
+    # Try to find matching saves on this platform for this user. Only
+    # slot-bound saves participate in sync; null-slot saves are web-UI /
+    # archival uploads and must never be paired with a device push.
+    saves_on_platform = [
+        s
+        for s in db_save_handler.get_saves(
+            user_id=device.user_id,
+            platform_id=platform.id,
+        )
+        if s.slot is not None
+    ]
 
     matched_save = None
     for save in saves_on_platform:

--- a/backend/tasks/manual/recompute_save_content_hashes.py
+++ b/backend/tasks/manual/recompute_save_content_hashes.py
@@ -23,6 +23,7 @@ from tasks.tasks import Task, TaskType, update_job_meta
 from utils.context import initialize_context
 
 META_FLUSH_EVERY = 100
+PAGE_SIZE = 1000
 
 
 @dataclass
@@ -69,44 +70,58 @@ class RecomputeSaveContentHashesTask(Task):
         log.info(f"Starting {self.title} task...")
         stats = RecomputeSaveHashesStats()
 
-        saves = db_save_handler.get_all_saves()
-        for save in saves:
-            stats.saves_scanned += 1
+        # Keyset-paginate by primary key instead of loading every Save row
+        # at once. On instances with very large save libraries the full
+        # table can be hundreds of thousands of rows; .all() would pull
+        # them all into the worker's RAM and pin them for the whole run.
+        last_id = 0
+        while True:
+            batch = db_save_handler.get_saves_after_id(
+                after_id=last_id, limit=PAGE_SIZE
+            )
+            if not batch:
+                break
 
-            relative_path = f"{save.file_path}/{save.file_name}"
-            try:
-                new_hash = await fs_asset_handler.compute_content_hash(relative_path)
-            except Exception as e:
-                log.warning(
-                    f"Failed to compute content_hash for save {save.id} "
-                    f"({relative_path}): {e}"
-                )
-                stats.errors += 1
+            for save in batch:
+                stats.saves_scanned += 1
+                last_id = save.id
+
+                relative_path = f"{save.file_path}/{save.file_name}"
+                try:
+                    new_hash = await fs_asset_handler.compute_content_hash(
+                        relative_path
+                    )
+                except Exception as e:
+                    log.warning(
+                        f"Failed to compute content_hash for save {save.id} "
+                        f"({relative_path}): {e}"
+                    )
+                    stats.errors += 1
+                    self._maybe_flush(stats)
+                    continue
+
+                if new_hash is None:
+                    stats.saves_missing_fs += 1
+                    self._maybe_flush(stats)
+                    continue
+
+                if new_hash == save.content_hash:
+                    stats.saves_unchanged += 1
+                    self._maybe_flush(stats)
+                    continue
+
+                try:
+                    db_save_handler.update_save(save.id, {"content_hash": new_hash})
+                    stats.saves_updated += 1
+                    log.debug(
+                        f"Rewrote content_hash for save {save.id} "
+                        f"({relative_path}): {save.content_hash} -> {new_hash}"
+                    )
+                except Exception as e:
+                    log.warning(f"Failed to update save {save.id}: {e}")
+                    stats.errors += 1
+
                 self._maybe_flush(stats)
-                continue
-
-            if new_hash is None:
-                stats.saves_missing_fs += 1
-                self._maybe_flush(stats)
-                continue
-
-            if new_hash == save.content_hash:
-                stats.saves_unchanged += 1
-                self._maybe_flush(stats)
-                continue
-
-            try:
-                db_save_handler.update_save(save.id, {"content_hash": new_hash})
-                stats.saves_updated += 1
-                log.debug(
-                    f"Rewrote content_hash for save {save.id} "
-                    f"({relative_path}): {save.content_hash} -> {new_hash}"
-                )
-            except Exception as e:
-                log.warning(f"Failed to update save {save.id}: {e}")
-                stats.errors += 1
-
-            self._maybe_flush(stats)
 
         stats.flush()
         log.info(

--- a/backend/tasks/manual/recompute_save_content_hashes.py
+++ b/backend/tasks/manual/recompute_save_content_hashes.py
@@ -1,0 +1,127 @@
+"""Recompute content_hash for existing save rows after the
+compute_content_hash path-resolution fix.
+
+Background: previously, compute_content_hash dispatched on
+zipfile.is_zipfile(relative_path), which silently returned False whenever the
+server process's CWD did not equal ASSETS_BASE_PATH. Every zip save fell
+through to the raw-MD5 path, so DB content_hash values for zip saves never
+reflected the intended per-entry zip-hash. Once the path fix lands, existing
+zip saves still have the old (raw-MD5) value stored; sync negotiations from
+clients computing the correct zip-hash will disagree with the server forever
+unless we re-scan.
+
+This task iterates every Save row, recomputes content_hash via the now-fixed
+algorithm, and updates the row if the value changed. Safe to re-run.
+"""
+
+from dataclasses import dataclass
+
+from handler.database import db_save_handler
+from handler.filesystem import fs_asset_handler
+from logger.logger import log
+from tasks.tasks import Task, TaskType, update_job_meta
+from utils.context import initialize_context
+
+META_FLUSH_EVERY = 100
+
+
+@dataclass
+class RecomputeSaveHashesStats:
+    """Counters reported via RQ job meta for the recompute task."""
+
+    saves_scanned: int = 0
+    saves_updated: int = 0
+    saves_unchanged: int = 0
+    saves_missing_fs: int = 0
+    errors: int = 0
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "saves_scanned": self.saves_scanned,
+            "saves_updated": self.saves_updated,
+            "saves_unchanged": self.saves_unchanged,
+            "saves_missing_fs": self.saves_missing_fs,
+            "errors": self.errors,
+        }
+
+    def flush(self) -> None:
+        """Push the current snapshot into the RQ job meta payload."""
+        update_job_meta({"recompute_save_hashes_stats": self.to_dict()})
+
+
+class RecomputeSaveContentHashesTask(Task):
+    def __init__(self) -> None:
+        super().__init__(
+            title="Recompute save content hashes",
+            description=(
+                "Re-scan every save row and rewrite content_hash with the "
+                "current compute_content_hash algorithm. One-time recovery "
+                "after the zip-hash dispatch fix."
+            ),
+            task_type=TaskType.CLEANUP,
+            enabled=True,
+            manual_run=True,
+            cron_string=None,
+        )
+
+    @initialize_context()
+    async def run(self) -> dict[str, int]:
+        log.info(f"Starting {self.title} task...")
+        stats = RecomputeSaveHashesStats()
+
+        saves = db_save_handler.get_all_saves()
+        for save in saves:
+            stats.saves_scanned += 1
+
+            relative_path = f"{save.file_path}/{save.file_name}"
+            try:
+                new_hash = await fs_asset_handler.compute_content_hash(relative_path)
+            except Exception as e:
+                log.warning(
+                    f"Failed to compute content_hash for save {save.id} "
+                    f"({relative_path}): {e}"
+                )
+                stats.errors += 1
+                self._maybe_flush(stats)
+                continue
+
+            if new_hash is None:
+                stats.saves_missing_fs += 1
+                self._maybe_flush(stats)
+                continue
+
+            if new_hash == save.content_hash:
+                stats.saves_unchanged += 1
+                self._maybe_flush(stats)
+                continue
+
+            try:
+                db_save_handler.update_save(save.id, {"content_hash": new_hash})
+                stats.saves_updated += 1
+                log.debug(
+                    f"Rewrote content_hash for save {save.id} "
+                    f"({relative_path}): {save.content_hash} -> {new_hash}"
+                )
+            except Exception as e:
+                log.warning(f"Failed to update save {save.id}: {e}")
+                stats.errors += 1
+
+            self._maybe_flush(stats)
+
+        stats.flush()
+        log.info(
+            f"{self.title} complete: scanned={stats.saves_scanned}, "
+            f"updated={stats.saves_updated}, unchanged={stats.saves_unchanged}, "
+            f"missing_fs={stats.saves_missing_fs}, errors={stats.errors}"
+        )
+        return stats.to_dict()
+
+    @staticmethod
+    def _maybe_flush(stats: RecomputeSaveHashesStats) -> None:
+        """Push the meta payload at coarse batch boundaries instead of on
+        every row, so large libraries don't churn Redis."""
+        if stats.saves_scanned % META_FLUSH_EVERY == 0:
+            stats.flush()
+
+
+recompute_save_content_hashes_task = RecomputeSaveContentHashesTask()

--- a/backend/tasks/sync_push_pull_task.py
+++ b/backend/tasks/sync_push_pull_task.py
@@ -237,14 +237,10 @@ async def _process_remote_save(
 
     # Find matching server save. Only slot-bound saves participate in sync;
     # null-slot saves are web-UI / archival uploads and must never be paired
-    # with a device push.
-    saves = [
-        s
-        for s in db_save_handler.get_saves(
-            user_id=device.user_id, platform_id=platform.id
-        )
-        if s.slot is not None
-    ]
+    # with a device push. Filter in SQL so archival rows never load.
+    saves = db_save_handler.get_saves(
+        user_id=device.user_id, platform_id=platform.id, slot_not_null=True
+    )
     matched_save = None
     for save in saves:
         if save.file_name == remote_save.file_name:
@@ -372,13 +368,10 @@ async def _push_missing_saves(
 
         # Only slot-bound saves participate in sync; null-slot saves are
         # web-UI / archival uploads and must never be pushed to a device.
-        server_saves = [
-            s
-            for s in db_save_handler.get_saves(
-                user_id=device.user_id, platform_id=platform.id
-            )
-            if s.slot is not None
-        ]
+        # Filter in SQL so archival rows never load.
+        server_saves = db_save_handler.get_saves(
+            user_id=device.user_id, platform_id=platform.id, slot_not_null=True
+        )
 
         remote_set = remote_files.get(platform_slug, set())
         remote_dir = platform_paths.get(platform_slug, "")

--- a/backend/tasks/sync_push_pull_task.py
+++ b/backend/tasks/sync_push_pull_task.py
@@ -235,8 +235,16 @@ async def _process_remote_save(
         log.debug(f"Unknown platform slug: {remote_save.platform_slug}")
         return "skipped"
 
-    # Find matching server save
-    saves = db_save_handler.get_saves(user_id=device.user_id, platform_id=platform.id)
+    # Find matching server save. Only slot-bound saves participate in sync;
+    # null-slot saves are web-UI / archival uploads and must never be paired
+    # with a device push.
+    saves = [
+        s
+        for s in db_save_handler.get_saves(
+            user_id=device.user_id, platform_id=platform.id
+        )
+        if s.slot is not None
+    ]
     matched_save = None
     for save in saves:
         if save.file_name == remote_save.file_name:
@@ -362,9 +370,15 @@ async def _push_missing_saves(
         if not platform:
             continue
 
-        server_saves = db_save_handler.get_saves(
-            user_id=device.user_id, platform_id=platform.id
-        )
+        # Only slot-bound saves participate in sync; null-slot saves are
+        # web-UI / archival uploads and must never be pushed to a device.
+        server_saves = [
+            s
+            for s in db_save_handler.get_saves(
+                user_id=device.user_id, platform_id=platform.id
+            )
+            if s.slot is not None
+        ]
 
         remote_set = remote_files.get(platform_slug, set())
         remote_dir = platform_paths.get(platform_slug, "")

--- a/backend/tests/_zipfile_shim.py
+++ b/backend/tests/_zipfile_shim.py
@@ -1,0 +1,19 @@
+"""Restore the stdlib zipfile module before writing fixture ZIPs.
+
+Mirrors the pattern from `backend/utils/zip_cache.py`: a third-party
+package (`zipfile-inflate64`) in the import chain replaces
+`zipfile._get_compressor` with an incompatible signature on
+CPython 3.13.5, breaking `ZipFile.write()` / `ZipFile.writestr()`.
+Reloading restores the original implementation.
+
+Tests that build fixture ZIPs should call `reload_zipfile()` immediately
+before opening the archive.
+"""
+
+import importlib
+import zipfile
+
+
+def reload_zipfile() -> None:
+    """Restore stdlib zipfile internals overridden by zipfile-inflate64."""
+    importlib.reload(zipfile)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -90,6 +90,12 @@ def rom(admin_user: User, platform: Platform):
 
 @pytest.fixture
 def save(rom: Rom, platform: Platform, admin_user: User):
+    """Slot-bound save (the canonical device-uploaded shape).
+
+    Sync negotiation only considers saves with a non-null slot — null-slot
+    saves are treated as web-UI / archival backups. Tests that need to
+    represent an archival save should use the `archival_save` fixture.
+    """
     save = Save(
         rom_id=rom.id,
         user_id=admin_user.id,
@@ -98,6 +104,28 @@ def save(rom: Rom, platform: Platform, admin_user: User):
         file_name_no_ext="test_save",
         file_extension="sav",
         emulator="test_emulator",
+        slot="autosave",
+        file_path=f"{platform.slug}/saves/test_emulator",
+        file_size_bytes=1.0,
+    )
+    return db_save_handler.add_save(save)
+
+
+@pytest.fixture
+def archival_save(rom: Rom, platform: Platform, admin_user: User):
+    """Null-slot save representing a web-UI / archival upload.
+
+    These should never appear in negotiate plans.
+    """
+    save = Save(
+        rom_id=rom.id,
+        user_id=admin_user.id,
+        file_name="archival.sav",
+        file_name_no_tags="archival",
+        file_name_no_ext="archival",
+        file_extension="sav",
+        emulator="test_emulator",
+        slot=None,
         file_path=f"{platform.slug}/saves/test_emulator",
         file_size_bytes=1.0,
     )

--- a/backend/tests/endpoints/test_saves.py
+++ b/backend/tests/endpoints/test_saves.py
@@ -1962,9 +1962,12 @@ class TestContentHashDeduplication:
         )
         mock_scan_save.return_value = mock_save
 
+        # The save fixture has slot="autosave"; post to the same slot so the
+        # slot-scoped dedupe lookup actually fires. (Different slots are
+        # legitimately distinct records per the slot-scoped dedupe contract.)
         response = client.post(
             "/api/saves",
-            params={"rom_id": rom.id, "slot": "Slot1"},
+            params={"rom_id": rom.id, "slot": "autosave"},
             files={
                 "saveFile": (
                     "new.sav",
@@ -2130,3 +2133,262 @@ class TestContentHashComputation:
         hash2 = await fs_asset_handler._compute_file_hash(str(file2))
 
         assert hash1 != hash2
+
+
+def _build_fixture_a_zip() -> bytes:
+    """Single-entry zip; pinned digest b3636b49ca5c3d807adee33e75d410ca."""
+    import zipfile
+
+    from tests._zipfile_shim import reload_zipfile
+
+    reload_zipfile()
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as zf:
+        zf.writestr("save.bin", b"\x42" * 256)
+    return buf.getvalue()
+
+
+def _build_fixture_b_zip() -> bytes:
+    """Three-entry zip with a subdir; pinned digest 8cf6bb36a82a5ee4d7d15fc98599908d."""
+    import zipfile
+
+    from tests._zipfile_shim import reload_zipfile
+
+    reload_zipfile()
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as zf:
+        zf.writestr("inner/a.txt", b"alpha")
+        zf.writestr("inner/b.txt", b"beta")
+        zf.writestr("top.bin", b"\x00\x01\x02")
+    return buf.getvalue()
+
+
+def _build_fixture_c_zip() -> bytes:
+    """Switch-shaped nested zip; pinned digest c0c992d1f1f883f56065bb13b68dfdee."""
+    import zipfile
+
+    from tests._zipfile_shim import reload_zipfile
+
+    reload_zipfile()
+    buf = BytesIO()
+    title = "0100F2C0115B6000"
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as zf:
+        zf.writestr(f"{title}/NX6400000-SYSTEM/SYDAT.BIN", b"system data v1")
+        zf.writestr(f"{title}/album/000_Photo.jpg", b"\xff\xd8\xff\xe0jpegdata" * 8)
+        zf.writestr(f"{title}/album/000_Thumb.jpg", b"\xff\xd8thumbdata")
+        zf.writestr(f"{title}/slot_01/caption.sav", b"slot1 caption")
+        zf.writestr(f"{title}/slot_01/progress.sav", b"\x01" * 64)
+        zf.writestr(f"{title}/slot_02/caption.sav", b"slot2 caption")
+        zf.writestr(f"{title}/slot_02/progress.sav", b"\x02" * 64)
+        zf.writestr(f"{title}/storage/CacheStorageKey.dat", b"key=abcd1234")
+        zf.writestr(f"{title}/storage/empty.dat", b"")
+        zf.writestr(f"{title}/Pokémon.dat", b"unicode-name")
+    return buf.getvalue()
+
+
+FIXTURE_A_HASH = "b3636b49ca5c3d807adee33e75d410ca"
+FIXTURE_B_HASH = "8cf6bb36a82a5ee4d7d15fc98599908d"
+FIXTURE_C_HASH = "c0c992d1f1f883f56065bb13b68dfdee"
+
+
+@pytest.fixture
+def _isolated_assets_dir(tmp_path, monkeypatch):
+    """Redirect the shared fs_asset_handler to a tmp dir for the test's duration.
+
+    Upload, scan, compute_content_hash, and remove_file all dispatch through
+    self.base_path; rebinding base_path to a tmp dir keeps the test from
+    leaking files into the real ROMM_BASE_PATH and lets every IO path resolve
+    consistently.
+    """
+    from pathlib import Path
+
+    from handler.filesystem import fs_asset_handler
+
+    new_base = Path(tmp_path).resolve()
+    monkeypatch.setattr(fs_asset_handler, "base_path", new_base)
+    return new_base
+
+
+class TestUploadHashContract:
+    """Round-trip a real zip through the upload endpoint and pin the
+    content_hash the server stores.
+
+    The compute_content_hash path-resolution bug (commit 7996c1293) lived
+    precisely here: scan_save -> compute_content_hash -> is_zipfile. Mocking
+    scan_save or compute_content_hash defeats the purpose. These tests
+    intentionally exercise the unmocked pipeline so any regression in zip
+    detection, per-entry hash assembly, or path handling fails loudly.
+    """
+
+    def _upload(
+        self,
+        client,
+        access_token: str,
+        rom: Rom,
+        payload: bytes,
+        filename: str,
+        slot: str = "autosave",
+    ):
+        return client.post(
+            f"/api/saves?rom_id={rom.id}&slot={slot}&emulator=test_emulator",
+            files={
+                "saveFile": (filename, BytesIO(payload), "application/octet-stream")
+            },
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+    def test_fixture_a_round_trip_pins_hash(
+        self,
+        client,
+        access_token: str,
+        rom: Rom,
+        _isolated_assets_dir,
+    ):
+        payload = _build_fixture_a_zip()
+        response = self._upload(client, access_token, rom, payload, "fixture_a.zip")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["content_hash"] == FIXTURE_A_HASH
+
+    def test_fixture_b_round_trip_pins_hash(
+        self,
+        client,
+        access_token: str,
+        rom: Rom,
+        _isolated_assets_dir,
+    ):
+        payload = _build_fixture_b_zip()
+        response = self._upload(client, access_token, rom, payload, "fixture_b.zip")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["content_hash"] == FIXTURE_B_HASH
+
+    def test_fixture_c_round_trip_pins_hash(
+        self,
+        client,
+        access_token: str,
+        rom: Rom,
+        _isolated_assets_dir,
+    ):
+        payload = _build_fixture_c_zip()
+        response = self._upload(client, access_token, rom, payload, "fixture_c.zip")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["content_hash"] == FIXTURE_C_HASH
+
+    def test_identical_repost_to_same_slot_dedupes_to_first_id(
+        self,
+        client,
+        access_token: str,
+        rom: Rom,
+        _isolated_assets_dir,
+    ):
+        """Second upload of identical bytes to the same slot should return the
+        first record's id (server-side dedupe via content_hash)."""
+        payload = _build_fixture_a_zip()
+
+        first = self._upload(client, access_token, rom, payload, "fixture_a.zip")
+        assert first.status_code == status.HTTP_200_OK
+        first_id = first.json()["id"]
+
+        second = self._upload(client, access_token, rom, payload, "fixture_a.zip")
+        assert second.status_code == status.HTTP_200_OK
+        assert second.json()["id"] == first_id
+        assert second.json()["content_hash"] == FIXTURE_A_HASH
+
+
+class TestSlotScopedDedupeMatrix:
+    """Verify the slot-scoped content_hash dedupe rules.
+
+    Pre-fix, get_save_by_content_hash ignored slot, so identical bytes uploaded
+    to different slots collapsed into one record (breaking clone-save-to-new-
+    slot). Each scenario below pins one cell of the truth table.
+    """
+
+    def _upload(
+        self,
+        client,
+        access_token: str,
+        rom: Rom,
+        payload: bytes,
+        slot: str,
+        filename: str = "matrix.zip",
+    ):
+        return client.post(
+            f"/api/saves?rom_id={rom.id}&slot={slot}&emulator=test_emulator",
+            files={
+                "saveFile": (filename, BytesIO(payload), "application/octet-stream")
+            },
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+    def test_same_bytes_same_slot_dedupes(
+        self,
+        client,
+        access_token: str,
+        rom: Rom,
+        _isolated_assets_dir,
+    ):
+        payload = _build_fixture_a_zip()
+
+        first = self._upload(client, access_token, rom, payload, slot="slot1")
+        second = self._upload(client, access_token, rom, payload, slot="slot1")
+
+        assert first.status_code == status.HTTP_200_OK
+        assert second.status_code == status.HTTP_200_OK
+        assert second.json()["id"] == first.json()["id"]
+
+    def test_same_bytes_different_slots_creates_distinct_records(
+        self,
+        client,
+        access_token: str,
+        rom: Rom,
+        _isolated_assets_dir,
+    ):
+        """Clone-save-to-new-slot must yield a separate DB row.
+
+        Pre-fix this case incorrectly returned the first slot's id because the
+        DAO dropped the slot filter from the content_hash lookup.
+        """
+        payload = _build_fixture_a_zip()
+
+        first = self._upload(client, access_token, rom, payload, slot="slot1")
+        second = self._upload(client, access_token, rom, payload, slot="slot2")
+
+        assert first.status_code == status.HTTP_200_OK
+        assert second.status_code == status.HTTP_200_OK
+        assert second.json()["id"] != first.json()["id"]
+        assert second.json()["slot"] == "slot2"
+        assert second.json()["content_hash"] == first.json()["content_hash"]
+
+    def test_different_bytes_same_slot_creates_distinct_records(
+        self,
+        client,
+        access_token: str,
+        rom: Rom,
+        _isolated_assets_dir,
+    ):
+        """No false-positive dedupe across distinct content within one slot."""
+        import zipfile
+
+        from tests._zipfile_shim import reload_zipfile
+
+        payload_a = _build_fixture_a_zip()
+
+        reload_zipfile()
+        buf = BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as zf:
+            zf.writestr("save.bin", b"\x43" * 256)
+        payload_b = buf.getvalue()
+
+        first = self._upload(
+            client, access_token, rom, payload_a, slot="slot1", filename="a.zip"
+        )
+        second = self._upload(
+            client, access_token, rom, payload_b, slot="slot1", filename="b.zip"
+        )
+
+        assert first.status_code == status.HTTP_200_OK
+        assert second.status_code == status.HTTP_200_OK
+        assert second.json()["id"] != first.json()["id"]
+        assert second.json()["content_hash"] != first.json()["content_hash"]

--- a/backend/tests/endpoints/test_sync.py
+++ b/backend/tests/endpoints/test_sync.py
@@ -466,6 +466,36 @@ class TestNegotiateAdvanced:
         assert len(download_ops) >= 1
         assert any(op["save_id"] == save.id for op in download_ops)
 
+    def test_negotiate_excludes_archival_null_slot_saves(
+        self, client, access_token: str, admin_user: User, archival_save: Save
+    ):
+        """Null-slot saves (web-UI / archival uploads) must not appear in
+        negotiate plans.
+
+        Archival saves are pure backups; clients can opt in to import them
+        outside the sync flow. Surfacing them in negotiate as 'download'
+        produces phantom operations on every device that's never synced them.
+        """
+        device = db_device_handler.add_device(
+            Device(id="neg-archival-dev", user_id=admin_user.id, sync_enabled=True)
+        )
+
+        response = client.post(
+            "/api/sync/negotiate",
+            json={"device_id": device.id, "saves": []},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        ops_for_archival = [
+            op for op in data["operations"] if op.get("save_id") == archival_save.id
+        ]
+        assert ops_for_archival == [], (
+            f"Archival null-slot save unexpectedly surfaced in negotiate: "
+            f"{ops_for_archival}"
+        )
+
     def test_negotiate_deleted_by_client_skipped(
         self, client, access_token: str, admin_user: User, save: Save
     ):

--- a/backend/tests/handler/database/test_saves_handler.py
+++ b/backend/tests/handler/database/test_saves_handler.py
@@ -444,6 +444,127 @@ class TestDBSavesHandlerGetSaveByContentHash:
         assert result.id == created.id
 
 
+class TestDBSavesHandlerSlotNotNullFilter:
+    """Pin the slot_not_null kwarg: when true, archival/null-slot saves are
+    excluded; when false (default), they are returned alongside slot-bound
+    rows. Sync callsites use slot_not_null=True so the database does the
+    filter instead of pulling the whole table into Python."""
+
+    def test_slot_not_null_false_returns_both(self, admin_user: User, rom: Rom):
+        slot_save = Save(
+            rom_id=rom.id,
+            user_id=admin_user.id,
+            file_name="slotted.sav",
+            file_name_no_tags="slotted",
+            file_name_no_ext="slotted",
+            file_extension="sav",
+            emulator="test_emu",
+            file_path=f"{rom.platform_slug}/saves",
+            file_size_bytes=100,
+            slot="autosave",
+        )
+        archival_save = Save(
+            rom_id=rom.id,
+            user_id=admin_user.id,
+            file_name="archival.sav",
+            file_name_no_tags="archival",
+            file_name_no_ext="archival",
+            file_extension="sav",
+            emulator="test_emu",
+            file_path=f"{rom.platform_slug}/saves",
+            file_size_bytes=100,
+            slot=None,
+        )
+        db_save_handler.add_save(slot_save)
+        db_save_handler.add_save(archival_save)
+
+        saves = db_save_handler.get_saves(user_id=admin_user.id, rom_id=rom.id)
+
+        names = {s.file_name for s in saves}
+        assert "slotted.sav" in names
+        assert "archival.sav" in names
+
+    def test_slot_not_null_true_excludes_null_slot(self, admin_user: User, rom: Rom):
+        slot_save = Save(
+            rom_id=rom.id,
+            user_id=admin_user.id,
+            file_name="slotted_only.sav",
+            file_name_no_tags="slotted_only",
+            file_name_no_ext="slotted_only",
+            file_extension="sav",
+            emulator="test_emu",
+            file_path=f"{rom.platform_slug}/saves",
+            file_size_bytes=100,
+            slot="autosave",
+        )
+        archival_save = Save(
+            rom_id=rom.id,
+            user_id=admin_user.id,
+            file_name="archival_only.sav",
+            file_name_no_tags="archival_only",
+            file_name_no_ext="archival_only",
+            file_extension="sav",
+            emulator="test_emu",
+            file_path=f"{rom.platform_slug}/saves",
+            file_size_bytes=100,
+            slot=None,
+        )
+        db_save_handler.add_save(slot_save)
+        db_save_handler.add_save(archival_save)
+
+        saves = db_save_handler.get_saves(
+            user_id=admin_user.id, rom_id=rom.id, slot_not_null=True
+        )
+
+        names = {s.file_name for s in saves}
+        assert "slotted_only.sav" in names
+        assert "archival_only.sav" not in names
+        assert all(s.slot is not None for s in saves)
+
+    def test_slot_not_null_true_composes_with_slot_value(
+        self, admin_user: User, rom: Rom
+    ):
+        """slot_not_null and slot can both be set; the explicit slot filter
+        wins (and is implicitly not-null), so slot_not_null=True is a no-op
+        in that case. Pin that behavior so callers don't have to reason
+        about the interaction."""
+        db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name="compose_a.sav",
+                file_name_no_tags="compose_a",
+                file_name_no_ext="compose_a",
+                file_extension="sav",
+                emulator="test_emu",
+                file_path=f"{rom.platform_slug}/saves",
+                file_size_bytes=100,
+                slot="A",
+            )
+        )
+        db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name="compose_b.sav",
+                file_name_no_tags="compose_b",
+                file_name_no_ext="compose_b",
+                file_extension="sav",
+                emulator="test_emu",
+                file_path=f"{rom.platform_slug}/saves",
+                file_size_bytes=100,
+                slot="B",
+            )
+        )
+
+        saves = db_save_handler.get_saves(
+            user_id=admin_user.id, rom_id=rom.id, slot="A", slot_not_null=True
+        )
+
+        assert len(saves) == 1
+        assert saves[0].slot == "A"
+
+
 class TestDBSavesHandlerGetSavesAfterId:
     """Cover keyset pagination used by the recompute_save_content_hashes
     maintenance task. Per-page bounded reads avoid materializing the full

--- a/backend/tests/handler/database/test_saves_handler.py
+++ b/backend/tests/handler/database/test_saves_handler.py
@@ -444,6 +444,66 @@ class TestDBSavesHandlerGetSaveByContentHash:
         assert result.id == created.id
 
 
+class TestDBSavesHandlerGetSavesAfterId:
+    """Cover keyset pagination used by the recompute_save_content_hashes
+    maintenance task. Per-page bounded reads avoid materializing the full
+    saves table on instances with very large libraries."""
+
+    def test_paginates_in_order_and_terminates(self, admin_user: User, rom: Rom):
+        created_ids = []
+        for i in range(5):
+            created = db_save_handler.add_save(
+                Save(
+                    rom_id=rom.id,
+                    user_id=admin_user.id,
+                    file_name=f"page_{i}.sav",
+                    file_name_no_tags=f"page_{i}",
+                    file_name_no_ext=f"page_{i}",
+                    file_extension="sav",
+                    emulator="test_emu",
+                    file_path=f"{rom.platform_slug}/saves",
+                    file_size_bytes=100,
+                    slot=f"slot_{i}",
+                )
+            )
+            created_ids.append(created.id)
+
+        seen: list[int] = []
+        last_id = 0
+        while True:
+            batch = db_save_handler.get_saves_after_id(after_id=last_id, limit=2)
+            if not batch:
+                break
+            for s in batch:
+                seen.append(s.id)
+                last_id = s.id
+
+        for cid in created_ids:
+            assert cid in seen
+        # IDs returned monotonically by primary key
+        assert seen == sorted(seen)
+
+    def test_after_id_excludes_anchor_row(self, admin_user: User, rom: Rom):
+        created = db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name="anchor.sav",
+                file_name_no_tags="anchor",
+                file_name_no_ext="anchor",
+                file_extension="sav",
+                emulator="test_emu",
+                file_path=f"{rom.platform_slug}/saves",
+                file_size_bytes=100,
+                slot="anchor_slot",
+            )
+        )
+
+        batch = db_save_handler.get_saves_after_id(after_id=created.id, limit=10)
+
+        assert all(s.id > created.id for s in batch)
+
+
 class TestDBSavesHandlerSummary:
     def test_get_saves_summary_basic(self, admin_user: User, rom: Rom):
         from datetime import datetime, timedelta, timezone

--- a/backend/tests/handler/database/test_saves_handler.py
+++ b/backend/tests/handler/database/test_saves_handler.py
@@ -319,6 +319,131 @@ class TestDBSavesHandlerSlotFiltering:
         assert ordered_saves_asc[1].id == created2.id
 
 
+class TestDBSavesHandlerGetSaveByContentHash:
+    """Pin the slot filter behavior of get_save_by_content_hash (commit
+    3d71ef3f6). Legacy callers still pass slot=None and expect cross-slot
+    lookup, while sync negotiation passes a concrete slot value and expects
+    a strict match.
+    """
+
+    def test_returns_row_matching_slot_when_multiple_slots_share_hash(
+        self, admin_user: User, rom: Rom
+    ):
+        """Two rows share (rom_id, user_id, content_hash) but differ in slot.
+        A call with a specific slot must return the row with that slot, not
+        the other."""
+        shared_hash = "abc123abc123abc123abc123abc12345"
+
+        slot_a = db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name="hash_match_a.sav",
+                file_name_no_tags="hash_match_a",
+                file_name_no_ext="hash_match_a",
+                file_extension="sav",
+                emulator="test_emu",
+                file_path=f"{rom.platform_slug}/saves",
+                file_size_bytes=100,
+                slot="Slot A",
+                content_hash=shared_hash,
+            )
+        )
+        slot_b = db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name="hash_match_b.sav",
+                file_name_no_tags="hash_match_b",
+                file_name_no_ext="hash_match_b",
+                file_extension="sav",
+                emulator="test_emu",
+                file_path=f"{rom.platform_slug}/saves",
+                file_size_bytes=100,
+                slot="Slot B",
+                content_hash=shared_hash,
+            )
+        )
+
+        result_a = db_save_handler.get_save_by_content_hash(
+            user_id=admin_user.id,
+            rom_id=rom.id,
+            content_hash=shared_hash,
+            slot="Slot A",
+        )
+        assert result_a is not None
+        assert result_a.id == slot_a.id
+
+        result_b = db_save_handler.get_save_by_content_hash(
+            user_id=admin_user.id,
+            rom_id=rom.id,
+            content_hash=shared_hash,
+            slot="Slot B",
+        )
+        assert result_b is not None
+        assert result_b.id == slot_b.id
+
+    def test_returns_none_when_slot_does_not_match(self, admin_user: User, rom: Rom):
+        """A single row exists. Querying with a different slot value returns
+        None, even though the (rom_id, user_id, content_hash) tuple matches."""
+        target_hash = "ffffffffffffffffffffffffffffffff"
+
+        db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name="only_slot.sav",
+                file_name_no_tags="only_slot",
+                file_name_no_ext="only_slot",
+                file_extension="sav",
+                emulator="test_emu",
+                file_path=f"{rom.platform_slug}/saves",
+                file_size_bytes=100,
+                slot="autosave",
+                content_hash=target_hash,
+            )
+        )
+
+        result = db_save_handler.get_save_by_content_hash(
+            user_id=admin_user.id,
+            rom_id=rom.id,
+            content_hash=target_hash,
+            slot="manual",
+        )
+        assert result is None
+
+    def test_slot_none_finds_row_with_concrete_slot(self, admin_user: User, rom: Rom):
+        """Legacy / cross-slot lookup: passing slot=None must not filter by
+        slot at all and must still return the row, regardless of the row's
+        own slot value."""
+        target_hash = "1234567890abcdef1234567890abcdef"
+
+        created = db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name="cross_slot.sav",
+                file_name_no_tags="cross_slot",
+                file_name_no_ext="cross_slot",
+                file_extension="sav",
+                emulator="test_emu",
+                file_path=f"{rom.platform_slug}/saves",
+                file_size_bytes=100,
+                slot="autosave",
+                content_hash=target_hash,
+            )
+        )
+
+        result = db_save_handler.get_save_by_content_hash(
+            user_id=admin_user.id,
+            rom_id=rom.id,
+            content_hash=target_hash,
+            slot=None,
+        )
+        assert result is not None
+        assert result.id == created.id
+
+
 class TestDBSavesHandlerSummary:
     def test_get_saves_summary_basic(self, admin_user: User, rom: Rom):
         from datetime import datetime, timedelta, timezone

--- a/backend/tests/handler/filesystem/test_assets_handler.py
+++ b/backend/tests/handler/filesystem/test_assets_handler.py
@@ -1,8 +1,13 @@
+import hashlib
 import os
+import shutil
+import tempfile
+import zipfile
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+from tests._zipfile_shim import reload_zipfile
 
 from handler.filesystem.assets_handler import ASSETS_BASE_PATH, FSAssetsHandler
 from models.user import User
@@ -326,3 +331,172 @@ class TestFSAssetsHandler:
         assert emulator in saves_with_emulator
         assert emulator not in saves_without_emulator
         assert saves_with_emulator.startswith(saves_without_emulator)
+
+
+class TestComputeContentHash:
+    """Regression coverage for compute_content_hash dispatch."""
+
+    @pytest.fixture
+    def temp_base(self):
+        path = tempfile.mkdtemp()
+        yield path
+        shutil.rmtree(path, ignore_errors=True)
+
+    @pytest.fixture
+    def handler(self, temp_base: str):
+        handler = FSAssetsHandler()
+        handler.base_path = Path(temp_base).resolve()
+        return handler
+
+    @staticmethod
+    def _expected_zip_hash(zip_path: Path) -> str:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            file_hashes = [
+                f"{n}:{hashlib.md5(zf.read(n), usedforsecurity=False).hexdigest()}"
+                for n in sorted(zf.namelist())
+                if not n.endswith("/")
+            ]
+        combined = "\n".join(file_hashes)
+        return hashlib.md5(combined.encode(), usedforsecurity=False).hexdigest()
+
+    @staticmethod
+    def _raw_md5(path: Path) -> str:
+        h = hashlib.md5(usedforsecurity=False)
+        with open(path, "rb") as f:
+            while chunk := f.read(8192):
+                h.update(chunk)
+        return h.hexdigest()
+
+    @pytest.mark.asyncio
+    async def test_zip_dispatches_to_per_entry_hash(
+        self, handler: FSAssetsHandler, temp_base: str
+    ):
+        """A zip file's content_hash must equal the per-entry zip-hash, not raw MD5.
+
+        Regression for the path-resolution bug where compute_content_hash called
+        zipfile.is_zipfile() with a bare relative path. Because the server WORKDIR
+        is not ASSETS_BASE_PATH, that open() failed silently, is_zipfile returned
+        False, and the dispatch fell through to _compute_file_hash (raw MD5) for
+        every zip save.
+        """
+        relative = "users/test/saves/test.zip"
+        zip_full = Path(temp_base) / relative
+        zip_full.parent.mkdir(parents=True, exist_ok=True)
+        reload_zipfile()
+        with zipfile.ZipFile(zip_full, "w") as zf:
+            zf.writestr("inner/a.txt", b"alpha bytes")
+            zf.writestr("inner/b.bin", b"\x00\x01\x02\x03")
+
+        expected_zip_hash = self._expected_zip_hash(zip_full)
+        raw_md5 = self._raw_md5(zip_full)
+        assert expected_zip_hash != raw_md5  # different algorithms; sanity check
+
+        result = await handler.compute_content_hash(relative)
+
+        assert result == expected_zip_hash, (
+            "compute_content_hash should dispatch to per-entry zip-hash for zip "
+            "files; got raw MD5 or None, meaning is_zipfile failed to resolve the "
+            "relative path."
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_zip_returns_raw_md5(
+        self, handler: FSAssetsHandler, temp_base: str
+    ):
+        """Non-zip files dispatch to _compute_file_hash (raw MD5)."""
+        relative = "users/test/saves/test.srm"
+        full = Path(temp_base) / relative
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_bytes(b"raw save data \x00\x01\xff")
+
+        expected = self._raw_md5(full)
+
+        result = await handler.compute_content_hash(relative)
+
+        assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_none(self, handler: FSAssetsHandler):
+        result = await handler.compute_content_hash("users/missing/file.zip")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_zip_hash_pinned_single_entry(
+        self, handler: FSAssetsHandler, temp_base: str
+    ):
+        """Smallest possible zip: one file, stored compression. Pins the
+        algorithm against a known digest. Any change to the protocol (sort,
+        separator, hash, encoding) fails here.
+        """
+        relative = "users/test/saves/simple.zip"
+        full = Path(temp_base) / relative
+        full.parent.mkdir(parents=True, exist_ok=True)
+        reload_zipfile()
+        with zipfile.ZipFile(full, "w", zipfile.ZIP_STORED) as zf:
+            zf.writestr("save.bin", b"\x42" * 256)
+
+        # md5("save.bin:" + md5(b"\x42"*256).hexdigest())
+        pinned = "b3636b49ca5c3d807adee33e75d410ca"
+
+        result = await handler.compute_content_hash(relative)
+        assert (
+            result == pinned
+        ), f"single-entry per-entry zip-hash drifted: got={result} want={pinned}"
+
+    @pytest.mark.asyncio
+    async def test_zip_hash_pinned_mixed(
+        self, handler: FSAssetsHandler, temp_base: str
+    ):
+        """Three-entry zip with one subdir; baseline mixed shape."""
+        relative = "users/test/saves/pinned.zip"
+        full = Path(temp_base) / relative
+        full.parent.mkdir(parents=True, exist_ok=True)
+        reload_zipfile()
+        with zipfile.ZipFile(full, "w", zipfile.ZIP_STORED) as zf:
+            zf.writestr("inner/a.txt", b"alpha")
+            zf.writestr("inner/b.txt", b"beta")
+            zf.writestr("top.bin", b"\x00\x01\x02")
+
+        pinned = "8cf6bb36a82a5ee4d7d15fc98599908d"
+
+        result = await handler.compute_content_hash(relative)
+        assert result == pinned, (
+            f"per-entry zip-hash drifted from documented protocol: "
+            f"got={result} want={pinned}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_zip_hash_pinned_nested_switch_shape(
+        self, handler: FSAssetsHandler, temp_base: str
+    ):
+        """Switch-save-shaped zip: deep nesting, mixed sizes, empty file,
+        unicode filename. Mirrors what real Switch saves look like (the
+        original bug surface) so this test exercises the algorithm against
+        a realistic layout.
+        """
+        relative = "users/test/saves/switch.zip"
+        full = Path(temp_base) / relative
+        full.parent.mkdir(parents=True, exist_ok=True)
+        reload_zipfile()
+        with zipfile.ZipFile(full, "w", zipfile.ZIP_STORED) as zf:
+            title = "0100F2C0115B6000"
+            zf.writestr(f"{title}/NX6400000-SYSTEM/SYDAT.BIN", b"system data v1")
+            zf.writestr(
+                f"{title}/album/000_Photo.jpg",
+                b"\xff\xd8\xff\xe0jpegdata" * 8,
+            )
+            zf.writestr(f"{title}/album/000_Thumb.jpg", b"\xff\xd8thumbdata")
+            zf.writestr(f"{title}/slot_01/caption.sav", b"slot1 caption")
+            zf.writestr(f"{title}/slot_01/progress.sav", b"\x01" * 64)
+            zf.writestr(f"{title}/slot_02/caption.sav", b"slot2 caption")
+            zf.writestr(f"{title}/slot_02/progress.sav", b"\x02" * 64)
+            zf.writestr(f"{title}/storage/CacheStorageKey.dat", b"key=abcd1234")
+            zf.writestr(f"{title}/storage/empty.dat", b"")
+            zf.writestr(f"{title}/Pokémon.dat", b"unicode-name")
+
+        pinned = "c0c992d1f1f883f56065bb13b68dfdee"
+
+        result = await handler.compute_content_hash(relative)
+        assert (
+            result == pinned
+        ), f"nested-switch-shape zip-hash drifted: got={result} want={pinned}"

--- a/backend/tests/tasks/test_recompute_save_content_hashes.py
+++ b/backend/tests/tasks/test_recompute_save_content_hashes.py
@@ -1,0 +1,403 @@
+"""Tests for RecomputeSaveContentHashesTask.
+
+Background lives in commit 7996c1293: every zip save's content_hash was
+incorrectly stored as the raw MD5 of the zip wrapper instead of the
+per-entry zip-hash. This task walks every Save row, recomputes via the
+fixed dispatch, and rewrites stale values. These tests pin the
+update / unchanged / missing-fs accounting.
+
+ZIP_STORED is used everywhere so the wrapper bytes are deterministic and
+the pinned per-entry digests stay valid.
+"""
+
+import hashlib
+import zipfile
+from pathlib import Path
+
+import pytest
+from tests._zipfile_shim import reload_zipfile
+
+from handler.database import db_save_handler
+from handler.filesystem import fs_asset_handler
+from models.assets import Save
+from models.platform import Platform
+from models.rom import Rom
+from models.user import User
+from tasks.manual.recompute_save_content_hashes import (
+    RecomputeSaveContentHashesTask,
+    recompute_save_content_hashes_task,
+)
+
+FIXTURE_A_PINNED_HASH = "b3636b49ca5c3d807adee33e75d410ca"
+
+
+def _write_fixture_a_zip(target: Path) -> bytes:
+    """Write the shared Fixture A zip to target; return the raw bytes."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    reload_zipfile()
+    with zipfile.ZipFile(target, "w", zipfile.ZIP_STORED) as zf:
+        zf.writestr("save.bin", b"\x42" * 256)
+    return target.read_bytes()
+
+
+@pytest.fixture
+def isolated_assets_dir(tmp_path, monkeypatch):
+    """Redirect fs_asset_handler to tmp_path so writes/lookups stay scoped."""
+    new_base = Path(tmp_path).resolve()
+    monkeypatch.setattr(fs_asset_handler, "base_path", new_base)
+    return new_base
+
+
+class TestRecomputeSaveContentHashesTask:
+    @pytest.fixture
+    def task(self) -> RecomputeSaveContentHashesTask:
+        return RecomputeSaveContentHashesTask()
+
+    def test_module_singleton_exists(self):
+        assert recompute_save_content_hashes_task is not None
+        assert isinstance(
+            recompute_save_content_hashes_task, RecomputeSaveContentHashesTask
+        )
+
+    def test_init(self, task: RecomputeSaveContentHashesTask):
+        assert task.title == "Recompute save content hashes"
+        assert task.manual_run is True
+        assert task.cron_string is None
+
+    async def test_correct_hash_is_unchanged(
+        self,
+        task: RecomputeSaveContentHashesTask,
+        isolated_assets_dir: Path,
+        admin_user: User,
+        rom: Rom,
+        platform: Platform,
+    ):
+        """A save whose stored hash already matches must not be rewritten."""
+        rel_dir = f"{platform.fs_slug}/saves/test_emulator"
+        file_name = "correct.zip"
+        zip_path = isolated_assets_dir / rel_dir / file_name
+        _write_fixture_a_zip(zip_path)
+
+        save = db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name=file_name,
+                file_name_no_tags="correct",
+                file_name_no_ext="correct",
+                file_extension="zip",
+                emulator="test_emulator",
+                slot="autosave",
+                file_path=rel_dir,
+                file_size_bytes=zip_path.stat().st_size,
+                content_hash=FIXTURE_A_PINNED_HASH,
+            )
+        )
+
+        stats = await task.run()
+
+        assert stats["saves_scanned"] == 1
+        assert stats["saves_unchanged"] == 1
+        assert stats["saves_updated"] == 0
+        assert stats["saves_missing_fs"] == 0
+        assert stats["errors"] == 0
+
+        refreshed = db_save_handler.get_save(user_id=admin_user.id, id=save.id)
+        assert refreshed is not None
+        assert refreshed.content_hash == FIXTURE_A_PINNED_HASH
+
+    async def test_stale_raw_md5_is_rewritten_to_zip_hash(
+        self,
+        task: RecomputeSaveContentHashesTask,
+        isolated_assets_dir: Path,
+        admin_user: User,
+        rom: Rom,
+        platform: Platform,
+    ):
+        """A zip save whose stored hash is the raw wrapper MD5 (the pre-fix
+        value) must be rewritten to the per-entry zip-hash. This is the exact
+        recovery the task exists for."""
+        rel_dir = f"{platform.fs_slug}/saves/test_emulator"
+        file_name = "stale.zip"
+        zip_path = isolated_assets_dir / rel_dir / file_name
+        raw_bytes = _write_fixture_a_zip(zip_path)
+
+        # Pre-fix value: raw MD5 of the zip wrapper, not the per-entry digest.
+        stale_raw_md5 = hashlib.md5(raw_bytes, usedforsecurity=False).hexdigest()
+        assert stale_raw_md5 != FIXTURE_A_PINNED_HASH
+
+        save = db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name=file_name,
+                file_name_no_tags="stale",
+                file_name_no_ext="stale",
+                file_extension="zip",
+                emulator="test_emulator",
+                slot="autosave",
+                file_path=rel_dir,
+                file_size_bytes=zip_path.stat().st_size,
+                content_hash=stale_raw_md5,
+            )
+        )
+
+        stats = await task.run()
+
+        assert stats["saves_scanned"] == 1
+        assert stats["saves_updated"] == 1
+        assert stats["saves_unchanged"] == 0
+        assert stats["saves_missing_fs"] == 0
+        assert stats["errors"] == 0
+
+        refreshed = db_save_handler.get_save(user_id=admin_user.id, id=save.id)
+        assert refreshed is not None
+        assert refreshed.content_hash == FIXTURE_A_PINNED_HASH
+
+    async def test_raw_md5_non_zip_correct_hash_is_unchanged(
+        self,
+        task: RecomputeSaveContentHashesTask,
+        isolated_assets_dir: Path,
+        admin_user: User,
+        rom: Rom,
+        platform: Platform,
+    ):
+        """A non-zip save (e.g. raw .sav) whose stored hash already matches
+        the raw MD5 of its bytes must not be rewritten. This exercises the
+        _compute_file_hash dispatch path that the zip-only suite missed.
+        """
+        rel_dir = f"{platform.fs_slug}/saves/test_emulator"
+        file_name = "raw_correct.sav"
+        sav_path = isolated_assets_dir / rel_dir / file_name
+        sav_path.parent.mkdir(parents=True, exist_ok=True)
+        sav_bytes = b"raw save bytes, definitely not a zip"
+        sav_path.write_bytes(sav_bytes)
+        # Sanity: this file must NOT look like a zip to the dispatch.
+        assert not zipfile.is_zipfile(sav_path)
+
+        raw_md5 = hashlib.md5(sav_bytes, usedforsecurity=False).hexdigest()
+        save = db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name=file_name,
+                file_name_no_tags="raw_correct",
+                file_name_no_ext="raw_correct",
+                file_extension="sav",
+                emulator="test_emulator",
+                slot="autosave",
+                file_path=rel_dir,
+                file_size_bytes=sav_path.stat().st_size,
+                content_hash=raw_md5,
+            )
+        )
+
+        stats = await task.run()
+
+        assert stats["saves_scanned"] == 1
+        assert stats["saves_unchanged"] == 1
+        assert stats["saves_updated"] == 0
+        assert stats["saves_missing_fs"] == 0
+        assert stats["errors"] == 0
+
+        refreshed = db_save_handler.get_save(user_id=admin_user.id, id=save.id)
+        assert refreshed is not None
+        assert refreshed.content_hash == raw_md5
+
+    async def test_raw_md5_non_zip_stale_hash_is_rewritten(
+        self,
+        task: RecomputeSaveContentHashesTask,
+        isolated_assets_dir: Path,
+        admin_user: User,
+        rom: Rom,
+        platform: Platform,
+    ):
+        """A non-zip save whose stored hash is wrong must be rewritten to the
+        raw MD5 of its bytes. This pins that the dispatch correctly routes
+        non-zip files to _compute_file_hash and not _compute_zip_hash.
+        """
+        rel_dir = f"{platform.fs_slug}/saves/test_emulator"
+        file_name = "raw_stale.sav"
+        sav_path = isolated_assets_dir / rel_dir / file_name
+        sav_path.parent.mkdir(parents=True, exist_ok=True)
+        sav_bytes = b"\x00\x01\x02arbitrary bytes\xff\xfe"
+        sav_path.write_bytes(sav_bytes)
+        assert not zipfile.is_zipfile(sav_path)
+
+        raw_md5 = hashlib.md5(sav_bytes, usedforsecurity=False).hexdigest()
+        stale_hash = "0" * 32
+        assert stale_hash != raw_md5
+
+        save = db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name=file_name,
+                file_name_no_tags="raw_stale",
+                file_name_no_ext="raw_stale",
+                file_extension="sav",
+                emulator="test_emulator",
+                slot="autosave",
+                file_path=rel_dir,
+                file_size_bytes=sav_path.stat().st_size,
+                content_hash=stale_hash,
+            )
+        )
+
+        stats = await task.run()
+
+        assert stats["saves_scanned"] == 1
+        assert stats["saves_updated"] == 1
+        assert stats["saves_unchanged"] == 0
+        assert stats["saves_missing_fs"] == 0
+        assert stats["errors"] == 0
+
+        refreshed = db_save_handler.get_save(user_id=admin_user.id, id=save.id)
+        assert refreshed is not None
+        assert refreshed.content_hash == raw_md5
+
+    async def test_raw_md5_non_zip_routes_through_compute_file_hash(
+        self,
+        task: RecomputeSaveContentHashesTask,
+        isolated_assets_dir: Path,
+        admin_user: User,
+        rom: Rom,
+        platform: Platform,
+    ):
+        """Direct dispatch check: for a non-zip file, compute_content_hash
+        must call _compute_file_hash, not _compute_zip_hash. Spying on both
+        nails down the routing in a way the hash-equality assertions don't.
+        """
+        from unittest.mock import patch
+
+        from handler.filesystem import fs_asset_handler
+
+        rel_dir = f"{platform.fs_slug}/saves/test_emulator"
+        file_name = "raw_spy.sav"
+        sav_path = isolated_assets_dir / rel_dir / file_name
+        sav_path.parent.mkdir(parents=True, exist_ok=True)
+        sav_path.write_bytes(b"spy on me")
+        assert not zipfile.is_zipfile(sav_path)
+
+        db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name=file_name,
+                file_name_no_tags="raw_spy",
+                file_name_no_ext="raw_spy",
+                file_extension="sav",
+                emulator="test_emulator",
+                slot="autosave",
+                file_path=rel_dir,
+                file_size_bytes=sav_path.stat().st_size,
+                content_hash="anything",
+            )
+        )
+
+        original_file_hash = fs_asset_handler._compute_file_hash
+        original_zip_hash = fs_asset_handler._compute_zip_hash
+
+        with patch.object(
+            fs_asset_handler,
+            "_compute_file_hash",
+            wraps=original_file_hash,
+        ) as spy_file, patch.object(
+            fs_asset_handler,
+            "_compute_zip_hash",
+            wraps=original_zip_hash,
+        ) as spy_zip:
+            await task.run()
+
+        assert spy_file.call_count == 1
+        assert spy_zip.call_count == 0
+
+    async def test_missing_file_is_counted_but_unchanged(
+        self,
+        task: RecomputeSaveContentHashesTask,
+        isolated_assets_dir: Path,
+        admin_user: User,
+        rom: Rom,
+        platform: Platform,
+    ):
+        """A DB row whose backing file is gone must be tallied as missing_fs
+        and the stored hash must be left alone (no overwrite-to-None)."""
+        rel_dir = f"{platform.fs_slug}/saves/test_emulator"
+        file_name = "ghost.zip"
+
+        original_hash = "deadbeefdeadbeefdeadbeefdeadbeef"
+        save = db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name=file_name,
+                file_name_no_tags="ghost",
+                file_name_no_ext="ghost",
+                file_extension="zip",
+                emulator="test_emulator",
+                slot="autosave",
+                file_path=rel_dir,
+                file_size_bytes=1,
+                content_hash=original_hash,
+            )
+        )
+
+        # Sanity: ensure the file really isn't on disk.
+        assert not (isolated_assets_dir / rel_dir / file_name).exists()
+
+        stats = await task.run()
+
+        assert stats["saves_scanned"] == 1
+        assert stats["saves_missing_fs"] == 1
+        assert stats["saves_updated"] == 0
+        assert stats["saves_unchanged"] == 0
+        assert stats["errors"] == 0
+
+        refreshed = db_save_handler.get_save(user_id=admin_user.id, id=save.id)
+        assert refreshed is not None
+        assert refreshed.content_hash == original_hash
+
+    async def test_update_save_failure_increments_errors(
+        self,
+        task: RecomputeSaveContentHashesTask,
+        isolated_assets_dir: Path,
+        admin_user: User,
+        rom: Rom,
+        platform: Platform,
+        mocker,
+    ):
+        """A row whose hash genuinely needs rewriting but whose update_save
+        call raises should land in the errors bucket, not silently succeed."""
+        rel_dir = f"{platform.fs_slug}/saves/test_emulator"
+        file_name = "fixture_a.zip"
+        _write_fixture_a_zip(isolated_assets_dir / rel_dir / file_name)
+
+        db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name=file_name,
+                file_name_no_tags="fixture_a",
+                file_name_no_ext="fixture_a",
+                file_extension="zip",
+                emulator="test_emulator",
+                slot="autosave",
+                file_path=rel_dir,
+                file_size_bytes=1,
+                content_hash="00000000000000000000000000000000",
+            )
+        )
+
+        mocker.patch.object(
+            db_save_handler,
+            "update_save",
+            side_effect=RuntimeError("simulated DB failure"),
+        )
+
+        stats = await task.run()
+
+        assert stats["saves_scanned"] == 1
+        assert stats["errors"] == 1
+        assert stats["saves_updated"] == 0
+        assert stats["saves_unchanged"] == 0
+        assert stats["saves_missing_fs"] == 0

--- a/backend/tests/tasks/test_sync_push_pull.py
+++ b/backend/tests/tasks/test_sync_push_pull.py
@@ -1,10 +1,23 @@
 """Tests for SyncPushPullTask initialization and configuration."""
 
-from unittest.mock import patch
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tasks.sync_push_pull_task import SyncPushPullTask, sync_push_pull_task
+from handler.database import db_device_handler, db_save_handler
+from handler.sync.ssh_handler import RemoteSaveInfo
+from models.assets import Save
+from models.device import Device, SyncMode
+from models.platform import Platform
+from models.rom import Rom
+from models.user import User
+from tasks.sync_push_pull_task import (
+    SyncPushPullTask,
+    _process_remote_save,
+    _push_missing_saves,
+    sync_push_pull_task,
+)
 from tasks.tasks import PeriodicTask, TaskType
 
 
@@ -67,3 +80,194 @@ class TestRunPushPullSync:
             mock_handler.get_device_by_id.return_value = None
             result = await run_push_pull_sync(device_id="test", force=True)
             assert result["status"] == "error"  # Device not found, but didn't skip
+
+
+class TestNullSlotLeakInProcessRemoteSave:
+    """Bug R1a: `_process_remote_save` selects the first save with matching
+    filename, including null-slot archival saves. This mirrors the negotiate
+    Invariant 2 leak — archival saves must never participate in device sync.
+    """
+
+    @pytest.fixture
+    def device(self, admin_user: User) -> Device:
+        return db_device_handler.add_device(
+            Device(
+                id="pp-dev-1",
+                user_id=admin_user.id,
+                sync_mode=SyncMode.PUSH_PULL,
+                sync_enabled=True,
+                sync_config={"ssh_host": "1.2.3.4"},
+            )
+        )
+
+    async def test_remote_filename_does_not_match_null_slot_archival(
+        self,
+        device: Device,
+        admin_user: User,
+        rom: Rom,
+        platform: Platform,
+        archival_save: Save,
+    ):
+        """Only an archival (null-slot) save exists with the colliding name.
+        A remote file with that filename must NOT be paired with the archival
+        row. The function should treat this as 'no matching server save' and
+        return 'skipped' (it certainly must not write to the archival save).
+        """
+        remote_save = RemoteSaveInfo(
+            path=f"/remote/{platform.fs_slug}/{archival_save.file_name}",
+            file_name=archival_save.file_name,
+            platform_slug=platform.fs_slug,
+            file_size=999,
+            mtime=datetime.now(timezone.utc),
+        )
+
+        ssh = MagicMock()
+        ssh.download_save = AsyncMock(
+            return_value=("/tmp/should_not_be_called", "deadbeef")
+        )
+        ssh.upload_save = AsyncMock()
+
+        with patch("tasks.sync_push_pull_task.get_ssh_sync_handler", return_value=ssh):
+            action = await _process_remote_save(
+                device, conn=MagicMock(), remote_save=remote_save
+            )
+
+        # Archival rows must not be selected as a sync target.
+        assert action == "skipped"
+        # The archival row's bytes must be untouched.
+        refreshed = db_save_handler.get_save(user_id=admin_user.id, id=archival_save.id)
+        assert refreshed is not None
+        assert refreshed.content_hash == archival_save.content_hash
+        assert refreshed.file_size_bytes == archival_save.file_size_bytes
+        # And nothing should have been downloaded from the device for this row.
+        ssh.download_save.assert_not_called()
+
+    async def test_remote_filename_matches_slotted_save_when_archival_collides(
+        self,
+        device: Device,
+        admin_user: User,
+        rom: Rom,
+        platform: Platform,
+        save: Save,
+    ):
+        """When both an archival and a slotted save share the filename, the
+        function must pick the slotted save, not the archival row that appears
+        first in the unfiltered query result.
+        """
+        # Create an additional archival (null-slot) save with the same filename
+        # as the slotted `save` fixture (test_save.sav). Insert it FIRST so the
+        # unfiltered iteration order favours it under the current bug.
+        archival = db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name=save.file_name,
+                file_name_no_tags=save.file_name_no_tags,
+                file_name_no_ext=save.file_name_no_ext,
+                file_extension=save.file_extension,
+                emulator=save.emulator,
+                slot=None,
+                file_path=save.file_path,
+                file_size_bytes=42,
+                content_hash="archival_hash_unique",
+            )
+        )
+
+        remote_save = RemoteSaveInfo(
+            path=f"/remote/{platform.fs_slug}/{save.file_name}",
+            file_name=save.file_name,
+            platform_slug=platform.fs_slug,
+            file_size=1,
+            mtime=datetime.now(timezone.utc),
+        )
+
+        ssh = MagicMock()
+        ssh.download_save = AsyncMock(
+            return_value=("/tmp/should_not_matter", save.content_hash or "x")
+        )
+        ssh.upload_save = AsyncMock()
+
+        with patch(
+            "tasks.sync_push_pull_task.get_ssh_sync_handler", return_value=ssh
+        ), patch("tasks.sync_push_pull_task.fs_asset_handler"), patch(
+            "tasks.sync_push_pull_task.compare_save_state"
+        ) as mock_cmp, patch(
+            "tasks.sync_push_pull_task.AnyioPath"
+        ) as mock_anyio_path:
+            mock_cmp.return_value = MagicMock(action="no_op", reason=None)
+            mock_anyio_path.return_value.exists = AsyncMock(return_value=False)
+            await _process_remote_save(
+                device, conn=MagicMock(), remote_save=remote_save
+            )
+
+            # compare_save_state should have been called with the SLOTTED save's
+            # hash, not the archival one. The bug picks the archival because it
+            # appears first in the unfiltered iteration.
+            kwargs = mock_cmp.call_args.kwargs
+            assert (
+                kwargs["server_hash"] != "archival_hash_unique"
+            ), "archival null-slot save leaked into push-pull match path"
+
+        # Archival row must remain untouched regardless.
+        refreshed = db_save_handler.get_save(user_id=admin_user.id, id=archival.id)
+        assert refreshed is not None
+        assert refreshed.content_hash == "archival_hash_unique"
+
+
+class TestNullSlotLeakInPushMissingSaves:
+    """Bug R1b: `_push_missing_saves` iterates every Save for the platform,
+    including null-slot archival rows, and uploads them to the device.
+    """
+
+    @pytest.fixture
+    def device(self, admin_user: User) -> Device:
+        return db_device_handler.add_device(
+            Device(
+                id="pp-dev-2",
+                user_id=admin_user.id,
+                sync_mode=SyncMode.PUSH_PULL,
+                sync_enabled=True,
+                sync_config={"ssh_host": "1.2.3.4"},
+            )
+        )
+
+    async def test_archival_save_is_not_pushed_to_device(
+        self,
+        device: Device,
+        admin_user: User,
+        platform: Platform,
+        save: Save,
+        archival_save: Save,
+    ):
+        """Only the slotted save should be uploaded. The null-slot archival
+        save must never be pushed to a device under push-pull sync.
+        """
+        ssh = MagicMock()
+        ssh.upload_save = AsyncMock()
+
+        save_directories = [
+            {"platform_slug": platform.fs_slug, "path": "/remote/saves"}
+        ]
+        # Empty remote_saves means every server save would be considered "missing".
+        with patch(
+            "tasks.sync_push_pull_task.get_ssh_sync_handler", return_value=ssh
+        ), patch("tasks.sync_push_pull_task.fs_asset_handler") as mock_assets:
+            mock_assets.validate_path.side_effect = lambda p: f"/server/{p}"
+            pushed = await _push_missing_saves(
+                device,
+                conn=MagicMock(),
+                remote_saves=[],
+                save_directories=save_directories,
+            )
+
+        uploaded_local_paths = [call.args[1] for call in ssh.upload_save.call_args_list]
+        # The archival file_name MUST NOT appear in any uploaded path.
+        assert not any(
+            archival_save.file_name in p for p in uploaded_local_paths
+        ), f"archival save {archival_save.file_name} leaked into device push: {uploaded_local_paths}"
+        # The slotted save SHOULD have been pushed.
+        assert any(
+            save.file_name in p for p in uploaded_local_paths
+        ), f"slotted save was not pushed: {uploaded_local_paths}"
+        # And the upload count should reflect slotted-only.
+        assert pushed == 1

--- a/backend/tests/test_startup.py
+++ b/backend/tests/test_startup.py
@@ -1,0 +1,66 @@
+"""Tests for startup-time auto-enqueue of the recompute task."""
+
+import startup
+
+
+def test_enqueue_recompute_skips_when_no_missing_hashes(mocker):
+    """Saves all have content_hash -> no enqueue."""
+    mocker.patch.object(
+        startup.db_save_handler, "count_saves_missing_content_hash", return_value=0
+    )
+    enqueue = mocker.patch.object(startup.low_prio_queue, "enqueue")
+
+    startup._enqueue_recompute_save_hashes_if_needed()
+
+    enqueue.assert_not_called()
+
+
+def test_enqueue_recompute_fires_when_missing_hashes_present(mocker):
+    """At least one Save row has NULL content_hash -> enqueue exactly once."""
+    mocker.patch.object(
+        startup.db_save_handler, "count_saves_missing_content_hash", return_value=42
+    )
+    enqueue = mocker.patch.object(startup.low_prio_queue, "enqueue")
+
+    startup._enqueue_recompute_save_hashes_if_needed()
+
+    enqueue.assert_called_once()
+    args, kwargs = enqueue.call_args
+    # First positional arg is the bound task.run method
+    assert args[0].__self__ is startup.recompute_save_content_hashes_task
+    # Sanity-check the meta payload routes correctly in the task list UI
+    assert kwargs["meta"]["task_name"] == (
+        startup.recompute_save_content_hashes_task.title
+    )
+    assert kwargs["meta"]["task_type"] == (
+        startup.recompute_save_content_hashes_task.task_type.value
+    )
+    # Job timeout must be passed; otherwise long-running recomputes get killed
+    # by RQ's default short timeout on very large libraries.
+    assert kwargs["job_timeout"] == startup.TASK_TIMEOUT
+
+
+def test_enqueue_recompute_swallows_count_error(mocker):
+    """A failed COUNT query must not crash startup."""
+    mocker.patch.object(
+        startup.db_save_handler,
+        "count_saves_missing_content_hash",
+        side_effect=RuntimeError("db gone"),
+    )
+    enqueue = mocker.patch.object(startup.low_prio_queue, "enqueue")
+
+    startup._enqueue_recompute_save_hashes_if_needed()
+
+    enqueue.assert_not_called()
+
+
+def test_enqueue_recompute_swallows_enqueue_error(mocker):
+    """A failed enqueue must not crash startup."""
+    mocker.patch.object(
+        startup.db_save_handler, "count_saves_missing_content_hash", return_value=5
+    )
+    mocker.patch.object(
+        startup.low_prio_queue, "enqueue", side_effect=RuntimeError("redis gone")
+    )
+
+    startup._enqueue_recompute_save_hashes_if_needed()

--- a/backend/tests/test_startup.py
+++ b/backend/tests/test_startup.py
@@ -1,6 +1,7 @@
 """Tests for startup-time auto-enqueue of the recompute task."""
 
 import startup
+from rq.exceptions import DuplicateJobError
 
 
 def test_enqueue_recompute_skips_when_no_missing_hashes(mocker):
@@ -38,6 +39,25 @@ def test_enqueue_recompute_fires_when_missing_hashes_present(mocker):
     # Job timeout must be passed; otherwise long-running recomputes get killed
     # by RQ's default short timeout on very large libraries.
     assert kwargs["job_timeout"] == startup.TASK_TIMEOUT
+    # Deterministic job_id + unique=True prevent duplicate enqueues across
+    # API process restarts while a previous recompute is still running.
+    assert kwargs["job_id"] == startup.RECOMPUTE_SAVE_HASHES_JOB_ID
+    assert kwargs["unique"] is True
+
+
+def test_enqueue_recompute_silently_skips_duplicate(mocker):
+    """A DuplicateJobError from RQ (job already queued/running) is logged and
+    swallowed, not propagated."""
+    mocker.patch.object(
+        startup.db_save_handler, "count_saves_missing_content_hash", return_value=10
+    )
+    mocker.patch.object(
+        startup.low_prio_queue,
+        "enqueue",
+        side_effect=DuplicateJobError("already enqueued"),
+    )
+
+    startup._enqueue_recompute_save_hashes_if_needed()
 
 
 def test_enqueue_recompute_swallows_count_error(mocker):

--- a/backend/tests/test_sync_watcher.py
+++ b/backend/tests/test_sync_watcher.py
@@ -2,11 +2,17 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from handler.database import db_device_handler, db_save_handler
 from handler.filesystem.sync_handler import FSSyncHandler
+from models.assets import Save
+from models.device import Device, SyncMode
+from models.platform import Platform
+from models.rom import Rom
+from models.user import User
 
 
 class TestExtractDeviceAndPlatform:
@@ -110,3 +116,164 @@ class TestProcessSyncChanges:
             from sync_watcher import process_sync_changes
 
             process_sync_changes([("added", "/some/path/file.sav")])
+
+
+class TestProcessIncomingFileFilenameOnlyMatching:
+    """Bug R2: `_process_incoming_file` matches incoming files purely by
+    filename, with no slot check. An incoming device push whose filename
+    collides with a null-slot archival save will overwrite the archival row.
+    """
+
+    @pytest.fixture
+    def temp_dir(self):
+        d = tempfile.mkdtemp()
+        yield d
+        shutil.rmtree(d, ignore_errors=True)
+
+    @pytest.fixture(autouse=True)
+    def patch_fs_sync_handler(self, temp_dir):
+        handler = FSSyncHandler.__new__(FSSyncHandler)
+        handler.base_path = Path(temp_dir)
+        with patch("sync_watcher.get_fs_sync_handler", return_value=handler):
+            yield handler
+
+    @pytest.fixture
+    def device(self, admin_user: User) -> Device:
+        return db_device_handler.add_device(
+            Device(
+                id="watcher-dev-1",
+                user_id=admin_user.id,
+                sync_mode=SyncMode.FILE_TRANSFER,
+                sync_enabled=True,
+            )
+        )
+
+    @pytest.fixture
+    def incoming_file(self, temp_dir, device: Device, platform: Platform):
+        """Create a real incoming file the watcher will hash and stat."""
+        incoming_dir = Path(temp_dir) / device.id / "incoming" / platform.fs_slug
+        incoming_dir.mkdir(parents=True, exist_ok=True)
+        path = incoming_dir / "collision.sav"
+        path.write_bytes(b"incoming bytes from device, must not clobber archival")
+        return str(path)
+
+    def test_archival_save_is_not_overwritten_by_filename_collision(
+        self,
+        device: Device,
+        admin_user: User,
+        rom: Rom,
+        platform: Platform,
+        incoming_file: str,
+    ):
+        """Only an archival (null-slot) save exists with the colliding name.
+        A device push of a file with that name must NOT overwrite the archival
+        row's bytes, hash, or size — there is no slotted save to match.
+        """
+        from sync_watcher import _process_incoming_file
+
+        archival = db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name="collision.sav",
+                file_name_no_tags="collision",
+                file_name_no_ext="collision",
+                file_extension="sav",
+                emulator="test_emulator",
+                slot=None,
+                file_path=f"{platform.slug}/saves/test_emulator",
+                file_size_bytes=12345,
+                content_hash="archival_pinned_hash",
+            )
+        )
+
+        # Force a server-side overwrite path if the bug picks the archival.
+        with patch("sync_watcher.compare_save_state") as mock_cmp, patch(
+            "sync_watcher.fs_asset_handler"
+        ), patch("sync_watcher.asyncio") as mock_asyncio:
+            mock_cmp.return_value = MagicMock(action="upload", reason=None)
+            mock_asyncio.run = MagicMock()
+            _process_incoming_file(
+                device=device,
+                session_id=1,
+                platform_slug=platform.fs_slug,
+                filename="collision.sav",
+                full_path=incoming_file,
+            )
+
+        # The archival row's hash/size MUST be untouched.
+        refreshed = db_save_handler.get_save(user_id=admin_user.id, id=archival.id)
+        assert refreshed is not None
+        assert refreshed.content_hash == "archival_pinned_hash"
+        assert refreshed.file_size_bytes == 12345
+
+    def test_slotted_save_is_matched_when_archival_collides_on_filename(
+        self,
+        device: Device,
+        admin_user: User,
+        rom: Rom,
+        platform: Platform,
+        incoming_file: str,
+    ):
+        """When both an archival and a slotted save share the filename, the
+        watcher must pick the slotted save (the device-uploaded shape). The
+        bug picks the first row returned, which can be the archival.
+        """
+        from sync_watcher import _process_incoming_file
+
+        # Insert archival FIRST so unfiltered iteration order favours it.
+        archival = db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name="collision.sav",
+                file_name_no_tags="collision",
+                file_name_no_ext="collision",
+                file_extension="sav",
+                emulator="test_emulator",
+                slot=None,
+                file_path=f"{platform.slug}/saves/test_emulator",
+                file_size_bytes=12345,
+                content_hash="archival_pinned_hash",
+            )
+        )
+        slotted = db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name="collision.sav",
+                file_name_no_tags="collision",
+                file_name_no_ext="collision",
+                file_extension="sav",
+                emulator="test_emulator",
+                slot="autosave",
+                file_path=f"{platform.slug}/saves/test_emulator",
+                file_size_bytes=99,
+                content_hash="slotted_old_hash",
+            )
+        )
+
+        with patch("sync_watcher.compare_save_state") as mock_cmp, patch(
+            "sync_watcher.fs_asset_handler"
+        ), patch("sync_watcher.asyncio") as mock_asyncio:
+            mock_cmp.return_value = MagicMock(action="upload", reason=None)
+            mock_asyncio.run = MagicMock()
+            _process_incoming_file(
+                device=device,
+                session_id=1,
+                platform_slug=platform.fs_slug,
+                filename="collision.sav",
+                full_path=incoming_file,
+            )
+
+        # The slotted save should be the one updated. The archival must remain.
+        archival_after = db_save_handler.get_save(user_id=admin_user.id, id=archival.id)
+        slotted_after = db_save_handler.get_save(user_id=admin_user.id, id=slotted.id)
+        assert archival_after is not None
+        assert slotted_after is not None
+        assert (
+            archival_after.content_hash == "archival_pinned_hash"
+        ), "archival row was overwritten by filename-only match"
+        assert (
+            slotted_after.content_hash != "slotted_old_hash"
+        ), "slotted save should have been updated, but the bug picked archival"


### PR DESCRIPTION
## Description

Cleanup pass on save-sync addressing three independent failure modes
discovered during 4.9 alpha testing that interact in production data:
`content_hash` drift between client and server, null-slot archival
saves leaking into sync flows, and content-hash dedupe collapsing
legitimately-distinct slots.

### Bug fixes

- **Hash drift in `compute_content_hash`** — `zipfile.is_zipfile` was
  called with a relative path, so it silently returned `False` whenever
  the process's CWD wasn't `ASSETS_BASE_PATH`. Every zip save fell
  through to the raw-MD5 branch, persisting hashes that disagreed with
  clients computing the intended per-entry zip-hash. Resolve to a full
  path before the dispatch.

- **Null-slot leak into sync flows** — `_build_negotiate_plan`,
  `sync_push_pull_task`, and `sync_watcher` all treated null-slot
  saves as sync-eligible. Null-slot saves represent web-UI / archival
  uploads; including them in negotiate plans matched them against
  device pushes by filename and overwrote archival data. Filter at
  all three call sites.

- **Dedupe lookups ignored slot** — two upload-path lookups matched
  without considering slot, collapsing legitimately-distinct uploads
  into one record:
  - `get_save_by_content_hash` matched on `(rom_id, user_id,
    content_hash)`, so identical bytes uploaded to different slots
    collapsed.
  - `get_save_by_filename` matched on `(rom_id, user_id, file_name)`.
    When two uploads to different slots happened in the same
    wall-clock second (the datetime tag is per-second), the second
    upload UPDATED the first record's slot instead of creating a new
    row.

  Both now accept an optional slot kwarg, passed from the upload
  endpoint.

### One-shot recovery

- **\`recompute_save_content_hashes\` manual task** — walks every Save
  row, recomputes via the fixed dispatch, and updates rows whose
  values differ. Idempotent and safe to re-run. Counters tracked via
  RQ job meta.

- **Auto-enqueue on first startup** — backend startup runs a single
  \`COUNT(*) WHERE content_hash IS NULL\` query. If any rows exist, the
  recompute task is enqueued on the low-priority RQ queue and the API
  process moves on. Worker handles the recompute out-of-band.
  Subsequent restarts find zero NULL hashes and skip. Admins can
  still trigger the task manually.

> [!NOTE]
> On first restart after upgrade, the API enqueues a one-shot
> recompute of \`content_hash\` for any Save rows missing one. Runs in
> the background on the low-priority RQ worker; API startup is not
> blocked. Subsequent restarts are no-ops. Operators can also
> trigger \`recompute_save_content_hashes\` manually.

---

> AI Disclosure
> Planning and review assisted by Claude Code.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes