### PR TITLE
Fix ROM name handling in UNMATCHED scans to replace placeholders

### DIFF
--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -959,9 +959,14 @@ async def scan_rom(
     if not newly_added and (
         scan_type == ScanType.UNMATCHED or scan_type == ScanType.UPDATE
     ):
+        # A ROM's name defaults to its raw filename (extension included) when first
+        # created. Treat that placeholder as "no name" so a freshly matched provider
+        # name replaces it, instead of keeping the filename (with its extension) as
+        # the title.
+        existing_name = rom.name if rom.name != rom.fs_name else None
         rom_attrs.update(
             {
-                "name": rom.name or rom_attrs.get("name") or None,
+                "name": existing_name or rom_attrs.get("name") or rom.name or None,
                 "summary": rom.summary or rom_attrs.get("summary") or None,
                 # Don't overwrite existing manually uploaded cover image
                 "url_cover": (

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -311,6 +311,133 @@ async def test_scan_rom_unmatched_skips_ra_when_id_and_metadata_exist(
     assert result.ra_id == 2774
 
 
+@patch.object(meta_playmatch_handler, "is_enabled", return_value=False)
+@patch.object(meta_hasheous_handler, "get_ra_game", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "get_igdb_game", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "lookup_rom", new_callable=AsyncMock)
+async def test_scan_rom_unmatched_replaces_placeholder_name(
+    mock_lookup, mock_get_igdb, mock_get_ra, mock_playmatch_enabled
+):
+    """UNMATCHED scan must replace the placeholder name (the raw filename set
+    when the ROM is first created) with a freshly matched provider name,
+    instead of keeping the filename (extension included) as the title."""
+    hasheous_result = HasheousRom(
+        hasheous_id=999,
+        igdb_id=None,
+        tgdb_id=None,
+        ra_id=None,
+        name="Snow Bros.",
+    )
+    mock_lookup.return_value = hasheous_result
+    mock_get_igdb.return_value = hasheous_result
+    mock_get_ra.return_value = hasheous_result
+
+    platform = Platform(
+        id=1, slug="n64", fs_slug="n64", name="Nintendo 64", igdb_id=4, hasheous_id=64
+    )
+    platform = db_platform_handler.add_platform(platform)
+
+    # Never-matched ROM: name defaults to the raw filename and no provider ids set.
+    rom = Rom(
+        platform_id=platform.id,
+        fs_name="Snow Brothers (USA).zip",
+        fs_name_no_tags="Snow Brothers",
+        fs_name_no_ext="Snow Brothers (USA)",
+        fs_extension="zip",
+        fs_path="n64/Snow Brothers (USA)",
+        name="Snow Brothers (USA).zip",
+        fs_size_bytes=1024,
+        tags=[],
+    )
+    rom = db_rom_handler.add_rom(rom)
+
+    async with initialize_context():
+        result = await scan_rom(
+            platform=platform,
+            scan_type=ScanType.UNMATCHED,
+            rom=rom,
+            fs_rom={
+                "fs_name": "Snow Brothers (USA).zip",
+                "flat": True,
+                "nested": False,
+                "files": [],
+                "crc_hash": "",
+                "md5_hash": "",
+                "sha1_hash": "",
+                "ra_hash": "",
+            },
+            metadata_sources=[MetadataSource.HASHEOUS],
+            newly_added=False,
+        )
+
+    assert result.hasheous_id == 999
+    # The placeholder filename must be replaced by the provider name.
+    assert result.name == "Snow Bros."
+
+
+@patch.object(meta_playmatch_handler, "is_enabled", return_value=False)
+@patch.object(meta_hasheous_handler, "get_ra_game", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "get_igdb_game", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "lookup_rom", new_callable=AsyncMock)
+async def test_scan_rom_unmatched_preserves_custom_name(
+    mock_lookup, mock_get_igdb, mock_get_ra, mock_playmatch_enabled
+):
+    """UNMATCHED scan must keep a user-set name (one that differs from the raw
+    filename) rather than overwriting it with a provider name."""
+    hasheous_result = HasheousRom(
+        hasheous_id=999,
+        igdb_id=None,
+        tgdb_id=None,
+        ra_id=None,
+        name="Snow Bros.",
+    )
+    mock_lookup.return_value = hasheous_result
+    mock_get_igdb.return_value = hasheous_result
+    mock_get_ra.return_value = hasheous_result
+
+    platform = Platform(
+        id=1, slug="n64", fs_slug="n64", name="Nintendo 64", igdb_id=4, hasheous_id=64
+    )
+    platform = db_platform_handler.add_platform(platform)
+
+    # ROM with a custom name that differs from its filename.
+    rom = Rom(
+        platform_id=platform.id,
+        fs_name="Snow Brothers (USA).zip",
+        fs_name_no_tags="Snow Brothers",
+        fs_name_no_ext="Snow Brothers (USA)",
+        fs_extension="zip",
+        fs_path="n64/Snow Brothers (USA)",
+        name="My Custom Title",
+        fs_size_bytes=1024,
+        tags=[],
+    )
+    rom = db_rom_handler.add_rom(rom)
+
+    async with initialize_context():
+        result = await scan_rom(
+            platform=platform,
+            scan_type=ScanType.UNMATCHED,
+            rom=rom,
+            fs_rom={
+                "fs_name": "Snow Brothers (USA).zip",
+                "flat": True,
+                "nested": False,
+                "files": [],
+                "crc_hash": "",
+                "md5_hash": "",
+                "sha1_hash": "",
+                "ra_hash": "",
+            },
+            metadata_sources=[MetadataSource.HASHEOUS],
+            newly_added=False,
+        )
+
+    assert result.hasheous_id == 999
+    # The custom name must be preserved.
+    assert result.name == "My Custom Title"
+
+
 def _top_level_rom_file(**kwargs) -> RomFile:
     """Build a RomFile whose `is_top_level` cached_property is pre-seeded to
     True, so it passes lookup_rom's filtering without a persisted rom."""


### PR DESCRIPTION
**Description**

When a ROM is first created, its name defaults to the raw filename (including extension) as a placeholder. During UNMATCHED and UPDATE scans, the code should replace this placeholder with a freshly matched provider name, but should preserve any user-set custom names.

Fixes #3610

The fix distinguishes between:
1. **Placeholder names** (ROM name equals its raw filename) - these are replaced with provider metadata
2. **Custom names** (ROM name differs from its filename) - these are preserved

This ensures that:
- Never-matched ROMs get proper provider names instead of keeping filenames with extensions as titles
- User-customized ROM names are not overwritten by provider matches

**Changes**

- **`backend/handler/scan_handler.py`**: Updated `fetch_hasheous_rom()` to treat a ROM's name as "no name" when it matches the raw filename, allowing provider names to replace it while preserving intentional custom names
- **`backend/tests/handler/test_fastapi.py`**: Added two test cases:
  - `test_scan_rom_unmatched_replaces_placeholder_name` - verifies placeholder filenames are replaced
  - `test_scan_rom_unmatched_preserves_custom_name` - verifies custom names are preserved

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've added unit tests that cover the changes

https://claude.ai/code/session_01Shf4omKSP6dHC3dC2Jjg7b