### PR TITLE
fix(screenscraper): utilize ss.fr jeuinfos.php endpoint for non-hashable platforms

### DIFF
--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -699,11 +699,23 @@ class SSHandler(MetadataHandler):
         sha1_hash = first_file.sha1_hash
         crc_hash = first_file.crc_hash
         fs_size_bytes = first_file.file_size_bytes
+        rom_name = (
+            first_file.archive_members[0]["name"].split("/")[-1]
+            if first_file.archive_members is not None
+            and len(first_file.archive_members) == 1
+            else first_file.file_name
+        )
 
-        if not (md5_hash or sha1_hash or crc_hash):
+        # Files on NON_HASHABLE_PLATFORMS (or any file when SKIP_HASH_CALCULATION
+        # is enabled) have no hashes. jeuInfos can still identify the game from the
+        # filename (romnom) + platform (systemeid) — a stronger matcher than the
+        # jeuRecherche name search the get_rom fallback uses — so only bail out when
+        # we have neither a hash nor a filename to match on.
+        if not (md5_hash or sha1_hash or crc_hash or rom_name):
             log.info(
-                "No hashes provided for ScreenScraper lookup. "
-                "At least one of md5_hash, sha1_hash, or crc_hash is required."
+                "No hashes or filename provided for ScreenScraper lookup. "
+                "At least one of md5_hash, sha1_hash, crc_hash, or a filename "
+                "is required."
             )
             return SSRom(ss_id=None), False
 
@@ -713,12 +725,7 @@ class SSHandler(MetadataHandler):
             sha1=sha1_hash,
             crc=crc_hash,
             rom_size_bytes=fs_size_bytes,
-            rom_name=(
-                first_file.archive_members[0]["name"].split("/")[-1]
-                if first_file.archive_members is not None
-                and len(first_file.archive_members) == 1
-                else first_file.file_name
-            ),
+            rom_name=rom_name,
             rom_type=_get_rom_type(first_file),
         )
         if not res:

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -699,6 +699,103 @@ class TestLookupRom:
         f.file_name = "bios.bin"
         return f
 
+    def _make_unhashed_file(
+        self, file_name: str = "Adventure Island II (USA).nes"
+    ) -> MagicMock:
+        """A top-level file with no hashes, as produced for NON_HASHABLE_PLATFORMS
+        or when SKIP_HASH_CALCULATION is enabled."""
+        f = MagicMock()
+        f.file_size_bytes = 131072
+        f.is_top_level = True
+        f.file_extension = "nes"
+        f.md5_hash = ""
+        f.sha1_hash = ""
+        f.crc_hash = ""
+        f.file_name = file_name
+        f.archive_members = None
+        return f
+
+    @pytest.mark.asyncio
+    async def test_no_hash_still_attempts_jeuinfos_by_filename(self):
+        """A file with no hashes must still reach jeuInfos using the filename
+        (romnom) + platform (systemeid), instead of bailing out and degrading to
+        the weaker jeuRecherche name search."""
+        handler = SSHandler()
+        mock_file = self._make_unhashed_file("Adventure Island II (USA).nes")
+        captured = {}
+
+        async def capture(**kwargs):
+            captured.update(kwargs)
+            return None
+
+        with patch.object(handler.ss_service, "get_game_info", side_effect=capture):
+            result, is_not_game = await handler.lookup_rom(
+                MagicMock(platform_slug="nes"), 3, [mock_file]
+            )
+
+        assert captured, "get_game_info should be called even without hashes"
+        assert captured.get("rom_name") == "Adventure Island II (USA).nes"
+        assert captured.get("system_id") == 3
+        assert not captured.get("md5")
+        assert not captured.get("sha1")
+        assert not captured.get("crc")
+        assert result["ss_id"] is None
+        assert is_not_game is False
+
+    @pytest.mark.asyncio
+    async def test_no_hash_match_builds_game(self):
+        """When jeuInfos matches an un-hashed file by filename, the game is built
+        and returned (the romnom matcher bridges number-style differences such as
+        'Adventure Island II' -> 'Adventure Island 2')."""
+        config = _make_config(region_priority=["us"])
+        game = {
+            "id": "1234",
+            "noms": [{"region": "us", "text": "Adventure Island 2"}],
+            "medias": [],
+            "synopsis": [],
+            "dates": [],
+            "genres": [],
+            "familles": [],
+            "modes": [],
+            "joueurs": {},
+            "note": {},
+        }
+        handler = SSHandler()
+        mock_file = self._make_unhashed_file("Adventure Island II (USA).nes")
+        rom = MagicMock(platform_slug="nes", platform_id=1, id=100, regions=["USA"])
+
+        with (
+            patch("handler.metadata.ss_handler.cm.get_config", return_value=config),
+            patch.object(handler.ss_service, "get_game_info", return_value=game),
+        ):
+            result, is_not_game = await handler.lookup_rom(rom, 3, [mock_file])
+
+        assert result["ss_id"] == 1234
+        assert result["name"] == "Adventure Island 2"
+        assert is_not_game is False
+
+    @pytest.mark.asyncio
+    async def test_no_hash_no_filename_skips_lookup(self):
+        """With neither a hash nor a filename there is nothing to match on, so the
+        lookup is skipped without spending an API call."""
+        handler = SSHandler()
+        mock_file = self._make_unhashed_file(file_name="")
+        called = False
+
+        async def capture(**kwargs):
+            nonlocal called
+            called = True
+            return None
+
+        with patch.object(handler.ss_service, "get_game_info", side_effect=capture):
+            result, is_not_game = await handler.lookup_rom(
+                MagicMock(platform_slug="nes"), 3, [mock_file]
+            )
+
+        assert called is False
+        assert result["ss_id"] is None
+        assert is_not_game is False
+
     @pytest.mark.asyncio
     async def test_returns_notgame_flag_on_notgame_field(self):
         notgame_response = {


### PR DESCRIPTION
**Description**

Fixes #3474 (supersedes #3142).

When RomM scans a game with ScreenScraper enabled, `ss_handler.lookup_rom` bailed
out early the moment the selected file had no CRC/MD5/SHA1 hash — logging
*"No hashes provided for ScreenScraper lookup"* and never reaching its
`jeuInfos.php` (`get_game_info`) call. Matching then degraded to the weaker
`jeuRecherche.php` name search.

Files are un-hashed in two common situations:
1. **Platforms RomM doesn't hash by design** (`NON_HASHABLE_PLATFORMS`) — PS3/4/5,
   Switch & Switch 2, Wii U, Xbox 360/One/Series, Windows, Linux/Mac, mobile & VR.
2. **Hashing turned off globally** via the `SKIP_HASH_CALCULATION` setting — which
   makes *every* platform fall into this path.

The transport layer already supports a hash-less `jeuInfos?romnom=…&systemeid=…`
request (`crc`/`md5`/`sha1` are all optional), and that endpoint's filename
matcher is far more tolerant than `jeuRecherche` — it ignores extensions and
region/revision tags and bridges number-style ("II" vs "2"), spacing, and
localized titles.

This PR relaxes the early-return so a hash-less file still tries
`jeuInfos` (`romnom` + `systemeid`) before falling back to `jeuRecherche`. The
lookup now only short-circuits when there is **neither a hash nor a filename** to
match on. `jeuRecherche` remains the last-resort fallback, so the change is
roughly **quota-neutral** (the new call replaces the old fallback call when it
matches).

In side-by-side testing on 100 real No-Intro filenames (SNES, Game Boy, N64,
Mega Drive): `jeuRecherche` matched 90/100 (N64 only ~68%), whereas
`jeuInfos?romnom=<full filename>` matched 100/100 — 10 additional correct matches
with zero regressions and zero false positives. Wins were exactly the cases
`jeuRecherche` can't bridge (e.g. "Adventure Island II" → "Adventure Island 2",
"1080 Snowboarding" → "1080 - TenEighty Snowboarding").

This is purely a matching-accuracy change; nothing was broken before, affected
platforms just matched worse than they could. The user-facing manual search
(multi-result picker) is unchanged and keeps using `jeuRecherche`.

> This PR was written primarily by Claude Code, including the PR description.

**Files modified**

- `backend/handler/metadata/ss_handler.py` — In `SSHandler.lookup_rom`, hoist the
  `rom_name` (romnom) computation above the guard and change the early-return
  condition from "no hash" to "no hash **and** no filename", so a hash-less file
  still calls `get_game_info` with `romnom` + `systemeid`. Updated the log message
  accordingly. No change to the transport layer or to `scan_handler.fetch_ss_rom`
  (it already returns on a `lookup_rom` hit before reaching the `jeuRecherche`
  fallback).
- `backend/tests/handler/metadata/test_ss_handler.py` — Added 3 tests to
  `TestLookupRom` plus a `_make_unhashed_file` helper:
  - `test_no_hash_still_attempts_jeuinfos_by_filename` — an un-hashed file still
    calls `get_game_info` with `rom_name` + `system_id`.
  - `test_no_hash_match_builds_game` — a filename match for an un-hashed file is
    built and returned.
  - `test_no_hash_no_filename_skips_lookup` — guard: no hash *and* no filename
    short-circuits without an API call.

**Testing notes**

- `cd backend && uv run pytest tests/handler/metadata/test_ss_handler.py` → 44 passed.
- The 3 new tests were confirmed to fail against the pre-fix code (proving they
  exercise the bug), then pass after the change.
- Full backend suite: `uv run pytest` → **1523 passed**, 0 failures.
- `trunk fmt` + `trunk check` on the changed files → no issues.
- No new VCR cassettes needed — the tests mock `get_game_info` directly, matching
  the existing `TestLookupRom` style.

**For reviewers**

- ~~For a **multi-file** rom on a non-hashable platform, `lookup_rom` selects the
  largest top-level *file* and uses its filename as `romnom`, which may not be the
  game title — so the `jeuInfos` attempt can miss and fall through to
  `jeuRecherche` (graceful; not a regression). Most non-hashable titles are
  single-file (`.iso`/`.nsp`/`.pkg`), so impact is limited.~~ I really doubt this matters as 
  it would be really weird for the largest file to not be the game and we make this assumption 
  in other places.
- The pre-existing notgame warning *"Received notgame entry from hash lookup"* can
  now also fire from a filename-only lookup. Left as-is to keep the diff focused;
  happy to reword if preferred.
- `romtaille` (file size) is still sent on the hash-less call. Per ScreenScraper's
  behavior, size never gates a match (it's a tiebreaker at most), so it's safe and
  keeps the call identical to the hashed path.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A — backend matching-logic change, no UI impact.
