### PR TITLE
fix(v2): correct route name when navigating after platform/collection delete

### DIFF
--- a/frontend/src/v2/views/Gallery/Collection.vue
+++ b/frontend/src/v2/views/Gallery/Collection.vue
@@ -18,6 +18,7 @@ import { RDivider, type RTabNavItem } from "@v2/lib";
 import { computed, nextTick, onMounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { onBeforeRouteUpdate, useRoute, useRouter } from "vue-router";
+import { ROUTES } from "@/plugins/router";
 import collectionApi from "@/services/api/collection";
 import storeAuth from "@/stores/auth";
 import storeCollections, {
@@ -267,7 +268,7 @@ async function onDelete() {
     snackbar.success(`Collection "${c.name}" deleted`, {
       icon: "mdi-check-bold",
     });
-    router.push({ name: "collections" });
+    router.push({ name: ROUTES.COLLECTIONS_INDEX });
   } catch (err) {
     const e = err as {
       response?: { data?: { msg?: string; detail?: string } };

--- a/frontend/src/v2/views/Gallery/Platform.vue
+++ b/frontend/src/v2/views/Gallery/Platform.vue
@@ -372,7 +372,7 @@ async function onDelete() {
     snackbar.success(`Platform "${p.display_name}" deleted`, {
       icon: "mdi-check-bold",
     });
-    router.push({ name: "platforms" });
+    router.push({ name: ROUTES.PLATFORMS_INDEX });
   } catch (err) {
     const e = err as {
       response?: { data?: { msg?: string } };


### PR DESCRIPTION
**Description**

Fixes #3598.

Deleting a platform in the v2 UI showed `Failed to delete platform: unknown error` even though the platform was actually deleted. The success handler navigated with `router.push({ name: "platforms" })`, but no route named `"platforms"` exists (the real name is `ROUTES.PLATFORMS_INDEX` / `"platforms-index"`). Vue Router throws on the unknown route name, and that error was caught by the same `try/catch` wrapping the delete call, surfacing the misleading "unknown error" snackbar despite the deletion succeeding.

The identical bug existed in the collection delete flow (`router.push({ name: "collections" })`), so it is fixed here too.

Changes:
- `Platform.vue`: navigate to `ROUTES.PLATFORMS_INDEX` instead of `"platforms"`.
- `Collection.vue`: navigate to `ROUTES.COLLECTIONS_INDEX` instead of `"collections"` (and import `ROUTES`).

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

**Verification**

`npm run typecheck` and `eslint` both pass on the changed files.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The AI diagnosed the root cause, made the code changes across both gallery views, and ran the typecheck/lint verification. The work was reviewed before submission.

https://claude.ai/code/session_01Cv77VUJgPe1H7ipSRitjpH