### PR TITLE
fix(screenscraper): use internal filename as romnom for single-file archive games

### DIFF
--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -18,7 +18,7 @@ from handler.metadata.moby_handler import MobyMetadata
 from handler.metadata.ra_handler import RAMetadata
 from handler.metadata.ss_handler import SSMetadata
 from models.collection import Collection
-from models.rom import Rom, RomFileCategory, RomUserStatus
+from models.rom import Rom, RomArchiveMember, RomFileCategory, RomUserStatus
 
 from .base import BaseModel, UTCDatetime
 
@@ -147,14 +147,6 @@ class RomUserSchema(BaseModel):
         return rom_user_schema_factory()
 
 
-class ArchiveMemberSchema(TypedDict):
-    name: str
-    size: int
-    crc_hash: str
-    md5_hash: str
-    sha1_hash: str
-
-
 class RomFileSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -172,7 +164,7 @@ class RomFileSchema(BaseModel):
     sha1_hash: str | None
     ra_hash: str | None
     chd_sha1_hash: str | None
-    archive_members: list[ArchiveMemberSchema] | None
+    archive_members: list[RomArchiveMember] | None
     category: RomFileCategory | None
 
 

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -714,7 +714,7 @@ class SSHandler(MetadataHandler):
             crc=crc_hash,
             rom_size_bytes=fs_size_bytes,
             rom_name=(
-                first_file.archive_members[0]["name"]
+                first_file.archive_members[0]["name"].split("/")[-1]
                 if first_file.archive_members is not None
                 and len(first_file.archive_members) == 1
                 else first_file.file_name

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -713,7 +713,11 @@ class SSHandler(MetadataHandler):
             sha1=sha1_hash,
             crc=crc_hash,
             rom_size_bytes=fs_size_bytes,
-            rom_name=first_file.file_name,
+            rom_name=(
+                first_file.archive_members[0]["name"]
+                if first_file.archive_members and len(first_file.archive_members) == 1
+                else first_file.file_name
+            ),
             rom_type=_get_rom_type(first_file),
         )
         if not res:

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -715,7 +715,8 @@ class SSHandler(MetadataHandler):
             rom_size_bytes=fs_size_bytes,
             rom_name=(
                 first_file.archive_members[0]["name"]
-                if first_file.archive_members and len(first_file.archive_members) == 1
+                if first_file.archive_members is not None
+                and len(first_file.archive_members) == 1
                 else first_file.file_name
             ),
             rom_type=_get_rom_type(first_file),

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -4,7 +4,7 @@ import copy
 import enum
 from datetime import datetime
 from functools import cached_property
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from sqlalchemy import (
     TIMESTAMP,
@@ -64,6 +64,14 @@ class SiblingRom(BaseModel):
     )
 
 
+class RomArchiveMember(TypedDict):
+    name: str
+    size: int
+    crc_hash: str
+    md5_hash: str
+    sha1_hash: str
+
+
 class RomFile(BaseModel):
     __tablename__ = "rom_files"
 
@@ -80,7 +88,7 @@ class RomFile(BaseModel):
     sha1_hash: Mapped[str | None] = mapped_column(String(100))
     ra_hash: Mapped[str | None] = mapped_column(String(100))
     chd_sha1_hash: Mapped[str | None] = mapped_column(String(100))
-    archive_members: Mapped[list[dict[str, Any]] | None] = mapped_column(
+    archive_members: Mapped[list[RomArchiveMember] | None] = mapped_column(
         CustomJSON(), default=None, nullable=True
     )
     category: Mapped[RomFileCategory | None] = mapped_column(

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -717,6 +717,93 @@ class TestLookupRom:
         assert is_not_game is True
 
     @pytest.mark.asyncio
+    async def test_romnom_uses_archive_member_name_for_single_file_archive(self):
+        handler = SSHandler()
+        mock_file = self._make_mock_file()
+        mock_file.file_name = "Mario.zip"
+        mock_file.archive_members = [
+            {
+                "name": "mario.n64",
+                "size": 1024,
+                "crc_hash": "",
+                "md5_hash": "",
+                "sha1_hash": "",
+            }
+        ]
+        captured = {}
+
+        async def capture(**kwargs):
+            captured.update(kwargs)
+            return None
+
+        with patch.object(handler.ss_service, "get_game_info", side_effect=capture):
+            await handler.lookup_rom(MagicMock(platform_slug="n64"), 14, [mock_file])
+        assert captured.get("rom_name") == "mario.n64"
+
+    @pytest.mark.asyncio
+    async def test_romnom_uses_archive_filename_for_multi_file_archive(self):
+        handler = SSHandler()
+        mock_file = self._make_mock_file()
+        mock_file.file_name = "Mario.zip"
+        mock_file.archive_members = [
+            {
+                "name": "mario.bin",
+                "size": 1024,
+                "crc_hash": "",
+                "md5_hash": "",
+                "sha1_hash": "",
+            },
+            {
+                "name": "mario.cue",
+                "size": 64,
+                "crc_hash": "",
+                "md5_hash": "",
+                "sha1_hash": "",
+            },
+        ]
+        captured = {}
+
+        async def capture(**kwargs):
+            captured.update(kwargs)
+            return None
+
+        with patch.object(handler.ss_service, "get_game_info", side_effect=capture):
+            await handler.lookup_rom(MagicMock(platform_slug="psx"), 57, [mock_file])
+        assert captured.get("rom_name") == "Mario.zip"
+
+    @pytest.mark.asyncio
+    async def test_romnom_uses_archive_filename_when_no_archive_members(self):
+        handler = SSHandler()
+        mock_file = self._make_mock_file()
+        mock_file.file_name = "mario.n64"
+        mock_file.archive_members = None
+        captured = {}
+
+        async def capture(**kwargs):
+            captured.update(kwargs)
+            return None
+
+        with patch.object(handler.ss_service, "get_game_info", side_effect=capture):
+            await handler.lookup_rom(MagicMock(platform_slug="n64"), 14, [mock_file])
+        assert captured.get("rom_name") == "mario.n64"
+
+    @pytest.mark.asyncio
+    async def test_romnom_uses_archive_filename_when_archive_members_empty(self):
+        handler = SSHandler()
+        mock_file = self._make_mock_file()
+        mock_file.file_name = "Mario.zip"
+        mock_file.archive_members = []
+        captured = {}
+
+        async def capture(**kwargs):
+            captured.update(kwargs)
+            return None
+
+        with patch.object(handler.ss_service, "get_game_info", side_effect=capture):
+            await handler.lookup_rom(MagicMock(platform_slug="n64"), 14, [mock_file])
+        assert captured.get("rom_name") == "Mario.zip"
+
+    @pytest.mark.asyncio
     async def test_returns_notgame_flag_on_zzz_prefix(self):
         notgame_response = {
             "id": "0",

--- a/frontend/src/__generated__/index.ts
+++ b/frontend/src/__generated__/index.ts
@@ -94,6 +94,7 @@ export type { RAProgression } from './models/RAProgression';
 export type { RAUserGameProgression } from './models/RAUserGameProgression';
 export type { RegionBreakdownItem } from './models/RegionBreakdownItem';
 export type { Role } from './models/Role';
+export type { RomArchiveMember } from './models/RomArchiveMember';
 export type { RomFileCategory } from './models/RomFileCategory';
 export type { RomFileSchema } from './models/RomFileSchema';
 export type { RomFiltersDict } from './models/RomFiltersDict';

--- a/frontend/src/__generated__/models/MetadataMediaType.ts
+++ b/frontend/src/__generated__/models/MetadataMediaType.ts
@@ -2,4 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type MetadataMediaType = 'bezel' | 'box2d' | 'box2d_back' | 'box3d' | 'miximage' | 'physical' | 'screenshot' | 'title_screen' | 'marquee' | 'logo' | 'fanart' | 'video' | 'video_normalized' | 'manual';
+export type MetadataMediaType = 'bezel' | 'box2d' | 'box2d_back' | 'box3d' | 'miximage' | 'miximage_v2' | 'physical' | 'screenshot' | 'title_screen' | 'marquee' | 'logo' | 'fanart' | 'video' | 'video_normalized' | 'manual';

--- a/frontend/src/__generated__/models/RomArchiveMember.ts
+++ b/frontend/src/__generated__/models/RomArchiveMember.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type RomArchiveMember = {
+    name: string;
+    size: number;
+    crc_hash: string;
+    md5_hash: string;
+    sha1_hash: string;
+};
+

--- a/frontend/src/__generated__/models/RomFileSchema.ts
+++ b/frontend/src/__generated__/models/RomFileSchema.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { RomArchiveMember } from './RomArchiveMember';
 import type { RomFileCategory } from './RomFileCategory';
 export type RomFileSchema = {
     id: number;
@@ -18,7 +19,7 @@ export type RomFileSchema = {
     sha1_hash: (string | null);
     ra_hash: (string | null);
     chd_sha1_hash: (string | null);
-    archive_members: null;
+    archive_members: (Array<RomArchiveMember> | null);
     category: (RomFileCategory | null);
 };
 

--- a/frontend/src/__generated__/models/RomSSMetadata.ts
+++ b/frontend/src/__generated__/models/RomSSMetadata.ts
@@ -15,6 +15,7 @@ export type RomSSMetadata = {
     manual_url?: (string | null);
     marquee_url?: (string | null);
     miximage_url?: (string | null);
+    miximage_v2_url?: (string | null);
     physical_url?: (string | null);
     screenshot_url?: (string | null);
     steamgrid_url?: (string | null);
@@ -26,6 +27,7 @@ export type RomSSMetadata = {
     box3d_path?: (string | null);
     fanart_path?: (string | null);
     miximage_path?: (string | null);
+    miximage_v2_path?: (string | null);
     physical_path?: (string | null);
     marquee_path?: (string | null);
     logo_path?: (string | null);


### PR DESCRIPTION
**Description**
When RomM sends a `jeuInfos.php` hash lookup to ScreenScraper, `romnom` was always set to the archive filename on disk (e.g. `Mario.zip`). For single-file archives, the hash is computed from the internal file (e.g. `mario.n64`), so sending the archive name sends slightly incorrect info to ss.fr during a KO scrape.

When `archive_members` has exactly one entry (populated by #3412), `romnom` now uses that member's internal filename instead. Multi-file archives and non-archive files continue to use the filesystem filename unchanged.

Closes #3444.

> **AI Disclosure:** This PR was written with Claude Code (Anthropic). Code generation, research, and debugging were AI-assisted; logic and design decisions were reviewed and directed by the author.

**Checklist**
- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes