### PR TITLE
feat: tile animations, semantic log module names, and log module filter

### DIFF
--- a/backend/logger/formatter.py
+++ b/backend/logger/formatter.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 from pprint import pformat
 
@@ -80,6 +81,29 @@ def redact_sensitive(text: str) -> str:
     return SENSITIVE_KEYS_REGEX.sub(r"\1=***", text)
 
 
+def resolve_module_name(record: logging.LogRecord) -> str:
+    """Derive the semantic module name shown in logs.
+
+    Resolution order:
+    1. An explicit ``extra={"module_name": ...}`` on the log call — the manual
+       override (e.g. the scan handler groups all its lines under ``scan``).
+    2. The record's module: the source filename without its extension.
+    3. For package ``__init__`` files the bare filename carries no meaning
+       (``backend/endpoints/roms/__init__.py`` → ``__init__``); fall back to the
+       package — the parent directory name — so it reads as ``roms`` instead.
+    """
+    explicit = getattr(record, "module_name", None)
+    if explicit:
+        return str(explicit)
+
+    module = record.module
+    if module == "__init__" and record.pathname:
+        parent = os.path.basename(os.path.dirname(record.pathname))
+        if parent:
+            return parent
+    return module
+
+
 def should_strip_ansi() -> bool:
     """Determine if ANSI escape codes should be stripped."""
     # Check if an explicit environment variable is set to control color behavior
@@ -112,21 +136,10 @@ class Formatter(logging.Formatter):
         """
         level = "%(levelname)s"
         dots = f"{RESET}:"
-        identifier = (
-            f"\t  {BLUE}[RomM]{LIGHTMAGENTA}[{record.module_name.lower()}]"
-            if hasattr(record, "module_name")
-            else f"\t  {BLUE}[RomM]{LIGHTMAGENTA}[%(module)s]"
-        )
-        identifier_warning = (
-            f"  {BLUE}[RomM]{LIGHTMAGENTA}[{record.module_name.lower()}]"
-            if hasattr(record, "module_name")
-            else f"  {BLUE}[RomM]{LIGHTMAGENTA}[%(module)s]"
-        )
-        identifier_critical = (
-            f" {BLUE}[RomM]{LIGHTMAGENTA}[{record.module_name.lower()}]"
-            if hasattr(record, "module_name")
-            else f" {BLUE}[RomM]{LIGHTMAGENTA}[%(module)s]"
-        )
+        module_label = resolve_module_name(record).lower()
+        identifier = f"\t  {BLUE}[RomM]{LIGHTMAGENTA}[{module_label}]"
+        identifier_warning = f"  {BLUE}[RomM]{LIGHTMAGENTA}[{module_label}]"
+        identifier_critical = f" {BLUE}[RomM]{LIGHTMAGENTA}[{module_label}]"
         msg = f"{RESET_ALL}%(message)s"
 
         message = pformat(record.msg) if hasattr(record, "pprint") else "%(message)s"

--- a/backend/logger/formatter.py
+++ b/backend/logger/formatter.py
@@ -93,7 +93,7 @@ def resolve_module_name(record: logging.LogRecord) -> str:
        package — the parent directory name — so it reads as ``roms`` instead.
     """
     explicit = getattr(record, "module_name", None)
-    if explicit:
+    if explicit is not None:
         return str(explicit)
 
     module = record.module

--- a/backend/logger/log_stream_handler.py
+++ b/backend/logger/log_stream_handler.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Final
 
-from logger.formatter import redact_sensitive, strip_ansi
+from logger.formatter import redact_sensitive, resolve_module_name, strip_ansi
 
 # Redis keys shared between the logging handler (producer, runs in every
 # process), the forwarder (relays pub/sub to Socket.IO) and the REST backfill
@@ -34,12 +34,12 @@ class LogStreamHandler(logging.Handler):
             from handler.redis_handler import redis_client
             from utils import json_module
 
-            module = getattr(record, "module_name", record.module)
+            module = resolve_module_name(record)
             payload = json_module.dumps(
                 {
                     "ts": int(record.created * 1000),
                     "level": record.levelname,
-                    "module": str(module).lower(),
+                    "module": module.lower(),
                     "message": redact_sensitive(strip_ansi(record.getMessage())),
                 }
             )

--- a/frontend/src/locales/bg_BG/logs.json
+++ b/frontend/src/locales/bg_BG/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/cs_CZ/logs.json
+++ b/frontend/src/locales/cs_CZ/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/de_DE/logs.json
+++ b/frontend/src/locales/de_DE/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/en_GB/logs.json
+++ b/frontend/src/locales/en_GB/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/en_US/logs.json
+++ b/frontend/src/locales/en_US/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/es_ES/logs.json
+++ b/frontend/src/locales/es_ES/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "Todos los niveles",
   "level-filter": "Filtrar por nivel",
+  "module-all": "Todos los módulos",
+  "module-filter": "Filtrar por módulo",
   "search-placeholder": "Buscar en los logs",
   "pause": "Pausar",
   "resume": "Reanudar",

--- a/frontend/src/locales/fr_FR/logs.json
+++ b/frontend/src/locales/fr_FR/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/hu_HU/logs.json
+++ b/frontend/src/locales/hu_HU/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/it_IT/logs.json
+++ b/frontend/src/locales/it_IT/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/ja_JP/logs.json
+++ b/frontend/src/locales/ja_JP/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/ko_KR/logs.json
+++ b/frontend/src/locales/ko_KR/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/pl_PL/logs.json
+++ b/frontend/src/locales/pl_PL/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/pt_BR/logs.json
+++ b/frontend/src/locales/pt_BR/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/ro_RO/logs.json
+++ b/frontend/src/locales/ro_RO/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/ru_RU/logs.json
+++ b/frontend/src/locales/ru_RU/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/zh_CN/logs.json
+++ b/frontend/src/locales/zh_CN/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/locales/zh_TW/logs.json
+++ b/frontend/src/locales/zh_TW/logs.json
@@ -1,6 +1,8 @@
 {
   "level-all": "All levels",
   "level-filter": "Filter by level",
+  "module-all": "All modules",
+  "module-filter": "Filter by module",
   "search-placeholder": "Search logs",
   "pause": "Pause",
   "resume": "Resume",

--- a/frontend/src/v2/components/Collections/CollectionTile.vue
+++ b/frontend/src/v2/components/Collections/CollectionTile.vue
@@ -170,8 +170,8 @@ const morphStyle = computed(() =>
 html[data-input="mouse"] .coll-tile:hover .coll-tile__cover,
 html[data-input="touch"] .coll-tile:hover .coll-tile__cover,
 .coll-tile:focus-visible .coll-tile__cover {
-  transform: translateY(-2px);
-  box-shadow: var(--r-elev-2);
+  transform: scale(1.05);
+  box-shadow: var(--r-elev-3);
 }
 
 /* Keyboard / gamepad focus — ring + brand glow on the cover, brighten

--- a/frontend/src/v2/components/GameDetails/OverviewTab.vue
+++ b/frontend/src/v2/components/GameDetails/OverviewTab.vue
@@ -381,8 +381,8 @@ const coverSource = computed(() => {
 /* Tile-row variant — the eyebrow pins to the top of the tile column
    (instead of centring through the ~190px-tall CollectionTile) so the
    label hovers over the mosaic rather than drifting halfway down it.
-   Vertical padding on the scroll container gives the hover-lift
-   (CollectionTile's translateY + elevated shadow) room to render
+   Vertical padding on the scroll container gives the hover-pop
+   (CollectionTile's scale + elevated shadow) room to render
    before the scroll container clips it — `overflow-x: auto` also
    clips on Y per the CSS spec, so without this the shadow and
    lifted edge get sheared off. */

--- a/frontend/src/v2/components/Platforms/PlatformTile.vue
+++ b/frontend/src/v2/components/Platforms/PlatformTile.vue
@@ -136,7 +136,6 @@ html[data-input="touch"] .plat-tile:hover,
 .plat-tile:focus-visible {
   background: var(--r-color-surface);
   border-color: var(--r-color-border-strong);
-  transform: translateY(-2px);
 }
 
 /* Keyboard / gamepad focus — stronger border + stacked brand glow so
@@ -161,7 +160,9 @@ html[data-input="touch"] .plat-tile:hover,
   display: grid;
   place-items: center;
   opacity: 0.9;
-  transition: opacity var(--r-motion-fast);
+  transition:
+    opacity var(--r-motion-fast),
+    transform var(--r-motion-fast);
 }
 
 .plat-tile__playable {
@@ -178,6 +179,7 @@ html[data-input="mouse"] .plat-tile:hover .plat-tile__icon,
 html[data-input="touch"] .plat-tile:hover .plat-tile__icon,
 .plat-tile:focus-visible .plat-tile__icon {
   opacity: 1;
+  transform: scale(1.05);
 }
 
 .plat-tile__name {

--- a/frontend/src/v2/composables/useGalleryCoverRatios/index.test.ts
+++ b/frontend/src/v2/composables/useGalleryCoverRatios/index.test.ts
@@ -54,7 +54,7 @@ describe("useGalleryCoverRatios", () => {
     onCardRatio({ romId: 102, ratio: 0.5 });
     expect(ratioVersion.value).toBe(0); // still debouncing
 
-    vi.advanceTimersByTime(150);
+    vi.advanceTimersByTime(350);
     expect(ratioVersion.value).toBe(1); // one bump for the whole burst
   });
 
@@ -65,12 +65,12 @@ describe("useGalleryCoverRatios", () => {
     );
 
     onCardRatio({ romId: 101, ratio: 0.7 });
-    vi.advanceTimersByTime(150);
+    vi.advanceTimersByTime(350);
     expect(ratioVersion.value).toBe(1);
     expect(ratioAt(0)).toBeCloseTo(0.7);
 
     onCardRatio({ romId: 101, ratio: 0.705 }); // delta 0.005 < 0.01
-    vi.advanceTimersByTime(150);
+    vi.advanceTimersByTime(350);
     expect(ratioVersion.value).toBe(1); // no new bump
     expect(ratioAt(0)).toBeCloseTo(0.7); // value unchanged
   });

--- a/frontend/src/v2/views/CollectionsIndex.vue
+++ b/frontend/src/v2/views/CollectionsIndex.vue
@@ -543,9 +543,11 @@ const showListHeader = computed(
               <RLetterHeading :label="g.letter" />
               <div class="r-v2-cidx__grid">
                 <CollectionTile
-                  v-for="c in g.items"
+                  v-for="(c, i) in g.items"
                   :id="c.id"
                   :key="`${c.kind}-${c.id}`"
+                  class="r-v2-card-fade"
+                  :style="{ '--card-fade-i': i }"
                   :to="c.link"
                   :name="c.name"
                   :rom-count="c.rom_count"
@@ -559,9 +561,11 @@ const showListHeader = computed(
           </template>
           <div v-else class="r-v2-cidx__grid">
             <CollectionTile
-              v-for="c in curatedTiles"
+              v-for="(c, i) in curatedTiles"
               :id="c.id"
               :key="`${c.kind}-${c.id}`"
+              class="r-v2-card-fade"
+              :style="{ '--card-fade-i': i }"
               :to="c.link"
               :name="c.name"
               :rom-count="c.rom_count"
@@ -588,9 +592,11 @@ const showListHeader = computed(
               <RLetterHeading :label="g.letter" />
               <div class="r-v2-cidx__grid">
                 <CollectionTile
-                  v-for="c in g.items"
+                  v-for="(c, i) in g.items"
                   :id="c.id"
                   :key="`${c.kind}-${c.id}`"
+                  class="r-v2-card-fade"
+                  :style="{ '--card-fade-i': i }"
                   :to="c.link"
                   :name="c.name"
                   :rom-count="c.rom_count"
@@ -604,9 +610,11 @@ const showListHeader = computed(
           </template>
           <div v-else class="r-v2-cidx__grid">
             <CollectionTile
-              v-for="c in virtualTiles"
+              v-for="(c, i) in virtualTiles"
               :id="c.id"
               :key="`${c.kind}-${c.id}`"
+              class="r-v2-card-fade"
+              :style="{ '--card-fade-i': i }"
               :to="c.link"
               :name="c.name"
               :rom-count="c.rom_count"

--- a/frontend/src/v2/views/Home.vue
+++ b/frontend/src/v2/views/Home.vue
@@ -342,10 +342,12 @@ function collectionCovers(c: {
           />
         </template>
         <PlatformTile
-          v-for="p in filledPlatforms"
+          v-for="(p, i) in filledPlatforms"
           v-else
           :key="`plat-${p.id}`"
           :id="p.id"
+          class="r-v2-card-fade"
+          :style="{ '--card-fade-i': i }"
           :slug="p.slug"
           :fs-slug="p.fs_slug"
           :display-name="p.display_name"
@@ -365,9 +367,11 @@ function collectionCovers(c: {
           <RIcon icon="mdi-bookmark-outline" size="20" />
         </template>
         <CollectionTile
-          v-for="c in allCollections"
+          v-for="(c, i) in allCollections"
           :id="c.id"
           :key="`coll-${c.id}`"
+          class="r-v2-card-fade"
+          :style="{ '--card-fade-i': i }"
           :to="`/collection/${c.id}`"
           :name="c.name"
           :rom-count="c.rom_count"

--- a/frontend/src/v2/views/PlatformsIndex.vue
+++ b/frontend/src/v2/views/PlatformsIndex.vue
@@ -459,9 +459,11 @@ const groupedBuckets = computed<Bucket[] | null>(() => {
           <h3 v-else class="r-v2-pidx__group-heading">{{ g.label }}</h3>
           <div class="r-v2-pidx__grid">
             <PlatformTile
-              v-for="p in g.items"
+              v-for="(p, i) in g.items"
               :id="p.id"
               :key="p.id"
+              class="r-v2-card-fade"
+              :style="{ '--card-fade-i': i }"
               :slug="p.slug"
               :fs-slug="p.fs_slug"
               :display-name="p.display_name"
@@ -475,9 +477,11 @@ const groupedBuckets = computed<Bucket[] | null>(() => {
       <!-- Grid mode, flat. -->
       <div v-else class="r-v2-pidx__grid">
         <PlatformTile
-          v-for="p in sortedForGrid"
+          v-for="(p, i) in sortedForGrid"
           :id="p.id"
           :key="p.id"
+          class="r-v2-card-fade"
+          :style="{ '--card-fade-i': i }"
           :slug="p.slug"
           :fs-slug="p.fs_slug"
           :display-name="p.display_name"

--- a/frontend/src/v2/views/Settings/Logs.vue
+++ b/frontend/src/v2/views/Settings/Logs.vue
@@ -50,6 +50,7 @@ const autoTail = ref(true);
 const loading = ref(true);
 
 const levelFilter = ref<string>("ALL");
+const moduleFilter = ref<string>("ALL");
 const search = ref("");
 
 // ANSI SGR escapes are stripped server-side now, but lines buffered before
@@ -71,6 +72,22 @@ const levelItems = computed(() => [
   ...LEVELS.map((l) => ({ title: l, value: l })),
 ]);
 
+// Module options are data-driven — the backend has no fixed catalogue, so
+// they're derived from whatever modules the buffered entries carry. The
+// active selection is always kept in the list (even if its module has
+// scrolled out of the ring buffer) so the select never goes blank.
+const moduleItems = computed(() => {
+  const mods = new Set<string>();
+  for (const e of entries.value) {
+    if (e.module) mods.add(e.module);
+  }
+  if (moduleFilter.value !== "ALL") mods.add(moduleFilter.value);
+  return [
+    { title: t("logs.module-all"), value: "ALL" },
+    ...[...mods].sort().map((m) => ({ title: m, value: m })),
+  ];
+});
+
 // Rank levels so "minimum severity" filtering shows the selected level
 // and everything above it.
 const LEVEL_RANK: Record<string, number> = {
@@ -84,9 +101,11 @@ const LEVEL_RANK: Record<string, number> = {
 const filtered = computed<LogRow[]>(() => {
   const minRank =
     levelFilter.value === "ALL" ? 0 : (LEVEL_RANK[levelFilter.value] ?? 0);
+  const mod = moduleFilter.value;
   const q = search.value.trim().toLowerCase();
   return entries.value.filter((e) => {
     if ((LEVEL_RANK[e.level] ?? 0) < minRank) return false;
+    if (mod !== "ALL" && e.module !== mod) return false;
     if (
       q &&
       !e.message.toLowerCase().includes(q) &&
@@ -235,6 +254,17 @@ function downloadLogs() {
         prepend-inner-icon="mdi-filter-variant"
         :aria-label="t('logs.level-filter')"
       />
+      <RSelect
+        v-model="moduleFilter"
+        class="r-v2-logs__module-select"
+        :items="moduleItems"
+        item-title="title"
+        item-value="value"
+        density="compact"
+        hide-details
+        prepend-inner-icon="mdi-cube-outline"
+        :aria-label="t('logs.module-filter')"
+      />
       <RTextField
         v-model="search"
         class="r-v2-logs__search"
@@ -362,6 +392,11 @@ function downloadLogs() {
 }
 
 .r-v2-logs__level-select {
+  width: 160px;
+  flex: 0 0 auto;
+}
+
+.r-v2-logs__module-select {
   width: 160px;
   flex: 0 0 auto;
 }


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

This PR bundles two related logging improvements with the tile animation polish.

### Logging

- **Semantic module names.** The `module` shown in logs (stdout + the live-logs viewer) was derived from `record.module` — the bare source filename — so package files logged as `__init__` (e.g. `backend/endpoints/roms/__init__.py` → `__init__`). A new shared helper `resolve_module_name()` resolves it as: explicit `extra={"module_name": ...}` override → the record's module → for `__init__` files, the **package (parent directory) name** instead. That example now reads `roms`, `endpoints/sockets/__init__.py` → `sockets`, and so on. Regular modules and the existing `scan` override are unchanged. The logic is centralised so both the stdout `Formatter` and the `LogStreamHandler` (Redis → Socket.IO → UI) share it.
- **Filter live logs by module.** The live-logs viewer (Settings → Logs) gains a module dropdown beside the existing level filter. Options are data-driven from the buffered entries (the backend has no fixed catalogue), the active selection stays selectable even if it scrolls out of the ring buffer, and it composes with the level + search filters. New i18n keys (`logs.module-all`, `logs.module-filter`) added to all 17 locales — Spanish translated, English placeholders elsewhere.

### Tiles

- **Entrance cascade.** Platform and collection tiles now use the shared `r-v2-card-fade` reveal (staggered scale-up + rise) that game cards already use, applied at every gallery site (Home rows, Platforms/Collections index grids).
- **Hover pop.** Hover/focus now scales the visual element (`scale(1.05)` + elevated shadow) to match the GameCard cover, replacing the previous flat `translateY`.
- The platform tile's root hover lift was removed because it conflicted with the entrance animation's retained transform (`fill: both`) — the same reason GameCard keeps its root transform-free and animates the inner art. Hover feedback stays via the background/border change + the icon scale.

### Verification

- `npm run typecheck`, ESLint (0 errors, no new warnings vs. baseline), `frontend/src/locales/check_i18n_locales.py` (✅ complete), and backend `py_compile` all pass locally.
- Interactive browser verification of the animations (both themes, all four input modalities) is still pending.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

<!-- N/A — interactive animations; see the Verification note above. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
