### PR TITLE
fix(ra): hash PSP compressed-ISO containers natively (#3600)

### DIFF
--- a/backend/adapters/services/rahasher.py
+++ b/backend/adapters/services/rahasher.py
@@ -8,6 +8,7 @@ from logger.formatter import LIGHTMAGENTA
 from logger.formatter import highlight as hl
 from logger.logger import log
 from utils.filesystem import COMPRESSED_FILE_EXTENSIONS
+from utils.psp_hasher import calculate_psp_ra_hash, is_psp_native_hash_file
 
 RAHASHER_VALID_HASH_REGEX = re.compile(r"[0-9a-f]{32}")
 
@@ -141,6 +142,8 @@ RA_BUFFER_HASH_UNSUPPORTED_IDS: frozenset[int] = frozenset(
     PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[ups] for ups in RA_BUFFER_HASH_UNSUPPORTED
 )
 
+PSP_RA_ID: int = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSP]
+
 
 class RAHasherError(Exception): ...
 
@@ -204,6 +207,19 @@ class RAHasherService:
                 resolved = await asyncio.to_thread(_pick_ra_file, folder)
                 if resolved is not None:
                     file_path = str(resolved)
+
+        # PSP compressed-ISO containers (.cso/.ciso/.zso/.dax) can't be read by
+        # RAHasher ("Could not open track"). Compute the PSP RA hash natively
+        # from the container instead, decompressing only PARAM.SFO + EBOOT.BIN.
+        # On failure we fall through to RAHasher (no worse than before).
+        if platform["ra_id"] == PSP_RA_ID and is_psp_native_hash_file(file_path):
+            native_hash = await asyncio.to_thread(calculate_psp_ra_hash, file_path)
+            if native_hash:
+                log.debug(
+                    f"Computed native {hl('RA', color=LIGHTMAGENTA)} hash for PSP "
+                    f"container {hl(file_path)}"
+                )
+                return native_hash
 
         log.debug(
             f"Executing {hl('RAHasher', color=LIGHTMAGENTA)} for platform: {hl(platform['slug'], color=LIGHTMAGENTA)} - file: {hl(file_path)}"

--- a/backend/tests/adapters/services/test_rahasher.py
+++ b/backend/tests/adapters/services/test_rahasher.py
@@ -574,6 +574,112 @@ class TestRAHasherWildcardFolderResolution:
         assert result == ""
 
 
+class TestRAHasherPspNativeHashing:
+    """PSP compressed-ISO containers (.cso/.ciso/.zso/.dax) are hashed natively
+    instead of being handed to RAHasher, which can't read them (issue #3600)."""
+
+    @pytest.fixture
+    def service(self):
+        return RAHasherService()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("ext", [".cso", ".ciso", ".zso", ".dax"])
+    async def test_native_hash_short_circuits_rahasher(
+        self, service: RAHasherService, ext
+    ):
+        """A successful native hash returns without spawning RAHasher."""
+        psp_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSP]
+
+        with (
+            patch(
+                "adapters.services.rahasher.calculate_psp_ra_hash",
+                return_value="a1b2c3d4e5f6789012345678901234ab",
+            ) as mock_native,
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+        ):
+            result = await service.calculate_hash(
+                {"ra_id": psp_id, "slug": "psp"}, f"/roms/psp/game{ext}"
+            )
+
+        assert result == "a1b2c3d4e5f6789012345678901234ab"
+        mock_native.assert_called_once_with(f"/roms/psp/game{ext}")
+        mock_subprocess.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_rahasher_when_native_fails(
+        self, service: RAHasherService
+    ):
+        """If native hashing returns nothing, RAHasher is still attempted."""
+        psp_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSP]
+
+        mock_proc = AsyncMock()
+        mock_proc.wait.return_value = 0
+        mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
+        mock_proc.stderr = None
+
+        with (
+            patch(
+                "adapters.services.rahasher.calculate_psp_ra_hash",
+                return_value="",
+            ) as mock_native,
+            patch(
+                "asyncio.create_subprocess_exec", return_value=mock_proc
+            ) as mock_subprocess,
+        ):
+            result = await service.calculate_hash(
+                {"ra_id": psp_id, "slug": "psp"}, "/roms/psp/game.cso"
+            )
+
+        assert result == "a1b2c3d4e5f6789012345678901234ab"
+        mock_native.assert_called_once()
+        mock_subprocess.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_native_hashing_skipped_for_non_psp_platform(
+        self, service: RAHasherService
+    ):
+        """A .cso on a non-PSP platform must not trigger native PSP hashing."""
+        psx_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSX]
+
+        mock_proc = AsyncMock()
+        mock_proc.wait.return_value = 0
+        mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
+        mock_proc.stderr = None
+
+        with (
+            patch("adapters.services.rahasher.calculate_psp_ra_hash") as mock_native,
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        ):
+            await service.calculate_hash(
+                {"ra_id": psx_id, "slug": "psx"}, "/roms/psx/game.cso"
+            )
+
+        mock_native.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_native_hashing_skipped_for_raw_iso(self, service: RAHasherService):
+        """Plain .iso PSP discs still go to RAHasher (it reads them fine)."""
+        psp_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSP]
+
+        mock_proc = AsyncMock()
+        mock_proc.wait.return_value = 0
+        mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
+        mock_proc.stderr = None
+
+        with (
+            patch("adapters.services.rahasher.calculate_psp_ra_hash") as mock_native,
+            patch(
+                "asyncio.create_subprocess_exec", return_value=mock_proc
+            ) as mock_subprocess,
+        ):
+            await service.calculate_hash(
+                {"ra_id": psp_id, "slug": "psp"}, "/roms/psp/game.iso"
+            )
+
+        mock_native.assert_not_called()
+        mock_subprocess.assert_called_once()
+
+
 class TestRAHasherError:
     """Test the RAHasherError exception."""
 

--- a/backend/tests/utils/test_psp_hasher.py
+++ b/backend/tests/utils/test_psp_hasher.py
@@ -1,0 +1,290 @@
+import hashlib
+import struct
+import zlib
+
+import pytest
+
+from utils.psp_hasher import (
+    PSP_NATIVE_HASH_EXTENSIONS,
+    _lz4_decompress_block,
+    calculate_psp_ra_hash,
+    is_psp_native_hash_file,
+)
+
+ISO_SECTOR_SIZE = 2048
+
+# Sector layout used by the synthetic ISO builder below.
+_ROOT_LBA = 18
+_PSP_GAME_LBA = 19
+_SYSDIR_LBA = 20
+_PARAM_LBA = 21
+_EBOOT_LBA = 22
+
+
+def _dir_record(name: bytes, lba: int, size: int, is_dir: bool) -> bytes:
+    """Build a minimal ISO9660 directory record (only the fields we parse)."""
+    record_len = 33 + len(name)
+    if record_len % 2:
+        record_len += 1  # records are padded to an even length
+    record = bytearray(record_len)
+    record[0] = record_len
+    struct.pack_into("<I", record, 2, lba)
+    struct.pack_into("<I", record, 10, size)
+    record[25] = 0x02 if is_dir else 0x00
+    record[32] = len(name)
+    record[33 : 33 + len(name)] = name
+    return bytes(record)
+
+
+def _extent(records: list[bytes]) -> bytes:
+    data = b"".join(records)
+    assert len(data) <= ISO_SECTOR_SIZE
+    return data + b"\x00" * (ISO_SECTOR_SIZE - len(data))
+
+
+def build_psp_iso(param_sfo: bytes, eboot_bin: bytes) -> bytes:
+    """Build a tiny but valid-enough ISO9660 holding the two PSP hash files."""
+    eboot_sectors = max(1, (len(eboot_bin) + ISO_SECTOR_SIZE - 1) // ISO_SECTOR_SIZE)
+    total_sectors = _EBOOT_LBA + eboot_sectors
+    iso = bytearray(total_sectors * ISO_SECTOR_SIZE)
+
+    pvd = bytearray(ISO_SECTOR_SIZE)
+    pvd[0] = 1
+    pvd[1:6] = b"CD001"
+    pvd[6] = 1
+    pvd[156 : 156 + 34] = _dir_record(b"\x00", _ROOT_LBA, ISO_SECTOR_SIZE, True)
+    iso[16 * ISO_SECTOR_SIZE : 17 * ISO_SECTOR_SIZE] = pvd
+
+    iso[_ROOT_LBA * ISO_SECTOR_SIZE : (_ROOT_LBA + 1) * ISO_SECTOR_SIZE] = _extent(
+        [
+            _dir_record(b"\x00", _ROOT_LBA, ISO_SECTOR_SIZE, True),
+            _dir_record(b"\x01", _ROOT_LBA, ISO_SECTOR_SIZE, True),
+            _dir_record(b"PSP_GAME", _PSP_GAME_LBA, ISO_SECTOR_SIZE, True),
+        ]
+    )
+    iso[_PSP_GAME_LBA * ISO_SECTOR_SIZE : (_PSP_GAME_LBA + 1) * ISO_SECTOR_SIZE] = (
+        _extent(
+            [
+                _dir_record(b"\x00", _PSP_GAME_LBA, ISO_SECTOR_SIZE, True),
+                _dir_record(b"\x01", _ROOT_LBA, ISO_SECTOR_SIZE, True),
+                # ";1" version suffix must be stripped during lookup
+                _dir_record(b"PARAM.SFO;1", _PARAM_LBA, len(param_sfo), False),
+                _dir_record(b"SYSDIR", _SYSDIR_LBA, ISO_SECTOR_SIZE, True),
+            ]
+        )
+    )
+    iso[_SYSDIR_LBA * ISO_SECTOR_SIZE : (_SYSDIR_LBA + 1) * ISO_SECTOR_SIZE] = _extent(
+        [
+            _dir_record(b"\x00", _SYSDIR_LBA, ISO_SECTOR_SIZE, True),
+            _dir_record(b"\x01", _PSP_GAME_LBA, ISO_SECTOR_SIZE, True),
+            _dir_record(b"EBOOT.BIN;1", _EBOOT_LBA, len(eboot_bin), False),
+        ]
+    )
+
+    iso[
+        _PARAM_LBA * ISO_SECTOR_SIZE : _PARAM_LBA * ISO_SECTOR_SIZE + len(param_sfo)
+    ] = param_sfo
+    iso[
+        _EBOOT_LBA * ISO_SECTOR_SIZE : _EBOOT_LBA * ISO_SECTOR_SIZE + len(eboot_bin)
+    ] = eboot_bin
+    return bytes(iso)
+
+
+def _lz4_literal_block(data: bytes) -> bytes:
+    """Encode ``data`` as a single literals-only LZ4 block (no matches)."""
+    out = bytearray()
+    out.append((15 if len(data) >= 15 else len(data)) << 4)
+    if len(data) >= 15:
+        remaining = len(data) - 15
+        while remaining >= 255:
+            out.append(255)
+            remaining -= 255
+        out.append(remaining)
+    out += data
+    return bytes(out)
+
+
+def build_ciso(iso: bytes, lz4: bool = False, block_size: int = 2048) -> bytes:
+    """Wrap a raw ISO in a CISO (.cso) or ZISO (.zso) container."""
+    num_blocks = (len(iso) + block_size - 1) // block_size
+    header = bytearray(24)
+    header[:4] = b"ZISO" if lz4 else b"CISO"
+    struct.pack_into("<I", header, 4, 24)
+    struct.pack_into("<Q", header, 8, len(iso))
+    struct.pack_into("<I", header, 16, block_size)
+    header[20] = 1
+
+    index: list[int] = []
+    body = bytearray()
+    pos = 24 + (num_blocks + 1) * 4
+    for i in range(num_blocks):
+        block = iso[i * block_size : (i + 1) * block_size]
+        if len(block) < block_size:
+            block = block + b"\x00" * (block_size - len(block))
+        if lz4:
+            # Store as a (non-plain) LZ4 block so the decoder path is exercised.
+            stored = _lz4_literal_block(block)
+            index.append(pos)
+        else:
+            compressor = zlib.compressobj(9, zlib.DEFLATED, -zlib.MAX_WBITS)
+            compressed = compressor.compress(block) + compressor.flush()
+            if len(compressed) >= block_size:
+                stored = block
+                index.append(pos | 0x80000000)  # plain block flag
+            else:
+                stored = compressed
+                index.append(pos)
+        body += stored
+        pos += len(stored)
+    index.append(pos)  # sentinel pointing past the last block
+
+    out = bytearray(header)
+    for entry in index:
+        out += struct.pack("<I", entry)
+    out += body
+    return bytes(out)
+
+
+def build_dax(iso: bytes) -> bytes:
+    """Wrap a raw ISO in a DAX (.dax) container (zlib blocks, no NC areas)."""
+    block_size = 0x2000
+    num_blocks = (len(iso) + block_size - 1) // block_size
+    offsets: list[int] = []
+    sizes: list[int] = []
+    body = bytearray()
+    pos = 32 + num_blocks * 4 + num_blocks * 2
+    for i in range(num_blocks):
+        block = iso[i * block_size : (i + 1) * block_size]
+        if len(block) < block_size:
+            block = block + b"\x00" * (block_size - len(block))
+        compressed = zlib.compress(block, 9)
+        offsets.append(pos)
+        sizes.append(len(compressed))
+        body += compressed
+        pos += len(compressed)
+
+    header = bytearray(32)
+    header[:4] = b"DAX\x00"
+    struct.pack_into("<I", header, 4, len(iso))
+    struct.pack_into("<I", header, 8, 1)  # version
+    struct.pack_into("<I", header, 12, 0)  # nc_areas
+
+    out = bytearray(header)
+    for offset in offsets:
+        out += struct.pack("<I", offset)
+    for size in sizes:
+        out += struct.pack("<H", size)
+    out += body
+    return bytes(out)
+
+
+@pytest.fixture
+def psp_files():
+    """Deterministic PARAM.SFO / EBOOT.BIN bytes and their expected RA hash."""
+    param_sfo = bytes((i * 37 + 11) & 0xFF for i in range(800))
+    eboot_bin = bytes((i * 53 + 7) & 0xFF for i in range(5000)) + b"\x00" * 1000
+    expected = hashlib.md5(param_sfo + eboot_bin, usedforsecurity=False).hexdigest()
+    return param_sfo, eboot_bin, expected
+
+
+class TestCalculatePspRaHash:
+    """End-to-end native hashing of each compressed-ISO container format."""
+
+    def test_cso_matches_expected_hash(self, tmp_path, psp_files):
+        param_sfo, eboot_bin, expected = psp_files
+        iso = build_psp_iso(param_sfo, eboot_bin)
+        path = tmp_path / "game.cso"
+        path.write_bytes(build_ciso(iso, lz4=False))
+
+        assert calculate_psp_ra_hash(str(path)) == expected
+
+    def test_zso_matches_expected_hash(self, tmp_path, psp_files):
+        param_sfo, eboot_bin, expected = psp_files
+        iso = build_psp_iso(param_sfo, eboot_bin)
+        path = tmp_path / "game.zso"
+        path.write_bytes(build_ciso(iso, lz4=True))
+
+        assert calculate_psp_ra_hash(str(path)) == expected
+
+    def test_dax_matches_expected_hash(self, tmp_path, psp_files):
+        param_sfo, eboot_bin, expected = psp_files
+        iso = build_psp_iso(param_sfo, eboot_bin)
+        path = tmp_path / "game.dax"
+        path.write_bytes(build_dax(iso))
+
+        assert calculate_psp_ra_hash(str(path)) == expected
+
+    def test_hash_is_independent_of_container(self, tmp_path, psp_files):
+        """A .cso and the equivalent .dax must yield the same RA hash."""
+        param_sfo, eboot_bin, _ = psp_files
+        iso = build_psp_iso(param_sfo, eboot_bin)
+        cso = tmp_path / "game.cso"
+        dax = tmp_path / "game.dax"
+        cso.write_bytes(build_ciso(iso, lz4=False))
+        dax.write_bytes(build_dax(iso))
+
+        assert calculate_psp_ra_hash(str(cso)) == calculate_psp_ra_hash(str(dax))
+
+    def test_returns_empty_for_unknown_magic(self, tmp_path):
+        path = tmp_path / "game.cso"
+        path.write_bytes(b"NOPE" + b"\x00" * 64)
+
+        assert calculate_psp_ra_hash(str(path)) == ""
+
+    def test_returns_empty_for_missing_file(self, tmp_path):
+        assert calculate_psp_ra_hash(str(tmp_path / "does-not-exist.cso")) == ""
+
+    def test_returns_empty_when_psp_files_absent(self, tmp_path):
+        """A valid ISO without PSP_GAME/PARAM.SFO can't be hashed natively."""
+        iso = bytearray(20 * ISO_SECTOR_SIZE)
+        pvd = bytearray(ISO_SECTOR_SIZE)
+        pvd[0] = 1
+        pvd[1:6] = b"CD001"
+        pvd[156 : 156 + 34] = _dir_record(b"\x00", _ROOT_LBA, ISO_SECTOR_SIZE, True)
+        iso[16 * ISO_SECTOR_SIZE : 17 * ISO_SECTOR_SIZE] = pvd
+        iso[_ROOT_LBA * ISO_SECTOR_SIZE : (_ROOT_LBA + 1) * ISO_SECTOR_SIZE] = _extent(
+            [
+                _dir_record(b"\x00", _ROOT_LBA, ISO_SECTOR_SIZE, True),
+                _dir_record(b"\x01", _ROOT_LBA, ISO_SECTOR_SIZE, True),
+            ]
+        )
+        path = tmp_path / "movie.cso"
+        path.write_bytes(build_ciso(bytes(iso), lz4=False))
+
+        assert calculate_psp_ra_hash(str(path)) == ""
+
+
+class TestLz4DecompressBlock:
+    """The hand-rolled LZ4 block decoder used for ZISO."""
+
+    def test_literals_only_round_trip(self):
+        data = bytes(range(256)) * 8  # 2048 bytes, all literals
+        block = _lz4_literal_block(data)
+
+        assert _lz4_decompress_block(block, len(data)) == data
+
+    def test_match_run_decodes(self):
+        """A single literal followed by a long back-reference (RLE)."""
+        block = bytearray()
+        block.append((1 << 4) | 0x0F)  # 1 literal, extended match length
+        block.append(0x41)
+        block += struct.pack("<H", 1)  # match offset 1
+        remaining = 2047 - 4 - 15  # total match length 2047, minus base 4 and nibble 15
+        while remaining >= 255:
+            block.append(255)
+            remaining -= 255
+        block.append(remaining)
+
+        assert _lz4_decompress_block(bytes(block), 2048) == b"\x41" * 2048
+
+
+class TestIsPspNativeHashFile:
+    def test_recognizes_native_extensions(self):
+        for ext in PSP_NATIVE_HASH_EXTENSIONS:
+            assert is_psp_native_hash_file(f"/roms/psp/game{ext}")
+            assert is_psp_native_hash_file(f"/roms/psp/game{ext.upper()}")
+
+    def test_rejects_other_extensions(self):
+        assert not is_psp_native_hash_file("/roms/psp/game.iso")
+        assert not is_psp_native_hash_file("/roms/psp/game.chd")
+        assert not is_psp_native_hash_file("/roms/psp/game.zip")

--- a/backend/utils/psp_hasher.py
+++ b/backend/utils/psp_hasher.py
@@ -350,7 +350,14 @@ def calculate_psp_ra_hash(file_path: str) -> str:
         iso = _Iso9660(image)
         param_sfo = _read_iso_file(iso, image, _PARAM_SFO_PATH)
         eboot_bin = _read_iso_file(iso, image, _EBOOT_BIN_PATH)
-    except (OSError, PspHashError, struct.error) as exc:
+    except (
+        OSError,
+        PspHashError,
+        struct.error,
+        zlib.error,
+        ValueError,
+        IndexError,
+    ) as exc:
         log.warning(
             f"Failed to read PSP files from {hl(file_path)} for native "
             f"{hl('RA', color=LIGHTMAGENTA)} hashing: {exc}"

--- a/backend/utils/psp_hasher.py
+++ b/backend/utils/psp_hasher.py
@@ -1,0 +1,377 @@
+"""Native RetroAchievements hashing for PSP compressed-ISO containers.
+
+RAHasher (RALibretro/rcheevos) reads raw ``.iso``, ``.bin``/``.cue`` and
+``.chd`` PSP discs, but not the block-compressed ISO containers PPSSPP uses
+(``.cso``/``.ciso``/``.zso``/``.dax``). For those it fails with "Could not open
+track" and the game is left without a RetroAchievements match.
+
+The PSP RA hash does not depend on the whole disc. rcheevos computes it as
+``MD5(PSP_GAME/PARAM.SFO contents + PSP_GAME/SYSDIR/EBOOT.BIN contents)``, each
+file capped at 64 MiB. Those two files are only a few MB, and the compressed
+containers are block-indexed, so we can decompress just the handful of blocks
+they occupy and hash them in-process, with no subprocess and no multi-GB
+temporary ISO. This produces the identical hash RA stores (and PPSSPP computes),
+so the game matches.
+"""
+
+import hashlib
+import os
+import struct
+import zlib
+from typing import BinaryIO
+
+from logger.formatter import LIGHTMAGENTA
+from logger.formatter import highlight as hl
+from logger.logger import log
+
+# Container extensions RAHasher can't read but which we can hash natively. The
+# real container is still detected by magic; the extension only gates whether we
+# attempt native hashing before falling back to RAHasher.
+PSP_NATIVE_HASH_EXTENSIONS: tuple[str, ...] = (".cso", ".ciso", ".zso", ".dax")
+
+# Files that make up the PSP RA hash, in order, relative to the ISO root.
+_PARAM_SFO_PATH = "PSP_GAME/PARAM.SFO"
+_EBOOT_BIN_PATH = "PSP_GAME/SYSDIR/EBOOT.BIN"
+
+# rcheevos caps each hashed file at MAX_BUFFER_SIZE (64 MiB). We mirror that so
+# our hash matches RA's database byte-for-byte even for oversized EBOOT.BIN.
+_MAX_HASH_BYTES = 64 * 1024 * 1024
+
+_ISO_SECTOR_SIZE = 2048
+_PVD_SECTOR = 16  # ISO9660 primary volume descriptor lives at sector 16
+
+# Top bit of a CISO/ZISO index entry marks an uncompressed (plain) block.
+_CISO_PLAIN_FLAG = 0x80000000
+_CISO_POSITION_MASK = 0x7FFFFFFF
+
+
+class PspHashError(Exception):
+    """Raised when a PSP container can't be parsed for native RA hashing."""
+
+
+def _inflate(raw: bytes) -> bytes:
+    """Inflate a deflate stream, tolerating both raw and zlib/gzip-wrapped data.
+
+    CISO writers disagree on whether blocks carry a zlib header (maxcso emits
+    raw deflate; the classic ``ciso`` tool emits a full zlib stream), so try
+    raw first and fall back to header auto-detection.
+    """
+    try:
+        return zlib.decompress(raw, -zlib.MAX_WBITS)
+    except zlib.error:
+        return zlib.decompress(raw, zlib.MAX_WBITS | 32)
+
+
+def _lz4_decompress_block(src: bytes, max_size: int) -> bytes:
+    """Decompress a single raw LZ4 block (no frame header), as used by ZISO."""
+    out = bytearray()
+    i, n = 0, len(src)
+    while i < n:
+        token = src[i]
+        i += 1
+
+        literal_len = token >> 4
+        if literal_len == 15:
+            while i < n:
+                b = src[i]
+                i += 1
+                literal_len += b
+                if b != 0xFF:
+                    break
+        out += src[i : i + literal_len]
+        i += literal_len
+        if i >= n:
+            break  # trailing literals: end of block
+
+        offset = src[i] | (src[i + 1] << 8)
+        i += 2
+        if offset == 0 or offset > len(out):
+            break
+
+        match_len = (token & 0x0F) + 4
+        if (token & 0x0F) == 15:
+            while i < n:
+                b = src[i]
+                i += 1
+                match_len += b
+                if b != 0xFF:
+                    break
+
+        start = len(out) - offset
+        for _ in range(match_len):
+            out.append(out[start])
+            start += 1
+        if len(out) >= max_size:
+            break
+
+    return bytes(out[:max_size])
+
+
+class _BlockDiscImage:
+    """Random-access view over a block-indexed compressed disc image.
+
+    Subclasses describe how to locate and decode a single block; this base
+    turns ``read_at`` byte ranges into the right block reads, decoding only the
+    blocks a range touches and caching the most recent few.
+    """
+
+    def __init__(self, fh: BinaryIO, size: int, block_size: int) -> None:
+        self._fh = fh
+        self.size = size
+        self._block_size = block_size
+        self._cache: dict[int, bytes] = {}
+
+    def _decode_block(self, index: int) -> bytes:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def _block(self, index: int) -> bytes:
+        cached = self._cache.get(index)
+        if cached is not None:
+            return cached
+        block = self._decode_block(index)
+        if len(self._cache) >= 4:
+            self._cache.clear()
+        self._cache[index] = block
+        return block
+
+    def read_at(self, offset: int, length: int) -> bytes:
+        out = bytearray()
+        end = min(offset + length, self.size)
+        pos = offset
+        while pos < end:
+            block = self._block(pos // self._block_size)
+            start = pos % self._block_size
+            take = min(len(block) - start, end - pos)
+            if take <= 0:
+                break
+            out += block[start : start + take]
+            pos += take
+        return bytes(out)
+
+    def close(self) -> None:
+        try:
+            self._fh.close()
+        except OSError:
+            pass
+
+
+class _CisoDiscImage(_BlockDiscImage):
+    """CISO (``.cso``/``.ciso``) and ZISO (``.zso``) block container.
+
+    Both share the same header and index layout; ZISO blocks are LZ4-compressed
+    while CISO blocks are deflate-compressed.
+    """
+
+    def __init__(self, fh: BinaryIO) -> None:
+        header = fh.read(24)
+        if len(header) < 24:
+            raise PspHashError("truncated CISO/ZISO header")
+
+        magic = header[:4]
+        total_bytes = struct.unpack_from("<Q", header, 8)[0]
+        block_size = struct.unpack_from("<I", header, 16)[0]
+        align = header[21]
+        if block_size == 0:
+            raise PspHashError("invalid CISO/ZISO block size")
+
+        num_blocks = (total_bytes + block_size - 1) // block_size
+        index_raw = fh.read((num_blocks + 1) * 4)
+        if len(index_raw) < (num_blocks + 1) * 4:
+            raise PspHashError("truncated CISO/ZISO index table")
+
+        self._index = struct.unpack(f"<{num_blocks + 1}I", index_raw)
+        self._align = align
+        self._lz4 = magic == b"ZISO"
+        super().__init__(fh, total_bytes, block_size)
+
+    def _decode_block(self, index: int) -> bytes:
+        entry = self._index[index]
+        nxt = self._index[index + 1]
+        pos = (entry & _CISO_POSITION_MASK) << self._align
+        next_pos = (nxt & _CISO_POSITION_MASK) << self._align
+
+        self._fh.seek(pos)
+        raw = self._fh.read(next_pos - pos)
+        if entry & _CISO_PLAIN_FLAG:
+            return raw[: self._block_size]
+        if self._lz4:
+            return _lz4_decompress_block(raw, self._block_size)
+        return _inflate(raw)
+
+
+class _DaxDiscImage(_BlockDiscImage):
+    """DAX (``.dax``) block container: fixed 8 KiB blocks, deflate-compressed,
+    with an optional table of non-compressed (raw) block ranges."""
+
+    _DAX_BLOCK_SIZE = 0x2000
+
+    def __init__(self, fh: BinaryIO) -> None:
+        header = fh.read(32)
+        if len(header) < 16:
+            raise PspHashError("truncated DAX header")
+
+        uncompressed_size = struct.unpack_from("<I", header, 4)[0]
+        version = struct.unpack_from("<I", header, 8)[0]
+        nc_areas = struct.unpack_from("<I", header, 12)[0]
+
+        num_blocks = (
+            uncompressed_size + self._DAX_BLOCK_SIZE - 1
+        ) // self._DAX_BLOCK_SIZE
+        offsets_raw = fh.read(num_blocks * 4)
+        sizes_raw = fh.read(num_blocks * 2)
+        if len(offsets_raw) < num_blocks * 4 or len(sizes_raw) < num_blocks * 2:
+            raise PspHashError("truncated DAX block tables")
+
+        self._offsets = struct.unpack(f"<{num_blocks}I", offsets_raw)
+        self._sizes = struct.unpack(f"<{num_blocks}H", sizes_raw)
+
+        self._plain_blocks: set[int] = set()
+        if version >= 1 and nc_areas:
+            nc_raw = fh.read(nc_areas * 8)
+            for k in range(0, len(nc_raw) - 7, 8):
+                start, count = struct.unpack_from("<II", nc_raw, k)
+                self._plain_blocks.update(range(start, start + count))
+
+        super().__init__(fh, uncompressed_size, self._DAX_BLOCK_SIZE)
+
+    def _decode_block(self, index: int) -> bytes:
+        self._fh.seek(self._offsets[index])
+        raw = self._fh.read(self._sizes[index])
+        if index in self._plain_blocks:
+            return raw[: self._block_size]
+        return _inflate(raw)
+
+
+class _Iso9660:
+    """Minimal ISO9660 reader: locates a file by path from the root directory.
+
+    Only what's needed to find ``PSP_GAME/PARAM.SFO`` and
+    ``PSP_GAME/SYSDIR/EBOOT.BIN``: it follows directory records from the primary
+    volume descriptor's root entry and ignores path tables, Joliet and UDF.
+    """
+
+    def __init__(self, image: _BlockDiscImage) -> None:
+        self._image = image
+        pvd = image.read_at(_PVD_SECTOR * _ISO_SECTOR_SIZE, _ISO_SECTOR_SIZE)
+        if len(pvd) < _ISO_SECTOR_SIZE or pvd[0] != 1 or pvd[1:6] != b"CD001":
+            raise PspHashError("not a valid ISO9660 image")
+
+        root_record = pvd[156:190]
+        self._root_lba = struct.unpack_from("<I", root_record, 2)[0]
+        self._root_size = struct.unpack_from("<I", root_record, 10)[0]
+
+    def find_file(self, path: str) -> tuple[int, int] | None:
+        """Return ``(lba, size)`` for a file path, or ``None`` if not found."""
+        components = [c for c in path.replace("\\", "/").split("/") if c]
+        lba, size = self._root_lba, self._root_size
+        for depth, component in enumerate(components):
+            want_dir = depth < len(components) - 1
+            located = self._find_in_dir(lba, size, component, want_dir)
+            if located is None:
+                return None
+            lba, size = located
+        return lba, size
+
+    def _find_in_dir(
+        self, dir_lba: int, dir_size: int, name: str, want_dir: bool
+    ) -> tuple[int, int] | None:
+        target = name.upper()
+        data = self._image.read_at(dir_lba * _ISO_SECTOR_SIZE, dir_size)
+        # Directory records never cross a sector boundary; a zero length byte
+        # means "skip to the next sector".
+        for sector_start in range(0, len(data), _ISO_SECTOR_SIZE):
+            sector = data[sector_start : sector_start + _ISO_SECTOR_SIZE]
+            pos = 0
+            while pos < len(sector):
+                record_len = sector[pos]
+                if record_len == 0:
+                    break
+                record = sector[pos : pos + record_len]
+                pos += record_len
+                if len(record) < 33:
+                    break
+
+                name_len = record[32]
+                identifier = record[33 : 33 + name_len]
+                # 0x00 / 0x01 are the "." and ".." self/parent entries.
+                if name_len == 1 and identifier in (b"\x00", b"\x01"):
+                    continue
+
+                is_dir = bool(record[25] & 0x02)
+                entry_name = identifier.split(b";", 1)[0].decode("ascii", "ignore")
+                if entry_name.upper() == target and is_dir == want_dir:
+                    lba = struct.unpack_from("<I", record, 2)[0]
+                    size = struct.unpack_from("<I", record, 10)[0]
+                    return lba, size
+        return None
+
+
+def _open_disc_image(file_path: str) -> _BlockDiscImage:
+    """Open a PSP compressed-ISO container, dispatching on its magic bytes."""
+    fh = open(file_path, "rb")  # noqa: SIM115 - ownership passes to the image
+    try:
+        magic = fh.read(4)
+        fh.seek(0)
+        if magic in (b"CISO", b"ZISO"):
+            return _CisoDiscImage(fh)
+        if magic == b"DAX\x00":
+            return _DaxDiscImage(fh)
+        raise PspHashError(f"unrecognized PSP container magic {magic!r}")
+    except BaseException:
+        fh.close()
+        raise
+
+
+def _read_iso_file(iso: _Iso9660, image: _BlockDiscImage, path: str) -> bytes | None:
+    located = iso.find_file(path)
+    if located is None:
+        return None
+    lba, size = located
+    return image.read_at(lba * _ISO_SECTOR_SIZE, min(size, _MAX_HASH_BYTES))
+
+
+def calculate_psp_ra_hash(file_path: str) -> str:
+    """Compute the RetroAchievements PSP hash from a compressed-ISO container.
+
+    Returns the 32-char MD5 hex digest, or an empty string if the container
+    can't be parsed or doesn't hold the expected PSP files (the caller then
+    falls back to RAHasher).
+    """
+    try:
+        image = _open_disc_image(file_path)
+    except (OSError, PspHashError) as exc:
+        log.warning(
+            f"Could not open PSP container {hl(file_path)} for native "
+            f"{hl('RA', color=LIGHTMAGENTA)} hashing: {exc}"
+        )
+        return ""
+
+    try:
+        iso = _Iso9660(image)
+        param_sfo = _read_iso_file(iso, image, _PARAM_SFO_PATH)
+        eboot_bin = _read_iso_file(iso, image, _EBOOT_BIN_PATH)
+    except (OSError, PspHashError, struct.error) as exc:
+        log.warning(
+            f"Failed to read PSP files from {hl(file_path)} for native "
+            f"{hl('RA', color=LIGHTMAGENTA)} hashing: {exc}"
+        )
+        return ""
+    finally:
+        image.close()
+
+    if param_sfo is None or eboot_bin is None:
+        log.warning(
+            f"PSP container {hl(file_path)} is missing PARAM.SFO or EBOOT.BIN; "
+            f"can't compute native {hl('RA', color=LIGHTMAGENTA)} hash"
+        )
+        return ""
+
+    md5 = hashlib.md5(usedforsecurity=False)
+    md5.update(param_sfo)
+    md5.update(eboot_bin)
+    return md5.hexdigest()
+
+
+def is_psp_native_hash_file(file_path: str) -> bool:
+    """Whether ``file_path`` is a PSP container we hash natively (by extension)."""
+    return os.path.splitext(file_path)[1].lower() in PSP_NATIVE_HASH_EXTENSIONS


### PR DESCRIPTION
PSP games stored as .cso (and .ciso/.zso/.dax) never matched on RetroAchievements because RomM hands these files to the external RAHasher binary, which can't read CSO/ZISO/DAX compressed-ISO containers and fails with "Could not open track". The game was then left without an RA link.

The PSP RA hash does not depend on the whole disc: rcheevos computes it as MD5(PSP_GAME/PARAM.SFO + PSP_GAME/SYSDIR/EBOOT.BIN), each file capped at 64 MiB. Those containers are block-indexed, so we can decompress just the blocks those two files occupy and hash them in-process, producing the identical hash RA stores (and PPSSPP computes).

Add utils/psp_hasher.py: a seekable block-decoder for CISO/ZISO (deflate and LZ4) and DAX containers, a minimal ISO9660 reader to locate the two files, and calculate_psp_ra_hash(). RAHasherService now computes the hash natively for PSP .cso/.ciso/.zso/.dax files, falling back to RAHasher on any failure. Raw .iso PSP discs still go to RAHasher, which reads them fine.


Claude-Session: https://claude.ai/code/session_01KsyrT6n8WYWWxR2XGoEASs

<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)
