### PR TITLE
Fix Docker volume mounts to enable hardlink optimization

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -216,8 +216,17 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/backend
 
-# Declare the supported volumes
-VOLUME ["/romm/resources", "/romm/library", "/romm/assets", "/romm/config", "/romm/sync", "/redis-data"]
+# Declare the supported volumes.
+#
+# We declare the parent `/romm` directory rather than each of its
+# subdirectories (resources, library, assets, config, sync) individually.
+# Listing the subdirectories causes Docker to create a separate mount point
+# (its own `st_dev`) for each one, even when the user bind-mounts a single
+# parent directory at `/romm`. That makes every cross-directory `os.link()`
+# fail with EXDEV ("Cross-device link"), forcing the asset import/export
+# hardlink optimization to fall back to a full copy. Declaring only `/romm`
+# keeps the subdirectories on a single filesystem so hardlinks can succeed.
+VOLUME ["/romm", "/redis-data"]
 
 # Expose non-privileged ports
 EXPOSE 8080 6379/tcp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -216,16 +216,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/backend
 
-# Declare the supported volumes.
-#
-# We declare the parent `/romm` directory rather than each of its
-# subdirectories (resources, library, assets, config, sync) individually.
-# Listing the subdirectories causes Docker to create a separate mount point
-# (its own `st_dev`) for each one, even when the user bind-mounts a single
-# parent directory at `/romm`. That makes every cross-directory `os.link()`
-# fail with EXDEV ("Cross-device link"), forcing the asset import/export
-# hardlink optimization to fall back to a full copy. Declaring only `/romm`
-# keeps the subdirectories on a single filesystem so hardlinks can succeed.
+# Declare the supported volumes
 VOLUME ["/romm", "/redis-data"]
 
 # Expose non-privileged ports

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -216,7 +216,8 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/backend
 
-# Declare the supported volumes
+# Declare only the parent `/romm`, not its subdirs, so Docker keeps them 
+# on one mount (`st_dev`) and cross-directory `os.link()` hardlinks don't fail.
 VOLUME ["/romm", "/redis-data"]
 
 # Expose non-privileged ports


### PR DESCRIPTION
**Description**

This change modifies the Docker `VOLUME` declaration to fix an issue where asset import/export hardlink optimization was failing due to cross-device link errors.

Previously, the Dockerfile declared each subdirectory individually (`/romm/resources`, `/romm/library`, `/romm/assets`, `/romm/config`, `/romm/sync`). When users bind-mounted a single parent directory at `/romm`, Docker would create separate mount points (each with its own `st_dev`) for each subdirectory. This caused `os.link()` operations to fail with `EXDEV` ("Cross-device link") errors, forcing the asset import/export process to fall back to slow full copies instead of using hardlinks.

The fix declares only the parent `/romm` directory (along with `/redis-data`) as volumes. This ensures all subdirectories remain on the same filesystem, allowing hardlink operations to succeed and enabling the hardlink optimization for asset import/export.

Fixes #3483

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

https://claude.ai/code/session_01STuknV2qjadTPHfSe5EV4q