### PR TITLE
fix(igdb): match ROMs by localized/alternative titles in scan

### DIFF
--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -432,6 +432,50 @@ def build_igdb_rom(
     )
 
 
+def _index_games_by_searchable_name(games: list[Game]) -> dict[str, Game]:
+    """Map every searchable title of each game to the game it belongs to.
+
+    A game is searchable not only by its primary English ``name`` but also by
+    any ``alternative_names`` and ``game_localizations`` titles IGDB knows.
+    No-Intro / ReDump filenames frequently use a localized title (e.g.
+    ``007 - Die Welt Ist Nicht Genug`` for ``James Bond 007: The World Is Not
+    Enough``); IGDB surfaces such a game through its ``alternative_name``
+    wildcard search, so the candidate index must include those titles or
+    ``find_best_match`` would score the localized filename only against the
+    English name and drop the match (issue #3435).
+
+    Primary names take precedence and use a lowest-igdb-id tiebreak (matching
+    prior behavior); alternative/localization titles fill in only names not
+    already claimed by a primary name.
+    """
+    index: dict[str, Game] = {}
+
+    # First pass: primary names. On collision the lowest IGDB id wins.
+    for game in games:
+        name = game.get("name", "")
+        if name and (name not in index or game["id"] < index[name]["id"]):
+            index[name] = game
+
+    # Second pass: alternative and localization titles, without displacing a
+    # primary name already claimed above.
+    for game in games:
+        alternative_names = game.get("alternative_names", [])
+        assert mark_list_expanded(alternative_names)
+        for alt in alternative_names:
+            alt_name = alt.get("name", "")
+            if alt_name and alt_name not in index:
+                index[alt_name] = game
+
+        game_localizations = game.get("game_localizations", [])
+        assert mark_list_expanded(game_localizations)
+        for loc in game_localizations:
+            loc_name = loc.get("name", "")
+            if loc_name and loc_name not in index:
+                index[loc_name] = game
+
+    return index
+
+
 class IGDBHandler(MetadataHandler):
     def __init__(self) -> None:
         self.igdb_service = IGDBService(twitch_auth=TwitchAuth())
@@ -484,14 +528,7 @@ class IGDBHandler(MetadataHandler):
             limit=self.pagination_limit,
         )
 
-        games_by_name: dict[str, Game] = {}
-        for game in roms:
-            game_name = game.get("name", "")
-            if (
-                game_name not in games_by_name
-                or game["id"] < games_by_name[game_name]["id"]
-            ):
-                games_by_name[game_name] = game
+        games_by_name = _index_games_by_searchable_name(roms)
 
         best_match, best_score = self.find_best_match(
             search_term,
@@ -533,11 +570,7 @@ class IGDBHandler(MetadataHandler):
                 limit=self.pagination_limit,
             )
 
-            extra_games_by_name: dict[str, Game] = {}
-            for game in extra_roms:
-                game_name = game.get("name", "")
-                if game_name not in extra_games_by_name:
-                    extra_games_by_name[game_name] = game
+            extra_games_by_name = _index_games_by_searchable_name(extra_roms)
 
             best_match, best_score = self.find_best_match(
                 search_term,

--- a/backend/tests/handler/metadata/test_igdb_handler.py
+++ b/backend/tests/handler/metadata/test_igdb_handler.py
@@ -10,8 +10,17 @@ from handler.metadata.igdb_handler import IGDBHandler
 GENESIS_IGDB_ID = 29
 
 
-def _make_game(game_id: int, name: str) -> dict:
-    """Build a minimal IGDB Game dict for testing."""
+def _make_game(
+    game_id: int,
+    name: str,
+    alternative_names: list[str] | None = None,
+    game_localizations: list[str] | None = None,
+) -> dict:
+    """Build a minimal IGDB Game dict for testing.
+
+    ``alternative_names`` and ``game_localizations`` accept plain title strings
+    and are wrapped into the ``{"name": ...}`` shape IGDB returns.
+    """
     return {
         "id": game_id,
         "name": name,
@@ -24,7 +33,7 @@ def _make_game(game_id: int, name: str) -> dict:
         "cover": None,
         "screenshots": [],
         "platforms": [{"id": GENESIS_IGDB_ID, "name": "Sega Mega Drive/Genesis"}],
-        "alternative_names": [],
+        "alternative_names": [{"name": n} for n in (alternative_names or [])],
         "genres": [],
         "franchise": None,
         "franchises": [],
@@ -41,7 +50,7 @@ def _make_game(game_id: int, name: str) -> dict:
         "videos": [],
         "age_ratings": [],
         "multiplayer_modes": [],
-        "game_localizations": [],
+        "game_localizations": [{"name": n} for n in (game_localizations or [])],
     }
 
 
@@ -154,4 +163,246 @@ class TestSearchRomGameTypeFilter:
         assert result["id"] == 5379, (
             f"Expected Ecco: The Tides of Time (id=5379), got {result.get('name')} (id={result.get('id')}). "
             "The expanded search must consider ALL results, not just the first."
+        )
+
+
+class TestSearchRomLocalizedNames:
+    """Tests for matching ROMs by localized / alternative titles.
+
+    Regression coverage for issue #3435: a ROM whose No-Intro / ReDump filename
+    uses a localized title (e.g. ``007 - Die Welt Ist Nicht Genug (Germany)``)
+    must match the IGDB game that lists that title in ``alternative_names`` or
+    ``game_localizations``, not only the primary English ``name``.
+    """
+
+    # James Bond 007: The World Is Not Enough, IGDB id 158962, has the German
+    # alternative name "007 - Die Welt Ist Nicht Genug" (issue #3435).
+    ENGLISH_NAME = "James Bond 007: The World Is Not Enough"
+    GERMAN_TITLE = "007 - Die Welt Ist Nicht Genug"
+    GAME_ID = 158962
+
+    @pytest.mark.asyncio
+    async def test_alt_name_match_in_primary_games_search(self):
+        """A localized filename must match when IGDB returns the game on the
+        primary games-endpoint pass and the term only matches an alternative
+        name, not the primary English name."""
+        handler = IGDBHandler()
+
+        game = _make_game(
+            self.GAME_ID,
+            self.ENGLISH_NAME,
+            alternative_names=[self.GERMAN_TITLE],
+        )
+
+        async def mock_list_games(
+            search_term=None, fields=None, where=None, limit=None
+        ):
+            # Primary games-endpoint pass returns the game (IGDB's fuzzy search
+            # surfaces it via the alt name), but the term won't match the
+            # English primary name on its own.
+            return [game]
+
+        with (
+            patch(
+                "handler.metadata.igdb_handler.IGDBHandler.is_enabled",
+                return_value=True,
+            ),
+            patch.object(
+                handler.igdb_service,
+                "list_games",
+                side_effect=mock_list_games,
+            ),
+            patch.object(
+                handler.igdb_service,
+                "search",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            result = await handler._search_rom(
+                "007 die welt ist nicht genug", GENESIS_IGDB_ID
+            )
+
+        assert result is not None
+        assert result["id"] == self.GAME_ID, (
+            f"Expected {self.ENGLISH_NAME} (id={self.GAME_ID}) via its German "
+            f"alternative name, got {result.get('name')} (id={result.get('id')})"
+        )
+
+    @pytest.mark.asyncio
+    async def test_alt_name_match_in_expanded_search(self):
+        """A localized filename must match when the game is only discovered via
+        the expanded ``/search`` alternative_name query and the term matches an
+        alternative name rather than the primary English name."""
+        handler = IGDBHandler()
+
+        game = _make_game(
+            self.GAME_ID,
+            self.ENGLISH_NAME,
+            alternative_names=[self.GERMAN_TITLE],
+        )
+
+        async def mock_list_games(
+            search_term=None, fields=None, where=None, limit=None
+        ):
+            # Expanded game-details lookup (id filter) returns the full game.
+            if where and where.startswith("("):
+                return [game]
+            # Primary pass returns nothing useful.
+            return []
+
+        expanded_results = [{"game": {"id": self.GAME_ID}, "name": self.ENGLISH_NAME}]
+
+        with (
+            patch(
+                "handler.metadata.igdb_handler.IGDBHandler.is_enabled",
+                return_value=True,
+            ),
+            patch.object(
+                handler.igdb_service,
+                "list_games",
+                side_effect=mock_list_games,
+            ),
+            patch.object(
+                handler.igdb_service,
+                "search",
+                new_callable=AsyncMock,
+                return_value=expanded_results,
+            ),
+        ):
+            result = await handler._search_rom(
+                "007 die welt ist nicht genug", GENESIS_IGDB_ID
+            )
+
+        assert result is not None
+        assert result["id"] == self.GAME_ID, (
+            f"Expected {self.ENGLISH_NAME} (id={self.GAME_ID}) via its German "
+            f"alternative name, got {result.get('name')} (id={result.get('id')})"
+        )
+
+    @pytest.mark.asyncio
+    async def test_localization_name_match_in_expanded_search(self):
+        """A localized filename must match when the matching title lives in
+        ``game_localizations`` rather than ``alternative_names``."""
+        handler = IGDBHandler()
+
+        game = _make_game(
+            self.GAME_ID,
+            self.ENGLISH_NAME,
+            game_localizations=[self.GERMAN_TITLE],
+        )
+
+        async def mock_list_games(
+            search_term=None, fields=None, where=None, limit=None
+        ):
+            if where and where.startswith("("):
+                return [game]
+            return []
+
+        expanded_results = [{"game": {"id": self.GAME_ID}, "name": self.ENGLISH_NAME}]
+
+        with (
+            patch(
+                "handler.metadata.igdb_handler.IGDBHandler.is_enabled",
+                return_value=True,
+            ),
+            patch.object(
+                handler.igdb_service,
+                "list_games",
+                side_effect=mock_list_games,
+            ),
+            patch.object(
+                handler.igdb_service,
+                "search",
+                new_callable=AsyncMock,
+                return_value=expanded_results,
+            ),
+        ):
+            result = await handler._search_rom(
+                "007 die welt ist nicht genug", GENESIS_IGDB_ID
+            )
+
+        assert result is not None
+        assert result["id"] == self.GAME_ID
+
+    @pytest.mark.asyncio
+    async def test_primary_english_name_still_matches(self):
+        """Indexing alternative titles must not regress matching by the primary
+        English name."""
+        handler = IGDBHandler()
+
+        game = _make_game(
+            self.GAME_ID,
+            self.ENGLISH_NAME,
+            alternative_names=[self.GERMAN_TITLE],
+        )
+
+        async def mock_list_games(
+            search_term=None, fields=None, where=None, limit=None
+        ):
+            return [game]
+
+        with (
+            patch(
+                "handler.metadata.igdb_handler.IGDBHandler.is_enabled",
+                return_value=True,
+            ),
+            patch.object(
+                handler.igdb_service,
+                "list_games",
+                side_effect=mock_list_games,
+            ),
+            patch.object(
+                handler.igdb_service,
+                "search",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            result = await handler._search_rom(
+                "james bond 007 the world is not enough", GENESIS_IGDB_ID
+            )
+
+        assert result is not None
+        assert result["id"] == self.GAME_ID
+
+    @pytest.mark.asyncio
+    async def test_primary_name_wins_over_other_games_alt_name(self):
+        """When a search term equals one game's primary name and another game's
+        alternative name, the primary-name owner must win (alt titles fill in
+        only names not already claimed by a primary name)."""
+        handler = IGDBHandler()
+
+        primary = _make_game(100, "Contra")
+        # A different, higher-id game that lists "Contra" as an alt title.
+        other = _make_game(200, "Probotector", alternative_names=["Contra"])
+
+        async def mock_list_games(
+            search_term=None, fields=None, where=None, limit=None
+        ):
+            return [other, primary]
+
+        with (
+            patch(
+                "handler.metadata.igdb_handler.IGDBHandler.is_enabled",
+                return_value=True,
+            ),
+            patch.object(
+                handler.igdb_service,
+                "list_games",
+                side_effect=mock_list_games,
+            ),
+            patch.object(
+                handler.igdb_service,
+                "search",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            result = await handler._search_rom("contra", GENESIS_IGDB_ID)
+
+        assert result is not None
+        assert result["id"] == 100, (
+            "Expected the game whose primary name is 'Contra' (id=100), not the "
+            f"game that merely lists it as an alternative name; got id={result.get('id')}"
         )


### PR DESCRIPTION
## Summary

IGDB scans silently dropped games whose filename uses a localized (non-English) title — even when that exact title exists in IGDB's alternative_names or game_localizations.

The root cause was in \_search_rom(): IGDB's alternative_name wildcard search did surface the correct game, but the handler then rebuilt its name -> game candidate dict using only the primary English name. The Jaro-Winkler re-check therefore scored the localized search term against the English title alone, fell below the similarity threshold, and discarded the match.

Example (issue #3435): the No-Intro filename 007 - Die Welt Ist Nicht Genug never matched James Bond 007: The World Is Not Enough, despite the German title being present in IGDB's alternative_names.

### What changed

- Added \_index_games_by_searchable_name(), which indexes each game by its primary name plus every alternative_names and game_localizations title IGDB returns.
- Both candidate-building passes in \_search_rom() (the primary games-endpoint pass and the expanded /search pass) now use this helper, so find_best_match scores the localized filename against the localized titles too.
- Precedence preserved: primary names win (lowest-IGDB-id tiebreak); alternative/localization titles fill in only names not already claimed by a primary name.

No new IGDB requests — alternative_names.name and game_localizations.name were already requested in GAMES_FIELDS; this change just makes use of data already fetched.

## Files modified

- backend/handler/metadata/igdb_handler.py — added the \_index_games_by_searchable_name() helper and replaced the two inline name -> game dict builders in \_search_rom() with it.
- backend/tests/handler/metadata/test_igdb_handler.py — added \_make_game() helper and a TestSearchRomLocalizedTitleMatching suite covering alt-name matching on the primary pass, alt-name and localization matching on the expanded pass, a regression test that the primary English name still matches, and a precedence test that a primary-name owner beats another game listing the same string as an alt name.

## Testing notes

- uv run pytest tests/handler/metadata/test_igdb_handler.py — 7 passed.
- Tests mock igdb_service.list_games/search, so no live API calls or new VCR cassettes are needed.

## Reviewer notes

- Behavior change in the expanded pass: the shared helper now applies the lowest-IGDB-id tiebreak for primary names in the expanded-search index too (previously first-seen). Intentional, for consistency with the primary pass.
- Matched name remains the English primary title when a match is found via an alt/localization name — the ROM is matched to the correct game and keeps IGDB's canonical title rather than the localized filename. This is intended.
- Closes #3435.

🤖 Written primarily by Claude Code (Opus 4.8), reviewed by the author.