### PR TITLE
Add rate limiting to metadata service API requests

### DIFF
--- a/backend/adapters/services/igdb.py
+++ b/backend/adapters/services/igdb.py
@@ -3,7 +3,7 @@ import http
 import json
 from collections.abc import Sequence
 from functools import partial
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Final, TypedDict
 
 import aiohttp
 import yarl
@@ -17,9 +17,14 @@ from handler.metadata.base_handler import UniversalPlatformSlug as UPS
 from logger.logger import log
 from utils import get_version
 from utils.context import ctx_aiohttp_session
+from utils.rate_limiter import RateLimiter
 
 if TYPE_CHECKING:
     from handler.metadata.igdb_handler import TwitchAuth
+
+# IGDB caps clients at 4 requests per second (max 8 open requests).
+IGDB_MAX_REQUESTS_PER_SECOND: Final[float] = 4
+_rate_limiter = RateLimiter(IGDB_MAX_REQUESTS_PER_SECOND)
 
 
 class IGDBInvalidCredentialsException(Exception):
@@ -94,6 +99,7 @@ class IGDBService:
         )
 
         try:
+            await _rate_limiter.acquire()
             res = await aiohttp_session.post(
                 url,
                 data=content,
@@ -142,6 +148,7 @@ class IGDBService:
                 content,
                 request_timeout,
             )
+            await _rate_limiter.acquire()
             res = await aiohttp_session.post(
                 url,
                 data=content,

--- a/backend/adapters/services/mobygames.py
+++ b/backend/adapters/services/mobygames.py
@@ -2,7 +2,7 @@ import asyncio
 import http
 import json
 from collections.abc import Collection
-from typing import Literal, overload
+from typing import Final, Literal, overload
 
 import aiohttp
 import yarl
@@ -14,6 +14,11 @@ from config import MOBYGAMES_API_KEY
 from logger.logger import log
 from utils import get_version
 from utils.context import ctx_aiohttp_session
+from utils.rate_limiter import RateLimiter
+
+# MobyGames caps the free/non-commercial tier at 1 request per second.
+MOBYGAMES_MAX_REQUESTS_PER_SECOND: Final[float] = 1
+_rate_limiter = RateLimiter(MOBYGAMES_MAX_REQUESTS_PER_SECOND)
 
 
 async def auth_middleware(
@@ -45,6 +50,7 @@ class MobyGamesService:
         )
 
         try:
+            await _rate_limiter.acquire()
             res = await aiohttp_session.get(
                 url,
                 headers={"user-agent": f"RomM/{get_version()}"},
@@ -85,6 +91,7 @@ class MobyGamesService:
                 url,
                 request_timeout,
             )
+            await _rate_limiter.acquire()
             res = await aiohttp_session.get(
                 url,
                 headers={"user-agent": f"RomM/{get_version()}"},

--- a/backend/adapters/services/retroachievements.py
+++ b/backend/adapters/services/retroachievements.py
@@ -2,7 +2,7 @@ import asyncio
 import http
 import json
 from collections.abc import AsyncIterator
-from typing import cast
+from typing import Final, cast
 
 import aiohttp
 import yarl
@@ -20,6 +20,12 @@ from config import RETROACHIEVEMENTS_API_KEY
 from logger.logger import log
 from utils import get_version
 from utils.context import ctx_aiohttp_session
+from utils.rate_limiter import RateLimiter
+
+# RetroAchievements does not publish a fixed limit; stay conservative to keep
+# within the "fair burst" allowance the API documents.
+RA_MAX_REQUESTS_PER_SECOND: Final[float] = 4
+_rate_limiter = RateLimiter(RA_MAX_REQUESTS_PER_SECOND)
 
 
 async def auth_middleware(
@@ -53,6 +59,7 @@ class RetroAchievementsService:
             request_timeout,
         )
         try:
+            await _rate_limiter.acquire()
             res = await aiohttp_session.get(
                 url,
                 headers={"user-agent": f"RomM/{get_version()}"},
@@ -90,6 +97,7 @@ class RetroAchievementsService:
                 url,
                 request_timeout,
             )
+            await _rate_limiter.acquire()
             res = await aiohttp_session.get(
                 url,
                 headers={"user-agent": f"RomM/{get_version()}"},

--- a/backend/adapters/services/retroachievements.py
+++ b/backend/adapters/services/retroachievements.py
@@ -22,8 +22,8 @@ from utils import get_version
 from utils.context import ctx_aiohttp_session
 from utils.rate_limiter import RateLimiter
 
-# RetroAchievements does not publish a fixed limit; stay conservative to keep
-# within the "fair burst" allowance the API documents.
+# RetroAchievements does not publish a fixed limit, try to stay
+# within the "fair burst" allowance the API documents
 RA_MAX_REQUESTS_PER_SECOND: Final[float] = 4
 _rate_limiter = RateLimiter(RA_MAX_REQUESTS_PER_SECOND)
 

--- a/backend/adapters/services/screenscraper.py
+++ b/backend/adapters/services/screenscraper.py
@@ -14,15 +14,40 @@ from config import SCREENSCRAPER_PASSWORD, SCREENSCRAPER_USER
 from logger.logger import log
 from utils import get_version
 from utils.context import ctx_aiohttp_session
-from utils.rate_limiter import RateLimiter
+from utils.rate_limiter import ConcurrencyLimiter
 
 SS_DEV_ID: Final = base64.b64decode("enVyZGkxNQ==").decode()
 SS_DEV_PASSWORD: Final = base64.b64decode("eFRKd29PRmpPUUc=").decode()
 LOGIN_ERROR_CHECK: Final = "Erreur de login"
 
-# ScreenScraper throttles the free tier to roughly one request per second.
-SS_MAX_REQUESTS_PER_SECOND: Final[float] = 1
-_rate_limiter = RateLimiter(SS_MAX_REQUESTS_PER_SECOND)
+# ScreenScraper enforces a per-account *thread* (concurrency) cap rather than a
+# request rate. Because a request can take several seconds, spacing out request
+# starts is not enough -- overlapping requests would exceed the cap and get
+# rejected. We instead bound simultaneous in-flight requests. The free/anonymous
+# tier allows a single thread; contributors and donors get more, which we learn
+# from `ssuser.maxthreads` in each response and apply via the limiter.
+SS_DEFAULT_MAX_THREADS: Final[int] = 1
+_concurrency_limiter = ConcurrencyLimiter(SS_DEFAULT_MAX_THREADS)
+
+
+def _update_thread_allowance(response: dict) -> None:
+    """Raise (or lower) the concurrency cap to the account's advertised threads.
+
+    ScreenScraper reports the per-account thread allowance in
+    ``response.ssuser.maxthreads`` (higher for contributors/donors). Honouring it
+    lets supporters scrape with their full concurrency instead of the
+    conservative default.
+    """
+    try:
+        max_threads = int(response["response"]["ssuser"]["maxthreads"])
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return
+
+    if max_threads < 1 or max_threads == _concurrency_limiter.max_concurrency:
+        return
+
+    log.info("ScreenScraper: setting thread allowance to %d", max_threads)
+    _concurrency_limiter.set_max_concurrency(max_threads)
 
 
 async def auth_middleware(
@@ -62,22 +87,24 @@ class ScreenScraperService:
             request_timeout,
         )
         try:
-            await _rate_limiter.acquire()
-            res = await aiohttp_session.get(
-                url,
-                headers={"user-agent": f"RomM/{get_version()}"},
-                middlewares=(auth_middleware,),
-                timeout=ClientTimeout(total=request_timeout),
-            )
-            res.raise_for_status()
-            res_text = await res.text()
-            if LOGIN_ERROR_CHECK in res_text:
-                log.error("Invalid ScreenScraper credentials")
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid ScreenScraper credentials",
+            async with _concurrency_limiter:
+                res = await aiohttp_session.get(
+                    url,
+                    headers={"user-agent": f"RomM/{get_version()}"},
+                    middlewares=(auth_middleware,),
+                    timeout=ClientTimeout(total=request_timeout),
                 )
-            return await res.json()
+                res.raise_for_status()
+                res_text = await res.text()
+                if LOGIN_ERROR_CHECK in res_text:
+                    log.error("Invalid ScreenScraper credentials")
+                    raise HTTPException(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        detail="Invalid ScreenScraper credentials",
+                    )
+                data = await res.json()
+            _update_thread_allowance(data)
+            return data
         except aiohttp.ServerTimeoutError:
             # Retry the request once if it times out
             pass
@@ -131,22 +158,24 @@ class ScreenScraperService:
                 url,
                 request_timeout,
             )
-            await _rate_limiter.acquire()
-            res = await aiohttp_session.get(
-                url,
-                headers={"user-agent": f"RomM/{get_version()}"},
-                middlewares=(auth_middleware,),
-                timeout=ClientTimeout(total=request_timeout),
-            )
-            res.raise_for_status()
-            res_text = await res.text()
-            if LOGIN_ERROR_CHECK in res_text:
-                log.error("Invalid ScreenScraper credentials")
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid ScreenScraper credentials",
+            async with _concurrency_limiter:
+                res = await aiohttp_session.get(
+                    url,
+                    headers={"user-agent": f"RomM/{get_version()}"},
+                    middlewares=(auth_middleware,),
+                    timeout=ClientTimeout(total=request_timeout),
                 )
-            return await res.json()
+                res.raise_for_status()
+                res_text = await res.text()
+                if LOGIN_ERROR_CHECK in res_text:
+                    log.error("Invalid ScreenScraper credentials")
+                    raise HTTPException(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        detail="Invalid ScreenScraper credentials",
+                    )
+                data = await res.json()
+            _update_thread_allowance(data)
+            return data
         except (aiohttp.ClientResponseError, aiohttp.ServerTimeoutError) as err:
             if isinstance(err, aiohttp.ClientResponseError):
                 if err.status == http.HTTPStatus.UNAUTHORIZED:

--- a/backend/adapters/services/screenscraper.py
+++ b/backend/adapters/services/screenscraper.py
@@ -22,10 +22,8 @@ LOGIN_ERROR_CHECK: Final = "Erreur de login"
 
 # ScreenScraper enforces a per-account *thread* (concurrency) cap rather than a
 # request rate. Because a request can take several seconds, spacing out request
-# starts is not enough -- overlapping requests would exceed the cap and get
-# rejected. We instead bound simultaneous in-flight requests. The free/anonymous
-# tier allows a single thread; contributors and donors get more, which we learn
-# from `ssuser.maxthreads` in each response and apply via the limiter.
+# starts is not enough, as overlapping requests would exceed the cap and get
+# rejected. We instead bound simultaneous in-flight requests.
 SS_DEFAULT_MAX_THREADS: Final[int] = 1
 _concurrency_limiter = ConcurrencyLimiter(SS_DEFAULT_MAX_THREADS)
 
@@ -34,12 +32,11 @@ def _update_thread_allowance(response: dict) -> None:
     """Raise (or lower) the concurrency cap to the account's advertised threads.
 
     ScreenScraper reports the per-account thread allowance in
-    ``response.ssuser.maxthreads`` (higher for contributors/donors). Honouring it
-    lets supporters scrape with their full concurrency instead of the
-    conservative default.
+    ``response.ssuser.maxthreads`` (higher for contributors/donors).
     """
     try:
         max_threads = int(response["response"]["ssuser"]["maxthreads"])
+        print("MAX THREADS: ", max_threads)
     except (AttributeError, KeyError, TypeError, ValueError):
         return
 
@@ -60,8 +57,8 @@ async def auth_middleware(
             "devpassword": SS_DEV_PASSWORD,
             "output": "json",
             "softname": "romm",
-            "ssid": SCREENSCRAPER_USER,
-            "sspassword": SCREENSCRAPER_PASSWORD,
+            "ssid": SCREENSCRAPER_USER or "",
+            "sspassword": SCREENSCRAPER_PASSWORD or "",
         },
     )
     return await handler(req)

--- a/backend/adapters/services/screenscraper.py
+++ b/backend/adapters/services/screenscraper.py
@@ -36,7 +36,6 @@ def _update_thread_allowance(response: dict) -> None:
     """
     try:
         max_threads = int(response["response"]["ssuser"]["maxthreads"])
-        print("MAX THREADS: ", max_threads)
     except (AttributeError, KeyError, TypeError, ValueError):
         return
 

--- a/backend/adapters/services/screenscraper.py
+++ b/backend/adapters/services/screenscraper.py
@@ -14,10 +14,15 @@ from config import SCREENSCRAPER_PASSWORD, SCREENSCRAPER_USER
 from logger.logger import log
 from utils import get_version
 from utils.context import ctx_aiohttp_session
+from utils.rate_limiter import RateLimiter
 
 SS_DEV_ID: Final = base64.b64decode("enVyZGkxNQ==").decode()
 SS_DEV_PASSWORD: Final = base64.b64decode("eFRKd29PRmpPUUc=").decode()
 LOGIN_ERROR_CHECK: Final = "Erreur de login"
+
+# ScreenScraper throttles the free tier to roughly one request per second.
+SS_MAX_REQUESTS_PER_SECOND: Final[float] = 1
+_rate_limiter = RateLimiter(SS_MAX_REQUESTS_PER_SECOND)
 
 
 async def auth_middleware(
@@ -57,6 +62,7 @@ class ScreenScraperService:
             request_timeout,
         )
         try:
+            await _rate_limiter.acquire()
             res = await aiohttp_session.get(
                 url,
                 headers={"user-agent": f"RomM/{get_version()}"},
@@ -125,6 +131,7 @@ class ScreenScraperService:
                 url,
                 request_timeout,
             )
+            await _rate_limiter.acquire()
             res = await aiohttp_session.get(
                 url,
                 headers={"user-agent": f"RomM/{get_version()}"},

--- a/backend/adapters/services/screenscraper_types.py
+++ b/backend/adapters/services/screenscraper_types.py
@@ -1,4 +1,16 @@
-from typing import Literal, TypedDict
+from typing import Literal, NotRequired, TypedDict
+
+
+# Per-account limits returned in `response.ssuser`. Contributors/donors get a
+# higher `maxthreads` allowance. All values arrive as strings.
+# Reference: https://api.screenscraper.fr/webapi2.php
+class SSUser(TypedDict):
+    id: NotRequired[str]
+    niveau: NotRequired[str]
+    maxthreads: NotRequired[str]
+    maxrequestspermin: NotRequired[str]
+    maxrequestsperday: NotRequired[str]
+    requeststoday: NotRequired[str]
 
 
 class SSText(TypedDict):

--- a/backend/adapters/services/screenscraper_types.py
+++ b/backend/adapters/services/screenscraper_types.py
@@ -1,8 +1,7 @@
 from typing import Literal, NotRequired, TypedDict
 
 
-# Per-account limits returned in `response.ssuser`. Contributors/donors get a
-# higher `maxthreads` allowance. All values arrive as strings.
+# Per-account limits returned in `response.ssuser`
 # Reference: https://api.screenscraper.fr/webapi2.php
 class SSUser(TypedDict):
     id: NotRequired[str]

--- a/backend/tests/adapters/services/conftest.py
+++ b/backend/tests/adapters/services/conftest.py
@@ -1,7 +1,27 @@
 from contextvars import ContextVar
+from unittest.mock import AsyncMock
 
 import aiohttp
+import pytest
 import pytest_asyncio
+
+
+@pytest.fixture(autouse=True)
+def _disable_metadata_rate_limiters(monkeypatch):
+    """Neutralize the pre-emptive rate limiters during tests.
+
+    Each metadata service spaces its requests via a module-level ``RateLimiter``
+    whose ``acquire`` sleeps to stay under the provider's req/s cap. Letting it
+    run would add real delays and inject extra ``asyncio.sleep`` calls that
+    interfere with retry assertions, so we replace ``acquire`` with a no-op.
+    """
+    for module in (
+        "adapters.services.igdb",
+        "adapters.services.mobygames",
+        "adapters.services.retroachievements",
+        "adapters.services.screenscraper",
+    ):
+        monkeypatch.setattr(f"{module}._rate_limiter.acquire", AsyncMock())
 
 
 @pytest_asyncio.fixture

--- a/backend/tests/adapters/services/conftest.py
+++ b/backend/tests/adapters/services/conftest.py
@@ -16,7 +16,6 @@ def disable_metadata_rate_limiters(monkeypatch):
         "adapters.services.igdb",
         "adapters.services.mobygames",
         "adapters.services.retroachievements",
-        "adapters.services.screenscraper",
     ):
         mod = __import__(module, fromlist=["_rate_limiter"])
         monkeypatch.setattr(mod._rate_limiter, "acquire", AsyncMock())

--- a/backend/tests/adapters/services/conftest.py
+++ b/backend/tests/adapters/services/conftest.py
@@ -5,23 +5,33 @@ import aiohttp
 import pytest
 import pytest_asyncio
 
+from adapters.services.screenscraper import SS_DEFAULT_MAX_THREADS
+from utils.rate_limiter import ConcurrencyLimiter
+
 
 @pytest.fixture(autouse=True)
 def _disable_metadata_rate_limiters(monkeypatch):
     """Neutralize the pre-emptive rate limiters during tests.
 
-    Each metadata service spaces its requests via a module-level ``RateLimiter``
-    whose ``acquire`` sleeps to stay under the provider's req/s cap. Letting it
-    run would add real delays and inject extra ``asyncio.sleep`` calls that
-    interfere with retry assertions, so we replace ``acquire`` with a no-op.
+    Each req/s-limited service spaces its requests via a module-level
+    ``RateLimiter`` whose ``acquire`` sleeps to stay under the provider's cap.
+    Letting it run would add real delays and inject extra ``asyncio.sleep`` calls
+    that interfere with retry assertions, so we replace ``acquire`` with a no-op.
     """
     for module in (
         "adapters.services.igdb",
         "adapters.services.mobygames",
         "adapters.services.retroachievements",
-        "adapters.services.screenscraper",
     ):
         monkeypatch.setattr(f"{module}._rate_limiter.acquire", AsyncMock())
+
+    # ScreenScraper uses a concurrency limiter whose capacity mutates at runtime
+    # from `ssuser.maxthreads`. Swap in a fresh instance so each test starts from
+    # the default allowance with a clean (per-loop) waiter queue.
+    monkeypatch.setattr(
+        "adapters.services.screenscraper._concurrency_limiter",
+        ConcurrencyLimiter(SS_DEFAULT_MAX_THREADS),
+    )
 
 
 @pytest_asyncio.fixture

--- a/backend/tests/adapters/services/conftest.py
+++ b/backend/tests/adapters/services/conftest.py
@@ -10,24 +10,18 @@ from utils.rate_limiter import ConcurrencyLimiter
 
 
 @pytest.fixture(autouse=True)
-def _disable_metadata_rate_limiters(monkeypatch):
-    """Neutralize the pre-emptive rate limiters during tests.
-
-    Each req/s-limited service spaces its requests via a module-level
-    ``RateLimiter`` whose ``acquire`` sleeps to stay under the provider's cap.
-    Letting it run would add real delays and inject extra ``asyncio.sleep`` calls
-    that interfere with retry assertions, so we replace ``acquire`` with a no-op.
-    """
+def disable_metadata_rate_limiters(monkeypatch):
+    """Neutralize the pre-emptive rate limiters during tests."""
     for module in (
         "adapters.services.igdb",
         "adapters.services.mobygames",
         "adapters.services.retroachievements",
+        "adapters.services.screenscraper",
     ):
-        monkeypatch.setattr(f"{module}._rate_limiter.acquire", AsyncMock())
+        mod = __import__(module, fromlist=["_rate_limiter"])
+        monkeypatch.setattr(mod._rate_limiter, "acquire", AsyncMock())
 
-    # ScreenScraper uses a concurrency limiter whose capacity mutates at runtime
-    # from `ssuser.maxthreads`. Swap in a fresh instance so each test starts from
-    # the default allowance with a clean (per-loop) waiter queue.
+    # Swap in a fresh instance of the concurrency limiter for each test
     monkeypatch.setattr(
         "adapters.services.screenscraper._concurrency_limiter",
         ConcurrencyLimiter(SS_DEFAULT_MAX_THREADS),

--- a/backend/tests/adapters/services/test_igdb.py
+++ b/backend/tests/adapters/services/test_igdb.py
@@ -16,11 +16,6 @@ class TestIGDBServiceUnit:
     @pytest.mark.asyncio
     async def test_request_acquires_rate_limiter(self, service, monkeypatch):
         """Test that the request reserves a rate-limiter slot before sending."""
-        acquire_mock = AsyncMock()
-        monkeypatch.setattr(
-            "adapters.services.igdb._rate_limiter.acquire", acquire_mock
-        )
-
         mock_session = AsyncMock()
         mock_response = MagicMock()
         mock_response.json = AsyncMock(return_value=[{"id": 1}])
@@ -33,5 +28,4 @@ class TestIGDBServiceUnit:
         with patch("adapters.services.igdb.ctx_aiohttp_session", mock_context):
             result = await service._request("https://api.igdb.com/v4/games")
 
-        acquire_mock.assert_awaited_once()
         assert result == [{"id": 1}]

--- a/backend/tests/adapters/services/test_igdb.py
+++ b/backend/tests/adapters/services/test_igdb.py
@@ -16,7 +16,7 @@ class TestIGDBServiceUnit:
         return IGDBService(twitch_auth=MagicMock())
 
     @pytest.mark.asyncio
-    async def test_request_acquires_rate_limiter(self, service, monkeypatch):
+    async def test_request_acquires_rate_limiter(self, service):
         """Test that the request reserves a rate-limiter slot before sending."""
         mock_response = MagicMock()
         mock_response.json = AsyncMock(return_value=[{"id": 1}])

--- a/backend/tests/adapters/services/test_igdb.py
+++ b/backend/tests/adapters/services/test_igdb.py
@@ -1,0 +1,37 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from adapters.services.igdb import IGDBService
+
+
+class TestIGDBServiceUnit:
+    """Unit tests with mocked dependencies."""
+
+    @pytest.fixture
+    def service(self):
+        """Create an IGDBService instance for testing."""
+        return IGDBService(twitch_auth=MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_request_acquires_rate_limiter(self, service, monkeypatch):
+        """Test that the request reserves a rate-limiter slot before sending."""
+        acquire_mock = AsyncMock()
+        monkeypatch.setattr(
+            "adapters.services.igdb._rate_limiter.acquire", acquire_mock
+        )
+
+        mock_session = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(return_value=[{"id": 1}])
+        mock_response.raise_for_status.return_value = None
+        mock_session.post.return_value = mock_response
+
+        mock_context = MagicMock()
+        mock_context.get.return_value = mock_session
+
+        with patch("adapters.services.igdb.ctx_aiohttp_session", mock_context):
+            result = await service._request("https://api.igdb.com/v4/games")
+
+        acquire_mock.assert_awaited_once()
+        assert result == [{"id": 1}]

--- a/backend/tests/adapters/services/test_igdb.py
+++ b/backend/tests/adapters/services/test_igdb.py
@@ -1,7 +1,9 @@
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from adapters.services import igdb
 from adapters.services.igdb import IGDBService
 
 
@@ -16,11 +18,21 @@ class TestIGDBServiceUnit:
     @pytest.mark.asyncio
     async def test_request_acquires_rate_limiter(self, service, monkeypatch):
         """Test that the request reserves a rate-limiter slot before sending."""
-        mock_session = AsyncMock()
         mock_response = MagicMock()
         mock_response.json = AsyncMock(return_value=[{"id": 1}])
         mock_response.raise_for_status.return_value = None
-        mock_session.post.return_value = mock_response
+
+        # Record the order in which the rate limiter is acquired and the request is sent
+        call_order: list[str] = []
+        acquire_mock = cast(AsyncMock, igdb._rate_limiter.acquire)
+        acquire_mock.side_effect = lambda *a, **k: call_order.append("acquire")
+
+        async def record_post(*args, **kwargs):
+            call_order.append("post")
+            return mock_response
+
+        mock_session = AsyncMock()
+        mock_session.post.side_effect = record_post
 
         mock_context = MagicMock()
         mock_context.get.return_value = mock_session
@@ -29,3 +41,10 @@ class TestIGDBServiceUnit:
             result = await service._request("https://api.igdb.com/v4/games")
 
         assert result == [{"id": 1}]
+        # The rate-limiter slot must be reserved, and before the request is sent.
+        acquire_mock.assert_awaited_once()
+        mock_session.post.assert_awaited_once()
+        assert call_order == [
+            "acquire",
+            "post",
+        ], "rate limiter must be acquired before the POST is sent"

--- a/backend/tests/adapters/services/test_mobygames.py
+++ b/backend/tests/adapters/services/test_mobygames.py
@@ -1,6 +1,7 @@
 import asyncio
 import http
 import json
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -8,6 +9,7 @@ import pytest
 import yarl
 from fastapi import HTTPException, status
 
+from adapters.services import mobygames
 from adapters.services.mobygames import (
     MobyGamesService,
     auth_middleware,
@@ -107,17 +109,35 @@ class TestMobyGamesServiceUnit:
     @pytest.mark.asyncio
     async def test_request_acquires_rate_limiter(self, service, monkeypatch):
         """Test that the request reserves a rate-limiter slot before sending."""
-        mock_session = AsyncMock()
         mock_response = MagicMock()
         mock_response.json = AsyncMock(return_value={"games": []})
         mock_response.raise_for_status.return_value = None
-        mock_session.get.return_value = mock_response
+
+        # Record the order in which the rate limiter is acquired and the request is sent
+        call_order: list[str] = []
+        acquire_mock = cast(AsyncMock, mobygames._rate_limiter.acquire)
+        acquire_mock.side_effect = lambda *a, **k: call_order.append("acquire")
+
+        async def record_get(*args, **kwargs):
+            call_order.append("get")
+            return mock_response
+
+        mock_session = AsyncMock()
+        mock_session.get.side_effect = record_get
 
         mock_context = MagicMock()
         mock_context.get.return_value = mock_session
 
         with patch("adapters.services.mobygames.ctx_aiohttp_session", mock_context):
             await service._request("https://api.mobygames.com/v1/games")
+
+        # The rate-limiter slot must be reserved, and before the request is sent.
+        acquire_mock.assert_awaited_once()
+        mock_session.get.assert_awaited_once()
+        assert call_order == [
+            "acquire",
+            "get",
+        ], "rate limiter must be acquired before the GET is sent"
 
     @pytest.mark.asyncio
     async def test_request_connection_error(self, service):

--- a/backend/tests/adapters/services/test_mobygames.py
+++ b/backend/tests/adapters/services/test_mobygames.py
@@ -107,11 +107,6 @@ class TestMobyGamesServiceUnit:
     @pytest.mark.asyncio
     async def test_request_acquires_rate_limiter(self, service, monkeypatch):
         """Test that the request reserves a rate-limiter slot before sending."""
-        acquire_mock = AsyncMock()
-        monkeypatch.setattr(
-            "adapters.services.mobygames._rate_limiter.acquire", acquire_mock
-        )
-
         mock_session = AsyncMock()
         mock_response = MagicMock()
         mock_response.json = AsyncMock(return_value={"games": []})
@@ -123,8 +118,6 @@ class TestMobyGamesServiceUnit:
 
         with patch("adapters.services.mobygames.ctx_aiohttp_session", mock_context):
             await service._request("https://api.mobygames.com/v1/games")
-
-        acquire_mock.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_request_connection_error(self, service):

--- a/backend/tests/adapters/services/test_mobygames.py
+++ b/backend/tests/adapters/services/test_mobygames.py
@@ -107,7 +107,7 @@ class TestMobyGamesServiceUnit:
         mock_response.json.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_request_acquires_rate_limiter(self, service, monkeypatch):
+    async def test_request_acquires_rate_limiter(self, service):
         """Test that the request reserves a rate-limiter slot before sending."""
         mock_response = MagicMock()
         mock_response.json = AsyncMock(return_value={"games": []})

--- a/backend/tests/adapters/services/test_mobygames.py
+++ b/backend/tests/adapters/services/test_mobygames.py
@@ -105,6 +105,28 @@ class TestMobyGamesServiceUnit:
         mock_response.json.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_request_acquires_rate_limiter(self, service, monkeypatch):
+        """Test that the request reserves a rate-limiter slot before sending."""
+        acquire_mock = AsyncMock()
+        monkeypatch.setattr(
+            "adapters.services.mobygames._rate_limiter.acquire", acquire_mock
+        )
+
+        mock_session = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(return_value={"games": []})
+        mock_response.raise_for_status.return_value = None
+        mock_session.get.return_value = mock_response
+
+        mock_context = MagicMock()
+        mock_context.get.return_value = mock_session
+
+        with patch("adapters.services.mobygames.ctx_aiohttp_session", mock_context):
+            await service._request("https://api.mobygames.com/v1/games")
+
+        acquire_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_request_connection_error(self, service):
         """Test request with connection error."""
         mock_session = AsyncMock()

--- a/backend/tests/adapters/services/test_retroachivements.py
+++ b/backend/tests/adapters/services/test_retroachivements.py
@@ -80,7 +80,7 @@ class TestRetroAchievementsServiceUnit:
         assert "Can't connect to RetroAchievements" in exc_info.value.detail
 
     @pytest.mark.asyncio
-    async def test_request_acquires_rate_limiter(self, service, monkeypatch):
+    async def test_request_acquires_rate_limiter(self, service):
         """Test that the request reserves a rate-limiter slot before sending."""
         mock_response = MagicMock()
         mock_response.json = AsyncMock(return_value={})

--- a/backend/tests/adapters/services/test_retroachivements.py
+++ b/backend/tests/adapters/services/test_retroachivements.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -5,6 +6,7 @@ import pytest
 import yarl
 from fastapi import HTTPException, status
 
+from adapters.services import retroachievements
 from adapters.services.retroachievements import (
     RetroAchievementsService,
     auth_middleware,
@@ -80,11 +82,21 @@ class TestRetroAchievementsServiceUnit:
     @pytest.mark.asyncio
     async def test_request_acquires_rate_limiter(self, service, monkeypatch):
         """Test that the request reserves a rate-limiter slot before sending."""
-        mock_session = AsyncMock()
         mock_response = MagicMock()
         mock_response.json = AsyncMock(return_value={})
         mock_response.raise_for_status.return_value = None
-        mock_session.get.return_value = mock_response
+
+        # Record the order in which the rate limiter is acquired and the request is sent
+        call_order: list[str] = []
+        acquire_mock = cast(AsyncMock, retroachievements._rate_limiter.acquire)
+        acquire_mock.side_effect = lambda *a, **k: call_order.append("acquire")
+
+        async def record_get(*args, **kwargs):
+            call_order.append("get")
+            return mock_response
+
+        mock_session = AsyncMock()
+        mock_session.get.side_effect = record_get
 
         mock_context = MagicMock()
         mock_context.get.return_value = mock_session
@@ -93,6 +105,14 @@ class TestRetroAchievementsServiceUnit:
             "adapters.services.retroachievements.ctx_aiohttp_session", mock_context
         ):
             await service._request("https://retroachievements.org/API")
+
+        # The rate-limiter slot must be reserved, and before the request is sent.
+        acquire_mock.assert_awaited_once()
+        mock_session.get.assert_awaited_once()
+        assert call_order == [
+            "acquire",
+            "get",
+        ], "rate limiter must be acquired before the GET is sent"
 
 
 class TestRetroAchievementsServiceIntegration:

--- a/backend/tests/adapters/services/test_retroachivements.py
+++ b/backend/tests/adapters/services/test_retroachivements.py
@@ -80,11 +80,6 @@ class TestRetroAchievementsServiceUnit:
     @pytest.mark.asyncio
     async def test_request_acquires_rate_limiter(self, service, monkeypatch):
         """Test that the request reserves a rate-limiter slot before sending."""
-        acquire_mock = AsyncMock()
-        monkeypatch.setattr(
-            "adapters.services.retroachievements._rate_limiter.acquire", acquire_mock
-        )
-
         mock_session = AsyncMock()
         mock_response = MagicMock()
         mock_response.json = AsyncMock(return_value={})
@@ -98,8 +93,6 @@ class TestRetroAchievementsServiceUnit:
             "adapters.services.retroachievements.ctx_aiohttp_session", mock_context
         ):
             await service._request("https://retroachievements.org/API")
-
-        acquire_mock.assert_awaited_once()
 
 
 class TestRetroAchievementsServiceIntegration:

--- a/backend/tests/adapters/services/test_retroachivements.py
+++ b/backend/tests/adapters/services/test_retroachivements.py
@@ -77,6 +77,30 @@ class TestRetroAchievementsServiceUnit:
         assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
         assert "Can't connect to RetroAchievements" in exc_info.value.detail
 
+    @pytest.mark.asyncio
+    async def test_request_acquires_rate_limiter(self, service, monkeypatch):
+        """Test that the request reserves a rate-limiter slot before sending."""
+        acquire_mock = AsyncMock()
+        monkeypatch.setattr(
+            "adapters.services.retroachievements._rate_limiter.acquire", acquire_mock
+        )
+
+        mock_session = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(return_value={})
+        mock_response.raise_for_status.return_value = None
+        mock_session.get.return_value = mock_response
+
+        mock_context = MagicMock()
+        mock_context.get.return_value = mock_session
+
+        with patch(
+            "adapters.services.retroachievements.ctx_aiohttp_session", mock_context
+        ):
+            await service._request("https://retroachievements.org/API")
+
+        acquire_mock.assert_awaited_once()
+
 
 class TestRetroAchievementsServiceIntegration:
     @pytest.fixture

--- a/backend/tests/adapters/services/test_screenscraper.py
+++ b/backend/tests/adapters/services/test_screenscraper.py
@@ -149,6 +149,29 @@ class TestScreenScraperServiceUnit:
         mock_response.json.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_request_acquires_rate_limiter(self, service, monkeypatch):
+        """Test that the request reserves a rate-limiter slot before sending."""
+        acquire_mock = AsyncMock()
+        monkeypatch.setattr(
+            "adapters.services.screenscraper._rate_limiter.acquire", acquire_mock
+        )
+
+        mock_session = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(return_value={"response": {}})
+        mock_response.text = AsyncMock(return_value="{}")
+        mock_response.raise_for_status.return_value = None
+        mock_session.get.return_value = mock_response
+
+        mock_context = MagicMock()
+        mock_context.get.return_value = mock_session
+
+        with patch("adapters.services.screenscraper.ctx_aiohttp_session", mock_context):
+            await service._request("https://api.screenscraper.fr/api2/jeuInfos.php")
+
+        acquire_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_request_login_error(self, service):
         """Test request with login error in response text."""
         mock_session = AsyncMock()

--- a/backend/tests/adapters/services/test_screenscraper.py
+++ b/backend/tests/adapters/services/test_screenscraper.py
@@ -149,12 +149,14 @@ class TestScreenScraperServiceUnit:
         mock_response.json.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_request_acquires_rate_limiter(self, service, monkeypatch):
-        """Test that the request reserves a rate-limiter slot before sending."""
+    async def test_request_holds_concurrency_slot(self, service, monkeypatch):
+        """Test that the request acquires and releases a concurrency slot."""
+        import adapters.services.screenscraper as ss_module
+
         acquire_mock = AsyncMock()
-        monkeypatch.setattr(
-            "adapters.services.screenscraper._rate_limiter.acquire", acquire_mock
-        )
+        release_mock = MagicMock()
+        monkeypatch.setattr(ss_module._concurrency_limiter, "acquire", acquire_mock)
+        monkeypatch.setattr(ss_module._concurrency_limiter, "release", release_mock)
 
         mock_session = AsyncMock()
         mock_response = MagicMock()
@@ -170,6 +172,55 @@ class TestScreenScraperServiceUnit:
             await service._request("https://api.screenscraper.fr/api2/jeuInfos.php")
 
         acquire_mock.assert_awaited_once()
+        release_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_request_updates_thread_allowance_from_ssuser(
+        self, service, monkeypatch
+    ):
+        """Test that `ssuser.maxthreads` raises the concurrency cap (donor perk)."""
+        import adapters.services.screenscraper as ss_module
+
+        assert ss_module._concurrency_limiter.max_concurrency == 1
+
+        mock_session = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(
+            return_value={"response": {"ssuser": {"maxthreads": "5"}}}
+        )
+        mock_response.text = AsyncMock(return_value="{}")
+        mock_response.raise_for_status.return_value = None
+        mock_session.get.return_value = mock_response
+
+        mock_context = MagicMock()
+        mock_context.get.return_value = mock_session
+
+        with patch("adapters.services.screenscraper.ctx_aiohttp_session", mock_context):
+            await service._request("https://api.screenscraper.fr/api2/jeuInfos.php")
+
+        assert ss_module._concurrency_limiter.max_concurrency == 5
+
+    @pytest.mark.asyncio
+    async def test_request_ignores_invalid_maxthreads(self, service, monkeypatch):
+        """Test that a missing or unparsable `maxthreads` leaves the cap untouched."""
+        import adapters.services.screenscraper as ss_module
+
+        mock_session = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(
+            return_value={"response": {"ssuser": {"maxthreads": "not-a-number"}}}
+        )
+        mock_response.text = AsyncMock(return_value="{}")
+        mock_response.raise_for_status.return_value = None
+        mock_session.get.return_value = mock_response
+
+        mock_context = MagicMock()
+        mock_context.get.return_value = mock_session
+
+        with patch("adapters.services.screenscraper.ctx_aiohttp_session", mock_context):
+            await service._request("https://api.screenscraper.fr/api2/jeuInfos.php")
+
+        assert ss_module._concurrency_limiter.max_concurrency == 1
 
     @pytest.mark.asyncio
     async def test_request_login_error(self, service):

--- a/backend/tests/adapters/services/test_screenscraper.py
+++ b/backend/tests/adapters/services/test_screenscraper.py
@@ -175,9 +175,7 @@ class TestScreenScraperServiceUnit:
         release_mock.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_request_updates_thread_allowance_from_ssuser(
-        self, service, monkeypatch
-    ):
+    async def test_request_updates_thread_allowance_from_ssuser(self, service):
         """Test that `ssuser.maxthreads` raises the concurrency cap (donor perk)."""
         import adapters.services.screenscraper as ss_module
 
@@ -201,7 +199,7 @@ class TestScreenScraperServiceUnit:
         assert ss_module._concurrency_limiter.max_concurrency == 5
 
     @pytest.mark.asyncio
-    async def test_request_ignores_invalid_maxthreads(self, service, monkeypatch):
+    async def test_request_ignores_invalid_maxthreads(self, service):
         """Test that a missing or unparsable `maxthreads` leaves the cap untouched."""
         import adapters.services.screenscraper as ss_module
 

--- a/backend/tests/utils/test_rate_limiter.py
+++ b/backend/tests/utils/test_rate_limiter.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from utils.rate_limiter import RateLimiter
+from utils.rate_limiter import ConcurrencyLimiter, RateLimiter
 
 
 def _record_sleeps(monkeypatch) -> list[float]:
@@ -55,3 +55,81 @@ class TestRateLimiter:
     def test_non_positive_rate_raises(self, rate):
         with pytest.raises(ValueError):
             RateLimiter(requests_per_second=rate)
+
+
+class TestConcurrencyLimiter:
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_non_positive_capacity_raises(self, value):
+        with pytest.raises(ValueError):
+            ConcurrencyLimiter(max_concurrency=value)
+
+    async def test_acquire_release_tracks_in_flight(self):
+        limiter = ConcurrencyLimiter(max_concurrency=2)
+
+        await limiter.acquire()
+        await limiter.acquire()
+        assert limiter.in_flight == 2
+
+        limiter.release()
+        assert limiter.in_flight == 1
+
+    async def test_context_manager_releases(self):
+        limiter = ConcurrencyLimiter(max_concurrency=1)
+
+        async with limiter:
+            assert limiter.in_flight == 1
+        assert limiter.in_flight == 0
+
+    async def test_context_manager_releases_on_error(self):
+        limiter = ConcurrencyLimiter(max_concurrency=1)
+
+        with pytest.raises(RuntimeError):
+            async with limiter:
+                raise RuntimeError("boom")
+
+        assert limiter.in_flight == 0
+
+    async def test_acquire_blocks_until_slot_freed(self):
+        limiter = ConcurrencyLimiter(max_concurrency=1)
+        await limiter.acquire()
+
+        waiter = asyncio.ensure_future(limiter.acquire())
+        await asyncio.sleep(0)  # Let the waiter run and block.
+        assert not waiter.done()
+
+        limiter.release()
+        await asyncio.wait_for(waiter, timeout=1)
+        assert limiter.in_flight == 1
+
+    async def test_set_max_concurrency_wakes_waiters(self):
+        limiter = ConcurrencyLimiter(max_concurrency=1)
+        await limiter.acquire()
+
+        waiter = asyncio.ensure_future(limiter.acquire())
+        await asyncio.sleep(0)
+        assert not waiter.done()
+
+        # Opening a second slot should release the blocked acquirer.
+        limiter.set_max_concurrency(2)
+        await asyncio.wait_for(waiter, timeout=1)
+        assert limiter.in_flight == 2
+
+    async def test_lowering_capacity_blocks_new_acquirers(self):
+        limiter = ConcurrencyLimiter(max_concurrency=2)
+        await limiter.acquire()
+        limiter.set_max_concurrency(1)
+
+        waiter = asyncio.ensure_future(limiter.acquire())
+        await asyncio.sleep(0)
+        # Already at the new cap, so the next acquirer must wait.
+        assert not waiter.done()
+
+        limiter.release()
+        await asyncio.wait_for(waiter, timeout=1)
+        assert limiter.in_flight == 1
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_set_non_positive_capacity_raises(self, value):
+        limiter = ConcurrencyLimiter(max_concurrency=1)
+        with pytest.raises(ValueError):
+            limiter.set_max_concurrency(value)

--- a/backend/utils/rate_limiter.py
+++ b/backend/utils/rate_limiter.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections import deque
 
 
 class RateLimiter:
@@ -26,3 +27,88 @@ class RateLimiter:
         delay = slot - now
         if delay > 0:
             await asyncio.sleep(delay)
+
+
+class ConcurrencyLimiter:
+    """Caps the number of in-flight operations, with a runtime-adjustable capacity.
+
+    Unlike :class:`RateLimiter`, which spaces out *when* requests start, this
+    bounds how many run *simultaneously*. It suits APIs that enforce a per-account
+    thread/connection cap (e.g. ScreenScraper) rather than a call rate: because a
+    slot is held for the whole request, slow responses can never cause overlapping
+    requests to exceed the cap.
+
+    The capacity can be raised or lowered at runtime via
+    :meth:`set_max_concurrency` -- for instance once an API response reveals the
+    account's allowance. Use it as an async context manager so the slot is always
+    released, even if the wrapped request raises::
+
+        async with limiter:
+            await do_request()
+
+    The implementation is loop-agnostic: waiter futures are created against the
+    running loop on acquisition, so a single shared instance works across the
+    distinct event loops used by, e.g., the test suite.
+    """
+
+    def __init__(self, max_concurrency: int) -> None:
+        if max_concurrency < 1:
+            raise ValueError("max_concurrency must be at least 1")
+        self._max_concurrency = max_concurrency
+        self._in_flight = 0
+        self._waiters: deque[asyncio.Future[None]] = deque()
+
+    @property
+    def max_concurrency(self) -> int:
+        return self._max_concurrency
+
+    @property
+    def in_flight(self) -> int:
+        return self._in_flight
+
+    def set_max_concurrency(self, max_concurrency: int) -> None:
+        if max_concurrency < 1:
+            raise ValueError("max_concurrency must be at least 1")
+        previous = self._max_concurrency
+        self._max_concurrency = max_concurrency
+        # Wake one waiter per newly opened slot; each re-checks capacity itself.
+        for _ in range(max(0, max_concurrency - previous)):
+            self._wake_next()
+
+    async def acquire(self) -> None:
+        # Re-check on every wake-up: another coroutine may have taken the slot,
+        # or the capacity may have been lowered while we waited.
+        while self._in_flight >= self._max_concurrency:
+            loop = asyncio.get_running_loop()
+            waiter = loop.create_future()
+            self._waiters.append(waiter)
+            try:
+                try:
+                    await waiter
+                finally:
+                    self._waiters.remove(waiter)
+            except asyncio.CancelledError:
+                # We were granted a slot but cancelled before using it; pass the
+                # grant on so a waiting peer is not stranded.
+                if not waiter.cancelled():
+                    self._wake_next()
+                raise
+        self._in_flight += 1
+
+    def release(self) -> None:
+        if self._in_flight > 0:
+            self._in_flight -= 1
+        self._wake_next()
+
+    def _wake_next(self) -> None:
+        for waiter in self._waiters:
+            if not waiter.done():
+                waiter.set_result(None)
+                return
+
+    async def __aenter__(self) -> "ConcurrencyLimiter":
+        await self.acquire()
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        self.release()

--- a/backend/utils/rate_limiter.py
+++ b/backend/utils/rate_limiter.py
@@ -32,23 +32,15 @@ class RateLimiter:
 class ConcurrencyLimiter:
     """Caps the number of in-flight operations, with a runtime-adjustable capacity.
 
-    Unlike :class:`RateLimiter`, which spaces out *when* requests start, this
-    bounds how many run *simultaneously*. It suits APIs that enforce a per-account
-    thread/connection cap (e.g. ScreenScraper) rather than a call rate: because a
-    slot is held for the whole request, slow responses can never cause overlapping
-    requests to exceed the cap.
+    It suits APIs that enforce a per-account thread/connection cap (e.g. ScreenScraper)
+    rather than a call rate. Because a slot is held for the whole request, slow
+    responses can never cause overlapping requests to exceed the cap.
 
-    The capacity can be raised or lowered at runtime via
-    :meth:`set_max_concurrency` -- for instance once an API response reveals the
-    account's allowance. Use it as an async context manager so the slot is always
-    released, even if the wrapped request raises::
+    Use it as an async context manager so the slot is always released, even if the
+    wrapped request raises:
 
         async with limiter:
             await do_request()
-
-    The implementation is loop-agnostic: waiter futures are created against the
-    running loop on acquisition, so a single shared instance works across the
-    distinct event loops used by, e.g., the test suite.
     """
 
     def __init__(self, max_concurrency: int) -> None:
@@ -76,7 +68,7 @@ class ConcurrencyLimiter:
             self._wake_next()
 
     async def acquire(self) -> None:
-        # Re-check on every wake-up: another coroutine may have taken the slot,
+        # Re-check on every wake-up, as another coroutine may have taken the slot,
         # or the capacity may have been lowered while we waited.
         while self._in_flight >= self._max_concurrency:
             loop = asyncio.get_running_loop()
@@ -88,7 +80,7 @@ class ConcurrencyLimiter:
                 finally:
                     self._waiters.remove(waiter)
             except asyncio.CancelledError:
-                # We were granted a slot but cancelled before using it; pass the
+                # We were granted a slot but cancelled before using it, so pass the
                 # grant on so a waiting peer is not stranded.
                 if not waiter.cancelled():
                     self._wake_next()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - "3000:3000" # Vite dev server (custom)
       - "5173:5173" # Vite dev server (default)
       - "8443:8443" # HTTPS dev server
+      - "5678:5678" # debugpy
       - "${DEV_PORT:-5000}:5000" # Backend API
     volumes:
       - ./backend:/app/backend

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,9 @@ fi
 # Start all services in the background
 echo "Starting backend..."
 cd /app/backend
-uv run python main.py &
+echo "Starting backend under debugpy on :5678..."
+# Add --wait-for-client after --listen to pause until VSCode attaches.
+uv run python -m debugpy --listen 0.0.0.0:5678 main.py &
 
 echo "Starting RQ scheduler..."
 RQ_REDIS_HOST=${REDIS_HOST:-127.0.0.1} \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,9 +39,13 @@ fi
 # Start all services in the background
 echo "Starting backend..."
 cd /app/backend
-echo "Starting backend under debugpy on :5678..."
-# Add --wait-for-client after --listen to pause until VSCode attaches.
-uv run python -m debugpy --listen 0.0.0.0:5678 main.py &
+if [[ ${DEV_MODE:-false} == "true" ]]; then
+	echo "Starting backend under debugpy on :5678..."
+	# Add --wait-for-client after --listen to pause until VSCode attaches.
+	uv run python -m debugpy --listen 0.0.0.0:5678 main.py &
+else
+	uv run python main.py &
+fi
 
 echo "Starting RQ scheduler..."
 RQ_REDIS_HOST=${REDIS_HOST:-127.0.0.1} \


### PR DESCRIPTION
**Description**

This PR implements rate limiting for all metadata service API requests to respect provider rate limits and prevent request throttling or bans.

**Changes:**

- **Rate Limiter Integration**: Added `RateLimiter` instances to four metadata services:
  - `igdb.py`: 4 requests/second (provider limit)
  - `mobygames.py`: 1 request/second (free tier limit)
  - `retroachievements.py`: 4 requests/second (conservative "fair burst" allowance)
  - `screenscraper.py`: 1 request/second (free tier limit)

- **Request Flow**: Each service now calls `await _rate_limiter.acquire()` before making HTTP requests, ensuring requests are spaced according to the provider's rate limit.

- **Test Coverage**: 
  - Added unit tests to verify rate limiter acquisition in all four services
  - Added autouse fixture in `conftest.py` to disable rate limiters during tests, preventing artificial delays and test interference

- **Test Infrastructure**: Created `_disable_metadata_rate_limiters` fixture to neutralize rate limiters during test execution, allowing tests to run without real delays while still verifying the rate limiter is called.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've added unit tests that cover the changes

https://claude.ai/code/session_01133QQuWvq8Zm25DZMP9PVr