### PR TITLE
test(roms): cover region-tag re-parse on rename (#3471)

### DIFF
--- a/backend/tests/endpoints/roms/test_rom.py
+++ b/backend/tests/endpoints/roms/test_rom.py
@@ -128,6 +128,30 @@ def test_update_rom_reparses_tags_on_fs_name_change(
     assert body["tags"] == []
 
 
+@patch.object(FSRomsHandler, "rename_fs_rom")
+@patch.object(IGDBHandler, "get_rom_by_id", return_value=IGDBRom(igdb_id=None))
+def test_update_rom_adds_region_tag_on_rename(
+    rename_fs_rom_mock: AsyncMock,
+    get_rom_by_id_mock: AsyncMock,
+    client: TestClient,
+    access_token: str,
+    rom: Rom,
+):
+    """Renaming an untagged ROM to add ``(Europe)`` surfaces the region (issue #3471)."""
+    assert rom.regions == []
+
+    response = client.put(
+        f"/api/roms/{rom.id}",
+        headers={"Authorization": f"Bearer {access_token}"},
+        data={"fs_name": "test_rom (Europe).zip"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    body = response.json()
+    assert body["fs_name"] == "test_rom (Europe).zip"
+    assert body["regions"] == ["Europe"]
+
+
 # Minimal valid PNG (1x1 transparent pixel)
 _PNG_BYTES = (
     b"\x89PNG\r\n\x1a\n"


### PR DESCRIPTION
**Description**

Adds regression coverage for region-tag re-parsing when a ROM is renamed via `PUT /api/roms/{id}` (issue #3471) and complements the existing PR by Zurdi (#3295).

When a ROM's `fs_name` changes, the update endpoint re-parses the filename so region / language / revision / version / tags stay in sync with the new name. There was no test asserting the specific case where an **untagged** ROM is renamed to **add** a region — e.g. `test_rom.zip` → `test_rom (Europe).zip` should surface `regions: ["Europe"]`. This PR adds that test.

This is a **test-only** change — no production code is modified. It locks in the existing behavior of the re-parse path (`endpoints/roms/__init__.py` → `FSRomsHandler.parse_tags` → the `REGIONS` table in `handler/filesystem/base_handler.py`) so a future regression in region detection on rename is caught.

It complements the existing `test_update_rom_reparses_tags_on_fs_name_change` test (which covers a rename carrying languages + revision but no region); this new test covers the untagged → region-added transition and explicitly asserts the `rom.regions == []` precondition.

**Files modified**

- `backend/tests/endpoints/roms/test_rom.py` — adds `test_update_rom_adds_region_tag_on_rename`. Mocks `FSRomsHandler.rename_fs_rom` and `IGDBHandler.get_rom_by_id` (no FS writes, no live metadata calls), PUTs `fs_name="test_rom (Europe).zip"`, and asserts a `200` with `fs_name` updated and `regions == ["Europe"]`.

**Testing notes**

```sh
cd backend
uv run pytest tests/endpoints/roms/test_rom.py -k region -vv
```

- New test passes; full `test_rom.py` file is green (43 passed locally).
- No cassettes added or changed — IGDB is stubbed with `IGDBRom(igdb_id=None)`, so the test makes no network calls.

**Reviewer notes**

- Test-only, single-concern, additive; safe to merge once green in CI.
- The stacked `@patch.object` decorators bind bottom-up, so `rename_fs_rom_mock` / `get_rom_by_id_mock` parameter names are swapped relative to the mocks they receive. This is harmless here (neither is referenced by name in the body) and is consistent with the existing sibling tests, but is called out for transparency in case the maintainers want to tidy the convention separately.

---

> AI assistance disclosure: this PR (test code and description) was written primarily by Claude Code, reviewed by me before submission.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A — backend test-only change.
