### PR TITLE
Normalize Sony serial codes to uppercase before cache lookup

### DIFF
--- a/backend/handler/metadata/base_handler.py
+++ b/backend/handler/metadata/base_handler.py
@@ -205,7 +205,7 @@ class MetadataHandler(abc.ABC):
         return search_term
 
     async def _sony_serial_format(self, index_key: str, serial_code: str) -> str | None:
-        index_entry = await async_cache.hget(index_key, serial_code)
+        index_entry = await async_cache.hget(index_key, serial_code.upper())
         if index_entry:
             index_entry = json.loads(index_entry)
             return index_entry["title"]

--- a/backend/tests/handler/metadata/test_base_handler.py
+++ b/backend/tests/handler/metadata/test_base_handler.py
@@ -188,6 +188,17 @@ class TestMetadataHandlerMethods:
             assert result is None
 
     @pytest.mark.asyncio
+    async def test_sony_serial_format_normalizes_casing(self, handler: MetadataHandler):
+        """Test Sony serial format uppercases the serial before lookup."""
+        with patch.object(async_cache, "hget", new_callable=AsyncMock) as mock_hget:
+            mock_hget.return_value = json.dumps({"title": "Found Game Title"})
+
+            result = await handler._sony_serial_format("test_key", "slus-12345")
+
+            mock_hget.assert_called_once_with("test_key", "SLUS-12345")
+            assert result == "Found Game Title"
+
+    @pytest.mark.asyncio
     async def test_ps1_serial_format(self, handler: MetadataHandler):
         """Test PS1 serial format."""
         with patch.object(


### PR DESCRIPTION
**Description**

This PR fixes a bug in the Sony serial format metadata handler where serial codes were not being normalized to uppercase before performing cache lookups. Sony serial codes (e.g., `SLUS-12345`) are case-insensitive identifiers, but the cache index stores them in uppercase. By normalizing the input serial code to uppercase, we ensure consistent lookups and prevent cache misses due to case mismatches.

**Changes**

- Modified `_sony_serial_format()` in `backend/handler/metadata/base_handler.py` to call `.upper()` on the serial code before passing it to the cache lookup
- Added unit test `test_sony_serial_format_normalizes_casing()` to verify the normalization behavior

**Checklist**

- [x] I've tested the changes locally
- [x] I've added unit tests that cover the changes

https://claude.ai/code/session_01VHtzKWXK7nbUDgEmHxpnKc