### PR TITLE
feat(auth): add OIDC_ALLOW_REGISTRATION toggle to gate OIDC auto-registration

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -142,6 +142,9 @@ INVITE_TOKEN_EXPIRY_SECONDS: Final[int] = safe_int(
 # OIDC
 OIDC_ENABLED: Final[bool] = safe_str_to_bool(_get_env("OIDC_ENABLED"))
 OIDC_AUTOLOGIN: Final[bool] = safe_str_to_bool(_get_env("OIDC_AUTOLOGIN"))
+OIDC_ALLOW_REGISTRATION: Final[bool] = safe_str_to_bool(
+    _get_env("OIDC_ALLOW_REGISTRATION", "true")
+)
 OIDC_PROVIDER: Final[str] = _get_env("OIDC_PROVIDER", "")
 OIDC_CLIENT_ID: Final[str] = _get_env("OIDC_CLIENT_ID", "")
 OIDC_CLIENT_SECRET: Final[str] = _get_env("OIDC_CLIENT_SECRET", "")

--- a/backend/handler/auth/base_handler.py
+++ b/backend/handler/auth/base_handler.py
@@ -13,6 +13,7 @@ from starlette.requests import HTTPConnection
 
 from config import (
     INVITE_TOKEN_EXPIRY_SECONDS,
+    OIDC_ALLOW_REGISTRATION,
     OIDC_CLAIM_ROLES,
     OIDC_ENABLED,
     OIDC_ROLE_ADMIN,
@@ -436,6 +437,15 @@ class OpenIDHandler:
 
         user = db_user_handler.get_user_by_email(email)
         if user is None:
+            if not OIDC_ALLOW_REGISTRATION:
+                log.error(
+                    "User with email '%s' not found and OIDC registration is disabled",
+                    hl(email, color=CYAN),
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="User registration is disabled. Please contact an administrator to create an account.",
+                )
             log.info(
                 "User with email '%s' not found, creating new user",
                 hl(email, color=CYAN),

--- a/backend/tests/handler/auth/test_oidc.py
+++ b/backend/tests/handler/auth/test_oidc.py
@@ -24,6 +24,16 @@ def mock_oidc_enabled(mocker):
 
 
 @pytest.fixture
+def mock_oidc_allow_registration_enabled(mocker):
+    mocker.patch("handler.auth.base_handler.OIDC_ALLOW_REGISTRATION", True)
+
+
+@pytest.fixture
+def mock_oidc_allow_registration_disabled(mocker):
+    mocker.patch("handler.auth.base_handler.OIDC_ALLOW_REGISTRATION", False)
+
+
+@pytest.fixture
 def mock_token():
     return {
         "access_token": "",
@@ -171,6 +181,7 @@ async def test_oidc_valid_token_decoding(
 async def test_oidc_valid_add_user(
     mocker,
     mock_oidc_enabled,
+    mock_oidc_allow_registration_enabled,
     mock_token,
     mock_openid_configuration,
     config_override,
@@ -216,6 +227,85 @@ async def test_oidc_valid_add_user(
     assert mock_add_user.call_args.args[0].email == mock_token["userinfo"]["email"]
     assert mock_add_user.call_args.args[0].enabled
     assert mock_add_user.call_args.args[0].role == romm_role
+
+
+async def test_oidc_registration_disabled_rejects_unknown_user(
+    mocker,
+    mock_oidc_enabled,
+    mock_oidc_allow_registration_disabled,
+    mock_token,
+    mock_openid_configuration,
+):
+    """Test that a login from an unknown email is rejected when registration is disabled."""
+    mocker.patch(
+        "handler.database.db_user_handler.get_user_by_email", return_value=None
+    )
+    mock_add_user = mocker.patch("handler.database.db_user_handler.add_user")
+    mocker.patch.object(
+        StarletteOAuth2App,
+        "load_server_metadata",
+        return_value=mock_openid_configuration,
+    )
+
+    oidc_handler = OpenIDHandler()
+    with pytest.raises(HTTPException, match="registration is disabled"):
+        await oidc_handler.get_current_active_user_from_openid_token(mock_token)
+
+    mock_add_user.assert_not_called()
+
+
+async def test_oidc_registration_enabled_creates_unknown_user(
+    mocker,
+    mock_oidc_enabled,
+    mock_oidc_allow_registration_enabled,
+    mock_token,
+    mock_openid_configuration,
+):
+    """Test that a login from an unknown email creates a new user when registration is enabled."""
+    mocker.patch(
+        "handler.database.db_user_handler.get_user_by_email", return_value=None
+    )
+    mock_user = MagicMock(enabled=True, role=Role.VIEWER)
+    mock_add_user = mocker.patch(
+        "handler.database.db_user_handler.add_user", return_value=mock_user
+    )
+    mocker.patch.object(
+        StarletteOAuth2App,
+        "load_server_metadata",
+        return_value=mock_openid_configuration,
+    )
+
+    oidc_handler = OpenIDHandler()
+    user, _ = await oidc_handler.get_current_active_user_from_openid_token(mock_token)
+
+    mock_add_user.assert_called_once()
+    assert user == mock_user
+
+
+async def test_oidc_registration_disabled_allows_existing_user(
+    mocker,
+    mock_oidc_enabled,
+    mock_oidc_allow_registration_disabled,
+    mock_token,
+    mock_openid_configuration,
+):
+    """Test that an existing user can still log in when registration is disabled."""
+    mock_user = MagicMock(enabled=True, role=Role.VIEWER)
+    mocker.patch(
+        "handler.database.db_user_handler.get_user_by_email", return_value=mock_user
+    )
+    mock_add_user = mocker.patch("handler.database.db_user_handler.add_user")
+    mocker.patch.object(
+        StarletteOAuth2App,
+        "load_server_metadata",
+        return_value=mock_openid_configuration,
+    )
+
+    oidc_handler = OpenIDHandler()
+    user, _ = await oidc_handler.get_current_active_user_from_openid_token(mock_token)
+
+    assert user == mock_user
+    mock_add_user.assert_not_called()
 
 
 async def test_oidc_valid_edit_user_role(

--- a/docs/BACKEND_ARCHITECTURE.md
+++ b/docs/BACKEND_ARCHITECTURE.md
@@ -1512,6 +1512,7 @@ Falls back to `FakeRedis` in test mode.
 | Variable                        | Default              | Description                     |
 | ------------------------------- | -------------------- | ------------------------------- |
 | `OIDC_ENABLED`                  | `false`              | Enable OpenID Connect           |
+| `OIDC_ALLOW_REGISTRATION`       | `true`               | Auto-create accounts on login   |
 | `OIDC_PROVIDER`                 |                      | Provider URL                    |
 | `OIDC_CLIENT_ID`                |                      | Client ID                       |
 | `OIDC_CLIENT_SECRET`            |                      | Client secret                   |

--- a/env.template
+++ b/env.template
@@ -38,6 +38,7 @@ DISABLE_LOGS_VIEWER=false  # Disable the backend logs viewer
 # OpenID Connect
 OIDC_ENABLED=false  # Enable OpenID Connect authentication
 OIDC_AUTOLOGIN=false  # Skip the OIDC button on the login page and auto-redirect
+OIDC_ALLOW_REGISTRATION=true  # Allow new accounts to be created automatically on first OIDC login
 OIDC_PROVIDER=  # Name of the OIDC provider in use
 OIDC_CLIENT_ID=  # Client ID for OIDC authentication
 OIDC_CLIENT_SECRET=  # Client secret for OIDC authentication


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

### Summary

Adds a new `OIDC_ALLOW_REGISTRATION` environment variable that controls whether a
successful OIDC/SSO login is allowed to **automatically create a new RomM account**.

Today, when a user logs in via OIDC and no RomM account matches their email, RomM
*always* provisions a new account, with no way to turn it off. That means anyone who can
authenticate to the configured identity provider effectively gets a RomM account
(a Viewer by default). This PR makes that behavior configurable so admins can run OIDC
in an "existing users only" mode.

**Behavior**
- `OIDC_ALLOW_REGISTRATION=true` (**default**) → unchanged from today: an unknown email
  auto-creates an account.
- `OIDC_ALLOW_REGISTRATION=false` → an unknown email is rejected with a `403` and a clear
  message; no account is created. **Existing users are unaffected** and continue to log
  in normally.

> [!NOTE]
> The default is `true`, so this change is **backward-compatible** — existing OIDC
> deployments keep auto-provisioning after upgrading. Opting into the stricter
> "existing users only" behavior is an explicit `OIDC_ALLOW_REGISTRATION=false`.

### Related issue

Partially addresses #3564. That issue requests two OIDC/SSO improvements:

1. **An "Allow Registration" toggle** — ✅ implemented by this PR.
2. **Support for multiple, first-class login providers (GitHub, Google, Microsoft,
   Discord) at once** — ❌ not included here; still open for a follow-up.

This PR delivers item 1 only, so it intentionally uses "addresses" rather than a closing
keyword — #3564 should remain open to track the remaining multi-provider work.

### Why

Self-hosters frequently point RomM at a shared or large identity provider and want SSO
for the handful of people who already have accounts — not open self-registration for
everyone in the directory. This makes auto-provisioning a configurable choice while
keeping the current behavior as the default.

### Files changed

| File | Change |
| --- | --- |
| `backend/config/__init__.py` | New `OIDC_ALLOW_REGISTRATION` constant, `safe_str_to_bool(_get_env("OIDC_ALLOW_REGISTRATION", "true"))` — defaults to `true`, same building blocks as the neighboring `OIDC_*` settings. |
| `backend/handler/auth/base_handler.py` | In `OpenIDHandler.get_current_active_user_from_openid_token`, gate account creation: when no user matches the email and registration is disabled, log and raise `HTTPException(403)` instead of creating the user. Mirrors the existing "no roles" 403 in the same method. |
| `backend/tests/handler/auth/test_oidc.py` | Two fixtures (`mock_oidc_allow_registration_enabled` / `_disabled`) plus three tests: unknown user rejected when disabled, unknown user created when enabled, existing user still logs in when disabled. Updated `test_oidc_valid_add_user` to set the toggle explicitly so it doesn't rely on the global default. |
| `env.template` | Documents `OIDC_ALLOW_REGISTRATION=true` in the OpenID Connect section. |
| `docs/BACKEND_ARCHITECTURE.md` | Adds the variable (default `true`) to the OIDC env-var reference table. |

No database migrations, model changes, or API schema changes.

### Testing notes

- OIDC handler tests: **17 passed** (14 existing + 3 new). Built with TDD — verified the
  new tests fail before the implementation and pass after, and re-ran them after changing
  the default to `true`.
- Full backend suite run locally: **1721 passed** (single-process). The toggle only
  affects the OIDC login path, which the OIDC tests cover.
- `mypy` clean on the changed source files (no new type errors).
- Manual: with `OIDC_ENABLED=true` and `OIDC_ALLOW_REGISTRATION=false`, a brand-new IdP
  user is rejected with the 403; an existing user logs in fine. With the default (`true`),
  the new user is created as before.

### Reviewer attention

- **Default is `true` (backward-compatible).** No behavior change on upgrade; the stricter
  mode is opt-in via `OIDC_ALLOW_REGISTRATION=false`. Flagging in case maintainers would
  prefer `false` (secure-by-default) instead — easy to flip.
- The flag is intentionally **not exposed in `/heartbeat`** (it's enforced backend-side),
  so the login page can't yet tailor its messaging — a possible follow-up.
- A rejected login surfaces as a raw JSON `403` from the OIDC callback, consistent with
  the existing "user has no roles" rejection rather than a styled page.
- User-facing docs (docs.romm.app) may want a matching entry beyond `docs/`.

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A — backend-only change, no UI.
