### PR TITLE
Fix state/save injection timing and corruption in EmulatorJS

### DIFF
--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -250,6 +250,24 @@ function displayMessage(
   }
 }
 
+// Poll until EmulatorJS' gameManager is ready to accept save/state
+// injection. A fixed delay is unreliable: heavier/threaded cores (SNES with
+// enhancement chips, N64, DS) need longer than a few ms to boot, and applying
+// a state before the core is ready leaves it broken (black screen).
+async function waitForGameManager(timeoutMs = 5000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const gameManager = window.EJS_emulator?.gameManager;
+    if (gameManager?.FS && gameManager.getSaveFilePath) return true;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return false;
+}
+
+// Settle window after boot before applying a state. Some cores need a few
+// frames rendered before loadState takes cleanly.
+const STATE_APPLY_SETTLE_MS = 500;
+
 // Saves management
 async function loadSave(save: SaveSchema) {
   saveRef.value = save;
@@ -360,15 +378,28 @@ window.EJS_onSaveState = async function ({
 
 window.EJS_onGameStart = async () => {
   sessionStartTime.value = new Date();
-  setTimeout(async () => {
-    if (props.save) await loadSave(props.save);
-    if (props.state) await loadState(props.state);
 
-    window.EJS_emulator.settings = {
-      ...window.EJS_emulator.settings,
-      "save-state-location": "browser",
-    };
-  }, 10);
+  void (async () => {
+    const ready = await waitForGameManager();
+    if (!ready) {
+      console.warn("Game manager not ready for save/state injection");
+    } else {
+      if (props.save) await loadSave(props.save);
+      if (props.state) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, STATE_APPLY_SETTLE_MS),
+        );
+        await loadState(props.state);
+      }
+    }
+
+    if (window.EJS_emulator) {
+      window.EJS_emulator.settings = {
+        ...window.EJS_emulator.settings,
+        "save-state-location": "browser",
+      };
+    }
+  })();
 
   const quickLoad = createQuickLoadButton();
   quickLoad.addEventListener("click", () => {
@@ -399,9 +430,16 @@ window.EJS_onGameStart = async () => {
   saveAndQuit.addEventListener("click", async () => {
     if (!romRef.value || !window.EJS_emulator) return immediateExit();
 
+    // Grab the screenshot while the game is still running (EmulatorJS reads
+    // the live canvas), then pause before serializing state/save. Reading
+    // state from a running threaded core (SNES, N64) races the worker thread
+    // and yields torn buffers, producing corrupt states that never load.
+    const screenshotFile = await window.EJS_emulator.gameManager.screenshot();
+    window.EJS_emulator.pause();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
     const stateFile = window.EJS_emulator.gameManager.getState();
     const saveFile = window.EJS_emulator.gameManager.getSaveFile();
-    const screenshotFile = await window.EJS_emulator.gameManager.screenshot();
 
     // Force a save of the current state
     await saveState({

--- a/frontend/src/views/Player/EmulatorJS/utils.ts
+++ b/frontend/src/views/Player/EmulatorJS/utils.ts
@@ -24,6 +24,14 @@ export async function saveState({
   stateFile: ArrayBuffer;
   screenshotFile?: ArrayBuffer;
 }): Promise<StateSchema | null> {
+  // A zero-length buffer means the core failed to serialize its state (a torn
+  // read from a running threaded core). Refuse to upload it so a broken
+  // capture can't overwrite the user's good states on the server.
+  if (stateFile.byteLength === 0) {
+    console.error("Refusing to upload empty state file");
+    return null;
+  }
+
   const filename = buildStateName(rom);
   try {
     const uploadedStates = await stateApi.uploadStates({


### PR DESCRIPTION
**Description**

This PR fixes critical timing and data corruption issues when loading save states in the EmulatorJS player, particularly affecting heavier cores (SNES with enhancement chips, N64, DS) that require longer boot times.

Fixes #2319

**Changes**

1. **Added `waitForGameManager()` polling function** - Replaces the unreliable fixed 10ms delay with a proper poll (up to 5s timeout) that waits for EmulatorJS' `gameManager` to be fully initialized before attempting save/state injection. This prevents "black screen" failures on cores that need longer to boot.

2. **Added state settle delay** - Introduces a 500ms delay after the game manager is ready but before applying a state, allowing the core to render a few frames and stabilize before state deserialization.

3. **Fixed state corruption on save/quit** - Reordered operations to capture the screenshot while the game is running (before pause), then pause and wait 50ms before reading state/save files. This prevents torn reads from threaded cores (SNES, N64) that race the worker thread and produce corrupt, unloadable states.

4. **Added empty state validation** - The `saveState()` utility now rejects zero-length state buffers (indicating serialization failure) to prevent corrupt captures from overwriting good states on the server.

5. **Improved error handling** - Added null checks and console warnings for edge cases where the game manager isn't ready.

**Testing**

- Existing tests pass
- Changes are isolated to the EmulatorJS player initialization and save/quit flow
- The polling and settle delays are conservative and only add ~500ms to the critical path on first load

https://claude.ai/code/session_01PoAdK2fmqHGmGuXWaKN1HT