### PR TITLE
chore: improve romm maintenance path

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -154,7 +154,7 @@ def save(rom: Rom, platform: Platform, admin_user: User):
         emulator="test_emulator",
         slot="autosave",
         file_path=f"{platform.slug}/saves/test_emulator",
-        file_size_bytes=1.0,
+        file_size_bytes=1,
     )
     return db_save_handler.add_save(save)
 
@@ -175,7 +175,7 @@ def archival_save(rom: Rom, platform: Platform, admin_user: User):
         emulator="test_emulator",
         slot=None,
         file_path=f"{platform.slug}/saves/test_emulator",
-        file_size_bytes=1.0,
+        file_size_bytes=1,
     )
     return db_save_handler.add_save(save)
 
@@ -191,7 +191,7 @@ def state(rom: Rom, platform: Platform, admin_user: User):
         file_extension="state",
         emulator="test_emulator",
         file_path=f"{platform.slug}/states/test_emulator",
-        file_size_bytes=2.0,
+        file_size_bytes=2,
     )
     return db_state_handler.add_state(state)
 
@@ -206,7 +206,7 @@ def screenshot(rom: Rom, platform: Platform, admin_user: User):
         file_name_no_ext="test_screenshot",
         file_extension="png",
         file_path=f"{platform.slug}/screenshots",
-        file_size_bytes=3.0,
+        file_size_bytes=3,
     )
     return db_screenshot_handler.add_screenshot(screenshot)
 

--- a/backend/tests/test_startup.py
+++ b/backend/tests/test_startup.py
@@ -4,7 +4,7 @@ import startup
 from rq.job import JOB_ID_PATTERN
 
 
-def test_enqueue_recompute_skips_when_no_missing_hashes(mocker):
+def test_enqueue_recompute_skips_when_no_missing_hashes(mocker) -> None:
     """Saves all have content_hash -> no enqueue."""
     mocker.patch.object(
         startup.db_save_handler, "count_saves_missing_content_hash", return_value=0
@@ -16,7 +16,7 @@ def test_enqueue_recompute_skips_when_no_missing_hashes(mocker):
     enqueue.assert_not_called()
 
 
-def test_enqueue_recompute_fires_when_missing_hashes_present(mocker):
+def test_enqueue_recompute_fires_when_missing_hashes_present(mocker) -> None:
     """At least one Save row has NULL content_hash -> enqueue exactly once."""
     mocker.patch.object(
         startup.db_save_handler, "count_saves_missing_content_hash", return_value=42
@@ -43,14 +43,14 @@ def test_enqueue_recompute_fires_when_missing_hashes_present(mocker):
     assert kwargs["job_id"] == startup.RECOMPUTE_SAVE_HASHES_JOB_ID
 
 
-def test_recompute_job_id_is_valid_rq_id():
+def test_recompute_job_id_is_valid_rq_id() -> None:
     """RQ rejects any job_id not matching [A-Za-z0-9_-]+ (ValueError in set_id),
     which the broad except here would swallow -> backfill silently never enqueues.
     A colon was the original culprit; assert the full contract, not just that."""
     assert JOB_ID_PATTERN.fullmatch(startup.RECOMPUTE_SAVE_HASHES_JOB_ID)
 
 
-def test_enqueue_recompute_skips_when_already_queued(mocker):
+def test_enqueue_recompute_skips_when_already_queued(mocker) -> None:
     """An in-flight job from a previous restart -> skip enqueue, don't double up."""
     mocker.patch.object(
         startup.db_save_handler, "count_saves_missing_content_hash", return_value=10
@@ -63,7 +63,7 @@ def test_enqueue_recompute_skips_when_already_queued(mocker):
     enqueue.assert_not_called()
 
 
-def test_enqueue_recompute_swallows_count_error(mocker):
+def test_enqueue_recompute_swallows_count_error(mocker) -> None:
     """A failed COUNT query must not crash startup."""
     mocker.patch.object(
         startup.db_save_handler,
@@ -77,7 +77,7 @@ def test_enqueue_recompute_swallows_count_error(mocker):
     enqueue.assert_not_called()
 
 
-def test_enqueue_recompute_swallows_enqueue_error(mocker):
+def test_enqueue_recompute_swallows_enqueue_error(mocker) -> None:
     """A failed enqueue must not crash startup."""
     mocker.patch.object(
         startup.db_save_handler, "count_saves_missing_content_hash", return_value=5


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in backend/tests/conftest.py, backend/tests/test_startup.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.