### PR TITLE
Test Build GitHub Action improvements

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -7,10 +7,10 @@ on:
     inputs:
       # trunk-ignore(checkov/CKV_GHA_7)
       branch:
-        description: "Git branch to build"
+        description: "Git branch"
         required: true
       registry:
-        description: "Container registry to push to"
+        description: "Container registry"
         required: true
         default: "ghcr"
         type: choice
@@ -106,7 +106,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           target: full-image
 
-      - name: Comment PR with Docker image link
+      # PR builds always push to GHCR only, so the image link is hardcoded to GHCR.
+      - name: Comment PR with GHCR image link
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         env:
@@ -115,12 +116,9 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const tag = process.env.HEAD_REF;
-            const images = [
-              `ghcr.io/${owner}/romm-testing:${tag}`,
-            ];
             github.rest.issues.updateComment({
               comment_id: ${{ steps.build-comment.outputs.comment-id }},
               owner: owner,
               repo: context.repo.repo,
-              body: `✅ Preview build completed!\n\nDocker image: \`${images[0]}\``
+              body: `✅ Preview build completed!\n\nDocker image: \`ghcr.io/${owner}/romm-testing:${tag}\``
             })

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -69,7 +69,7 @@ jobs:
         uses: docker/metadata-action@v5.8.0
         with:
           images: |
-            name=rommapp/romm-testing
+            name=${{ github.repository_owner }}/romm-testing
           tags: |
             type=raw,value=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
 
@@ -95,5 +95,5 @@ jobs:
               comment_id: ${{ steps.build-comment.outputs.comment-id }},
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `✅ Preview build completed!\n\nDocker image: \`rommapp/romm-testing:${process.env.HEAD_REF}\``
+              body: `✅ Preview build completed!\n\nDocker image: \`${{ github.repository_owner }}/romm-testing:${process.env.HEAD_REF}\``
             })

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -9,6 +9,14 @@ on:
       branch:
         description: "Git branch to build"
         required: true
+      registry:
+        description: "Container registry to push to"
+        required: true
+        default: "ghcr"
+        type: choice
+        options:
+          - ghcr
+          - dockerhub
 
 permissions:
   id-token: write
@@ -28,6 +36,8 @@ jobs:
       contents: write
       packages: write
       pull-requests: write
+    env:
+      USE_GHCR: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.registry == 'ghcr' }}
     steps:
       - name: Run only once per workflow
         run: echo "Triggered by ${{ github.event_name }}"
@@ -58,14 +68,34 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
 
+      - name: Login to GHCR
+        if: env.USE_GHCR == 'true'
+        uses: docker/login-action@v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Login to Docker Hub
+        if: env.USE_GHCR == 'false'
         uses: docker/login-action@v3.5.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Generate Docker metadata
-        id: meta
+      - name: Generate Docker metadata (GHCR)
+        if: env.USE_GHCR == 'true'
+        id: meta-ghcr
+        uses: docker/metadata-action@v5.8.0
+        with:
+          images: |
+            name=ghcr.io/${{ github.repository_owner }}/romm-testing
+          tags: |
+            type=raw,value=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
+
+      - name: Generate Docker metadata (Docker Hub)
+        if: env.USE_GHCR == 'false'
+        id: meta-dockerhub
         uses: docker/metadata-action@v5.8.0
         with:
           images: |
@@ -81,7 +111,7 @@ jobs:
           context: .
           push: true
           platforms: linux/arm64,linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.USE_GHCR == 'true' && steps.meta-ghcr.outputs.tags || steps.meta-dockerhub.outputs.tags }}
           target: full-image
 
       - name: Comment PR with Docker image link
@@ -89,11 +119,18 @@ jobs:
         uses: actions/github-script@v7
         env:
           HEAD_REF: ${{ github.head_ref }}
+          USE_GHCR: ${{ env.USE_GHCR }}
         with:
           script: |
+            const owner = context.repo.owner;
+            const tag = process.env.HEAD_REF;
+            const useGhcr = process.env.USE_GHCR === 'true';
+            const image = useGhcr
+              ? `ghcr.io/${owner}/romm-testing:${tag}`
+              : `${owner}/romm-testing:${tag}`;
             github.rest.issues.updateComment({
               comment_id: ${{ steps.build-comment.outputs.comment-id }},
-              owner: context.repo.owner,
+              owner: owner,
               repo: context.repo.repo,
-              body: `✅ Preview build completed!\n\nDocker image: \`${{ github.repository_owner }}/romm-testing:${process.env.HEAD_REF}\``
+              body: `✅ Preview build completed!\n\nDocker image: \`${image}\``
             })

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -40,6 +40,8 @@ jobs:
     env:
       USE_GHCR: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.registry == 'ghcr' || github.event.inputs.registry == 'both' }}
       USE_DOCKERHUB: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.registry == 'dockerhub' || github.event.inputs.registry == 'both') }}
+      # Key the Docker Hub namespace off the push credential rather than the GitHub owner.
+      DOCKERHUB_NAMESPACE: ${{ secrets.DOCKER_NAMESPACE || secrets.DOCKER_USERNAME || github.repository_owner }}
     steps:
       - name: Run only once per workflow
         run: echo "Triggered by ${{ github.event_name }}"
@@ -91,7 +93,7 @@ jobs:
         with:
           images: |
             ${{ env.USE_GHCR == 'true' && format('name=ghcr.io/{0}/romm-testing', github.repository_owner) || '' }}
-            ${{ env.USE_DOCKERHUB == 'true' && format('name={0}/romm-testing', github.repository_owner) || '' }}
+            ${{ env.USE_DOCKERHUB == 'true' && format('name={0}/romm-testing', env.DOCKERHUB_NAMESPACE) || '' }}
           tags: |
             type=raw,value=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -17,6 +17,7 @@ on:
         options:
           - ghcr
           - dockerhub
+          - both
 
 permissions:
   id-token: write
@@ -37,7 +38,8 @@ jobs:
       packages: write
       pull-requests: write
     env:
-      USE_GHCR: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.registry == 'ghcr' }}
+      USE_GHCR: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.registry == 'ghcr' || github.event.inputs.registry == 'both' }}
+      USE_DOCKERHUB: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.registry == 'dockerhub' || github.event.inputs.registry == 'both') }}
     steps:
       - name: Run only once per workflow
         run: echo "Triggered by ${{ github.event_name }}"
@@ -77,29 +79,19 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        if: env.USE_GHCR == 'false'
+        if: env.USE_DOCKERHUB == 'true'
         uses: docker/login-action@v3.5.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Generate Docker metadata (GHCR)
-        if: env.USE_GHCR == 'true'
-        id: meta-ghcr
+      - name: Generate Docker metadata
+        id: meta
         uses: docker/metadata-action@v5.8.0
         with:
           images: |
-            name=ghcr.io/${{ github.repository_owner }}/romm-testing
-          tags: |
-            type=raw,value=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
-
-      - name: Generate Docker metadata (Docker Hub)
-        if: env.USE_GHCR == 'false'
-        id: meta-dockerhub
-        uses: docker/metadata-action@v5.8.0
-        with:
-          images: |
-            name=${{ github.repository_owner }}/romm-testing
+            ${{ env.USE_GHCR == 'true' && format('name=ghcr.io/{0}/romm-testing', github.repository_owner) || '' }}
+            ${{ env.USE_DOCKERHUB == 'true' && format('name={0}/romm-testing', github.repository_owner) || '' }}
           tags: |
             type=raw,value=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
 
@@ -111,7 +103,7 @@ jobs:
           context: .
           push: true
           platforms: linux/arm64,linux/amd64
-          tags: ${{ env.USE_GHCR == 'true' && steps.meta-ghcr.outputs.tags || steps.meta-dockerhub.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           target: full-image
 
       - name: Comment PR with Docker image link
@@ -119,18 +111,16 @@ jobs:
         uses: actions/github-script@v7
         env:
           HEAD_REF: ${{ github.head_ref }}
-          USE_GHCR: ${{ env.USE_GHCR }}
         with:
           script: |
             const owner = context.repo.owner;
             const tag = process.env.HEAD_REF;
-            const useGhcr = process.env.USE_GHCR === 'true';
-            const image = useGhcr
-              ? `ghcr.io/${owner}/romm-testing:${tag}`
-              : `${owner}/romm-testing:${tag}`;
+            const images = [
+              `ghcr.io/${owner}/romm-testing:${tag}`,
+            ];
             github.rest.issues.updateComment({
               comment_id: ${{ steps.build-comment.outputs.comment-id }},
               owner: owner,
               repo: context.repo.repo,
-              body: `✅ Preview build completed!\n\nDocker image: \`${image}\``
+              body: `✅ Preview build completed!\n\nDocker image: \`${images[0]}\``
             })


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

This PR improves the GitHub Action used to create test builds. Previously, forks could not push images because the image name was hardcoded to `rommapp/romm-testing`. This has been updated to use `${{ github.repository_owner }}/romm-testing`, allowing forked repositories to publish images under their own namespace.

Additionally, support for pushing images to GitHub Container Registry (GHCR) has been added. When manually running the workflow, users can now select the target registry from a dropdown menu (Docker Hub, GHCR, or both). Pushing to Docker Hub still requires the appropriate Docker Hub secrets to be configured.

**Checklist**

- [X] I've tested the changes locally
- [X] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [X] I've added unit tests that cover the changes (does not apply)