### PR TITLE
feat: opt-in per-platform subfolder scanning

### DIFF
--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -132,7 +132,7 @@ class Config:
     SCAN_REGION_PRIORITY: list[str]
     SCAN_LANGUAGE_PRIORITY: list[str]
     SCAN_MEDIA: list[str]
-    SCAN_SUBFOLDERS: dict[str, bool]
+    SCAN_SUBFOLDERS: dict[str, bool | list[str]]
     GAMELIST_MEDIA_THUMBNAIL: MetadataMediaType
     GAMELIST_MEDIA_IMAGE: MetadataMediaType
 
@@ -161,13 +161,23 @@ class Config:
 
         return False
 
-    def should_scan_subfolders(self, fs_slug: str) -> bool:
-        """Whether the scanner should recurse into a platform's subfolders,
-        treating each subfolder as a group of ROMs rather than as a single
-        multi-file ROM. Opt-in per platform via `scan.subfolders` in config.yml.
+    def subfolder_scan_spec(self, fs_slug: str) -> bool | frozenset[str]:
+        """How the scanner should recurse into a platform's subfolders.
+
+        Opt-in per platform via `scan.subfolders` in config.yml, where the
+        value is either:
+          - ``True`` -> recurse every subfolder (each becomes a group of roms);
+          - a list of folder names -> recurse only those folders, leaving every
+            other folder as a single multi-file rom (so folder-based multi-file
+            games elsewhere on the platform stay intact);
+          - ``False`` / omitted -> don't recurse (default behavior).
+
+        Returns ``True``, a ``frozenset`` of folder names, or ``False``.
         """
-        subfolders = getattr(self, "SCAN_SUBFOLDERS", {})
-        return bool(subfolders.get(fs_slug, False))
+        value = getattr(self, "SCAN_SUBFOLDERS", {}).get(fs_slug, False)
+        if isinstance(value, list):
+            return frozenset(value)
+        return bool(value)
 
 
 class ConfigManager:
@@ -674,10 +684,15 @@ class ConfigManager:
             log.critical("Invalid config.yml: scan.subfolders must be a dictionary")
             sys.exit(3)
         else:
-            for fs_slug, enabled in self.config.SCAN_SUBFOLDERS.items():
-                if not isinstance(enabled, bool):
+            for fs_slug, value in self.config.SCAN_SUBFOLDERS.items():
+                is_bool = isinstance(value, bool)
+                is_str_list = isinstance(value, list) and all(
+                    isinstance(name, str) for name in value
+                )
+                if not (is_bool or is_str_list):
                     log.critical(
-                        f"Invalid config.yml: scan.subfolders.{fs_slug} must be a boolean"
+                        f"Invalid config.yml: scan.subfolders.{fs_slug} must be a "
+                        "boolean or a list of folder names"
                     )
                     sys.exit(3)
 

--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -132,6 +132,7 @@ class Config:
     SCAN_REGION_PRIORITY: list[str]
     SCAN_LANGUAGE_PRIORITY: list[str]
     SCAN_MEDIA: list[str]
+    SCAN_SUBFOLDERS: dict[str, bool]
     GAMELIST_MEDIA_THUMBNAIL: MetadataMediaType
     GAMELIST_MEDIA_IMAGE: MetadataMediaType
 
@@ -159,6 +160,14 @@ class Config:
                 return True
 
         return False
+
+    def should_scan_subfolders(self, fs_slug: str) -> bool:
+        """Whether the scanner should recurse into a platform's subfolders,
+        treating each subfolder as a group of ROMs rather than as a single
+        multi-file ROM. Opt-in per platform via `scan.subfolders` in config.yml.
+        """
+        subfolders = getattr(self, "SCAN_SUBFOLDERS", {})
+        return bool(subfolders.get(fs_slug, False))
 
 
 class ConfigManager:
@@ -430,6 +439,7 @@ class ConfigManager:
                     "manual",
                 ],
             ),
+            SCAN_SUBFOLDERS=pydash.get(self._raw_config, "scan.subfolders", {}),
             GAMELIST_AUTO_EXPORT_ON_SCAN=pydash.get(
                 self._raw_config, "scan.gamelist.export", False
             ),
@@ -660,6 +670,17 @@ class ConfigManager:
             log.critical("Invalid config.yml: scan.media must be a list")
             sys.exit(3)
 
+        if not isinstance(self.config.SCAN_SUBFOLDERS, dict):
+            log.critical("Invalid config.yml: scan.subfolders must be a dictionary")
+            sys.exit(3)
+        else:
+            for fs_slug, enabled in self.config.SCAN_SUBFOLDERS.items():
+                if not isinstance(enabled, bool):
+                    log.critical(
+                        f"Invalid config.yml: scan.subfolders.{fs_slug} must be a boolean"
+                    )
+                    sys.exit(3)
+
         # Drop unknown media types rather than exiting, since a newer release
         # may ship sample configs referencing media types this version doesn't know.
         unknown_media = [
@@ -779,6 +800,7 @@ class ConfigManager:
                     "language": self.config.SCAN_LANGUAGE_PRIORITY,
                 },
                 "media": self.config.SCAN_MEDIA,
+                "subfolders": self.config.SCAN_SUBFOLDERS,
                 "gamelist": {
                     "export": self.config.GAMELIST_AUTO_EXPORT_ON_SCAN,
                     "media": {

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -247,7 +247,9 @@ async def _identify_rom(
 
     # Update properties that don't require metadata
     parsed_tags = fs_rom_handler.parse_tags(fs_rom["fs_name"])
-    roms_path = fs_rom_handler.get_roms_fs_structure(platform.fs_slug)
+    # The discovered path is the rom's actual directory, which may be a
+    # subfolder of the platform roms folder when subfolder scanning is enabled.
+    roms_path = fs_rom["fs_path"]
 
     # Create the entry early so we have the ID
     newly_added: bool = rom is None
@@ -602,7 +604,10 @@ async def _identify_platform(
             )
 
     for fs_roms_batch in batched(fs_roms, 200, strict=False):
-        roms_by_fs_name = db_rom_handler.get_roms_by_fs_name(
+        # Key matches on the rom's full path (fs_path/fs_name), not just the
+        # file name, so identically-named files in different subfolders don't
+        # collide when subfolder scanning is enabled.
+        roms_by_full_path = db_rom_handler.get_roms_by_fs_name(
             platform_id=platform.id,
             fs_names={fs_rom["fs_name"] for fs_rom in fs_roms_batch},
         )
@@ -612,7 +617,7 @@ async def _identify_platform(
         roms_to_scan: list[tuple[FSRom, Rom | None]] = []
 
         for fs_rom in fs_roms_batch:
-            rom = roms_by_fs_name.get(fs_rom["fs_name"])
+            rom = roms_by_full_path.get(f"{fs_rom['fs_path']}/{fs_rom['fs_name']}")
             if _should_scan_rom(
                 scan_type=scan_type,
                 rom=rom,
@@ -644,12 +649,28 @@ async def _identify_platform(
                     log.error(f"Error scanning ROM {fs_rom['fs_name']}: {result}")
 
     missing_roms = db_rom_handler.mark_missing_roms(
-        platform.id, [rom["fs_name"] for rom in fs_roms]
+        platform.id, [f"{rom['fs_path']}/{rom['fs_name']}" for rom in fs_roms]
     )
     if len(missing_roms) > 0:
         log.warning(f"{hl('Missing')} roms from filesystem:")
+        # A folder that subfolder scanning now recurses into used to be a
+        # single multi-file rom; that old entry shows up here as missing.
+        # Flag those so the expected "missing" is clear and the user knows to
+        # delete the stale entry. A superseded folder's path equals (or is a
+        # parent of) a discovered rom's directory.
+        recursed_paths = {rom["fs_path"] for rom in fs_roms}
         for r in missing_roms:
-            log.warning(f" - {r.fs_name}")
+            superseded = any(
+                p == r.full_path or p.startswith(f"{r.full_path}/")
+                for p in recursed_paths
+            )
+            if superseded:
+                log.warning(
+                    f" - {r.fs_name} (now scanned as a folder of roms — "
+                    "delete this stale entry to clean up)"
+                )
+            else:
+                log.warning(f" - {r.fs_name}")
 
     missing_firmware = db_firmware_handler.mark_missing_firmware(
         platform.id, [fw for fw in fs_firmware]

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -1314,7 +1314,11 @@ class DBRomsHandler(DBBaseHandler):
         return (
             session.scalars(
                 select(Rom)
-                .options(load_only(Rom.id, Rom.fs_name))
+                # `fs_path` is eager-loaded alongside `fs_name` so callers can
+                # read `rom.full_path` after the session closes (the returned
+                # instances are detached); without it that lazy-loads and raises
+                # DetachedInstanceError.
+                .options(load_only(Rom.id, Rom.fs_name, Rom.fs_path))
                 .where(
                     and_(
                         Rom.platform_id == platform_id,

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -1171,7 +1171,11 @@ class DBRomsHandler(DBBaseHandler):
         fs_names: Iterable[str],
         session: Session = None,  # type: ignore
     ) -> dict[str, Rom]:
-        """Retrieve a dictionary of roms by their filesystem names.
+        """Retrieve a dictionary of roms keyed by their full path (fs_path/fs_name).
+
+        Filters by file name for an indexed lookup, but keys the result on the
+        full path so identically-named files in different subfolders (subfolder
+        scanning) remain distinct.
 
         Eager-loads only `platform` (used downstream by the scan loop via
         `rom.platform_slug` / `rom.platform.fs_slug`). This deliberately
@@ -1195,7 +1199,7 @@ class DBRomsHandler(DBBaseHandler):
             .all()
         )
 
-        return {rom.fs_name: rom for rom in roms}
+        return {rom.full_path: rom for rom in roms}
 
     @begin_session
     def update_rom(
@@ -1278,19 +1282,23 @@ class DBRomsHandler(DBBaseHandler):
     ) -> Sequence[Rom]:
         """Sync `missing_from_fs` for a platform against the keep-list.
 
+        The keep-list holds rom full paths (fs_path/fs_name) so that
+        identically-named files in different subfolders are tracked
+        independently when subfolder scanning is enabled.
+
         Reads the rows once and writes only those whose state actually
         changes, so a re-scan of an unchanged platform issues no updates.
         """
         keep_set = set(fs_roms_to_keep)
         rows = session.execute(
-            select(Rom.id, Rom.fs_name, Rom.missing_from_fs).where(
+            select(Rom.id, Rom.fs_path, Rom.fs_name, Rom.missing_from_fs).where(
                 Rom.platform_id == platform_id
             )
         ).all()
 
         flips: dict[bool, list[int]] = {True: [], False: []}
-        for rom_id, fs_name, was_missing in rows:
-            is_missing = fs_name not in keep_set
+        for rom_id, fs_path, fs_name, was_missing in rows:
+            is_missing = f"{fs_path}/{fs_name}" not in keep_set
             if is_missing != was_missing:
                 flips[is_missing].append(rom_id)
 

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -665,13 +665,18 @@ class FSRomsHandler(FSHandler):
                 rom_sha1_h,
             )
 
-    async def _collect_fs_roms(self, rel_roms_path: str, recurse: bool) -> list[dict]:
+    async def _collect_fs_roms(
+        self, rel_roms_path: str, recurse: bool | frozenset[str]
+    ) -> list[dict]:
         """Discover roms under ``rel_roms_path``.
 
         Single files are flat roms (``fs_path`` = their parent directory).
-        Directories are single multi-file roms, except when ``recurse`` is on:
-        then each (non-hidden) directory is a group of roms and is descended
-        into, so files nested at any depth are picked up as individual roms.
+        A directory is a single multi-file rom unless ``recurse`` says to
+        descend into it, in which case its contents are collected as
+        individual roms. ``recurse`` is ``True`` (descend every folder), a set
+        of folder names (descend only those — every other folder stays a
+        multi-file rom), or ``False`` (descend none).
+
         Hidden (dot-prefixed) directories are never descended into, and a
         directory holding an ``.m3u`` playlist is kept whole as a single
         multi-file rom (a multi-disc game) even while recursing, so it isn't
@@ -686,11 +691,9 @@ class FSRomsHandler(FSHandler):
             await self.list_directories(rel_roms_path)
         ):
             dir_path = f"{rel_roms_path}/{directory}"
-            if (
-                recurse
-                and not directory.startswith(".")
-                and not await self._is_multi_disc_dir(dir_path)
-            ):
+            if self._should_recurse_dir(
+                directory, recurse
+            ) and not await self._is_multi_disc_dir(dir_path):
                 fs_roms.extend(await self._collect_fs_roms(dir_path, recurse))
             else:
                 fs_roms.append(
@@ -703,6 +706,21 @@ class FSRomsHandler(FSHandler):
                 )
 
         return fs_roms
+
+    @staticmethod
+    def _should_recurse_dir(directory: str, recurse: bool | frozenset[str]) -> bool:
+        """Whether to descend into ``directory`` (collecting its contents as
+        individual roms) rather than treat it as one multi-file rom.
+
+        Hidden (dot-prefixed) folders are never descended into. Otherwise
+        ``recurse`` is ``True`` (all folders), a set of folder names (only
+        those), or ``False`` (none).
+        """
+        if directory.startswith("."):
+            return False
+        if isinstance(recurse, frozenset):
+            return directory in recurse
+        return recurse
 
     async def _is_multi_disc_dir(self, rel_dir_path: str) -> bool:
         """True if a directory directly contains an ``.m3u`` playlist.
@@ -720,7 +738,7 @@ class FSRomsHandler(FSHandler):
         """Return the number of filesystem roms for a platform without
         materializing FSRom objects.
         """
-        recurse = cm.get_config().should_scan_subfolders(platform.fs_slug)
+        recurse = cm.get_config().subfolder_scan_spec(platform.fs_slug)
         try:
             rel_roms_path = self.get_roms_fs_structure(platform.fs_slug)
             return len(await self._collect_fs_roms(rel_roms_path, recurse))
@@ -735,7 +753,7 @@ class FSRomsHandler(FSHandler):
         Returns:
             list with all the filesystem roms for a platform
         """
-        recurse = cm.get_config().should_scan_subfolders(platform.fs_slug)
+        recurse = cm.get_config().subfolder_scan_spec(platform.fs_slug)
         try:
             rel_roms_path = self.get_roms_fs_structure(
                 platform.fs_slug

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -88,6 +88,7 @@ NON_HASHABLE_PLATFORMS = frozenset(
 
 class FSRom(TypedDict):
     fs_name: str
+    fs_path: str
     flat: bool
     nested: bool
     files: list[RomFile]
@@ -316,10 +317,10 @@ class FSRomsHandler(FSHandler):
         from adapters.services.rahasher import RAHasherService
         from handler.metadata import meta_ra_handler
 
-        rel_roms_path = self.get_roms_fs_structure(
-            rom.platform.fs_slug
-        )  # Relative path to roms
-        abs_fs_path = self.validate_path(rel_roms_path)  # Absolute path to roms
+        # The rom's stored directory is the source of truth for its location,
+        # so multi-folder roms (those in a platform subfolder) resolve correctly.
+        rel_roms_path = rom.fs_path  # Relative path to the rom's directory
+        abs_fs_path = self.validate_path(rel_roms_path)  # Absolute path to that dir
         rom_files: list[RomFile] = []
 
         # Skip hashing games for platforms that don't have a hash database or when hashes are disabled
@@ -664,20 +665,67 @@ class FSRomsHandler(FSHandler):
                 rom_sha1_h,
             )
 
+    async def _collect_fs_roms(self, rel_roms_path: str, recurse: bool) -> list[dict]:
+        """Discover roms under ``rel_roms_path``.
+
+        Single files are flat roms (``fs_path`` = their parent directory).
+        Directories are single multi-file roms, except when ``recurse`` is on:
+        then each (non-hidden) directory is a group of roms and is descended
+        into, so files nested at any depth are picked up as individual roms.
+        Hidden (dot-prefixed) directories are never descended into, and a
+        directory holding an ``.m3u`` playlist is kept whole as a single
+        multi-file rom (a multi-disc game) even while recursing, so it isn't
+        split into one rom per disc.
+        """
+        fs_roms: list[dict] = [
+            {"fs_name": rom, "fs_path": rel_roms_path, "flat": True, "nested": False}
+            for rom in self.exclude_single_files(await self.list_files(rel_roms_path))
+        ]
+
+        for directory in self.exclude_multi_roms(
+            await self.list_directories(rel_roms_path)
+        ):
+            dir_path = f"{rel_roms_path}/{directory}"
+            if (
+                recurse
+                and not directory.startswith(".")
+                and not await self._is_multi_disc_dir(dir_path)
+            ):
+                fs_roms.extend(await self._collect_fs_roms(dir_path, recurse))
+            else:
+                fs_roms.append(
+                    {
+                        "fs_name": directory,
+                        "fs_path": rel_roms_path,
+                        "flat": False,
+                        "nested": True,
+                    }
+                )
+
+        return fs_roms
+
+    async def _is_multi_disc_dir(self, rel_dir_path: str) -> bool:
+        """True if a directory directly contains an ``.m3u`` playlist.
+
+        Such a directory is a single multi-file rom (a multi-disc game), so it
+        is kept whole instead of being recursed into when subfolder scanning
+        is enabled — preventing a multi-disc game from being split into one
+        rom per disc.
+        """
+        return any(
+            f.lower().endswith(".m3u") for f in await self.list_files(rel_dir_path)
+        )
+
     async def count_roms(self, platform: Platform) -> int:
         """Return the number of filesystem roms for a platform without
         materializing FSRom objects.
         """
+        recurse = cm.get_config().should_scan_subfolders(platform.fs_slug)
         try:
             rel_roms_path = self.get_roms_fs_structure(platform.fs_slug)
-            fs_single_roms = await self.list_files(path=rel_roms_path)
-            fs_multi_roms = await self.list_directories(path=rel_roms_path)
+            return len(await self._collect_fs_roms(rel_roms_path, recurse))
         except FileNotFoundError as e:
             raise RomsNotFoundException(platform=platform.fs_slug) from e
-
-        return len(self.exclude_single_files(fs_single_roms)) + len(
-            self.exclude_multi_roms(fs_multi_roms)
-        )
 
     async def get_roms(self, platform: Platform) -> list[FSRom]:
         """Gets all filesystem roms for a platform
@@ -687,28 +735,20 @@ class FSRomsHandler(FSHandler):
         Returns:
             list with all the filesystem roms for a platform
         """
+        recurse = cm.get_config().should_scan_subfolders(platform.fs_slug)
         try:
             rel_roms_path = self.get_roms_fs_structure(
                 platform.fs_slug
             )  # Relative path to roms
-
-            fs_single_roms = await self.list_files(path=rel_roms_path)
-            fs_multi_roms = await self.list_directories(path=rel_roms_path)
+            fs_roms = await self._collect_fs_roms(rel_roms_path, recurse)
         except FileNotFoundError as e:
             raise RomsNotFoundException(platform=platform.fs_slug) from e
-
-        fs_roms: list[dict] = [
-            {"fs_name": rom, "flat": True, "nested": False}
-            for rom in self.exclude_single_files(fs_single_roms)
-        ] + [
-            {"fs_name": rom, "flat": False, "nested": True}
-            for rom in self.exclude_multi_roms(fs_multi_roms)
-        ]
 
         return sorted(
             [
                 FSRom(
                     fs_name=rom["fs_name"],
+                    fs_path=rom["fs_path"],
                     flat=rom["flat"],
                     nested=rom["nested"],
                     files=[],
@@ -719,7 +759,7 @@ class FSRomsHandler(FSHandler):
                 )
                 for rom in fs_roms
             ],
-            key=lambda rom: rom["fs_name"],
+            key=lambda rom: (rom["fs_path"], rom["fs_name"]),
         )
 
     async def rename_fs_rom(self, old_name: str, new_name: str, fs_path: str) -> None:

--- a/backend/tests/handler/filesystem/test_roms_handler.py
+++ b/backend/tests/handler/filesystem/test_roms_handler.py
@@ -377,6 +377,145 @@ class TestFSRomsHandler:
             # Check excluded files are not present
             assert "excluded_test.tmp" not in rom_names
 
+    def _make_subfolder_config(self, subfolders: dict[str, bool]) -> Config:
+        return Config(
+            EXCLUDED_PLATFORMS=[],
+            EXCLUDED_SINGLE_EXT=["tmp"],
+            EXCLUDED_SINGLE_FILES=[],
+            EXCLUDED_MULTI_FILES=["@eaDir"],
+            EXCLUDED_MULTI_PARTS_EXT=["tmp"],
+            EXCLUDED_MULTI_PARTS_FILES=[],
+            PLATFORMS_BINDING={},
+            PLATFORMS_VERSIONS={},
+            ROMS_FOLDER_NAME="roms",
+            FIRMWARE_FOLDER_NAME="bios",
+            SCAN_SUBFOLDERS=subfolders,
+        )
+
+    def _build_subfolder_library(self, tmp_path: Path, platform: Platform) -> None:
+        """Library with a flat rom, a grouping subfolder (with a nested
+        sub-subfolder and a basename colliding with the root), a hidden
+        folder, and a folder-style multi-file rom."""
+        roms = tmp_path / platform.fs_slug / "roms"
+        roms.mkdir(parents=True)
+        (roms / "Game A.zip").write_text("a")
+        group = roms / "All but the Best"
+        group.mkdir()
+        (group / "Game A.zip").write_text("dup")  # same basename, different folder
+        (group / "Hidden Gem.zip").write_text("c")
+        deeper = group / "deeper"
+        deeper.mkdir()
+        (deeper / "Way Down.zip").write_text("d")
+        hidden = roms / ".hidden"
+        hidden.mkdir()
+        (hidden / "disc.chd").write_text("x")
+        multi = roms / "Multi Disc Game"
+        multi.mkdir()
+        (multi / "disc1.bin").write_text("p")
+
+    @pytest.mark.asyncio
+    async def test_get_roms_subfolders_disabled(
+        self, platform: Platform, tmp_path: Path
+    ):
+        """By default a subfolder is a single multi-file rom, not a group."""
+        self._build_subfolder_library(tmp_path, platform)
+        handler = FSRomsHandler()
+        handler.base_path = tmp_path
+
+        with patch(
+            "handler.filesystem.roms_handler.cm.get_config",
+            lambda: self._make_subfolder_config({}),
+        ):
+            roms = await handler.get_roms(platform)
+            count = await handler.count_roms(platform)
+
+        keys = {(r["fs_path"], r["fs_name"]) for r in roms}
+        base = f"{platform.fs_slug}/roms"
+        assert (base, "Game A.zip") in keys
+        # Directories surface as multi-file roms, not as groups.
+        assert (base, "All but the Best") in keys
+        assert (base, "Multi Disc Game") in keys
+        assert (base, ".hidden") in keys
+        # Nothing inside any subfolder is surfaced.
+        assert not any(r["fs_path"] != base for r in roms)
+        assert len(roms) == 4
+        assert count == len(roms)
+
+    @pytest.mark.asyncio
+    async def test_get_roms_subfolders_enabled(
+        self, platform: Platform, tmp_path: Path
+    ):
+        """With subfolder scanning on, groups are descended into (recursively),
+        hidden folders are skipped, and identically-named files in different
+        folders stay distinct via their full path."""
+        self._build_subfolder_library(tmp_path, platform)
+        handler = FSRomsHandler()
+        handler.base_path = tmp_path
+
+        with patch(
+            "handler.filesystem.roms_handler.cm.get_config",
+            lambda: self._make_subfolder_config({platform.fs_slug: True}),
+        ):
+            roms = await handler.get_roms(platform)
+            count = await handler.count_roms(platform)
+
+        base = f"{platform.fs_slug}/roms"
+        keys = {(r["fs_path"], r["fs_name"]) for r in roms}
+        assert (base, "Game A.zip") in keys
+        assert (f"{base}/All but the Best", "Game A.zip") in keys  # collision kept
+        assert (f"{base}/All but the Best", "Hidden Gem.zip") in keys
+        assert (f"{base}/All but the Best/deeper", "Way Down.zip") in keys
+        # Group folders are descended into, so "Multi Disc Game" parts surface.
+        assert (f"{base}/Multi Disc Game", "disc1.bin") in keys
+        # Hidden folder is not descended into; it remains a multi-file rom.
+        assert (base, ".hidden") in keys
+        assert (f"{base}/.hidden", "disc.chd") not in keys
+        # All full-path keys are unique and count matches.
+        full_paths = [f"{r['fs_path']}/{r['fs_name']}" for r in roms]
+        assert len(full_paths) == len(set(full_paths))
+        assert sum(1 for r in roms if r["fs_name"] == "Game A.zip") == 2
+        assert count == len(roms)
+
+    @pytest.mark.asyncio
+    async def test_get_roms_subfolders_m3u_dir_kept_whole(
+        self, platform: Platform, tmp_path: Path
+    ):
+        """A subfolder holding an .m3u playlist is a multi-disc game: it stays a
+        single multi-file rom even with subfolder scanning on (not split per
+        disc), while a plain grouping folder is still recursed."""
+        roms = tmp_path / platform.fs_slug / "roms"
+        roms.mkdir(parents=True)
+        (roms / "Flat Game.zip").write_text("a")
+        # Multi-disc game declared by an .m3u playlist -> one rom.
+        md = roms / "Final Fantasy VII"
+        md.mkdir()
+        (md / "disc1.chd").write_text("1")
+        (md / "disc2.chd").write_text("2")
+        (md / "Final Fantasy VII.m3u").write_text("disc1.chd\ndisc2.chd")
+        # Plain grouping folder (no .m3u) -> recursed into.
+        grp = roms / "Hacks"
+        grp.mkdir()
+        (grp / "Hack A.zip").write_text("h")
+
+        handler = FSRomsHandler()
+        handler.base_path = tmp_path
+        with patch(
+            "handler.filesystem.roms_handler.cm.get_config",
+            lambda: self._make_subfolder_config({platform.fs_slug: True}),
+        ):
+            roms_found = await handler.get_roms(platform)
+            count = await handler.count_roms(platform)
+
+        base = f"{platform.fs_slug}/roms"
+        keys = {(r["fs_path"], r["fs_name"]) for r in roms_found}
+        # The .m3u folder stays a single multi-file rom (not split per disc).
+        assert (base, "Final Fantasy VII") in keys
+        assert (f"{base}/Final Fantasy VII", "disc1.chd") not in keys
+        # A normal grouping folder is still recursed.
+        assert (f"{base}/Hacks", "Hack A.zip") in keys
+        assert (base, "Flat Game.zip") in keys
+        assert count == len(roms_found)
+
     @pytest.mark.asyncio
     async def test_get_rom_files_single_rom(
         self, handler: FSRomsHandler, rom_single, config

--- a/backend/tests/handler/filesystem/test_roms_handler.py
+++ b/backend/tests/handler/filesystem/test_roms_handler.py
@@ -377,7 +377,7 @@ class TestFSRomsHandler:
             # Check excluded files are not present
             assert "excluded_test.tmp" not in rom_names
 
-    def _make_subfolder_config(self, subfolders: dict[str, bool]) -> Config:
+    def _make_subfolder_config(self, subfolders: dict[str, bool | list[str]]) -> Config:
         return Config(
             EXCLUDED_PLATFORMS=[],
             EXCLUDED_SINGLE_EXT=["tmp"],
@@ -515,6 +515,42 @@ class TestFSRomsHandler:
         assert (f"{base}/Hacks", "Hack A.zip") in keys
         assert (base, "Flat Game.zip") in keys
         assert count == len(roms_found)
+
+    @pytest.mark.asyncio
+    async def test_get_roms_subfolders_named_list(
+        self, platform: Platform, tmp_path: Path
+    ):
+        """A list value recurses only the named folders; every other folder
+        (including a folder-based multi-file game) stays a single multi-file
+        rom, and a non-named folder nested inside a named one is not split."""
+        self._build_subfolder_library(tmp_path, platform)
+        handler = FSRomsHandler()
+        handler.base_path = tmp_path
+
+        with patch(
+            "handler.filesystem.roms_handler.cm.get_config",
+            lambda: self._make_subfolder_config(
+                {platform.fs_slug: ["All but the Best"]}
+            ),
+        ):
+            roms = await handler.get_roms(platform)
+            count = await handler.count_roms(platform)
+
+        base = f"{platform.fs_slug}/roms"
+        keys = {(r["fs_path"], r["fs_name"]) for r in roms}
+        # Named folder is recursed -> its files become individual roms.
+        assert (f"{base}/All but the Best", "Game A.zip") in keys
+        assert (f"{base}/All but the Best", "Hidden Gem.zip") in keys
+        # A non-named folder nested inside it is kept whole (not recursed).
+        assert (f"{base}/All but the Best", "deeper") in keys
+        assert (f"{base}/All but the Best/deeper", "Way Down.zip") not in keys
+        # Folders NOT in the list stay as single multi-file roms.
+        assert (base, "Multi Disc Game") in keys
+        assert (f"{base}/Multi Disc Game", "disc1.bin") not in keys
+        # Top-level flat file and hidden folder behave as usual.
+        assert (base, "Game A.zip") in keys
+        assert (base, ".hidden") in keys
+        assert count == len(roms)
 
     @pytest.mark.asyncio
     async def test_get_rom_files_single_rom(

--- a/backend/tests/handler/test_db_handler.py
+++ b/backend/tests/handler/test_db_handler.py
@@ -584,7 +584,10 @@ def test_mark_missing_roms_small_platform(platform: Platform):
     )
 
     # Keep only rom_a and rom_c
-    missing = db_rom_handler.mark_missing_roms(platform.id, ["rom_a.zip", "rom_c.zip"])
+    missing = db_rom_handler.mark_missing_roms(
+        platform.id,
+        [f"{platform.slug}/roms/rom_a.zip", f"{platform.slug}/roms/rom_c.zip"],
+    )
 
     assert len(missing) == 1
     assert missing[0].fs_name == "rom_b.zip"
@@ -627,7 +630,9 @@ def test_mark_missing_roms_large_platform(platform: Platform):
 
     # Build a large keep list to verify mark_missing_roms() handles many entries.
     # Only rom_present.zip actually exists in DB; the rest are just filler.
-    fs_roms_to_keep = ["rom_present.zip"] + [f"filler_{i}.zip" for i in range(501)]
+    fs_roms_to_keep = [f"{platform.slug}/roms/rom_present.zip"] + [
+        f"filler_{i}.zip" for i in range(501)
+    ]
 
     missing = db_rom_handler.mark_missing_roms(platform.id, fs_roms_to_keep)
 
@@ -662,7 +667,7 @@ def test_mark_missing_roms_large_platform_all_present(platform: Platform):
         roms.append(rom)
 
     # Keep list has all real ROMs plus filler to exceed 500
-    fs_roms_to_keep = [f"rom_{i}.zip" for i in range(3)] + [
+    fs_roms_to_keep = [f"{platform.slug}/roms/rom_{i}.zip" for i in range(3)] + [
         f"filler_{i}.zip" for i in range(500)
     ]
 

--- a/backend/tests/handler/test_db_handler.py
+++ b/backend/tests/handler/test_db_handler.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 
 import pytest
+from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.exc import IntegrityError
 
 from config import ROMM_DB_DRIVER
@@ -591,6 +592,13 @@ def test_mark_missing_roms_small_platform(platform: Platform):
 
     assert len(missing) == 1
     assert missing[0].fs_name == "rom_b.zip"
+
+    # Regression: the returned (detached) instances must carry `fs_path` so
+    # callers can read `rom.full_path` after the session closes without a
+    # DetachedInstanceError (the missing-rom warning in scan.py does exactly
+    # that). Assert fs_path was eager-loaded, and that full_path resolves.
+    assert "fs_path" not in sa_inspect(missing[0]).unloaded
+    assert missing[0].full_path == f"{platform.slug}/roms/rom_b.zip"
 
     updated_b = db_rom_handler.get_rom(rom_b.id)
     assert updated_b is not None

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -70,6 +70,7 @@ async def test_scan_rom():
             rom=rom,
             fs_rom={
                 "fs_name": "Paper Mario (USA).z64",
+                "fs_path": "n64/roms",
                 "flat": True,
                 "nested": False,
                 "files": [
@@ -160,6 +161,7 @@ async def test_scan_rom_complete_clears_unselected_metadata(
             rom=rom,
             fs_rom={
                 "fs_name": "Paper Mario (USA).z64",
+                "fs_path": "n64/roms",
                 "flat": True,
                 "nested": False,
                 "files": [],
@@ -230,6 +232,7 @@ async def test_scan_rom_unmatched_fetches_ra_when_id_set_but_no_metadata(
             rom=rom,
             fs_rom={
                 "fs_name": "Jak and Daxter.chd",
+                "fs_path": "ps2/roms",
                 "flat": True,
                 "nested": False,
                 "files": [],
@@ -292,6 +295,7 @@ async def test_scan_rom_unmatched_skips_ra_when_id_and_metadata_exist(
             rom=rom,
             fs_rom={
                 "fs_name": "Jak and Daxter.chd",
+                "fs_path": "ps2/roms",
                 "flat": True,
                 "nested": False,
                 "files": [],

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -145,6 +145,35 @@
 #       image: screenshot  # Use as the <image> tag in the exported gamelist.xml
 #   pegasus:
 #     export: false # Whether to export metadata.pegasus.txt for Pegasus
+#   # Recurse into platform subfolders, treating every nested file as its own
+#   # ROM rather than collapsing each subfolder into a single multi-file ROM.
+#   # Opt-in per platform by its filesystem folder name. Use this when a
+#   # platform organizes its ROMs into subfolders (e.g. Hacks/, Homebrew/,
+#   # Translations/) and you don't want to flatten them. Leave a platform out
+#   # (or set it to false) to keep the default behavior, where a subfolder is a
+#   # single multi-file ROM (multi-disc games, etc.). Default: off everywhere.
+#   #
+#   # Behavior & limitations (read before enabling):
+#   #   - Hidden (dot-prefixed) folders are never descended into.
+#   #   - A subfolder that contains an .m3u playlist is treated as a single
+#   #     multi-file ROM (a multi-disc game) and is NOT split into one ROM per
+#   #     disc, even on an enabled platform. Any other subfolder is recursed,
+#   #     so a multi-disc game stored as a bare folder (no .m3u) would be split
+#   #     into separate ROMs — add an .m3u (or use flat disc-tagged files).
+#   #   - ROM identity is path-based. Enabling this for a platform that already
+#   #     had a folder scanned as one multi-file ROM will mark that old entry as
+#   #     "missing from filesystem" and import its contents as new ROMs; delete
+#   #     the stale entry afterwards (the scan log flags these). Likewise, moving
+#   #     a ROM between subfolders (or turning this back off) reads as remove +
+#   #     re-add, so save states, play history, favorites and collection
+#   #     membership won't follow.
+#   #   - Two files with the same name in different subfolders become distinct
+#   #     ROMs; gamelist.xml metadata matching is by filename, so both may match
+#   #     the same gamelist entry.
+#   subfolders:
+#     nes: true
+#     snes: true
+#     megadrive: true
 
 # EmulatorJS per-core options
 # emulatorjs:

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -145,21 +145,24 @@
 #       image: screenshot  # Use as the <image> tag in the exported gamelist.xml
 #   pegasus:
 #     export: false # Whether to export metadata.pegasus.txt for Pegasus
-#   # Recurse into platform subfolders, treating every nested file as its own
-#   # ROM rather than collapsing each subfolder into a single multi-file ROM.
-#   # Opt-in per platform by its filesystem folder name. Use this when a
-#   # platform organizes its ROMs into subfolders (e.g. Hacks/, Homebrew/,
-#   # Translations/) and you don't want to flatten them. Leave a platform out
-#   # (or set it to false) to keep the default behavior, where a subfolder is a
-#   # single multi-file ROM (multi-disc games, etc.). Default: off everywhere.
+#   # Recurse into platform subfolders, treating nested files as their own
+#   # ROMs rather than collapsing each subfolder into a single multi-file ROM.
+#   # Opt-in per platform. The value is either:
+#   #   - true  -> recurse EVERY subfolder of the platform;
+#   #   - a list of folder names -> recurse ONLY those folders, leaving every
+#   #     other folder as a single multi-file ROM (so folder-based multi-file
+#   #     games elsewhere on the platform stay intact — the recommended form
+#   #     when a platform mixes grouping folders with multi-file games);
+#   #   - false / omitted -> default behavior (a subfolder is one multi-file ROM).
 #   #
 #   # Behavior & limitations (read before enabling):
 #   #   - Hidden (dot-prefixed) folders are never descended into.
 #   #   - A subfolder that contains an .m3u playlist is treated as a single
 #   #     multi-file ROM (a multi-disc game) and is NOT split into one ROM per
-#   #     disc, even on an enabled platform. Any other subfolder is recursed,
-#   #     so a multi-disc game stored as a bare folder (no .m3u) would be split
-#   #     into separate ROMs — add an .m3u (or use flat disc-tagged files).
+#   #     disc, even when recursed.
+#   #   - With `true`, a multi-disc/multi-file game stored as a bare folder
+#   #     (no .m3u) WOULD be split into separate ROMs. Use the named-list form
+#   #     (don't list that game's folder) to keep it whole.
 #   #   - ROM identity is path-based. Enabling this for a platform that already
 #   #     had a folder scanned as one multi-file ROM will mark that old entry as
 #   #     "missing from filesystem" and import its contents as new ROMs; delete
@@ -171,9 +174,9 @@
 #   #     ROMs; gamelist.xml metadata matching is by filename, so both may match
 #   #     the same gamelist entry.
 #   subfolders:
-#     nes: true
-#     snes: true
-#     megadrive: true
+#     nes: true                          # recurse every NES subfolder
+#     snes: ["Hacks", "Translations"]    # recurse only these; keep other folders whole
+#     megadrive: false
 
 # EmulatorJS per-core options
 # emulatorjs:

--- a/frontend/src/locales/bg_BG/rom.json
+++ b/frontend/src/locales/bg_BG/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "Направи публична",
   "screenshot-make-private": "Направи лична",
   "screenshot-public": "Публична",
-  "screenshot-visibility-failed": "Видимостта не може да се промени: {error}"
+  "screenshot-visibility-failed": "Видимостта не може да се промени: {error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/cs_CZ/rom.json
+++ b/frontend/src/locales/cs_CZ/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "Zveřejnit",
   "screenshot-make-private": "Nastavit jako soukromé",
   "screenshot-public": "Veřejné",
-  "screenshot-visibility-failed": "Nepodařilo se změnit viditelnost: {error}"
+  "screenshot-visibility-failed": "Nepodařilo se změnit viditelnost: {error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/de_DE/rom.json
+++ b/frontend/src/locales/de_DE/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "Veröffentlichen",
   "screenshot-make-private": "Privat machen",
   "screenshot-public": "Öffentlich",
-  "screenshot-visibility-failed": "Sichtbarkeit konnte nicht geändert werden: {error}"
+  "screenshot-visibility-failed": "Sichtbarkeit konnte nicht geändert werden: {error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/en_GB/rom.json
+++ b/frontend/src/locales/en_GB/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "Make public",
   "screenshot-make-private": "Make private",
   "screenshot-public": "Public",
-  "screenshot-visibility-failed": "Couldn't update visibility: {error}"
+  "screenshot-visibility-failed": "Couldn't update visibility: {error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/en_US/rom.json
+++ b/frontend/src/locales/en_US/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "Make public",
   "screenshot-make-private": "Make private",
   "screenshot-public": "Public",
-  "screenshot-visibility-failed": "Couldn't update visibility: {error}"
+  "screenshot-visibility-failed": "Couldn't update visibility: {error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/es_ES/rom.json
+++ b/frontend/src/locales/es_ES/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "Hacer pública",
   "screenshot-make-private": "Hacer privada",
   "screenshot-public": "Pública",
-  "screenshot-visibility-failed": "No se pudo actualizar la visibilidad: {error}"
+  "screenshot-visibility-failed": "No se pudo actualizar la visibilidad: {error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/fr_FR/rom.json
+++ b/frontend/src/locales/fr_FR/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "Rendre publique",
   "screenshot-make-private": "Rendre privée",
   "screenshot-public": "Publique",
-  "screenshot-visibility-failed": "Impossible de mettre à jour la visibilité : {error}"
+  "screenshot-visibility-failed": "Impossible de mettre à jour la visibilité : {error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/hu_HU/rom.json
+++ b/frontend/src/locales/hu_HU/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "Közzététel",
   "screenshot-make-private": "Priváttá tétel",
   "screenshot-public": "Nyilvános",
-  "screenshot-visibility-failed": "A láthatóság nem frissíthető: {error}"
+  "screenshot-visibility-failed": "A láthatóság nem frissíthető: {error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/it_IT/rom.json
+++ b/frontend/src/locales/it_IT/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "Rendi pubblico",
   "screenshot-make-private": "Rendi privato",
   "screenshot-public": "Pubblico",
-  "screenshot-visibility-failed": "Impossibile aggiornare la visibilità: {error}"
+  "screenshot-visibility-failed": "Impossibile aggiornare la visibilità: {error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/ja_JP/rom.json
+++ b/frontend/src/locales/ja_JP/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "公開する",
   "screenshot-make-private": "非公開にする",
   "screenshot-public": "公開",
-  "screenshot-visibility-failed": "表示設定を更新できませんでした：{error}"
+  "screenshot-visibility-failed": "表示設定を更新できませんでした：{error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/ko_KR/rom.json
+++ b/frontend/src/locales/ko_KR/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "공개로 전환",
   "screenshot-make-private": "비공개로 전환",
   "screenshot-public": "공개",
-  "screenshot-visibility-failed": "공개 설정을 변경할 수 없습니다: {error}"
+  "screenshot-visibility-failed": "공개 설정을 변경할 수 없습니다: {error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/pl_PL/rom.json
+++ b/frontend/src/locales/pl_PL/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "Upublicznij",
   "screenshot-make-private": "Ustaw jako prywatne",
   "screenshot-public": "Publiczne",
-  "screenshot-visibility-failed": "Nie udało się zaktualizować widoczności: {error}"
+  "screenshot-visibility-failed": "Nie udało się zaktualizować widoczności: {error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/pt_BR/rom.json
+++ b/frontend/src/locales/pt_BR/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "Tornar pública",
   "screenshot-make-private": "Tornar privada",
   "screenshot-public": "Pública",
-  "screenshot-visibility-failed": "Não foi possível atualizar a visibilidade: {error}"
+  "screenshot-visibility-failed": "Não foi possível atualizar a visibilidade: {error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/ro_RO/rom.json
+++ b/frontend/src/locales/ro_RO/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "Fă publică",
   "screenshot-make-private": "Fă privată",
   "screenshot-public": "Publică",
-  "screenshot-visibility-failed": "Vizibilitatea nu a putut fi actualizată: {error}"
+  "screenshot-visibility-failed": "Vizibilitatea nu a putut fi actualizată: {error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/ru_RU/rom.json
+++ b/frontend/src/locales/ru_RU/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "Сделать публичной",
   "screenshot-make-private": "Сделать приватной",
   "screenshot-public": "Публичная",
-  "screenshot-visibility-failed": "Не удалось изменить видимость: {error}"
+  "screenshot-visibility-failed": "Не удалось изменить видимость: {error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/zh_CN/rom.json
+++ b/frontend/src/locales/zh_CN/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "设为公开",
   "screenshot-make-private": "设为私密",
   "screenshot-public": "公开",
-  "screenshot-visibility-failed": "无法更新可见性：{error}"
+  "screenshot-visibility-failed": "无法更新可见性：{error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/locales/zh_TW/rom.json
+++ b/frontend/src/locales/zh_TW/rom.json
@@ -405,5 +405,7 @@
   "screenshot-make-public": "設為公開",
   "screenshot-make-private": "設為私密",
   "screenshot-public": "公開",
-  "screenshot-visibility-failed": "無法更新可見性：{error}"
+  "screenshot-visibility-failed": "無法更新可見性：{error}",
+  "location": "Location",
+  "location-copied": "Location copied to clipboard."
 }

--- a/frontend/src/v2/components/GameDetails/FilesTab/FilesSummary.vue
+++ b/frontend/src/v2/components/GameDetails/FilesTab/FilesSummary.vue
@@ -4,16 +4,38 @@
 // Carries the missing-from-fs flag when applicable.
 import { RIcon } from "@v2/lib";
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import type { DetailedRomSchema } from "@/__generated__";
 import { formatBytes } from "@/utils";
 import HashChip from "@/v2/components/shared/HashChip.vue";
 import MissingFSBadge from "@/v2/components/shared/MissingFSBadge.vue";
+import { useSnackbar } from "@/v2/composables/useSnackbar";
 
 defineOptions({ inheritAttrs: false });
 
 const props = defineProps<{ rom: DetailedRomSchema }>();
 
+const { t } = useI18n();
+const snackbar = useSnackbar();
+
 const fileCount = computed(() => props.rom.files?.length ?? 0);
+
+// Full on-disk path of the ROM — the directory it lives in plus its
+// name. Surfaces *where* a ROM sits in the library (e.g. a platform
+// subfolder like `roms/nes/Hacks (NES)/…`), which is otherwise only
+// implicit. Distinct from the per-file relative paths in the list.
+const fullPath = computed(() => `${props.rom.fs_path}/${props.rom.fs_name}`);
+
+async function copyLocation() {
+  try {
+    await navigator.clipboard.writeText(fullPath.value);
+    snackbar.success(t("rom.location-copied"), { icon: "mdi-check-bold" });
+  } catch {
+    snackbar.error(t("common.clipboard-unavailable"), {
+      icon: "mdi-close-circle",
+    });
+  }
+}
 
 interface RomHash {
   label: string;
@@ -56,6 +78,22 @@ const hashes = computed<RomHash[]>(() => {
         </template>
       </div>
     </header>
+
+    <button
+      type="button"
+      class="r-v2-files-summary__location"
+      :title="t('rom.location')"
+      :aria-label="`${t('rom.location')}: ${fullPath}`"
+      @click="copyLocation"
+    >
+      <RIcon icon="mdi-map-marker-outline" size="14" />
+      <span class="r-v2-files-summary__location-path">{{ fullPath }}</span>
+      <RIcon
+        icon="mdi-content-copy"
+        size="13"
+        class="r-v2-files-summary__location-copy"
+      />
+    </button>
 
     <div v-if="hashes.length > 0" class="r-v2-files-summary__hashes">
       <HashChip
@@ -108,6 +146,45 @@ const hashes = computed<RomHash[]>(() => {
 }
 .r-v2-files-summary__sep {
   opacity: 0.5;
+}
+.r-v2-files-summary__location {
+  appearance: none;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 0;
+  min-width: 0;
+  color: var(--r-color-fg-muted);
+  font-size: 11.5px;
+  transition: color var(--r-motion-fast) var(--r-motion-ease-out);
+}
+.r-v2-files-summary__location:hover {
+  color: var(--r-color-fg);
+}
+.r-v2-files-summary__location-path {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: var(--r-font-family-mono);
+}
+.r-v2-files-summary__location-copy {
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity var(--r-motion-fast) var(--r-motion-ease-out);
+}
+.r-v2-files-summary__location:hover .r-v2-files-summary__location-copy,
+html[data-input="key"]
+  .r-v2-files-summary__location:focus-visible
+  .r-v2-files-summary__location-copy,
+html[data-input="pad"]
+  .r-v2-files-summary__location:focus-visible
+  .r-v2-files-summary__location-copy {
+  opacity: 0.7;
 }
 .r-v2-files-summary__hashes {
   display: flex;


### PR DESCRIPTION
**Description**

Closes #2050.

Adds **opt-in, per-platform subfolder scanning**. When enabled for a platform, RomM recurses that platform's subfolders and treats each nested file as its own ROM (storing its real path on the entry), instead of collapsing a subfolder into a single multi-file ROM. This lets users keep libraries organized into `Hacks/`, `Translations/`, `Homebrew/`, etc. without flattening them — the original request in #2050, and aligned with @gantoine's "per-system option, keep it simple" direction.

Enable per platform in `config.yml` (default **off**, so existing setups are unaffected):

```yaml
scan:
  subfolders:
    nes: true
    snes: true
```

**Why this matters (the default isn't just incomplete — it's misleading)**

Tested on a real library: a `Hacks/` folder containing 3 different romhacks (two Castlevania hacks + a Chrono Trigger hack) is collapsed into one entry today and hash-matched to *one* of them — the other two are invisible and Play is ambiguous. With this flag enabled the same folder becomes 3 separate, correctly-identified games (cover art, metadata, even translated/Japanese titles).

**Implementation**

- **Per-platform, opt-in** via `scan.subfolders` (`fs_slug -> bool`); platforms left out behave exactly as before. No DB schema change / migration.
- **Path-based identity.** `get_roms_by_fs_name` keys results on full path and `mark_missing_roms` compares full paths, so identically-named files in different subfolders stay distinct. The `(platform_id, fs_name)` index is already non-unique. File resolution (download/delete/hash) uses `rom.fs_path`.
- **Recursion** skips hidden (dot-prefixed) folders and excluded media folders at every level.
- **Frontend:** the Files tab now shows a ROM's on-disk **Location** (click-to-copy), handy for ROMs found inside subfolders. New i18n keys added to all locales.

**Mitigations to reduce surprises when enabling**

- A subfolder containing an `.m3u` playlist is kept whole as a single multi-file ROM (a multi-disc game), so it isn't split into one ROM per disc even on an enabled platform.
- The scan log flags ROMs that became "missing" because a folder is now recursed (previously a single multi-file ROM), so the stale entry is easy to clean up.

**Behavior & limitations** (also documented in `config.example.yml`)

- On an enabled platform every subfolder is recursed; folder-based multi-file ROMs need an `.m3u` (or use flat disc-tagged files) to stay whole.
- Identity is path-based, so moving a ROM between subfolders (or turning the flag back off) reads as remove + re-add — saves/play history/favorites/collection membership won't follow.

**Testing**

- Backend unit tests for recursion (incl. collisions, hidden folders, `.m3u` kept whole), `get_roms_by_fs_name` full-path keying, and `mark_missing_roms`.
- Full backend suite passes locally; frontend typecheck / tests / build / i18n parity all pass.
- Verified end-to-end against a real library with metadata providers: scan → identify → download → UI, with a side-by-side of an opted-in vs default platform.

**Note on scope:** intentionally narrow vs the custom-format/template system @thekiefs is working on — a small, low-risk step that closes the original ask here and shouldn't conflict with the larger effort. Happy to adjust or fold it in.

> **AI disclosure:** this PR was written primarily with Claude Code (AI assistance) — code, tests, and docs — driven and reviewed by me.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots

## Screenshots

### Before — default behavior (a folder = one game)

A `Hacks/` folder that actually contains **3 different romhacks** (two Castlevania hacks + a Chrono Trigger hack) collapses into a single entry "Hack" — the other two are invisible and Play is ambiguous:


<img width="1914" height="800" alt="10" src="https://github.com/user-attachments/assets/ab43945a-bdc2-4b93-b0f1-a5af73ecfd04" />

Across the platform it's worse: 4 SNES subfolders each masquerade as one game (e.g. "Hack", "Alcahest", "3 Ninjas Kick Back"), hiding ~15 games total:

<img width="987" height="907" alt="9" src="https://github.com/user-attachments/assets/a0e303db-2e35-45c9-8fa2-24601b314583" />


### After — `scan.subfolders: { nes: true }`

Same source files, platform opted in: every game from `Hacks/`, `Translations/`, `Homebrew/`, etc. is individually scanned and identified with cover art:

<img width="1999" height="926" alt="11" src="https://github.com/user-attachments/assets/b5bf7f17-75ce-4b20-8b66-618fd44d5a66" />


A translated romhack from `Translated (NES)/`, now a first-class identified game — note the on-disk **Location** shown in the Files tab:

<img width="1210" height="631" alt="12" src="https://github.com/user-attachments/assets/d85ea328-4101-45a6-9e6f-83306a530eaa" />


### Side by side (one scan, same library)

NES (opted in) → 27 individual games; SNES (default) → 9 collapsed entries:

<img width="753" height="237" alt="7" src="https://github.com/user-attachments/assets/5d20ec09-0993-494d-a53e-2b298de392a4" />

