### PR TITLE
fix: guard SiblingBadge against missing sibling_roms (scan crash with Group ROMs)

### DIFF
--- a/frontend/src/v2/components/GameCard/SiblingBadge.vue
+++ b/frontend/src/v2/components/GameCard/SiblingBadge.vue
@@ -42,11 +42,18 @@ const { groupRoms } = useUISettings();
 // "pinned" pattern GameActionBtn uses for `more` / `status` menus).
 const menuOpen = ref(false);
 
+// The scan socket (`scan:scanning_rom`) emits roms with `sibling_roms`
+// stripped from the payload, so it can be undefined here even though the
+// type marks it required. Default to an empty list — otherwise reading
+// `.length`/`.map` throws while a scan streams roms and `groupRoms` is on.
+// REST payloads always include it (possibly empty).
+const siblings = computed(() => props.rom.sibling_roms ?? []);
+
 const visible = computed(
-  () => groupRoms.value === true && props.rom.sibling_roms.length > 0,
+  () => groupRoms.value === true && siblings.value.length > 0,
 );
 
-const totalCount = computed(() => props.rom.sibling_roms.length + 1);
+const totalCount = computed(() => siblings.value.length + 1);
 
 const tooltipText = computed(() =>
   t("rom.versions-count", { n: totalCount.value }),
@@ -65,7 +72,7 @@ const versions = computed(() => [
     current: true,
     main: props.rom.rom_user?.is_main_sibling === true,
   },
-  ...props.rom.sibling_roms.map((s) => ({
+  ...siblings.value.map((s) => ({
     id: s.id,
     label: s.fs_name_no_ext,
     current: false,


### PR DESCRIPTION
**Description**

Fixes a v2 gallery crash during scans when **"Group ROMs"** is enabled (#3567).

`SiblingBadge` reads `props.rom.sibling_roms.length` / `.map`, but the `scan:scanning_rom` socket emit strips `sibling_roms` from the payload (`backend/endpoints/sockets/scan.py` — `SimpleRomSchema...model_dump(exclude={..., "sibling_roms"})`). So a freshly-scanned rom reaches the component with the field `undefined`, even though `SimpleRomSchema` types it as required — TypeScript can't catch it, and it throws `TypeError: Cannot read properties of undefined (reading 'length')` at runtime, crashing every affected gallery card while a scan streams roms.

REST payloads always include `sibling_roms` (possibly `[]`), so only the socket path is affected.

**Fix:** default `sibling_roms` to `[]` via a `siblings` computed and read through it.

Closes #3567

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

> **AI disclosure:** this fix was written with Claude Code (AI assistance), reviewed by me.
