### PR TITLE
Exclude served resources from Vite dev watcher

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -127,6 +127,12 @@ export default defineConfig(({ mode }) => {
       extensions: [".js", ".json", ".jsx", ".mjs", ".ts", ".tsx", ".vue"],
     },
     server: {
+      watch: {
+        // Never crawl the served library resources: this path is a symlink
+        // into the user's library (covers, screenshots) and can hold hundreds
+        // of thousands of files, which OOMs the dev server's file watcher.
+        ignored: ["**/assets/romm/resources/**", "**/assets/romm/resources"],
+      },
       proxy: {
         "/api": {
           target: `http://127.0.0.1:${backendPort}`,


### PR DESCRIPTION
## Problem

When running the dev stack against a large library, the frontend dev server crashes with:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

`entrypoint.sh` symlinks `frontend/assets/romm/resources` to the library's resources dir (covers, screenshots). Vite's root is `frontend/`, so chokidar follows that symlink and tries to watch every file underneath. With a large library this is hundreds of thousands of files, which exhausts Node's ~2 GB heap and kills the dev server.

## Fix

Add `server.watch.ignored` for the resources tree. These are served static assets that never need HMR, so there's no reason to watch them. The watcher stays flat instead of crawling the whole library.

## Notes

This affects any sufficiently large library, not just generated test data; it just surfaces fastest there.

## AI assistance

Diagnosed and written with Claude Code.