### PR TITLE
fix: stop serving private user assets via unauthenticated nginx static route

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -181,8 +181,7 @@ COPY --from=frontend-build /front/dist ${WEBSERVER_FOLDER}
 
 COPY ./frontend/assets ${WEBSERVER_FOLDER}/assets
 RUN mkdir -p ${WEBSERVER_FOLDER}/assets/romm && \
-    ln -sf /romm/resources ${WEBSERVER_FOLDER}/assets/romm/resources && \
-    ln -sf /romm/assets ${WEBSERVER_FOLDER}/assets/romm/assets
+    ln -sf /romm/resources ${WEBSERVER_FOLDER}/assets/romm/resources
 COPY ./backend /backend
 
 # Setup init script and config files

--- a/docker/init_scripts/docker-entrypoint.sh
+++ b/docker/init_scripts/docker-entrypoint.sh
@@ -61,18 +61,17 @@ fi
 # Replace environment variables used in nginx configuration templates.
 /docker-entrypoint.d/20-envsubst-on-templates.sh >/dev/null
 
-# Fix symbolic links used by nginx for assets, if they do not point to the correct location,
+# Fix symbolic links used by nginx for resources,
+# if they don't point to the correct location,
 # set by the ROMM_BASE_PATH environment variable.
-for subfolder in assets resources; do
-	if [[ -L /var/www/html/assets/romm/${subfolder} ]]; then
-		target=$(readlink "/var/www/html/assets/romm/${subfolder}")
+if [[ -L /var/www/html/assets/romm/resources ]]; then
+	target=$(readlink "/var/www/html/assets/romm/resources")
 
-		# If the target is not the same as ${ROMM_BASE_PATH}/${subfolder}, recreate the symbolic link.
-		if [[ ${target} != "${ROMM_BASE_PATH}/${subfolder}" ]]; then
-			rm "/var/www/html/assets/romm/${subfolder}"
-			ln -s "${ROMM_BASE_PATH}/${subfolder}" "/var/www/html/assets/romm/${subfolder}"
-		fi
+	# If the target is not the same as ${ROMM_BASE_PATH}/resources, recreate the symbolic link.
+	if [[ ${target} != "${ROMM_BASE_PATH}/resources" ]]; then
+		rm "/var/www/html/assets/romm/resources"
+		ln -s "${ROMM_BASE_PATH}/resources" "/var/www/html/assets/romm/resources"
 	fi
-done
+fi
 
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,21 +5,19 @@ set -e
 echo "Starting entrypoint script..."
 
 # Create symlinks for frontend
-for subfolder in assets resources; do
-	if [[ -L /app/frontend/assets/romm/${subfolder} ]]; then
-		target=$(readlink "/app/frontend/assets/romm/${subfolder}")
+if [[ -L /app/frontend/assets/romm/resources ]]; then
+	target=$(readlink "/app/frontend/assets/romm/resources")
 
-		# If the target is not the same as ${ROMM_BASE_PATH}/${subfolder}, recreate the symbolic link.
-		if [[ ${target} != "${ROMM_BASE_PATH}/${subfolder}" ]]; then
-			rm "/app/frontend/assets/romm/${subfolder}"
-			ln -s "${ROMM_BASE_PATH}/${subfolder}" "/app/frontend/assets/romm/${subfolder}"
-		fi
-	elif [[ ! -e /app/frontend/assets/romm/${subfolder} ]]; then
-		# Ensure parent directory exists before creating symbolic link
-		mkdir -p "/app/frontend/assets/romm"
-		ln -s "${ROMM_BASE_PATH}/${subfolder}" "/app/frontend/assets/romm/${subfolder}"
+	# If the target is not the same as ${ROMM_BASE_PATH}/resources, recreate the symbolic link.
+	if [[ ${target} != "${ROMM_BASE_PATH}/resources" ]]; then
+		rm "/app/frontend/assets/romm/resources"
+		ln -s "${ROMM_BASE_PATH}/resources" "/app/frontend/assets/romm/resources"
 	fi
-done
+elif [[ ! -e /app/frontend/assets/romm/resources ]]; then
+	# Ensure parent directory exists before creating symbolic link
+	mkdir -p "/app/frontend/assets/romm"
+	ln -s "${ROMM_BASE_PATH}/resources" "/app/frontend/assets/romm/resources"
+fi
 
 # Define a signal handler to propagate termination signals
 function handle_termination() {

--- a/frontend/src/components/Settings/Administration/Users/Dialog/DeleteUser.vue
+++ b/frontend/src/components/Settings/Administration/Users/Dialog/DeleteUser.vue
@@ -65,7 +65,7 @@ function closeDialog() {
           <v-img
             :src="
               user.avatar_path
-                ? `/assets/romm/assets/${user.avatar_path}?ts=${user.updated_at}`
+                ? `/api/raw/assets/${user.avatar_path}?ts=${user.updated_at}`
                 : defaultAvatarPath
             "
           /> </v-avatar

--- a/frontend/src/components/Settings/Administration/Users/Dialog/EditUser.vue
+++ b/frontend/src/components/Settings/Administration/Users/Dialog/EditUser.vue
@@ -158,7 +158,7 @@ function closeDialog() {
                     :src="
                       imagePreviewUrl ||
                       (user.avatar_path
-                        ? `/assets/romm/assets/${user.avatar_path}?ts=${user.updated_at}`
+                        ? `/api/raw/assets/${user.avatar_path}?ts=${user.updated_at}`
                         : defaultAvatarPath)
                     "
                   >

--- a/frontend/src/components/Settings/Administration/Users/UsersTable.vue
+++ b/frontend/src/components/Settings/Administration/Users/UsersTable.vue
@@ -136,7 +136,7 @@ onMounted(() => {
             <v-img
               :src="
                 item.avatar_path
-                  ? `/assets/romm/assets/${item.avatar_path}?ts=${item.updated_at}`
+                  ? `/api/raw/assets/${item.avatar_path}?ts=${item.updated_at}`
                   : defaultAvatarPath
               "
             />

--- a/frontend/src/components/common/Navigation/SettingsDrawer.vue
+++ b/frontend/src/components/common/Navigation/SettingsDrawer.vue
@@ -92,7 +92,7 @@ function onClose() {
         <v-img
           :src="
             user?.avatar_path
-              ? `/assets/romm/assets/${user?.avatar_path}?ts=${user?.updated_at}`
+              ? `/api/raw/assets/${user?.avatar_path}?ts=${user?.updated_at}`
               : defaultAvatarPath
           "
           cover

--- a/frontend/src/components/common/Navigation/UserBtn.vue
+++ b/frontend/src/components/common/Navigation/UserBtn.vue
@@ -25,7 +25,7 @@ const { smAndDown } = useDisplay();
     <v-img
       :src="
         user?.avatar_path
-          ? `/assets/romm/assets/${user?.avatar_path}?ts=${user?.updated_at}`
+          ? `/api/raw/assets/${user?.avatar_path}?ts=${user?.updated_at}`
           : defaultAvatarPath
       "
     />

--- a/frontend/src/views/Settings/UserProfile.vue
+++ b/frontend/src/views/Settings/UserProfile.vue
@@ -92,7 +92,7 @@ onUnmounted(() => {
                   :src="
                     imagePreviewUrl ||
                     (userToEdit.avatar_path
-                      ? `/assets/romm/assets/${userToEdit.avatar_path}?ts=${userToEdit.updated_at}`
+                      ? `/api/raw/assets/${userToEdit.avatar_path}?ts=${userToEdit.updated_at}`
                       : defaultAvatarPath)
                   "
                 >


### PR DESCRIPTION
## Summary

The default Docker image symlinked `/romm/assets` into the nginx static web root (`/assets/romm/assets`), where it was served by an unauthenticated `location /assets { try_files ... }` block. `/romm/assets` holds **private user data** — save files, save states, screenshots, and avatars — which is meant to be accessible only through the authenticated `/api/raw/assets/{path}` route (`Scope.ASSETS_READ`).

Because nginx resolved the static symlink before the request reached the backend, that protection was bypassed: any **unauthenticated** caller could read another user's files given a (guessable/deterministic) asset path. The frontend additionally leaked each user's hex ID through avatar URLs served by the same static route, making path construction straightforward.

By contrast, `/romm/resources` (public cover art, screenshots, manuals) is legitimately served statically and is left unchanged.

## Changes

- **`docker/Dockerfile`** — drop the `ln -sf /romm/assets ...` symlink; keep only the `resources` symlink.
- **`docker/init_scripts/docker-entrypoint.sh`** and root **`entrypoint.sh`** — stop creating/maintaining the `assets` symlink; only `resources` is handled.
- **Frontend (6 files)** — avatar URLs now point at the authenticated `/api/raw/assets/${avatar_path}` route instead of `/assets/romm/assets/...`. Browser `<img>` loads authenticate via the existing session cookie (`HybridAuthBackend` checks the session before the `Authorization` header).

## Notes / out of scope

`get_raw_asset` enforces `ASSETS_READ` but does not scope reads to the requesting user's own folder, so any *authenticated* user can still read another user's assets via the API. That is intentional for avatars (admin user tables show everyone's) but means saves/states are cross-user readable for authenticated users — a separate authorization concern from this *unauthenticated* disclosure, left untouched here.

## Testing

- Verified only the 6 avatar references used the private static path; saves/states are not loaded through it.
- Confirmed session-cookie auth path so avatar `<img>` tags continue to load for logged-in users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)