### PR TITLE
feat: backend connection status notice + offline-aware boot

### DIFF
--- a/frontend/src/RomM.vue
+++ b/frontend/src/RomM.vue
@@ -1,13 +1,28 @@
 <script setup lang="ts">
 import { useIdle, useLocalStorage } from "@vueuse/core";
 import { storeToRefs } from "pinia";
-import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import {
+  computed,
+  defineAsyncComponent,
+  onMounted,
+  onUnmounted,
+  ref,
+  watch,
+} from "vue";
 import { useI18n } from "vue-i18n";
 import { useTheme } from "vuetify";
 import SoundtrackMiniPlayer from "@/components/common/SoundtrackMiniPlayer.vue";
 import { useUiVersion } from "@/composables/useUiVersion";
 import storeConsole from "@/stores/console";
 import storeLanguage from "@/stores/language";
+
+// Lazy-loaded: RomM.vue is the first module main.ts evaluates, and the banner
+// transitively imports the API layer (stores → services/api → router). A
+// static import would pull that graph into bootstrap and trip the
+// api-client ↔ router circular-import TDZ (see the theme/scope notes below).
+const BackendStatusBanner = defineAsyncComponent(
+  () => import("@/v2/components/AppShell/BackendStatusBanner.vue"),
+);
 
 const { locale } = useI18n();
 const languageStore = storeLanguage();
@@ -115,6 +130,10 @@ watch(
       </router-view>
       <router-view v-else name="v2" />
     </v-main>
+    <!-- v2-only: backend reachability strip. Mounted at the root so it
+         covers both the auth layout (login/setup) and the main shell, and
+         owns the app-wide connection poll + auto-recovery. -->
+    <BackendStatusBanner v-if="isV2" />
     <!-- v1 only: in v2 the soundtrack mini-player is mounted from
          the v2 AppLayout (`Soundtrack/MiniPlayer.vue`) so it can use
          v2 primitives + tokens. Two mini-players would race for the

--- a/frontend/src/locales/bg_BG/common.json
+++ b/frontend/src/locales/bg_BG/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "Все още няма издания",
   "changelog-empty-hint": "Хранилището все още не е публикувало издания.",
   "changelog-view-all": "Вижте всички издания в GitHub",
-  "visibility": "Видимост"
+  "visibility": "Видимост",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/cs_CZ/common.json
+++ b/frontend/src/locales/cs_CZ/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "Zatím žádná vydání",
   "changelog-empty-hint": "Repozitář zatím nezveřejnil žádná vydání.",
   "changelog-view-all": "Zobrazit všechna vydání na GitHubu",
-  "visibility": "Viditelnost"
+  "visibility": "Viditelnost",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/de_DE/common.json
+++ b/frontend/src/locales/de_DE/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "Noch keine Veröffentlichungen",
   "changelog-empty-hint": "Das Repository hat noch keine Veröffentlichungen.",
   "changelog-view-all": "Alle Veröffentlichungen auf GitHub ansehen",
-  "visibility": "Sichtbarkeit"
+  "visibility": "Sichtbarkeit",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/en_GB/common.json
+++ b/frontend/src/locales/en_GB/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "No releases yet",
   "changelog-empty-hint": "The repository hasn't published any releases.",
   "changelog-view-all": "View all releases on GitHub",
-  "visibility": "Visibility"
+  "visibility": "Visibility",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/en_US/common.json
+++ b/frontend/src/locales/en_US/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "No releases yet",
   "changelog-empty-hint": "The repository hasn't published any releases.",
   "changelog-view-all": "View all releases on GitHub",
-  "visibility": "Visibility"
+  "visibility": "Visibility",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/es_ES/common.json
+++ b/frontend/src/locales/es_ES/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "Aún no hay versiones",
   "changelog-empty-hint": "El repositorio aún no ha publicado ninguna versión.",
   "changelog-view-all": "Ver todas las versiones en GitHub",
-  "visibility": "Visibilidad"
+  "visibility": "Visibilidad",
+  "server-offline-retrying": "Se perdió la conexión con el servidor · reintentando…",
+  "server-reconnected": "Conexión con el servidor restablecida"
 }

--- a/frontend/src/locales/fr_FR/common.json
+++ b/frontend/src/locales/fr_FR/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "Aucune version pour l'instant",
   "changelog-empty-hint": "Le dépôt n'a publié aucune version.",
   "changelog-view-all": "Voir toutes les versions sur GitHub",
-  "visibility": "Visibilité"
+  "visibility": "Visibilité",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/hu_HU/common.json
+++ b/frontend/src/locales/hu_HU/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "Még nincsenek kiadások",
   "changelog-empty-hint": "A tároló még nem tett közzé kiadást.",
   "changelog-view-all": "Összes kiadás megtekintése a GitHubon",
-  "visibility": "Láthatóság"
+  "visibility": "Láthatóság",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/it_IT/common.json
+++ b/frontend/src/locales/it_IT/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "Nessuna release ancora",
   "changelog-empty-hint": "Il repository non ha ancora pubblicato release.",
   "changelog-view-all": "Vedi tutte le release su GitHub",
-  "visibility": "Visibilità"
+  "visibility": "Visibilità",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/ja_JP/common.json
+++ b/frontend/src/locales/ja_JP/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "まだリリースがありません",
   "changelog-empty-hint": "リポジトリにはまだリリースが公開されていません。",
   "changelog-view-all": "GitHub ですべてのリリースを表示",
-  "visibility": "公開設定"
+  "visibility": "公開設定",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/ko_KR/common.json
+++ b/frontend/src/locales/ko_KR/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "아직 릴리스가 없습니다",
   "changelog-empty-hint": "저장소에 게시된 릴리스가 아직 없습니다.",
   "changelog-view-all": "GitHub에서 모든 릴리스 보기",
-  "visibility": "공개 범위"
+  "visibility": "공개 범위",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/pl_PL/common.json
+++ b/frontend/src/locales/pl_PL/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "Brak wydań",
   "changelog-empty-hint": "Repozytorium nie opublikowało jeszcze żadnych wydań.",
   "changelog-view-all": "Zobacz wszystkie wydania na GitHub",
-  "visibility": "Widoczność"
+  "visibility": "Widoczność",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/pt_BR/common.json
+++ b/frontend/src/locales/pt_BR/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "Nenhuma versão ainda",
   "changelog-empty-hint": "O repositório ainda não publicou nenhuma versão.",
   "changelog-view-all": "Ver todas as versões no GitHub",
-  "visibility": "Visibilidade"
+  "visibility": "Visibilidade",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/ro_RO/common.json
+++ b/frontend/src/locales/ro_RO/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "Încă nu există versiuni",
   "changelog-empty-hint": "Depozitul nu a publicat încă nicio versiune.",
   "changelog-view-all": "Vezi toate versiunile pe GitHub",
-  "visibility": "Vizibilitate"
+  "visibility": "Vizibilitate",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/ru_RU/common.json
+++ b/frontend/src/locales/ru_RU/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "Релизов пока нет",
   "changelog-empty-hint": "В репозитории ещё нет опубликованных релизов.",
   "changelog-view-all": "Посмотреть все релизы на GitHub",
-  "visibility": "Видимость"
+  "visibility": "Видимость",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/zh_CN/common.json
+++ b/frontend/src/locales/zh_CN/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "暂无发行版",
   "changelog-empty-hint": "该仓库尚未发布任何发行版。",
   "changelog-view-all": "在 GitHub 上查看所有发行版",
-  "visibility": "可见性"
+  "visibility": "可见性",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/locales/zh_TW/common.json
+++ b/frontend/src/locales/zh_TW/common.json
@@ -149,5 +149,7 @@
   "changelog-empty-title": "尚無發行版",
   "changelog-empty-hint": "此儲存庫尚未發布任何發行版。",
   "changelog-view-all": "在 GitHub 上檢視所有發行版",
-  "visibility": "可見性"
+  "visibility": "可見性",
+  "server-offline-retrying": "Server connection lost · retrying…",
+  "server-reconnected": "Reconnected to the server"
 }

--- a/frontend/src/plugins/router.ts
+++ b/frontend/src/plugins/router.ts
@@ -563,6 +563,18 @@ router.beforeEach(async (to, _from, next) => {
   const currentRoute = to.name?.toString();
 
   try {
+    // Backend unreachable/broken — we can't trust the setup/auth state, and
+    // bouncing to /login would just strand the user on a page that can't work
+    // either. Let them stay on (and navigate within) whatever the cached state
+    // allows; the offline notice explains it and the connection layer
+    // re-routes correctly once the backend answers again.
+    if (!heartbeat.connected) {
+      document.title = to.meta.title
+        ? i18n.global.t(to.meta.title as string)
+        : "RomM";
+      return next();
+    }
+
     // Handle setup wizard
     if (heartbeat.value.SYSTEM.SHOW_SETUP_WIZARD) {
       return currentRoute !== "setup" ? next({ name: ROUTES.SETUP }) : next();

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -54,6 +54,11 @@ api.interceptors.response.use(
     // Remove request from set of inflight requests
     inflightRequests.delete(response.config.url);
 
+    // A successful response proves the backend is reachable. Surfaced via a
+    // DOM event (mirroring `network-quiesced`) so the v2 connection layer can
+    // react without this shared module importing anything from v2.
+    document.dispatchEvent(new CustomEvent("backend-online"));
+
     // If there are no more inflight requests, fetch app-wide data
     if (inflightRequests.size === 0) {
       networkQuiesced();
@@ -62,6 +67,25 @@ api.interceptors.response.use(
     return response;
   },
   async (error) => {
+    // Reachability signalling (see useServerConnection):
+    //   * no response (ERR_NETWORK / timeout) → definitively offline.
+    //   * 5xx from a non-heartbeat endpoint → "suspect"; ask the connection
+    //     layer to confirm via the authoritative /heartbeat probe (so one
+    //     buggy endpoint doesn't flash the banner, and the heartbeat request
+    //     itself never re-triggers this — which would loop).
+    //   * 4xx → backend is alive; leave the state alone.
+    const status = error.response?.status as number | undefined;
+    const url: string = error.config?.url ?? "";
+    if (!error.response) {
+      document.dispatchEvent(new CustomEvent("backend-offline"));
+    } else if (
+      status !== undefined &&
+      status >= 500 &&
+      !url.includes("heartbeat")
+    ) {
+      document.dispatchEvent(new CustomEvent("backend-suspect"));
+    }
+
     if (error.response?.status === 403) {
       // Clear cookies and redirect to login page
       Cookies.remove("romm_session");

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -92,6 +92,13 @@ api.interceptors.response.use(
     //     clears immediately instead of waiting for the next heartbeat poll.
     const status = error.response?.status as number | undefined;
     const url: string = error.config?.url ?? "";
+
+    // Ignore intentionally canceled requests (AbortController / signal). They do
+    // not indicate backend reachability problems.
+    if (axios.isCancel(error) || error.code === "ERR_CANCELED") {
+      return Promise.reject(error);
+    }
+
     if (!error.response) {
       document.dispatchEvent(new CustomEvent("backend-offline"));
     } else if (

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -67,13 +67,29 @@ api.interceptors.response.use(
     return response;
   },
   async (error) => {
+    // Mirror the success path's bookkeeping: a settled request — even a failed
+    // or canceled one — leaves the inflight set so `network-quiesced` can still
+    // fire once the network goes quiet.
+    inflightRequests.delete(error.config?.url);
+    if (inflightRequests.size === 0) {
+      networkQuiesced();
+    }
+
+    // Canceled requests (AbortController / `signal`) are routine here (gallery /
+    // search aborts). They surface as a response-less error but are not a
+    // network failure, so they must never flip the connection state.
+    if (axios.isCancel(error)) {
+      return Promise.reject(error);
+    }
+
     // Reachability signalling (see useServerConnection):
     //   * no response (ERR_NETWORK / timeout) → definitively offline.
     //   * 5xx from a non-heartbeat endpoint → "suspect"; ask the connection
     //     layer to confirm via the authoritative /heartbeat probe (so one
     //     buggy endpoint doesn't flash the banner, and the heartbeat request
     //     itself never re-triggers this — which would loop).
-    //   * 4xx → backend is alive; leave the state alone.
+    //   * 4xx → backend is alive; emit backend-online so a stale offline banner
+    //     clears immediately instead of waiting for the next heartbeat poll.
     const status = error.response?.status as number | undefined;
     const url: string = error.config?.url ?? "";
     if (!error.response) {
@@ -84,6 +100,8 @@ api.interceptors.response.use(
       !url.includes("heartbeat")
     ) {
       document.dispatchEvent(new CustomEvent("backend-suspect"));
+    } else if (status !== undefined && status >= 400 && status < 500) {
+      document.dispatchEvent(new CustomEvent("backend-online"));
     }
 
     if (error.response?.status === 403) {

--- a/frontend/src/stores/heartbeat.ts
+++ b/frontend/src/stores/heartbeat.ts
@@ -82,12 +82,19 @@ export default defineStore("heartbeat", {
         this.connected = true;
         return this.value;
       } catch (error) {
-        console.error("Error fetching heartbeat: ", error);
         // 5xx or no response (network/timeout) → backend is down/broken.
         // 4xx → backend is alive (auth/validation), so still "connected".
         const status = (error as { response?: { status?: number } }).response
           ?.status;
-        this.connected = status !== undefined && status < 500;
+        const nowConnected = status !== undefined && status < 500;
+        // Log only a genuine breakage, and only on the connected→disconnected
+        // transition: this heartbeat polls every few seconds while offline, so
+        // logging every failure would bury actionable errors. A 4xx is a
+        // healthy backend, not an error worth reporting here.
+        if (!nowConnected && this.connected) {
+          console.error("Error fetching heartbeat: ", error);
+        }
+        this.connected = nowConnected;
         return this.value;
       }
     },

--- a/frontend/src/stores/heartbeat.ts
+++ b/frontend/src/stores/heartbeat.ts
@@ -64,18 +64,36 @@ const defaultHeartbeat: Heartbeat = {
 export default defineStore("heartbeat", {
   state: () => ({
     value: { ...defaultHeartbeat },
+    // Whether the backend is currently healthy. Optimistic by default so the
+    // offline UI never flashes before the first request resolves. The
+    // heartbeat is the authoritative health check: a 5xx or a missing response
+    // (ERR_NETWORK / timeout) means the backend is down/broken; a 4xx still
+    // means it's alive (auth / validation). Consumed by the v2 offline banner
+    // and by the router guard so a broken backend isn't mistaken for "logged
+    // out, setup already done".
+    connected: true,
   }),
 
   actions: {
-    async fetchHeartbeat(): Promise<Heartbeat> {
+    async fetchHeartbeat(options?: { timeout?: number }): Promise<Heartbeat> {
       try {
-        const response = await api.get("/heartbeat");
+        const response = await api.get("/heartbeat", options);
         this.value = { ...this.value, ...response.data };
+        this.connected = true;
         return this.value;
       } catch (error) {
         console.error("Error fetching heartbeat: ", error);
+        // 5xx or no response (network/timeout) → backend is down/broken.
+        // 4xx → backend is alive (auth/validation), so still "connected".
+        const status = (error as { response?: { status?: number } }).response
+          ?.status;
+        this.connected = status !== undefined && status < 500;
         return this.value;
       }
+    },
+
+    setConnected(value: boolean) {
+      this.connected = value;
     },
 
     async fetchMetadataHeartbeat(source: string): Promise<boolean> {

--- a/frontend/src/v2/components/AppShell/BackendStatusBanner.vue
+++ b/frontend/src/v2/components/AppShell/BackendStatusBanner.vue
@@ -6,11 +6,11 @@
 // wherever the cached state allows — the card just explains the degraded
 // state and the connection layer auto-recovers.
 //
-// Calling `useServerConnection()` here in setup both gives us the reactive
-// `isOffline` flag AND installs the app-wide poll / passive listeners /
-// recovery (idempotent). It must run in a setup context so the composable's
-// `inject("emitter")` resolves — this component is mounted once, under
-// `v-if="isV2"` in RomM.vue, so it covers both the auth and main shells.
+// Calling `useServerConnection()` here in <script setup> both gives us the
+// reactive `isOffline` flag AND triggers the one-time install of the app-wide
+// poll / passive DOM-event listeners / recovery watcher (idempotent). This
+// component is mounted once, under `v-if="isV2"` in RomM.vue, so it covers both
+// the auth and main shells.
 import { RBtn, RIcon } from "@v2/lib";
 import { useI18n } from "vue-i18n";
 import { useServerConnection } from "@/v2/composables/useServerConnection";

--- a/frontend/src/v2/components/AppShell/BackendStatusBanner.vue
+++ b/frontend/src/v2/components/AppShell/BackendStatusBanner.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+// BackendStatusBanner — soft-red connection notice. Invisible while the
+// backend is healthy; surfaces a compact, centred toast-style card near the
+// top the moment the heartbeat probe (or a request) reports the backend as
+// down/broken. Unlike a redirect to /login, the user can keep navigating
+// wherever the cached state allows — the card just explains the degraded
+// state and the connection layer auto-recovers.
+//
+// Calling `useServerConnection()` here in setup both gives us the reactive
+// `isOffline` flag AND installs the app-wide poll / passive listeners /
+// recovery (idempotent). It must run in a setup context so the composable's
+// `inject("emitter")` resolves — this component is mounted once, under
+// `v-if="isV2"` in RomM.vue, so it covers both the auth and main shells.
+import { RBtn, RIcon } from "@v2/lib";
+import { useI18n } from "vue-i18n";
+import { useServerConnection } from "@/v2/composables/useServerConnection";
+
+defineOptions({ inheritAttrs: false });
+
+const { t } = useI18n();
+const { isOffline, retryNow } = useServerConnection();
+</script>
+
+<template>
+  <Transition name="r-backend-banner">
+    <div v-if="isOffline" class="r-backend-banner" role="alert">
+      <RIcon
+        icon="mdi-lan-disconnect"
+        size="18"
+        class="r-backend-banner__icon"
+      />
+      <span class="r-backend-banner__msg">
+        {{ t("common.server-offline-retrying") }}
+      </span>
+      <RBtn
+        size="small"
+        variant="text"
+        prepend-icon="mdi-refresh"
+        class="r-backend-banner__retry"
+        @click="retryNow"
+      >
+        {{ t("common.try-again") }}
+      </RBtn>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+/* Compact toast-style card, centred under the navbar. Soft-red glass: the
+   neutral deep-canvas panel tinted lightly with the danger token (no hex
+   literals, §X) so text stays legible and the red reads as "soft", not a
+   solid alarm bar. */
+.r-backend-banner {
+  position: fixed;
+  top: calc(var(--r-nav-h, 58px) + 14px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: calc(var(--r-z-snackbar) + 10);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  max-width: min(440px, calc(100vw - 32px));
+  padding: 8px 8px 8px 14px;
+  background: color-mix(
+    in srgb,
+    var(--r-color-status-base-danger) 16%,
+    var(--r-color-canvas-bg-deep)
+  );
+  border: 1px solid
+    color-mix(in srgb, var(--r-color-status-base-danger) 40%, transparent);
+  border-radius: var(--r-radius-lg);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  box-shadow:
+    0 10px 28px color-mix(in srgb, black 45%, transparent),
+    0 2px 6px color-mix(in srgb, black 30%, transparent);
+  color: var(--r-color-fg);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.r-backend-banner__icon {
+  flex-shrink: 0;
+  color: var(--r-color-danger-fg);
+}
+
+.r-backend-banner__msg {
+  min-width: 0;
+}
+
+.r-backend-banner__retry {
+  flex-shrink: 0;
+  color: var(--r-color-danger-fg);
+}
+
+/* Slide + fade down from the top edge. */
+.r-backend-banner-enter-active,
+.r-backend-banner-leave-active {
+  transition:
+    opacity var(--r-motion-med) var(--r-motion-ease-out),
+    transform var(--r-motion-med) var(--r-motion-ease-out);
+}
+.r-backend-banner-enter-from,
+.r-backend-banner-leave-to {
+  opacity: 0;
+  transform: translate(-50%, -12px);
+}
+
+/* On phones keep it centred but allow the safe full width. */
+html[data-bp~="xs"] .r-backend-banner {
+  left: 12px;
+  right: 12px;
+  transform: none;
+  max-width: none;
+  justify-content: center;
+}
+html[data-bp~="xs"] .r-backend-banner-enter-from,
+html[data-bp~="xs"] .r-backend-banner-leave-to {
+  transform: translateY(-12px);
+}
+</style>

--- a/frontend/src/v2/composables/useServerConnection/index.test.ts
+++ b/frontend/src/v2/composables/useServerConnection/index.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { shouldRefreshOnReconnect } from "./index";
+
+describe("shouldRefreshOnReconnect", () => {
+  it("refreshes only on a real reconnect (offline → online)", () => {
+    expect(shouldRefreshOnReconnect(true, false)).toBe(true);
+  });
+
+  it("does not refresh on the initial reading (no prior state)", () => {
+    expect(shouldRefreshOnReconnect(true, undefined)).toBe(false);
+  });
+
+  it("does not refresh while staying online", () => {
+    expect(shouldRefreshOnReconnect(true, true)).toBe(false);
+  });
+
+  it("does not refresh when going offline", () => {
+    expect(shouldRefreshOnReconnect(false, true)).toBe(false);
+  });
+
+  it("does not refresh while staying offline", () => {
+    expect(shouldRefreshOnReconnect(false, false)).toBe(false);
+  });
+});

--- a/frontend/src/v2/composables/useServerConnection/index.ts
+++ b/frontend/src/v2/composables/useServerConnection/index.ts
@@ -1,0 +1,97 @@
+// useServerConnection — single orchestrator for backend reachability in v2.
+//
+// Three signals keep `heartbeat.connected` (the shared source of truth) fresh:
+//   * Passive — the axios interceptor dispatches `backend-online` /
+//     `backend-offline` / `backend-suspect` DOM events on every response; we
+//     mirror them onto the store so the offline notice reacts the instant a
+//     request fails.
+//   * Active — a self-rescheduling `/heartbeat` poll (short per-call timeout,
+//     not the global 120s) detects breakage while idle and, crucially,
+//     reconnection. Polls faster while offline.
+//   * Recovery — on a false→true transition we do a full page refresh. A fresh
+//     boot re-runs initializeData() + the router guard from scratch, so the
+//     user lands on the correct destination (setup / login / home) with clean
+//     state instead of a half-recovered SPA.
+//
+// `install()` runs once for the app's lifetime (idempotent). The banner calls
+// `useServerConnection()` in its <script setup>, which both returns the
+// reactive `isOffline` flag and triggers the install.
+import { debounce } from "lodash";
+import { computed, effectScope, watch } from "vue";
+import storeHeartbeat from "@/stores/heartbeat";
+
+const POLL_ONLINE_MS = 10_000;
+const POLL_OFFLINE_MS = 5_000;
+const HEARTBEAT_TIMEOUT_MS = 5_000;
+
+let installed = false;
+
+/** A full refresh fires only on a real reconnect: offline (false) → online. */
+export function shouldRefreshOnReconnect(
+  now: boolean,
+  was: boolean | undefined,
+): boolean {
+  return now && was === false;
+}
+
+function install() {
+  const heartbeat = storeHeartbeat();
+
+  // Passive detection — the interceptor classifies each response:
+  //   * backend-online  → a request succeeded; the backend is up.
+  //   * backend-offline → a network-level failure (no response); down.
+  //   * backend-suspect → a 5xx from some endpoint; confirm authoritatively
+  //     via the /heartbeat probe rather than trusting a single failure. The
+  //     probe's own result (5xx/network → offline) drives `connected`.
+  document.addEventListener("backend-online", () =>
+    heartbeat.setConnected(true),
+  );
+  document.addEventListener("backend-offline", () =>
+    heartbeat.setConnected(false),
+  );
+  const confirmHealth = debounce(() => {
+    void heartbeat.fetchHeartbeat({ timeout: HEARTBEAT_TIMEOUT_MS });
+  }, 300);
+  document.addEventListener("backend-suspect", () => confirmHealth());
+
+  // Recovery — refresh the page on a real reconnect. Run in a detached effect
+  // scope so the watcher lives for the app's lifetime rather than the banner's
+  // (the banner unmounts on a live v1↔v2 UI switch, yet `install()` only ever
+  // runs once, so a scope-bound watcher would silently die on the way back).
+  effectScope(true).run(() => {
+    watch(
+      () => heartbeat.connected,
+      (now, was) => {
+        if (shouldRefreshOnReconnect(now, was)) window.location.reload();
+      },
+    );
+  });
+
+  // Active poll — self-reschedules, faster while offline for snappy recovery.
+  function scheduleNext() {
+    const delay = heartbeat.connected ? POLL_ONLINE_MS : POLL_OFFLINE_MS;
+    setTimeout(async () => {
+      await heartbeat.fetchHeartbeat({ timeout: HEARTBEAT_TIMEOUT_MS });
+      scheduleNext();
+    }, delay);
+  }
+  scheduleNext();
+}
+
+export function useServerConnection() {
+  const heartbeat = storeHeartbeat();
+
+  if (!installed) {
+    installed = true;
+    install();
+  }
+
+  const isOffline = computed(() => !heartbeat.connected);
+
+  /** Force an immediate reachability re-check (e.g. the notice's Retry). */
+  function retryNow() {
+    return heartbeat.fetchHeartbeat({ timeout: HEARTBEAT_TIMEOUT_MS });
+  }
+
+  return { isOffline, retryNow };
+}


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Makes the v2 frontend show a visible backend-connection notice (Immich-style) and resilient when the backend is down or erroring.

Before, when the heartbeat failed (5xx or network error) at boot, `fetchHeartbeat`/`fetchCurrentUser` swallowed the error and returned defaults, so a broken backend was indistinguishable from "logged out, setup already done" — and the router guard bounced the user to `/login` with no recovery. There was no reactive notion of "is the backend reachable".

What this adds:

- **Reachability flag** (`stores/heartbeat.ts`): new `connected` state. The heartbeat is the authoritative health check — `5xx`/no-response → down, `4xx` → alive (auth/validation). `fetchHeartbeat` gains an optional `timeout`.
- **Passive detection** (`services/api/index.ts`): the axios interceptor dispatches `backend-online` / `backend-offline` / `backend-suspect` DOM events (same pattern as `network-quiesced`, so shared code stays decoupled from v2). A `5xx` from a non-heartbeat endpoint asks the connection layer to confirm via the `/heartbeat` probe (avoids false alarms from one buggy endpoint; the heartbeat request itself is excluded to avoid a loop).
- **`useServerConnection` composable**: passive listeners + a self-rescheduling `/heartbeat` poll (short timeout, faster while offline). On a real reconnect (offline → online) it does a full page refresh, so a fresh boot re-runs init + the router guard and lands on the correct destination with clean state.
- **Offline-aware guard** (`plugins/router.ts`): when the backend is unreachable/broken it no longer redirects to `/login` — the user stays put and can keep navigating wherever cached state allows.
- **`BackendStatusBanner.vue`**: compact, centred, soft-red toast-style notice (tokens only, dual-theme, responsive) with a Retry action. Lazy-mounted in `RomM.vue` under `v-if="isV2"` so it covers both the auth and main shells (lazy import avoids the bootstrap api-client ↔ router TDZ).
- **i18n**: `server-offline-retrying` / `server-reconnected` added across all 17 locales.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Depends on: #3549

#### Screenshots (if applicable)

<img width="1904" height="909" alt="image" src="https://github.com/user-attachments/assets/06d5a7d8-087e-4515-9446-8252a0f7d722" />