### PR TITLE
fix heathbeat returning HTTP 500 when called before first time setup

### DIFF
--- a/backend/endpoints/heartbeat.py
+++ b/backend/endpoints/heartbeat.py
@@ -75,6 +75,7 @@ async def heartbeat() -> HeartbeatResponse:
     hltb_enabled = meta_hltb_handler.is_enabled()
     tgdb_enabled = meta_tgdb_handler.is_enabled()
     libretro_enabled = meta_libretro_handler.is_enabled()
+    platforms = await fs_platform_handler.get_platforms() if fs_platform_handler.detect_library_structure() is not None else []
 
     return {
         "SYSTEM": {
@@ -109,7 +110,7 @@ async def heartbeat() -> HeartbeatResponse:
             "LIBRETRO_API_ENABLED": libretro_enabled,
         },
         "FILESYSTEM": {
-            "FS_PLATFORMS": await fs_platform_handler.get_platforms(),
+            "FS_PLATFORMS": platforms,
         },
         "EMULATION": {
             "DISABLE_EMULATOR_JS": DISABLE_EMULATOR_JS,


### PR DESCRIPTION
**Description**
<sup>This change makes the heartbeat endpoint return an empty array of platforms instead of throwing an unhandled exception. </sup>

The condition used should be behaviorally identical to the logic used when determining if the folders are empty when initializing an empty library folder during setup create_setup_platforms
https://github.com/rommapp/romm/blob/00af28821c2571d88adb060109a7a8651383bcbd/backend/endpoints/heartbeat.py#L315

fixes #3541 

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

