### PR TITLE
fix: Crash on startup when no library

### DIFF
--- a/backend/handler/filesystem/platforms_handler.py
+++ b/backend/handler/filesystem/platforms_handler.py
@@ -4,10 +4,8 @@ from anyio import Path as AnyioPath
 
 from config import LIBRARY_BASE_PATH
 from config.config_manager import config_manager as cm
-from exceptions.fs_exceptions import (
-    FolderStructureNotMatchException,
-    PlatformAlreadyExistsException,
-)
+from exceptions.fs_exceptions import PlatformAlreadyExistsException
+from logger.logger import log
 
 from .base_handler import FSHandler, LibraryStructure
 
@@ -59,9 +57,9 @@ class FSPlatformsHandler(FSHandler):
         cnfg = cm.get_config()
 
         # Fallback to config hint when detection is inconclusive: default to
-        # Structure A (roms/{platform}) so a malformed library fails loudly
-        # (FolderStructureNotMatchException) rather than treating the bare
-        # library root as a flat list of platforms.
+        # Structure A (roms/{platform}) so the bare library root is not treated
+        # as a flat list of platforms. When the roms folder is missing entirely,
+        # get_platforms() bootstraps it instead of failing.
         return "" if cnfg.has_structure_path_b else cnfg.ROMS_FOLDER_NAME
 
     def get_platform_fs_structure(self, fs_slug: str) -> str:
@@ -90,6 +88,11 @@ class FSPlatformsHandler(FSHandler):
     async def get_platforms(self) -> list[str]:
         """Retrieves all platforms from the filesystem.
 
+        If no library structure exists yet (neither Structure A's top-level roms
+        folder nor a Structure B {platform}/roms folder), defaults to Structure A
+        by creating the roms folder and returns an empty list, so RomM starts
+        cleanly with an empty library instead of failing.
+
         Returns:
             List of platform slugs.
         """
@@ -97,8 +100,19 @@ class FSPlatformsHandler(FSHandler):
 
         try:
             platforms = await self.list_directories(path=self.get_platforms_directory())
-        except FileNotFoundError as e:
-            raise FolderStructureNotMatchException() from e
+        except FileNotFoundError:
+            # The platforms directory does not exist, which means no library
+            # structure has been set up yet. Bootstrap Structure A so the
+            # filesystem is in a valid state and report an empty library.
+            log.warning(
+                "No library structure found; creating default Structure A "
+                "(roms folder) and starting with an empty library."
+            )
+            try:
+                self.create_library_structure()
+            except OSError:
+                log.error("Failed to create default library structure", exc_info=True)
+            return []
 
         # For Structure B, only include directories that have a roms subfolder
         structure = self.detect_library_structure()

--- a/backend/tests/handler/filesystem/test_platforms_handler.py
+++ b/backend/tests/handler/filesystem/test_platforms_handler.py
@@ -229,6 +229,48 @@ class TestFSPlatformsHandler:
                 await handler.get_platforms()
                 mock_list.assert_called_once_with(path="")
 
+    async def test_get_platforms_bootstraps_structure_a_when_none_detected(
+        self, handler: FSPlatformsHandler, config
+    ):
+        """When no structure exists, get_platforms creates Structure A (roms folder)
+        and returns an empty list instead of raising."""
+        config.has_structure_path_a = False
+        config.has_structure_path_b = False
+        with patch(
+            "handler.filesystem.platforms_handler.cm.get_config", return_value=config
+        ):
+            with patch.object(
+                handler, "list_directories", side_effect=FileNotFoundError
+            ):
+                with patch.object(handler, "create_library_structure") as mock_create:
+                    result = await handler.get_platforms()
+
+                    assert result == []
+                    mock_create.assert_called_once()
+
+    async def test_get_platforms_returns_empty_when_bootstrap_fails(
+        self, handler: FSPlatformsHandler, config
+    ):
+        """If creating the default structure fails, get_platforms still returns an
+        empty list rather than propagating the error (so the heartbeat stays healthy).
+        """
+        config.has_structure_path_a = False
+        config.has_structure_path_b = False
+        with patch(
+            "handler.filesystem.platforms_handler.cm.get_config", return_value=config
+        ):
+            with patch.object(
+                handler, "list_directories", side_effect=FileNotFoundError
+            ):
+                with patch.object(
+                    handler,
+                    "create_library_structure",
+                    side_effect=PermissionError("read-only filesystem"),
+                ):
+                    result = await handler.get_platforms()
+
+                    assert result == []
+
     def test_integration_with_base_handler_methods(self, handler: FSPlatformsHandler):
         """Test that FSPlatformsHandler properly inherits from FSHandler"""
         # Test that handler has base methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,9 @@ DEP002 = [ # DEP002 rule: Project should not contain unused dependencies
 [tool.uv]
 package = false
 exclude-newer = "7 days"
-exclude-newer-package = { starlette = "2026-05-22" }
+# vcrpy < 8.2.0 references aiohttp.streams.AsyncStreamReaderMixin, removed in
+# aiohttp 3.14; allow the fixed release past the global 7-day window.
+exclude-newer-package = { starlette = "2026-05-22", vcrpy = "2026-06-17" }
 
 [tool.ty.environment]
 root = ["./backend"]

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-starlette = "2026-05-22T22:00:00Z"
+starlette = "2026-05-23T00:00:00Z"
 
 [[package]]
 name = "aiohappyeyeballs"

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,8 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-starlette = "2026-05-23T00:00:00Z"
+starlette = "2026-05-22T22:00:00Z"
+vcrpy = "2026-06-17T22:00:00Z"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -2009,8 +2010,7 @@ version = "0.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
-    { name = "vcrpy", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
-    { name = "vcrpy", version = "7.0.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
+    { name = "vcrpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/9c/f4027c5f1693847b06d11caf4b4f6bb09f22c1581ada4663877ec166b8c6/pytest_recording-0.13.4.tar.gz", hash = "sha256:568d64b2a85992eec4ae0a419c855d5fd96782c5fb016784d86f18053792768c", size = 26576, upload-time = "2025-05-08T10:41:11.231Z" }
 wheels = [
@@ -2773,37 +2773,15 @@ wheels = [
 
 [[package]]
 name = "vcrpy"
-version = "5.1.0"
+version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "platform_python_implementation == 'PyPy'",
-]
 dependencies = [
-    { name = "pyyaml", marker = "platform_python_implementation == 'PyPy'" },
-    { name = "wrapt", marker = "platform_python_implementation == 'PyPy'" },
-    { name = "yarl", marker = "platform_python_implementation == 'PyPy'" },
+    { name = "pyyaml" },
+    { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/ea/a166a3cce4ac5958ba9bbd9768acdb1ba38ae17ff7986da09fa5b9dbc633/vcrpy-5.1.0.tar.gz", hash = "sha256:bbf1532f2618a04f11bce2a99af3a9647a32c880957293ff91e0a5f187b6b3d2", size = 84576, upload-time = "2023-07-31T03:19:32.231Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/db/08183b845b0040bb877dad2bd7e4e0976fc232bb3476d7ee369c6c4f8b5a/vcrpy-8.2.1.tar.gz", hash = "sha256:d73a6e4eb6dae8148e659764b7a00e68cc51ba29ba9e6a85e1f0790ad96b97df", size = 90511, upload-time = "2026-06-16T13:20:52.906Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/5b/3f70bcb279ad30026cc4f1df0a0491a0205a24dddd88301f396c485de9e7/vcrpy-5.1.0-py2.py3-none-any.whl", hash = "sha256:605e7b7a63dcd940db1df3ab2697ca7faf0e835c0852882142bafb19649d599e", size = 41969, upload-time = "2023-07-31T03:19:30.128Z" },
-]
-
-[[package]]
-name = "vcrpy"
-version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "platform_python_implementation != 'PyPy'",
-]
-dependencies = [
-    { name = "pyyaml", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "urllib3", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "wrapt", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "yarl", marker = "platform_python_implementation != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/d3/856e06184d4572aada1dd559ddec3bedc46df1f2edc5ab2c91121a2cccdb/vcrpy-7.0.0.tar.gz", hash = "sha256:176391ad0425edde1680c5b20738ea3dc7fb942520a48d2993448050986b3a50", size = 85502, upload-time = "2024-12-31T00:07:57.894Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/5d/1f15b252890c968d42b348d1e9b0aa12d5bf3e776704178ec37cceccdb63/vcrpy-7.0.0-py2.py3-none-any.whl", hash = "sha256:55791e26c18daa363435054d8b35bd41a4ac441b6676167635d1b37a71dbe124", size = 42321, upload-time = "2024-12-31T00:07:55.277Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7c/0e812ab83f5289404c674f3461ba783250b967d34b5ab034d361236ec042/vcrpy-8.2.1-py3-none-any.whl", hash = "sha256:7ce58c9e2792b246f79d6f4b3e9660676cc6f853be17e1547305b4437ab1ff85", size = 44925, upload-time = "2026-06-16T13:20:51.734Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-starlette = "2026-05-23T00:00:00Z"
+starlette = "2026-05-22T22:00:00Z"
 
 [[package]]
 name = "aiohappyeyeballs"


### PR DESCRIPTION
Prevent crash on startup by bootstrapping library structure A when none is detected

<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)
