### PR TITLE
fix(frontend): contain hover-video to miximage frame + restore dev HMR

### DIFF
--- a/frontend/src/v2/components/shared/GameCover.vue
+++ b/frontend/src/v2/components/shared/GameCover.vue
@@ -358,9 +358,10 @@ defineExpose({
 .game-cover__video {
   position: absolute;
   top: 0.75rem;
-  left: 0.35rem;
+  left: 0.3rem;
   width: 97%;
-  object-fit: contain;
+  aspect-ratio: 745 / 550;
+  object-fit: cover;
   opacity: 0;
   transition: opacity 0.35s ease;
   pointer-events: none;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -65,11 +65,7 @@ export default defineConfig(({ mode }) => {
   };
 
   const backendPort = env.DEV_PORT ?? "5000";
-  // const devMode = env.DEV_MODE === "true";
   const httpsMode = env.DEV_HTTPS === "true";
-  // The PWA service worker intercepts dev requests and forces full page
-  // reloads on edits (CSS included), defeating HMR. Keep it off in dev unless
-  // explicitly testing the PWA (DEV_PWA=true).
   const pwaDevEnabled = env.DEV_PWA === "true";
 
   return {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -67,6 +67,10 @@ export default defineConfig(({ mode }) => {
   const backendPort = env.DEV_PORT ?? "5000";
   // const devMode = env.DEV_MODE === "true";
   const httpsMode = env.DEV_HTTPS === "true";
+  // The PWA service worker intercepts dev requests and forces full page
+  // reloads on edits (CSS included), defeating HMR. Keep it off in dev unless
+  // explicitly testing the PWA (DEV_PWA=true).
+  const pwaDevEnabled = env.DEV_PWA === "true";
 
   return {
     optimizeDeps: {
@@ -96,7 +100,7 @@ export default defineConfig(({ mode }) => {
           ],
         },
         devOptions: {
-          enabled: true,
+          enabled: pwaDevEnabled,
           type: "module",
         },
       }),


### PR DESCRIPTION
## What

Two small frontend fixes:

1. **Hover-video overflow (`GameCover.vue`)** — the miximage hover `<video>` set a width but no height bound, so a tall/narrow source computed an intrinsic-ratio height taller than the cover box and overflowed past the `miximage.png` bezel. It now matches the frame's box (`aspect-ratio` + `top`/`width`) and uses `object-fit: cover`, so the clip fills the bezel screen and crops the excess instead of spilling out.

2. **Dev HMR (`vite.config.js`)** — the PWA service worker (`devOptions.enabled: true`) intercepted dev requests and forced a full page reload on every edit (CSS included), defeating HMR. It's now gated behind a `DEV_PWA` env flag, so default dev gets working HMR. Set `DEV_PWA=true` to test the PWA in dev.

Fixes #3601

## Testing

- `npm run typecheck` passes
- `trunk check` clean on both files
- Hover video verified to stay within the bezel for tall/narrow sources
- After unregistering the existing dev service worker, CSS edits hot-swap without a full reload

## AI assistance

This change was made with AI assistance (Claude Code): the implementation, iteration on the cover-video fit approach, and the HMR/PWA diagnosis were AI-assisted, reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)