### PR TITLE
Fix double URL-encoding of ScreenScraper name-search term

### DIFF
--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -2,7 +2,7 @@ import html
 import re
 from datetime import datetime
 from typing import Final, NotRequired, TypedDict
-from urllib.parse import quote, urlparse
+from urllib.parse import urlparse
 
 import pydash
 from unidecode import unidecode as uc
@@ -624,7 +624,7 @@ class SSHandler(MetadataHandler):
             return None
 
         roms = await self.ss_service.search_games(
-            term=quote(uc(search_term), safe="/ "),
+            term=uc(search_term),
             system_id=platform_ss_id,
         )
 
@@ -873,7 +873,7 @@ class SSHandler(MetadataHandler):
             return []
 
         matched_games = await self.ss_service.search_games(
-            term=quote(uc(search_term), safe="/ "),
+            term=uc(search_term),
             system_id=platform_ss_id,
         )
 

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -819,3 +819,97 @@ class TestLookupRom:
             )
         assert result["ss_id"] is None
         assert is_not_game is True
+
+
+class TestSearchTermEncoding:
+    """Regression tests for issue #3467: the SS name-search term must be
+    URL-encoded exactly once.
+
+    The handler must pass the *raw* (un-percent-encoded) term to the service
+    layer, which percent-encodes it a single time when building the request URL
+    via ``with_query(...)``. Pre-encoding the term in the handler caused a
+    second round of encoding (``%2B`` -> ``%252B``), so ScreenScraper searched
+    for literal gibberish and returned no match for any title containing a
+    character that has to be URL-encoded (``+``, ``&``, an apostrophe, ...).
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("search_term", "literal", "double_encoded"),
+        [
+            ("super mario 3d world + bowsers fury", "+", "%2B"),
+            ("sonic & knuckles", "&", "%26"),
+            ("marvel's spider-man", "'", "%27"),
+        ],
+    )
+    async def test_search_rom_passes_unencoded_term_to_service(
+        self, search_term, literal, double_encoded
+    ):
+        """``_search_rom`` hands the service a term that is not pre-encoded."""
+        handler = SSHandler()
+        captured: dict = {}
+
+        async def capture(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        with patch.object(handler.ss_service, "search_games", side_effect=capture):
+            await handler._search_rom(search_term, 225)
+
+        term = captured["term"]
+        assert literal in term
+        assert double_encoded not in term
+
+    @pytest.mark.asyncio
+    async def test_search_rom_still_transliterates_unicode(self):
+        """Unidecode is still applied so accented titles match ScreenScraper."""
+        handler = SSHandler()
+        captured: dict = {}
+
+        async def capture(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        with patch.object(handler.ss_service, "search_games", side_effect=capture):
+            await handler._search_rom("Pokémon Snap", 14)
+
+        assert captured["term"] == "Pokemon Snap"
+
+    @pytest.mark.asyncio
+    async def test_get_matched_roms_by_name_passes_unencoded_term(self):
+        """``get_matched_roms_by_name`` also avoids pre-encoding the term."""
+        handler = SSHandler()
+        captured: dict = {}
+
+        async def capture(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        with (
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_USER", "user1"),
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_PASSWORD", "pw1"),
+            patch.object(handler.ss_service, "search_games", side_effect=capture),
+        ):
+            await handler.get_matched_roms_by_name(MagicMock(), "sonic & knuckles", 1)
+
+        term = captured["term"]
+        assert "&" in term
+        assert "%26" not in term
+
+    @pytest.mark.asyncio
+    async def test_search_rom_url_single_encodes_plus(self):
+        """End-to-end through the real service: a ``+`` is encoded exactly once
+        in the request URL (``%2B``), never doubly (``%252B``)."""
+        handler = SSHandler()
+        captured: dict = {}
+
+        async def capture_request(url, *args, **kwargs):
+            captured["url"] = url
+            return {"response": {"jeux": []}}
+
+        with patch.object(handler.ss_service, "_request", side_effect=capture_request):
+            await handler._search_rom("super mario 3d world + bowsers fury", 225)
+
+        url = captured["url"]
+        assert "%2B" in url
+        assert "%252B" not in url


### PR DESCRIPTION
**Description**

Fixes the double URL-encoding of the ScreenScraper name-search term (#3467).

The SS metadata handler pre-encoded the search term with `quote(...)` before
handing it to the service layer, which then percent-encodes the query **again**
when it builds the request URL via yarl's `with_query(...)`. Any character that
needs URL-encoding was therefore escaped twice (e.g. `+` → `%2B` → `%252B`), so
the request carried a doubly-escaped term:

```
.../jeuRecherche.php?recherche=super+mario+3d+world+%252B+bowsers+fury+-
                                                     ^^^^^ should be a single %2B
```

The fix removes the redundant `quote(...)` in both `_search_rom()` and
`get_matched_roms_by_name()` and passes the raw term (still transliterated to
ASCII via `unidecode`, which is *not* URL-encoding) to `search_games()`, letting
the URL builder encode it exactly once. Confirmed in a live scan — the request
now sends `recherche=...%2B...` instead of `...%252B...`.

> [!NOTE]
> This is a request-**correctness** fix and is deliberately scoped to the
> encoding bug only. It does **not**, on its own, make every previously
> unmatched title match. I tested against the live `jeuRecherche` API and found
> ScreenScraper normalizes punctuation (`+`/`%2b` and `&`/`%26` return identical
> results) and applies its own relevance ranking, so some titles still return no
> results for the full filename-derived term — e.g. the issue's own example,
> where the dump-style `Bowsers` (no apostrophe) does not match ScreenScraper's
> `Bowser's`. Improving name-search robustness (e.g. a shortened-term fallback)
> is a separate concern and out of scope here.

**Files modified**

- `backend/handler/metadata/ss_handler.py` — drop the redundant
  `quote(uc(search_term), safe="/ ")` pre-encoding in `_search_rom()` and
  `get_matched_roms_by_name()`; both now pass `uc(search_term)` so the term is
  percent-encoded only once by the service layer. Remove the now-unused `quote`
  import.
- `backend/tests/handler/metadata/test_ss_handler.py` — add a
  `TestSearchTermEncoding` regression class: the handler passes an
  un-percent-encoded term to the service for `+`/`&`/`'`, `unidecode`
  transliteration is still applied (`Pokémon` → `Pokemon`),
  `get_matched_roms_by_name` likewise doesn't pre-encode, and an end-to-end
  check through the real service asserts the request URL is single-encoded
  (`%2B`, never `%252B`).

**Testing notes**

- New regression tests fail against the pre-fix code (the captured URL shows the
  exact `%252B` from the issue) and pass after the fix.
- `uv run pytest tests/handler/metadata/test_ss_handler.py tests/adapters/services/test_screenscraper.py` → 99 passed.
- Full backend suite: `uv run pytest` → 1526 passed (no regressions).
- `trunk check` / `trunk fmt` clean on the changed files.
- Manually verified live: a scan of `Super Mario 3D World + Bowsers Fury - (US) (1.0.0).nsp` now emits a single-`%2B` `jeuRecherche` URL.

**Reviewer notes**

- `unidecode` (`uc(...)`) is intentionally kept — it transliterates accents to
  ASCII for better matching and is unrelated to URL-encoding. Only the
  `quote(...)` layer was removed.
- The post-search fuzzy matching uses the original (un-encoded) `search_term`,
  so dropping the pre-encoding doesn't affect scoring.
- Please weigh in on the scope decision: should the unmatched-title follow-up
  (ScreenScraper returning 0 results for the full term) be tracked as a separate
  issue? The encoding fix here stands on its own merits regardless.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A — server-side scan/metadata change, no UI impact.

---

> This PR was written primarily by Claude Code (code generation + this PR description).