### PR TITLE
fix(platform): accept embedded custom_name body on platform update

### DIFF
--- a/backend/endpoints/platform.py
+++ b/backend/endpoints/platform.py
@@ -114,7 +114,7 @@ async def update_platform(
     request: Request,
     id: Annotated[int, PathVar(description="Platform id.", ge=1)],
     custom_name: Annotated[
-        str | None, Body(description="Custom platform name.")
+        str | None, Body(embed=True, description="Custom platform name.")
     ] = None,
 ) -> PlatformSchema:
     """Update a platform."""

--- a/backend/tests/endpoints/test_platform.py
+++ b/backend/tests/endpoints/test_platform.py
@@ -12,3 +12,15 @@ def test_get_platforms(client, access_token, platform):
 
     platforms = response.json()
     assert len(platforms) == 1
+
+
+def test_update_platform_custom_name(client, access_token, platform):
+    # The body is an embedded key, not a bare scalar; sending {"custom_name": ...}
+    # must be accepted (regression against the single-body-param 422).
+    response = client.put(
+        f"/api/platforms/{platform.id}",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={"custom_name": "My Custom Name"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["custom_name"] == "My Custom Name"

--- a/frontend/src/__generated__/index.ts
+++ b/frontend/src/__generated__/index.ts
@@ -26,6 +26,7 @@ export type { Body_token_api_token_post } from './models/Body_token_api_token_po
 export type { Body_track_save_api_saves__id__track_post } from './models/Body_track_save_api_saves__id__track_post';
 export type { Body_untrack_save_api_saves__id__untrack_post } from './models/Body_untrack_save_api_saves__id__untrack_post';
 export type { Body_update_collection_api_collections__id__put } from './models/Body_update_collection_api_collections__id__put';
+export type { Body_update_platform_api_platforms__id__put } from './models/Body_update_platform_api_platforms__id__put';
 export type { Body_update_rom_api_roms__id__put } from './models/Body_update_rom_api_roms__id__put';
 export type { Body_update_save_api_saves__id__put } from './models/Body_update_save_api_saves__id__put';
 export type { Body_update_save_visibility_api_saves__id__visibility_put } from './models/Body_update_save_visibility_api_saves__id__visibility_put';

--- a/frontend/src/__generated__/models/Body_update_platform_api_platforms__id__put.ts
+++ b/frontend/src/__generated__/models/Body_update_platform_api_platforms__id__put.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Body_update_platform_api_platforms__id__put = {
+    /**
+     * Custom platform name.
+     */
+    custom_name?: (string | null);
+};
+


### PR DESCRIPTION
## Problem

Editing a platform's display name in v2 returns **422 Unprocessable Entity**.

Fixes #3584 3584

## Root cause

Commit `4724361f6` ("remove per-platform cover aspect-ratio setting") dropped `update_platform` from **two** `Body()` params (`aspect_ratio` + `custom_name`) to **one**. FastAPI treats these differently:

- **Multiple** scalar `Body()` params → embedded keys: `{"custom_name": "..."}`
- **A single** scalar `Body()` param → the body *is* the bare value: `"..."`

So the endpoint silently started expecting a raw JSON string, while the frontend service still sends `{ custom_name: "..." }` (`frontend/src/services/api/platform.ts`). FastAPI validates that object against `str | None` and rejects it with 422.

## Fix

- `Body(embed=True)` on `custom_name`, restoring the embedded-key contract the frontend already sends and that every sibling update endpoint uses.
- Regenerated frontend types: restores the `Body_update_platform_api_platforms__id__put` model and its index export.
- Added an endpoint regression test asserting `{"custom_name": ...}` returns 200 and applies the name.

## Verification

- `pytest tests/endpoints/test_platform.py` → 2 passed
- `npm run typecheck` → clean
- `trunk check` → clean on all touched files

## AI assistance

This change was written with Claude Code (Opus 4.8), including the diagnosis, fix, type regeneration, and test. Reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)