### PR TITLE
Fix save-sync negotiate thrash and unblock content_hash recompute

### DIFF
--- a/backend/endpoints/sync.py
+++ b/backend/endpoints/sync.py
@@ -115,17 +115,16 @@ def negotiate_sync(
 
     operations: list[SyncOperationSchema] = []
 
-    # Build a set of server saves for this user, keyed by (rom_id, file_name).
-    # Only slot-bound saves participate in sync; null-slot saves are web-UI or
-    # archival uploads and act as backups (clients can opt-in to import them
-    # outside the sync flow). Filtering in SQL avoids materializing archival
-    # rows we'd immediately discard.
+    # Pair on (rom_id, slot), keeping the newest row per slot: slot uploads are datetime-tagged (spec) so tagged filenames never equal the client's untagged name, and a slot accrues many rows over time. Null-slot rows stay archival-only.
     server_saves = db_save_handler.get_saves(
         user_id=request.user.id, slot_not_null=True
     )
-    server_save_map: dict[tuple[int, str], Save] = {}
+    server_save_map: dict[tuple[int, str | None], Save] = {}
     for save in server_saves:
-        server_save_map[(save.rom_id, save.file_name)] = save
+        key = (save.rom_id, save.slot)
+        current = server_save_map.get(key)
+        if current is None or to_utc(save.updated_at) > to_utc(current.updated_at):
+            server_save_map[key] = save
 
     # Get all sync records for this device
     all_save_ids = [s.id for s in server_saves]
@@ -139,7 +138,7 @@ def negotiate_sync(
 
     # Process each client save
     for client_save in payload.saves:
-        key = (client_save.rom_id, client_save.file_name)
+        key = (client_save.rom_id, client_save.slot)
         server_save = server_save_map.get(key)
 
         if server_save is None:
@@ -197,8 +196,8 @@ def negotiate_sync(
             )
         )
 
-    # Check for server saves the client didn't mention
-    for save in server_saves:
+    # Check for current saves the client didn't mention (superseded older rows per slot are history, not downloads)
+    for save in server_save_map.values():
         if save.id in matched_server_save_ids:
             continue
 

--- a/backend/startup.py
+++ b/backend/startup.py
@@ -71,14 +71,14 @@ def _enqueue_recompute_save_hashes_if_needed() -> None:
         log.debug("All saves have content_hash; skipping recompute auto-enqueue")
         return
 
-    if Job.exists(RECOMPUTE_SAVE_HASHES_JOB_ID, low_prio_queue.connection):
-        log.info(
-            "recompute_save_content_hashes already queued or running from a "
-            "previous restart; skipping enqueue"
-        )
-        return
-
     try:
+        if Job.exists(RECOMPUTE_SAVE_HASHES_JOB_ID, low_prio_queue.connection):
+            log.info(
+                "recompute_save_content_hashes already queued or running from a "
+                "previous restart; skipping enqueue"
+            )
+            return
+
         low_prio_queue.enqueue(
             recompute_save_content_hashes_task.run,
             job_id=RECOMPUTE_SAVE_HASHES_JOB_ID,

--- a/backend/startup.py
+++ b/backend/startup.py
@@ -4,7 +4,7 @@ import asyncio
 
 import sentry_sdk
 from opentelemetry import trace
-from rq.exceptions import DuplicateJobError
+from rq.job import Job
 
 from config import (
     ENABLE_SCHEDULED_CONVERT_IMAGES_TO_WEBP,
@@ -48,7 +48,7 @@ from utils.context import initialize_context
 
 tracer = trace.get_tracer(__name__)
 
-RECOMPUTE_SAVE_HASHES_JOB_ID = "recompute_save_content_hashes:bootstrap"
+RECOMPUTE_SAVE_HASHES_JOB_ID = "recompute_save_content_hashes_bootstrap"
 
 
 def _enqueue_recompute_save_hashes_if_needed() -> None:
@@ -71,11 +71,17 @@ def _enqueue_recompute_save_hashes_if_needed() -> None:
         log.debug("All saves have content_hash; skipping recompute auto-enqueue")
         return
 
+    if Job.exists(RECOMPUTE_SAVE_HASHES_JOB_ID, low_prio_queue.connection):
+        log.info(
+            "recompute_save_content_hashes already queued or running from a "
+            "previous restart; skipping enqueue"
+        )
+        return
+
     try:
         low_prio_queue.enqueue(
             recompute_save_content_hashes_task.run,
             job_id=RECOMPUTE_SAVE_HASHES_JOB_ID,
-            unique=True,
             job_timeout=TASK_TIMEOUT,
             meta={
                 "task_name": recompute_save_content_hashes_task.title,
@@ -85,11 +91,6 @@ def _enqueue_recompute_save_hashes_if_needed() -> None:
         log.info(
             f"Enqueued recompute_save_content_hashes ({missing} saves with NULL content_hash); "
             "running on low-priority worker"
-        )
-    except DuplicateJobError:
-        log.info(
-            "recompute_save_content_hashes already queued or running from a "
-            "previous restart; skipping enqueue"
         )
     except Exception:
         log.exception(

--- a/backend/tests/endpoints/test_sync.py
+++ b/backend/tests/endpoints/test_sync.py
@@ -1,6 +1,8 @@
 """Tests for sync endpoints."""
 
+import os
 from datetime import datetime, timedelta, timezone
+from io import BytesIO
 from unittest import mock
 
 from fastapi import status
@@ -9,6 +11,7 @@ from handler.database import (
     db_device_handler,
     db_device_save_sync_handler,
     db_play_session_handler,
+    db_save_handler,
     db_sync_session_handler,
 )
 from models.assets import Save
@@ -84,6 +87,7 @@ class TestSyncNegotiate:
                     {
                         "rom_id": save.rom_id,
                         "file_name": save.file_name,
+                        "slot": save.slot,
                         "content_hash": save.content_hash,
                         "updated_at": save.updated_at.isoformat(),
                         "file_size_bytes": 100,
@@ -95,7 +99,7 @@ class TestSyncNegotiate:
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        # If save has a hash, should be no_op; otherwise download/upload by timestamp
+        # Fixture save has no content_hash; hash-match no_op is covered by test_negotiate_matches_untagged_client_to_tagged_server_saves
         assert "session_id" in data
 
     def test_negotiate_device_not_found(self, client, access_token: str):
@@ -433,6 +437,7 @@ class TestNegotiateAdvanced:
                     {
                         "rom_id": save.rom_id,
                         "file_name": save.file_name,
+                        "slot": save.slot,
                         "content_hash": "different_hash",
                         "updated_at": "2026-03-01T00:00:00Z",
                         "file_size_bytes": 100,
@@ -518,6 +523,186 @@ class TestNegotiateAdvanced:
         data = response.json()
         ops_for_save = [op for op in data["operations"] if op.get("save_id") == save.id]
         assert len(ops_for_save) == 0
+
+    def test_negotiate_matches_untagged_client_to_tagged_server_saves(
+        self, client, access_token: str, admin_user: User, rom: Rom, platform
+    ):
+        """Spec datetime-tags every slot upload, so a slot accrues many tagged rows and the client reports the untagged canonical name. Pairing must be by (rom_id, slot) on the newest row, else every negotiate yields upload+download forever."""
+        device = db_device_handler.add_device(
+            Device(id="neg-tagged-dev", user_id=admin_user.id, sync_enabled=True)
+        )
+        for tag in ("2026-01-01_00-00-00", "2026-02-02_00-00-00"):
+            db_save_handler.add_save(
+                Save(
+                    rom_id=rom.id,
+                    user_id=admin_user.id,
+                    file_name=f"test_save [{tag}].sav",
+                    file_name_no_tags="test_save",
+                    file_name_no_ext=f"test_save [{tag}]",
+                    file_extension="sav",
+                    emulator="test_emulator",
+                    slot="autosave",
+                    content_hash="HASH_MATCH",
+                    file_path=f"{platform.slug}/saves/test_emulator",
+                    file_size_bytes=1.0,
+                )
+            )
+
+        response = client.post(
+            "/api/sync/negotiate",
+            json={
+                "device_id": device.id,
+                "saves": [
+                    {
+                        "rom_id": rom.id,
+                        "file_name": "test_save.sav",
+                        "slot": "autosave",
+                        "content_hash": "HASH_MATCH",
+                        "updated_at": "2026-03-01T00:00:00Z",
+                        "file_size_bytes": 100,
+                    }
+                ],
+            },
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["total_upload"] == 0
+        assert data["total_download"] == 0
+        rom_ops = [op for op in data["operations"] if op["rom_id"] == rom.id]
+        assert len(rom_ops) == 1
+        assert rom_ops[0]["action"] == "no_op"
+
+    def _upload_autosave(
+        self, client, access_token, rom, *, filename, content_hash, device_id
+    ):
+        """Upload through the real add_save so _apply_datetime_tag runs; scan_save is mocked to echo the server-computed (tagged) file_name, never a hand-authored one."""
+
+        def make_scanned(*, file_name, user, platform_fs_slug, rom_id, emulator):
+            return Save(
+                file_name=file_name,
+                file_name_no_tags=file_name.split(" [")[0],
+                file_name_no_ext=os.path.splitext(file_name)[0],
+                file_extension="zip",
+                file_path=f"{platform_fs_slug}/saves/{emulator or ''}",
+                file_size_bytes=100,
+                content_hash=content_hash,
+            )
+
+        with mock.patch(
+            "endpoints.saves.fs_asset_handler.write_file", new_callable=mock.AsyncMock
+        ), mock.patch(
+            "endpoints.saves.fs_asset_handler.remove_file", new_callable=mock.AsyncMock
+        ), mock.patch(
+            "endpoints.saves.scan_save",
+            new=mock.AsyncMock(side_effect=make_scanned),
+        ):
+            return client.post(
+                f"/api/saves?rom_id={rom.id}&slot=autosave&emulator=eden"
+                f"&device_id={device_id}",
+                files={
+                    "saveFile": (
+                        filename,
+                        BytesIO(b"save bytes"),
+                        "application/octet-stream",
+                    )
+                },
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
+    def _negotiate(self, client, access_token, device_id, saves):
+        resp = client.post(
+            "/api/sync/negotiate",
+            json={"device_id": device_id, "saves": saves},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        return resp.json()
+
+    @staticmethod
+    def _autosave_entry(rom, content_hash):
+        return {
+            "rom_id": rom.id,
+            "file_name": "pokemon_violet.zip",
+            "slot": "autosave",
+            "content_hash": content_hash,
+            "updated_at": "2026-03-01T00:00:00Z",
+            "file_size_bytes": 100,
+        }
+
+    def test_save_upload_then_negotiate_converges(
+        self, client, access_token: str, admin_user: User, rom: Rom, platform
+    ):
+        """Full round-trip: upload tags the filename (real add_save), then the client reports its untagged canonical name. Must converge to no_op, not re-upload. This is the regression that hand-fed-filename mocks missed."""
+        device = db_device_handler.add_device(
+            Device(id="conv-rt-dev", user_id=admin_user.id, sync_enabled=True)
+        )
+        up = self._upload_autosave(
+            client,
+            access_token,
+            rom,
+            filename="pokemon_violet.zip",
+            content_hash="HASH_RT",
+            device_id=device.id,
+        )
+        assert up.status_code == status.HTTP_200_OK
+        stored = up.json()
+        assert stored["file_name"] != "pokemon_violet.zip"
+        assert " [" in stored["file_name"]
+
+        data = self._negotiate(
+            client, access_token, device.id, [self._autosave_entry(rom, "HASH_RT")]
+        )
+        assert data["total_upload"] == 0
+        assert data["total_download"] == 0
+        rom_ops = [op for op in data["operations"] if op["rom_id"] == rom.id]
+        assert len(rom_ops) == 1
+        assert rom_ops[0]["action"] == "no_op"
+
+    def test_three_device_sync_converges(
+        self, client, access_token: str, admin_user: User, rom: Rom, platform
+    ):
+        """A uploads; B and C each download exactly once then converge to no_op. The pre-fix tagged-filename keying made every device upload+download forever -- this is the 3-device scenario done with faithful (untagged client / tagged server) names."""
+        device_a = db_device_handler.add_device(
+            Device(id="conv-a", user_id=admin_user.id, sync_enabled=True)
+        )
+        up = self._upload_autosave(
+            client,
+            access_token,
+            rom,
+            filename="pokemon_violet.zip",
+            content_hash="HASH_3D",
+            device_id=device_a.id,
+        )
+        assert up.status_code == status.HTTP_200_OK
+        save_id = up.json()["id"]
+
+        a_data = self._negotiate(
+            client, access_token, device_a.id, [self._autosave_entry(rom, "HASH_3D")]
+        )
+        assert a_data["total_upload"] == 0
+        assert a_data["total_download"] == 0
+
+        for dev_id in ("conv-b", "conv-c"):
+            dev = db_device_handler.add_device(
+                Device(id=dev_id, user_id=admin_user.id, sync_enabled=True)
+            )
+            first = self._negotiate(client, access_token, dev.id, [])
+            downloads = [
+                op
+                for op in first["operations"]
+                if op["action"] == "download" and op["save_id"] == save_id
+            ]
+            assert len(downloads) == 1
+            db_device_save_sync_handler.upsert_sync(
+                device_id=dev.id, save_id=save_id, synced_at=datetime.now(timezone.utc)
+            )
+            second = self._negotiate(
+                client, access_token, dev.id, [self._autosave_entry(rom, "HASH_3D")]
+            )
+            assert second["total_upload"] == 0
+            assert second["total_download"] == 0
 
     def test_complete_failed_session_rejected(
         self, client, access_token: str, admin_user: User

--- a/backend/tests/test_startup.py
+++ b/backend/tests/test_startup.py
@@ -1,7 +1,6 @@
 """Tests for startup-time auto-enqueue of the recompute task."""
 
 import startup
-from rq.exceptions import DuplicateJobError
 
 
 def test_enqueue_recompute_skips_when_no_missing_hashes(mocker):
@@ -21,6 +20,7 @@ def test_enqueue_recompute_fires_when_missing_hashes_present(mocker):
     mocker.patch.object(
         startup.db_save_handler, "count_saves_missing_content_hash", return_value=42
     )
+    mocker.patch.object(startup.Job, "exists", return_value=False)
     enqueue = mocker.patch.object(startup.low_prio_queue, "enqueue")
 
     startup._enqueue_recompute_save_hashes_if_needed()
@@ -39,25 +39,26 @@ def test_enqueue_recompute_fires_when_missing_hashes_present(mocker):
     # Job timeout must be passed; otherwise long-running recomputes get killed
     # by RQ's default short timeout on very large libraries.
     assert kwargs["job_timeout"] == startup.TASK_TIMEOUT
-    # Deterministic job_id + unique=True prevent duplicate enqueues across
-    # API process restarts while a previous recompute is still running.
     assert kwargs["job_id"] == startup.RECOMPUTE_SAVE_HASHES_JOB_ID
-    assert kwargs["unique"] is True
 
 
-def test_enqueue_recompute_silently_skips_duplicate(mocker):
-    """A DuplicateJobError from RQ (job already queued/running) is logged and
-    swallowed, not propagated."""
+def test_recompute_job_id_has_no_colon():
+    """RQ's Job.set_id rejects ':' in a job_id; a colon raised ValueError that
+    the broad except swallowed, so the backfill never enqueued."""
+    assert ":" not in startup.RECOMPUTE_SAVE_HASHES_JOB_ID
+
+
+def test_enqueue_recompute_skips_when_already_queued(mocker):
+    """An in-flight job from a previous restart -> skip enqueue, don't double up."""
     mocker.patch.object(
         startup.db_save_handler, "count_saves_missing_content_hash", return_value=10
     )
-    mocker.patch.object(
-        startup.low_prio_queue,
-        "enqueue",
-        side_effect=DuplicateJobError("already enqueued"),
-    )
+    mocker.patch.object(startup.Job, "exists", return_value=True)
+    enqueue = mocker.patch.object(startup.low_prio_queue, "enqueue")
 
     startup._enqueue_recompute_save_hashes_if_needed()
+
+    enqueue.assert_not_called()
 
 
 def test_enqueue_recompute_swallows_count_error(mocker):
@@ -79,6 +80,7 @@ def test_enqueue_recompute_swallows_enqueue_error(mocker):
     mocker.patch.object(
         startup.db_save_handler, "count_saves_missing_content_hash", return_value=5
     )
+    mocker.patch.object(startup.Job, "exists", return_value=False)
     mocker.patch.object(
         startup.low_prio_queue, "enqueue", side_effect=RuntimeError("redis gone")
     )

--- a/backend/tests/test_startup.py
+++ b/backend/tests/test_startup.py
@@ -1,6 +1,7 @@
 """Tests for startup-time auto-enqueue of the recompute task."""
 
 import startup
+from rq.job import JOB_ID_PATTERN
 
 
 def test_enqueue_recompute_skips_when_no_missing_hashes(mocker):
@@ -42,10 +43,11 @@ def test_enqueue_recompute_fires_when_missing_hashes_present(mocker):
     assert kwargs["job_id"] == startup.RECOMPUTE_SAVE_HASHES_JOB_ID
 
 
-def test_recompute_job_id_has_no_colon():
-    """RQ's Job.set_id rejects ':' in a job_id; a colon raised ValueError that
-    the broad except swallowed, so the backfill never enqueued."""
-    assert ":" not in startup.RECOMPUTE_SAVE_HASHES_JOB_ID
+def test_recompute_job_id_is_valid_rq_id():
+    """RQ rejects any job_id not matching [A-Za-z0-9_-]+ (ValueError in set_id),
+    which the broad except here would swallow -> backfill silently never enqueues.
+    A colon was the original culprit; assert the full contract, not just that."""
+    assert JOB_ID_PATTERN.fullmatch(startup.RECOMPUTE_SAVE_HASHES_JOB_ID)
 
 
 def test_enqueue_recompute_skips_when_already_queued(mocker):


### PR DESCRIPTION
## Description

Follow-up to #3448, continuing to refine the save-sync negotiation logic. That
PR fixed `content_hash` drift, the null-slot archival leak, and dedupe scoping;
testing against production data since then surfaced two further issues that
interact: `negotiate` pairs saves on the tagged filename and never converges,
and the recompute backfill #3448 added has been silently failing to enqueue.

### Bug fixes

- **Negotiate pairs on the tagged filename, so it never converges** —
  `add_save` datetime-tags every slot-bound upload's filename
  (`name [YYYY-MM-DD_HH-MM-SS].ext`), but `negotiate_sync` keyed its
  server-save map on the exact `file_name`. Clients report the *untagged*
  canonical name (`computeUploadFileName`), so the lookup always missed:
  every client save came back as `upload` ("exists on client but not on
  server"), and every tagged server row came back as `download` ("exists on
  server but not on client"). The result is perpetual bidirectional sync and
  unbounded row growth per slot (observed 100+ timestamped rows for a single
  game). The content-hash comparison never even ran. Pair on `(rom_id, slot)`
  and collapse each slot to its newest row so `compare_save_state` decides the
  action. The datetime tag is unchanged.

- **`content_hash` recompute never enqueues** — the bootstrap enqueue added in
  #3448 used a job_id containing `:` (`recompute_save_content_hashes:bootstrap`).
  RQ 2.x `Job.set_id` raises `ValueError('id must not contain ":"')`, which the
  broad `except` swallowed, so the one-shot recompute task never ran and legacy
  raw/NULL `content_hash` rows were never reconciled. Drop the colon, remove the
  unsupported `unique=True` kwarg (not an RQ enqueue option — it would be
  forwarded to the task as a `TypeError`), and replace the dead
  `DuplicateJobError` branch with a real `Job.exists` guard.

### Tests

- Real upload -> negotiate round-trip that runs `_apply_datetime_tag` for real
  (the `scan_save` mock only echoes the server-computed tagged filename, never a
  hand-authored one) and asserts the follow-up negotiate is `no_op`.
- 3-device convergence test: the uploader settles to `no_op`; each puller
  downloads exactly once, then converges. Both new tests fail against the old
  `file_name` keying.
- Startup enqueue tests updated; added a regression asserting the job_id
  contains no `:`.

> [!NOTE]
> This also repairs the #3448 recompute backfill so it actually runs: on the
> first restart after deploy, the API enqueues the one-shot `content_hash`
> recompute for any rows still missing/stale (low-priority worker,
> non-blocking). Until this lands, that backfill has been failing silently on
> every boot.

---

> AI Disclosure
> Planning and review assisted by Claude Code.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
