### PR TITLE
fix(screenscraper): stop persisting SS media download URLs

### DIFF
--- a/backend/alembic/versions/0092_strip_ss_media_urls.py
+++ b/backend/alembic/versions/0092_strip_ss_media_urls.py
@@ -1,0 +1,128 @@
+"""Drop stored ScreenScraper media download URLs
+
+ScreenScraper media URLs were saved into roms.ss_metadata (the ``*_url`` entries)
+and into url_cover / url_manual / url_screenshots during a scan, even though the
+assets are downloaded to local files (``*_path``) that the UI renders from. The
+stored URLs are SS API queries (carrying auth params, re-derivable from the
+stored ss_id) and are never read after the download, so this migration removes
+them from existing rows (issue #3612):
+
+- drop every ``*_url`` key from ss_metadata
+- blank url_cover / url_manual and drop screenshot entries that point at
+  ScreenScraper; other providers' public URLs are left untouched as they are
+  valid cover fallbacks
+
+The per-asset change-detection tags (ss_metadata.cover_media, etc.) are not
+back-filled here as they cannot be derived without re-querying ScreenScraper;
+the next scan repopulates them.
+
+Revision ID: 0092_strip_ss_media_urls
+Revises: 0091_unique_platform_fs_name
+Create Date: 2026-06-26 00:00:00.000000
+
+"""
+
+from urllib.parse import urlparse
+
+import sqlalchemy as sa
+from alembic import op
+
+from utils.database import CustomJSON
+
+# revision identifiers, used by Alembic.
+revision = "0092_strip_ss_media_urls"
+down_revision = "0091_unique_platform_fs_name"
+branch_labels = None
+depends_on = None
+
+BATCH_SIZE = 1000
+
+roms_table = sa.table(
+    "roms",
+    sa.column("id", sa.Integer),
+    sa.column("ss_metadata", CustomJSON()),
+    sa.column("url_cover", sa.Text),
+    sa.column("url_manual", sa.Text),
+    sa.column("url_screenshots", CustomJSON()),
+)
+
+
+def _is_screenscraper_url(url: object) -> bool:
+    if not isinstance(url, str) or not url:
+        return False
+    try:
+        host = urlparse(url).hostname
+    except ValueError:
+        return False
+    if not host:
+        return False
+    host = host.lower()
+    return host == "screenscraper.fr" or host.endswith(".screenscraper.fr")
+
+
+def _clean_ss_metadata(ss_metadata: object) -> object:
+    """Return ss_metadata without any media download URL (``*_url``) keys."""
+    if not isinstance(ss_metadata, dict):
+        return ss_metadata
+    return {
+        key: value for key, value in ss_metadata.items() if not key.endswith("_url")
+    }
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    last_id = 0
+    while True:
+        rows = connection.execute(
+            sa.select(
+                roms_table.c.id,
+                roms_table.c.ss_metadata,
+                roms_table.c.url_cover,
+                roms_table.c.url_manual,
+                roms_table.c.url_screenshots,
+            )
+            .where(roms_table.c.id > last_id)
+            .order_by(roms_table.c.id)
+            .limit(BATCH_SIZE)
+        ).all()
+        if not rows:
+            break
+
+        for row in rows:
+            updates: dict = {}
+
+            if isinstance(row.ss_metadata, dict):
+                cleaned_meta = _clean_ss_metadata(row.ss_metadata)
+                if cleaned_meta != row.ss_metadata:
+                    updates["ss_metadata"] = cleaned_meta
+
+            if _is_screenscraper_url(row.url_cover):
+                updates["url_cover"] = ""
+
+            if _is_screenscraper_url(row.url_manual):
+                updates["url_manual"] = ""
+
+            if isinstance(row.url_screenshots, list):
+                kept_shots = [
+                    shot
+                    for shot in row.url_screenshots
+                    if not _is_screenscraper_url(shot)
+                ]
+                if kept_shots != row.url_screenshots:
+                    updates["url_screenshots"] = kept_shots
+
+            if updates:
+                connection.execute(
+                    sa.update(roms_table)
+                    .where(roms_table.c.id == row.id)
+                    .values(**updates)
+                )
+
+        last_id = rows[-1].id
+
+
+def downgrade() -> None:
+    # Irreversible: the dropped URLs and *_url entries cannot be reconstructed.
+    # The downloaded local assets remain valid, so this is a no-op.
+    pass

--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -60,7 +60,12 @@ from handler.metadata import (
     meta_ra_handler,
     meta_ss_handler,
 )
-from handler.metadata.ss_handler import add_ss_auth_to_url, get_preferred_media_types
+from handler.metadata.ss_handler import (
+    add_ss_auth_to_url,
+    get_preferred_media_types,
+    is_screenscraper_url,
+    pop_ss_media_urls,
+)
 from logger.formatter import BLUE
 from logger.formatter import highlight as hl
 from logger.logger import log
@@ -1594,6 +1599,17 @@ async def update_rom(
                     add_ss_auth_to_url(media_url),
                     media_path,
                 )
+
+    # Drop the SS media download URLs once the assets are saved locally; they
+    # must never be persisted (issue #3612). The download above already consumed
+    # them. SS-sourced cover/manual URLs are blanked for the same reason (the
+    # change-detection tags live in ss_metadata); other providers' URLs are kept.
+    if cleaned_data.get("ss_metadata"):
+        pop_ss_media_urls(cleaned_data["ss_metadata"])
+    if is_screenscraper_url(cleaned_data.get("url_cover")):
+        cleaned_data["url_cover"] = ""
+    if is_screenscraper_url(cleaned_data.get("url_manual")):
+        cleaned_data["url_manual"] = ""
 
     log.debug(
         f"Updating {hl(cleaned_data.get('name', ''), color=BLUE)} [{hl(cleaned_data.get('fs_name', ''))}] with data {cleaned_data}"

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -33,7 +33,12 @@ from handler.filesystem import (
 )
 from handler.filesystem.roms_handler import FSRom
 from handler.metadata import meta_gamelist_handler, meta_hltb_handler
-from handler.metadata.ss_handler import add_ss_auth_to_url, get_preferred_media_types
+from handler.metadata.ss_handler import (
+    add_ss_auth_to_url,
+    get_preferred_media_types,
+    is_screenscraper_url,
+    pop_ss_media_urls,
+)
 from handler.redis_handler import get_job_func_name, high_prio_queue, redis_client
 from handler.scan_handler import (
     MetadataSource,
@@ -353,6 +358,27 @@ async def _identify_rom(
         identified_roms=1 if scanned_rom.is_identified else 0,
     )
 
+    # ScreenScraper media URLs drive the in-scan download but must never be
+    # persisted: they are SS API queries (re-derivable from the stored ss_id) and
+    # are worthless once the asset is saved (issue #3612). Capture them for the
+    # download, then blank the SS-sourced url columns. Other providers' public
+    # URLs are kept as valid cover fallbacks. The resolved variant tags persisted
+    # in ss_metadata (cover_media, etc.) carry the change-detection signal.
+    cover_url = scanned_rom.url_cover
+    manual_url = scanned_rom.url_manual
+    screenshot_urls = list(scanned_rom.url_screenshots or [])
+    ss_media_urls: dict[str, str] = {}
+    if scanned_rom.ss_metadata:
+        ss_media_urls = pop_ss_media_urls(scanned_rom.ss_metadata)
+    if is_screenscraper_url(scanned_rom.url_cover):
+        scanned_rom.url_cover = ""
+    if is_screenscraper_url(scanned_rom.url_manual):
+        scanned_rom.url_manual = ""
+    if scanned_rom.url_screenshots:
+        scanned_rom.url_screenshots = [
+            url for url in scanned_rom.url_screenshots if not is_screenscraper_url(url)
+        ]
+
     _added_rom = db_rom_handler.add_rom(scanned_rom)
 
     if _added_rom.is_identified:
@@ -400,26 +426,46 @@ async def _identify_rom(
     if scan_type == ScanType.HASHES:
         return
 
+    # The asset source "changed" (forcing a re-download) when the stored URL
+    # differs (non-SS providers) OR, for SS, when the resolved variant tag
+    # differs - the SS URLs themselves are blanked, so the tag carries the signal.
+    def _ss_tag(entity: Rom | None, key: str) -> object:
+        return (getattr(entity, "ss_metadata", None) or {}).get(key)
+
     path_cover_s, path_cover_l = await fs_resource_handler.get_cover(
         entity=_added_rom,
-        overwrite=_added_rom.url_cover != rom.url_cover,
-        url_cover=add_ss_auth_to_url(_added_rom.url_cover),
+        overwrite=(
+            _added_rom.url_cover != rom.url_cover
+            or (
+                is_screenscraper_url(cover_url)
+                and _ss_tag(_added_rom, "cover_media") != _ss_tag(rom, "cover_media")
+            )
+        ),
+        url_cover=add_ss_auth_to_url(cover_url),
     )
 
     path_manual = await fs_resource_handler.get_manual(
         rom=_added_rom,
-        overwrite=_added_rom.url_manual != rom.url_manual,
-        url_manual=add_ss_auth_to_url(_added_rom.url_manual),
+        overwrite=(
+            _added_rom.url_manual != rom.url_manual
+            or (
+                is_screenscraper_url(manual_url)
+                and _ss_tag(_added_rom, "manual_media") != _ss_tag(rom, "manual_media")
+            )
+        ),
+        url_manual=add_ss_auth_to_url(manual_url),
     )
 
     screenshots_changed = pydash.xor(
         _added_rom.url_screenshots or [], rom.url_screenshots or []
+    ) or pydash.xor(
+        _ss_tag(_added_rom, "screenshot_media") or [],
+        _ss_tag(rom, "screenshot_media") or [],
     )
-    url_screenshots = _added_rom.url_screenshots or []
     path_screenshots = await fs_resource_handler.get_rom_screenshots(
         rom=_added_rom,
         overwrite=bool(screenshots_changed),
-        url_screenshots=[add_ss_auth_to_url(u) for u in url_screenshots],
+        url_screenshots=[add_ss_auth_to_url(u) for u in screenshot_urls],
     )
 
     _added_rom.path_cover_s = path_cover_s
@@ -438,12 +484,18 @@ async def _identify_rom(
         },
     )
 
-    # Handle special media files from Screenscraper
-    if _added_rom.ss_metadata and MetadataSource.SS in metadata_sources:
+    # Handle special media files from Screenscraper. The media URLs were captured
+    # (and stripped from storage) above; the *_path targets come from the stored
+    # metadata.
+    if (
+        ss_media_urls
+        and _added_rom.ss_metadata
+        and MetadataSource.SS in metadata_sources
+    ):
         preferred_media_types = get_preferred_media_types()
         for media_type in preferred_media_types:
             media_path = _added_rom.ss_metadata.get(f"{media_type.value}_path")
-            media_url = _added_rom.ss_metadata.get(f"{media_type.value}_url")
+            media_url = ss_media_urls.get(f"{media_type.value}_url")
             if media_path and media_url:
                 await fs_resource_handler.store_media_file(
                     add_ss_auth_to_url(media_url),

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -2,12 +2,16 @@ import html
 import re
 from datetime import datetime
 from typing import Final, NotRequired, TypedDict
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 import pydash
 from unidecode import unidecode as uc
 
-from adapters.services.screenscraper import ScreenScraperService
+from adapters.services.screenscraper import (
+    SS_DEV_ID,
+    SS_DEV_PASSWORD,
+    ScreenScraperService,
+)
 from adapters.services.screenscraper_types import SSGame, SSGameDate
 from config import SCREENSCRAPER_PASSWORD, SCREENSCRAPER_USER
 from config.config_manager import MetadataMediaType
@@ -31,15 +35,22 @@ from .base_handler import (
     strip_sensitive_query_params,
 )
 
-SENSITIVE_KEYS = {"ssid", "sspassword"}
+# Authentication query params ScreenScraper bakes into the media URLs it
+# returns. They are stripped before anything is stored (issue #3612) and
+# re-attached at download time by add_ss_auth_to_url. devid/devpassword are the
+# public app credentials; ssid/sspassword are the user's private credentials.
+SS_AUTH_PARAMS = {"ssid", "sspassword", "devid", "devpassword"}
 
 
-def _is_screenscraper_host(url: str) -> bool:
+def is_screenscraper_url(url: str | None) -> bool:
     """True only if the URL's hostname is screenscraper.fr or a subdomain.
 
     Substring matching would let an attacker-controlled host like
     screenscraper.fr.evil.example receive the user's credentials.
     """
+    if not url:
+        return False
+
     try:
         host = urlparse(url).hostname
     except ValueError:
@@ -59,7 +70,7 @@ def add_ss_auth_to_url(url: str | None) -> str:
     Only injects credentials for screenscraper.fr URLs; returns other URLs
     unchanged to avoid leaking credentials to third-party sources.
     """
-    if not url or not _is_screenscraper_host(url):
+    if not url or not is_screenscraper_url(url):
         return url or ""
 
     if not SCREENSCRAPER_USER or not SCREENSCRAPER_PASSWORD:
@@ -68,10 +79,41 @@ def add_ss_auth_to_url(url: str | None) -> str:
     return restore_sensitive_query_params(
         url,
         {
+            "devid": SS_DEV_ID,
+            "devpassword": SS_DEV_PASSWORD,
             "ssid": SCREENSCRAPER_USER,
             "sspassword": SCREENSCRAPER_PASSWORD,
         },
     )
+
+
+def pop_ss_media_urls(ss_metadata: dict) -> dict[str, str]:
+    """Remove the SS media download URLs from ss_metadata, returning them.
+
+    The ``*_url`` entries are only needed transiently to download assets; the
+    saved files live at the matching ``*_path``. They are never persisted, as
+    they would embed SS request params in the DB for no functional gain (see
+    issue #3612). Mutates ss_metadata in place and returns the removed URLs so
+    the caller can drive the download.
+    """
+    return {
+        key: ss_metadata.pop(key) for key in list(ss_metadata) if key.endswith("_url")
+    }
+
+
+def _ss_media_descriptor(url: str | None) -> str | None:
+    """Return the SS media variant descriptor (e.g. 'box-2D(wor)') from a media URL.
+
+    This is the value of the URL's ``media`` query param: the media type plus
+    region that ScreenScraper resolved. We persist it as a small change-detection
+    tag instead of the URL, so a re-scan can tell when a config change (e.g. a new
+    region priority) selects a different asset, without storing an SS API query.
+    The asset itself is keyed by the stored ss_id, so the URL is never needed.
+    """
+    if not url:
+        return None
+    values = parse_qs(urlparse(url).query).get("media")
+    return values[0] if values else None
 
 
 def get_preferred_regions(rom: Rom | None = None) -> list[str]:
@@ -207,6 +249,13 @@ class SSMetadata(SSMetadataMedia):
     genres: list[str]
     player_count: str
 
+    # Change-detection tags: the resolved media variant (e.g. "box-2D(wor)") for
+    # the cover, manual and screenshots. Persisted in place of the SS URLs so a
+    # re-scan can detect when a config change selects a different asset.
+    cover_media: NotRequired[str | None]
+    manual_media: NotRequired[str | None]
+    screenshot_media: NotRequired[list[str]]
+
 
 class SSRom(BaseRom):
     ss_id: int | None
@@ -265,7 +314,7 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
 
             if media.get("type") == "box-2D-back" and not ss_media["box2d_back_url"]:
                 ss_media["box2d_back_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
                 if MetadataMediaType.BOX2D_BACK in preferred_media_types:
                     ss_media["box2d_back_path"] = (
@@ -273,7 +322,7 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                     )
             elif media.get("type") == "bezel-16-9" and not ss_media["bezel_url"]:
                 ss_media["bezel_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
                 if MetadataMediaType.BEZEL in preferred_media_types:
                     ss_media["bezel_path"] = (
@@ -281,11 +330,11 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                     )
             elif media.get("type") == "box-2D" and not ss_media["box2d_url"]:
                 ss_media["box2d_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
             elif media.get("type") == "fanart" and not ss_media["fanart_url"]:
                 ss_media["fanart_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
                 if MetadataMediaType.FANART in preferred_media_types:
                     ss_media["fanart_path"] = (
@@ -293,11 +342,11 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                     )
             elif media.get("type") == "box-texture" and not ss_media["fullbox_url"]:
                 ss_media["fullbox_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
             elif media.get("type") == "wheel-hd" and not ss_media["logo_url"]:
                 ss_media["logo_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
 
                 if MetadataMediaType.LOGO in preferred_media_types:
@@ -306,7 +355,7 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                     )
             elif media.get("type") == "wheel" and not ss_media["logo_url"]:
                 ss_media["logo_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
                 if MetadataMediaType.LOGO in preferred_media_types:
                     ss_media["logo_path"] = (
@@ -314,11 +363,11 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                     )
             elif media.get("type") == "manuel" and not ss_media["manual_url"]:
                 ss_media["manual_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
             elif media.get("type") == "screenmarquee" and not ss_media["marquee_url"]:
                 ss_media["marquee_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
                 if MetadataMediaType.MARQUEE in preferred_media_types:
                     ss_media["marquee_path"] = (
@@ -330,7 +379,7 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                 or media.get("type") == "mixrbv1"
             ) and not ss_media["miximage_url"]:
                 ss_media["miximage_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
                 if MetadataMediaType.MIXIMAGE in preferred_media_types:
                     ss_media["miximage_path"] = (
@@ -338,7 +387,7 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                     )
             elif media.get("type") == "mixrbv2" and not ss_media["miximage_v2_url"]:
                 ss_media["miximage_v2_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
                 if MetadataMediaType.MIXIMAGE_V2 in preferred_media_types:
                     ss_media["miximage_v2_path"] = (
@@ -346,7 +395,7 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                     )
             elif media.get("type") == "support-2D" and not ss_media["physical_url"]:
                 ss_media["physical_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
                 if MetadataMediaType.PHYSICAL in preferred_media_types:
                     ss_media["physical_path"] = (
@@ -354,11 +403,11 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                     )
             elif media.get("type") == "ss" and not ss_media["screenshot_url"]:
                 ss_media["screenshot_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
             elif media.get("type") == "box-2D-side" and not ss_media["box2d_side_url"]:
                 ss_media["box2d_side_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
                 if MetadataMediaType.BOX2D_SIDE in preferred_media_types:
                     ss_media["box2d_side_path"] = (
@@ -366,11 +415,11 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                     )
             elif media.get("type") == "steamgrid" and not ss_media["steamgrid_url"]:
                 ss_media["steamgrid_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
             elif media.get("type") == "box-3D" and not ss_media["box3d_url"]:
                 ss_media["box3d_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
                 if MetadataMediaType.BOX3D in preferred_media_types:
                     ss_media["box3d_path"] = (
@@ -378,7 +427,7 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                     )
             elif media.get("type") == "sstitle" and not ss_media["title_screen_url"]:
                 ss_media["title_screen_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
                 if MetadataMediaType.TITLE_SCREEN in preferred_media_types:
                     ss_media["title_screen_path"] = (
@@ -386,7 +435,7 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                     )
             elif media.get("type") == "video" and not ss_media["video_url"]:
                 ss_media["video_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
                 if MetadataMediaType.VIDEO in preferred_media_types:
                     ss_media["video_path"] = (
@@ -397,7 +446,7 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                 and not ss_media["video_normalized_url"]
             ):
                 ss_media["video_normalized_url"] = strip_sensitive_query_params(
-                    media["url"], SENSITIVE_KEYS
+                    media["url"], SS_AUTH_PARAMS
                 )
                 if MetadataMediaType.VIDEO_NORMALIZED in preferred_media_types:
                     ss_media["video_normalized_path"] = (
@@ -579,6 +628,14 @@ def build_ss_game(rom: Rom, game: SSGame) -> SSRom:
                 else None
             ),
         ]
+    )
+
+    # Persist the resolved media variant tags (not the URLs) so a re-scan can
+    # detect when a config change selects different assets. See issue #3612.
+    ss_metadata["cover_media"] = _ss_media_descriptor(url_cover)
+    ss_metadata["manual_media"] = _ss_media_descriptor(url_manual)
+    ss_metadata["screenshot_media"] = pydash.compact(
+        [_ss_media_descriptor(url) for url in url_screenshots]
     )
 
     ss_id = int(game["id"]) if game.get("id") is not None else None

--- a/backend/tests/alembic/test_0092_strip_ss_media_urls.py
+++ b/backend/tests/alembic/test_0092_strip_ss_media_urls.py
@@ -1,0 +1,79 @@
+"""Unit tests for the data-transform helpers of migration 0092.
+
+The migration module name starts with a digit, so it is loaded by path rather
+than imported directly. Only the pure helpers are exercised here; the row
+iteration runs against a live DB in CI's alembic upgrade.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "0092_strip_ss_media_urls.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_0092", MIGRATION_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def migration():
+    return _load_migration()
+
+
+class TestIsScreenscraperUrl:
+    def test_screenscraper_host(self, migration):
+        assert migration._is_screenscraper_url(
+            "https://api.screenscraper.fr/api2/mediaJeu.php?media=box-2D(wor)"
+        )
+
+    def test_subdomain(self, migration):
+        assert migration._is_screenscraper_url("https://www.screenscraper.fr/img.png")
+
+    def test_non_screenscraper_host(self, migration):
+        url = "https://images.igdb.com/igdb/image/upload/t_cover_big/co1234.jpg"
+        assert not migration._is_screenscraper_url(url)
+
+    def test_lookalike_host(self, migration):
+        # Suffix attack must not be treated as ScreenScraper
+        assert not migration._is_screenscraper_url(
+            "https://screenscraper.fr.evil.example/img.png"
+        )
+
+    def test_empty_and_none(self, migration):
+        assert not migration._is_screenscraper_url("")
+        assert not migration._is_screenscraper_url(None)
+
+
+class TestCleanSsMetadata:
+    def test_removes_url_keys_keeps_rest(self, migration):
+        ss_metadata = {
+            "box2d_url": "https://screenscraper.fr/box.png",
+            "box2d_path": "roms/1/1/box2d.png",
+            "screenshot_url": "https://screenscraper.fr/ss.png",
+            "video_normalized_url": "https://screenscraper.fr/v.mp4",
+            "ss_score": "8.0",
+            "genres": ["Action"],
+        }
+        cleaned = migration._clean_ss_metadata(ss_metadata)
+        assert cleaned == {
+            "box2d_path": "roms/1/1/box2d.png",
+            "ss_score": "8.0",
+            "genres": ["Action"],
+        }
+
+    def test_empty_dict_unchanged(self, migration):
+        assert migration._clean_ss_metadata({}) == {}
+
+    def test_none_passthrough(self, migration):
+        assert migration._clean_ss_metadata(None) is None

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -6,16 +6,21 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 
+from adapters.services.screenscraper import SS_DEV_ID, SS_DEV_PASSWORD
 from adapters.services.screenscraper_types import SSGame
 from config.config_manager import Config, MetadataMediaType
 from handler.metadata.ss_handler import (
     SSHandler,
     _get_rom_type,
     _is_notgame,
+    _ss_media_descriptor,
     add_ss_auth_to_url,
+    build_ss_game,
     extract_media_from_ss_game,
     extract_metadata_from_ss_rom,
     get_preferred_regions,
+    is_screenscraper_url,
+    pop_ss_media_urls,
 )
 
 
@@ -519,16 +524,17 @@ class TestExtractMediaSensitiveKeyStripping:
         ):
             result = extract_media_from_ss_game(rom, game)
 
-        # ssid/sspassword must be stripped before storage so user creds don't
-        # end up in the DB. Dev creds and other params must be preserved so
-        # subsequent media fetches still resolve.
+        # All SS auth params (user creds AND dev creds) must be stripped before
+        # storage so no authentication detail ends up in the DB (issue #3612).
+        # Non-auth params are preserved so the change-check and re-auth download
+        # still resolve.
         stored_url = result["box2d_url"]
         assert stored_url is not None
         query = parse_qs(urlparse(stored_url).query)
         assert "ssid" not in query
         assert "sspassword" not in query
-        assert query.get("devid") == ["dev"]
-        assert query.get("devpassword") == ["devpass"]
+        assert "devid" not in query
+        assert "devpassword" not in query
         assert query.get("other") == ["keep"]
 
     def test_clean_url_unchanged(self):
@@ -624,13 +630,12 @@ class TestAddSsAuthToUrl:
         assert query.get("keep") == ["1"]
 
     def test_handles_stripped_url_from_extract_media(self):
-        """A URL that's already had ssid/sspassword stripped (the storage form)
-        gets credentials re-attached cleanly, with dev creds and other params
-        left intact."""
-        # Shape mirrors what extract_media_from_ss_game persists
-        stripped_url = (
-            "https://screenscraper.fr/img.png?devid=dev&devpassword=devpw&other=keep"
-        )
+        """A URL that's had all SS auth params stripped (the storage form) gets
+        the full credential set (user creds AND dev creds) re-attached cleanly,
+        with non-auth params left intact."""
+        # Shape mirrors what extract_media_from_ss_game persists: no auth params,
+        # only the functional ones needed to resolve the media.
+        stripped_url = "https://screenscraper.fr/img.png?systemeid=1&other=keep"
         with (
             patch("handler.metadata.ss_handler.SCREENSCRAPER_USER", "user1"),
             patch("handler.metadata.ss_handler.SCREENSCRAPER_PASSWORD", "pw1"),
@@ -640,8 +645,9 @@ class TestAddSsAuthToUrl:
         query = parse_qs(urlparse(result).query)
         assert query.get("ssid") == ["user1"]
         assert query.get("sspassword") == ["pw1"]
-        assert query.get("devid") == ["dev"]
-        assert query.get("devpassword") == ["devpw"]
+        assert query.get("devid") == [SS_DEV_ID]
+        assert query.get("devpassword") == [SS_DEV_PASSWORD]
+        assert query.get("systemeid") == ["1"]
         assert query.get("other") == ["keep"]
 
     def test_rejects_lookalike_and_attacker_hosts(self):
@@ -744,7 +750,166 @@ class TestAddSsAuthToUrl:
         download_query = parse_qs(urlparse(download_url).query)
         assert download_query.get("ssid") == ["download-user"]
         assert download_query.get("sspassword") == ["download-pw"]
+        assert download_query.get("devid") == [SS_DEV_ID]
+        assert download_query.get("devpassword") == [SS_DEV_PASSWORD]
         assert download_query.get("systemeid") == ["1"]
+
+    def test_appends_dev_credentials_when_configured(self):
+        """Dev creds are re-attached alongside user creds, since they are now
+        stripped from stored URLs and required for SS media downloads."""
+        url = "https://screenscraper.fr/img.png?systemeid=1"
+        with (
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_USER", "user1"),
+            patch("handler.metadata.ss_handler.SCREENSCRAPER_PASSWORD", "pw1"),
+        ):
+            result = add_ss_auth_to_url(url)
+
+        query = parse_qs(urlparse(result).query)
+        assert query.get("devid") == [SS_DEV_ID]
+        assert query.get("devpassword") == [SS_DEV_PASSWORD]
+        assert query.get("ssid") == ["user1"]
+        assert query.get("sspassword") == ["pw1"]
+
+
+class TestPopSsMediaUrls:
+    """Tests for pop_ss_media_urls: removes the never-persisted media URLs."""
+
+    def test_removes_all_url_fields_and_returns_them(self):
+        ss_metadata = {
+            "box2d_url": "https://screenscraper.fr/box.png?systemeid=1",
+            "box2d_path": "roms/1/100/box2d.png",
+            "screenshot_url": "https://screenscraper.fr/ss.png?systemeid=1",
+            "video_normalized_url": "https://screenscraper.fr/v.mp4",
+            "ss_score": "8.0",
+            "genres": ["Action"],
+        }
+
+        popped = pop_ss_media_urls(ss_metadata)
+
+        # Every *_url key is removed from the dict in place
+        assert all(not key.endswith("_url") for key in ss_metadata)
+        # Non-URL data (paths, scalar metadata) is left untouched
+        assert ss_metadata["box2d_path"] == "roms/1/100/box2d.png"
+        assert ss_metadata["ss_score"] == "8.0"
+        assert ss_metadata["genres"] == ["Action"]
+        # The removed URLs are returned so the caller can drive the download
+        assert popped == {
+            "box2d_url": "https://screenscraper.fr/box.png?systemeid=1",
+            "screenshot_url": "https://screenscraper.fr/ss.png?systemeid=1",
+            "video_normalized_url": "https://screenscraper.fr/v.mp4",
+        }
+
+    def test_no_url_fields_is_noop(self):
+        ss_metadata = {"box2d_path": "roms/1/100/box2d.png", "ss_score": "8.0"}
+
+        popped = pop_ss_media_urls(ss_metadata)
+
+        assert popped == {}
+        assert ss_metadata == {"box2d_path": "roms/1/100/box2d.png", "ss_score": "8.0"}
+
+    def test_empty_dict(self):
+        assert pop_ss_media_urls({}) == {}
+
+
+class TestIsScreenscraperUrl:
+    def test_host_and_subdomain(self):
+        assert is_screenscraper_url("https://screenscraper.fr/img.png")
+        assert is_screenscraper_url("https://api.screenscraper.fr/api2/mediaJeu.php")
+
+    def test_non_ss_and_lookalike(self):
+        assert not is_screenscraper_url("https://images.igdb.com/co1.jpg")
+        assert not is_screenscraper_url("https://screenscraper.fr.evil.example/x.png")
+
+    def test_empty_and_none(self):
+        assert not is_screenscraper_url("")
+        assert not is_screenscraper_url(None)
+
+
+class TestSsMediaDescriptor:
+    """Tests for _ss_media_descriptor: the non-sensitive change-detection tag."""
+
+    def test_extracts_media_param(self):
+        url = (
+            "https://api.screenscraper.fr/api2/mediaJeu.php"
+            "?systemeid=1&jeuid=2&media=box-2D(wor)"
+        )
+        assert _ss_media_descriptor(url) == "box-2D(wor)"
+
+    def test_region_change_yields_different_tag(self):
+        wor = "https://api.screenscraper.fr/api2/mediaJeu.php?jeuid=2&media=box-2D(wor)"
+        jp = "https://api.screenscraper.fr/api2/mediaJeu.php?jeuid=2&media=box-2D(jp)"
+        assert _ss_media_descriptor(wor) != _ss_media_descriptor(jp)
+
+    def test_no_media_param(self):
+        assert _ss_media_descriptor("https://screenscraper.fr/img.png") is None
+
+    def test_none(self):
+        assert _ss_media_descriptor(None) is None
+
+
+class TestBuildSsGameTags:
+    """build_ss_game must persist variant tags (not URLs) for change detection."""
+
+    def _game(self) -> SSGame:
+        base = "https://api.screenscraper.fr/api2/mediaJeu.php?systemeid=1&jeuid=42"
+        return cast(
+            SSGame,
+            {
+                "id": "42",
+                "noms": [{"region": "us", "text": "Test Game"}],
+                "medias": [
+                    {
+                        "type": "box-2D",
+                        "parent": "jeu",
+                        "region": "us",
+                        "url": f"{base}&media=box-2D(us)",
+                        "crc": "",
+                        "md5": "",
+                        "sha1": "",
+                        "size": "0",
+                        "format": "png",
+                    },
+                    {
+                        "type": "ss",
+                        "parent": "jeu",
+                        "region": "us",
+                        "url": f"{base}&media=ss(us)",
+                        "crc": "",
+                        "md5": "",
+                        "sha1": "",
+                        "size": "0",
+                        "format": "png",
+                    },
+                ],
+            },
+        )
+
+    def test_tags_populated_from_resolved_media(self):
+        config = _make_config(
+            region_priority=["us"], scan_media=["box2d", "screenshot"]
+        )
+        rom = MagicMock()
+        rom.platform_id = 1
+        rom.id = 100
+        rom.regions = ["USA"]
+
+        with (
+            patch("handler.metadata.ss_handler.cm.get_config", return_value=config),
+            patch(
+                "handler.metadata.ss_handler.fs_resource_handler.get_media_resources_path",
+                return_value="roms/1/100/m",
+            ),
+        ):
+            result = build_ss_game(rom, self._game())
+
+        ss_metadata = result["ss_metadata"]
+        # The variant tags are derived from the resolved media. They (not the
+        # URLs) are what survives persistence; pop_ss_media_urls removes the
+        # in-memory *_url fields at the persist boundary.
+        assert ss_metadata["cover_media"] == "box-2D(us)"
+        assert ss_metadata["screenshot_media"] == ["ss(us)"]
+        surviving = {k: v for k, v in ss_metadata.items() if not k.endswith("_url")}
+        assert surviving["cover_media"] == "box-2D(us)"
 
 
 class TestGetPlatform:

--- a/frontend/src/__generated__/models/RomSSMetadata.ts
+++ b/frontend/src/__generated__/models/RomSSMetadata.ts
@@ -44,5 +44,8 @@ export type RomSSMetadata = {
     game_modes?: Array<string>;
     genres?: Array<string>;
     player_count?: string;
+    cover_media?: (string | null);
+    manual_media?: (string | null);
+    screenshot_media?: Array<string>;
 };
 


### PR DESCRIPTION
**Description**

ScreenScraper media URLs were saved into the database during a scan, even though every asset is also downloaded to a local file that the UI actually renders from. They lived in two places on the `roms` table:

- the shared `url_cover` / `url_manual` / `url_screenshots` columns, and
- ~18 `*_url` entries inside the `ss_metadata` JSON blob.

These URLs are ScreenScraper API queries that carry authentication parameters (`devid`/`devpassword`/`ssid`/`sspassword`) and are never read after the in-scan download. Persisting them writes authentication detail into the DB (and into `/api/roms/*` responses) for no functional gain — an avoidable risk for anyone who backs up or shares their database, logs, or support bundles. This closes #3612.

**The approach:** the SS URLs are now held only in memory long enough to drive the download, then dropped before anything is persisted. Because the assets are keyed by the stored `ss_id` (non-sensitive) and every scan that downloads SS art already re-queries ScreenScraper, the URLs are always re-derivable and never need to be stored.

The one thing the stored URL was still used for after a scan is the re-scan "has this asset changed?" check. To preserve that without storing a query, we now persist a tiny, non-sensitive **variant tag** instead — the resolved `media` descriptor, e.g. `box-2D(wor)` — in `ss_metadata` (`cover_media` / `manual_media` / `screenshot_media`). On a re-scan, comparing that tag detects when a config change (e.g. a new region priority) selects a different asset, so UPDATE-scan refresh keeps working. Other metadata providers' URLs (IGDB, Moby, …) are plain public CDN links and are left untouched.

### What changed and why

- **Stop persisting SS URLs.** `ss_metadata.*_url` is dropped at the persist boundary; SS-sourced `url_cover`/`url_manual`/`url_screenshots` are blanked. Non-SS provider URLs are kept as valid cover fallbacks.
- **Keep the UPDATE-scan change check** via a non-sensitive variant tag rather than the URL, so config-driven art changes still re-download.
- **Re-attach credentials only at download time**, host-gated to `screenscraper.fr`, and never store them anywhere.
- **Clean up existing rows** with a data migration.

### Files modified

- `backend/handler/metadata/ss_handler.py` — Core logic. Strip the full SS auth param set (`ssid`/`sspassword`/`devid`/`devpassword`) from in-memory media URLs; re-add the full set in `add_ss_auth_to_url` at download time. New helpers: `pop_ss_media_urls` (drop the `*_url` keys), `_ss_media_descriptor` (extract the `media` tag), public `is_screenscraper_url` (host gate, renamed from a private helper). New `SSMetadata` tag fields and tag computation in `build_ss_game`.
- `backend/endpoints/sockets/scan.py` — Capture the SS media URLs and blank the SS-sourced url columns before `add_rom`; download cover/manual/screenshots and special media from the captured URLs; change the cover/manual/screenshots `overwrite` decision to "stored URL changed (non-SS) OR variant tag changed (SS)."
- `backend/endpoints/roms/__init__.py` — Manual-edit / `ss_id`-change flow: drop `*_url` and blank SS-sourced `url_cover`/`url_manual` before `update_rom` (after the download has consumed them).
- `backend/alembic/versions/0092_strip_ss_media_urls.py` — Batched data migration: drop every `*_url` from `ss_metadata`, and blank `url_cover`/`url_manual` / drop SS entries from `url_screenshots` only when they point at ScreenScraper. Cross-dialect (typed `CustomJSON`). Downgrade is intentionally a no-op (the stripped data can't be reconstructed; local assets remain valid).
- `backend/tests/handler/metadata/test_ss_handler.py` — Tests for auth stripping, dev-cred re-attachment, `pop_ss_media_urls`, `is_screenscraper_url`, `_ss_media_descriptor`, and `build_ss_game` tag output.
- `backend/tests/alembic/test_0092_strip_ss_media_urls.py` (+ `__init__.py`) — Unit tests for the migration's transform helpers (host gating, URL blanking, `*_url` removal).
- `frontend/src/__generated__/models/RomSSMetadata.ts` — Regenerated types; `RomSSMetadata` gained the three optional tag fields (additive, backward-compatible).

### Testing notes

- Full backend suite green (1817 passed); `trunk fmt && trunk check` (ruff/black/isort/mypy/bandit) clean.
- Migration verified on the dev MariaDB: `upgrade head` → `downgrade -1` → `upgrade head`.
- Verified against full real scans (ScreenScraper enabled):
  - Initial/COMPLETE: art downloads succeed, credentials re-attached and redacted in logs, `url_cover` stored blank, `cover_media` tag stored, `ss_metadata.*_url` absent.
  - UPDATE with no config change: ScreenScraper re-queried for ~107 roms, **zero** redundant asset downloads (the tag check correctly skipped everything).
  - UPDATE after changing region priority: only the assets whose resolved region actually changed re-downloaded (all `200`); covers stayed put as expected, since RomM's region selection is dominated by each rom's own filename region tag.

### Reviewer attention

- **The `overwrite` decision in `scan.py`** is the core new logic (`url changed OR SS variant tag changed`). Most relevant on UPDATE scans.
- **One-time self-heal:** the migration does not back-fill the new tags (they can't be derived without re-querying SS), so the first UPDATE scan after upgrade re-downloads each SS rom's art once, then settles.
- **Deliberate scope boundary:** SS "special" media (miximage, logo, bezel, marquee) still has no change check (`store_media_file` skips if the file exists), so it refreshes only on a Complete rescan while cover/screenshots refresh on UPDATE. This asymmetry is pre-existing and intentionally left out of scope; happy to file a follow-up.
- **v1 UI:** for SS roms, the legacy "re-download cover/manual" buttons and the cover "source" link key off the now-blank URL and will hide. Viewing/downloading the assets is unaffected (those use `path_*`).
- **API shape:** `ss_metadata` no longer contains `*_url` values and gains the three optional tag fields; existing consumers read `*_path`, not `*_url`.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

---

**AI assistance disclosure:** This PR — the code, the migration, the tests, and this description — was written primarily by Claude Code (Opus), under my direction and review. I verified the behavior against real scans locally as described above.
