### PR TITLE
Add ROM revision field to game details overview

### DIFF
--- a/frontend/src/locales/bg_BG/rom.json
+++ b/frontend/src/locales/bg_BG/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "Облак",
   "no-files-in-category-hint": "Превключи към друга категория от страничната лента, за да видиш другите файлове на този ROM.",
   "last-played": "Последно играна",
+  "revision": "Revision",
   "load-save-or-state": "Зареди запис или бърз запис",
   "screenshots-uploaded-n": "Качена е {n} екранна снимка. | Качени са {n} екранни снимки.",
   "screenshots-uploaded-with-failed": "Качена е {n} екранна снимка, {failed} неуспешни. | Качени са {n} екранни снимки, {failed} неуспешни.",

--- a/frontend/src/locales/cs_CZ/rom.json
+++ b/frontend/src/locales/cs_CZ/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "Cloud",
   "no-files-in-category-hint": "Přepněte na jinou kategorii v postranním panelu pro zobrazení dalších souborů této ROM.",
   "last-played": "Naposledy hráno",
+  "revision": "Revision",
   "load-save-or-state": "Načíst uloženou pozici nebo stav",
   "screenshots-uploaded-n": "Nahráno {n} screenshotů. | Nahrán {n} screenshot. | Nahrány {n} screenshoty. | Nahráno {n} screenshotů.",
   "screenshots-uploaded-with-failed": "Nahráno {n} screenshotů, {failed} selhalo. | Nahrán {n} screenshot, {failed} selhalo. | Nahrány {n} screenshoty, {failed} selhalo. | Nahráno {n} screenshotů, {failed} selhalo.",

--- a/frontend/src/locales/de_DE/rom.json
+++ b/frontend/src/locales/de_DE/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "Cloud",
   "no-files-in-category-hint": "Wechsle zu einer anderen Kategorie in der Seitenleiste, um andere Dateien dieser ROM zu sehen.",
   "last-played": "Zuletzt gespielt",
+  "revision": "Revision",
   "load-save-or-state": "Spielstand oder Zustand laden",
   "screenshots-uploaded-n": "{n} Screenshot hochgeladen. | {n} Screenshots hochgeladen.",
   "screenshots-uploaded-with-failed": "{n} Screenshot hochgeladen, {failed} fehlgeschlagen. | {n} Screenshots hochgeladen, {failed} fehlgeschlagen.",

--- a/frontend/src/locales/en_GB/rom.json
+++ b/frontend/src/locales/en_GB/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "Cloud",
   "no-files-in-category-hint": "Switch to another category from the sidebar to see this ROM's other files.",
   "last-played": "Last played",
+  "revision": "Revision",
   "load-save-or-state": "Load save or state",
   "screenshots-uploaded-n": "Uploaded {n} screenshot. | Uploaded {n} screenshots.",
   "screenshots-uploaded-with-failed": "Uploaded {n} screenshot, {failed} failed. | Uploaded {n} screenshots, {failed} failed.",

--- a/frontend/src/locales/en_US/rom.json
+++ b/frontend/src/locales/en_US/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "Cloud",
   "no-files-in-category-hint": "Switch to another category from the sidebar to see this ROM's other files.",
   "last-played": "Last played",
+  "revision": "Revision",
   "load-save-or-state": "Load save or state",
   "screenshots-uploaded-n": "Uploaded {n} screenshot. | Uploaded {n} screenshots.",
   "screenshots-uploaded-with-failed": "Uploaded {n} screenshot, {failed} failed. | Uploaded {n} screenshots, {failed} failed.",

--- a/frontend/src/locales/es_ES/rom.json
+++ b/frontend/src/locales/es_ES/rom.json
@@ -391,6 +391,7 @@
   "soundtrack-upload-title": "Subir",
   "screenshots-upload-title": "Subir capturas",
   "last-played": "Última vez jugado",
+  "revision": "Revision",
   "load-save-or-state": "Cargar partida o estado",
   "screenshots-uploaded-n": "{n} captura subida | {n} capturas subidas",
   "screenshots-uploaded-with-failed": "{n} captura subida, {failed} con error | {n} capturas subidas, {failed} con error",

--- a/frontend/src/locales/fr_FR/rom.json
+++ b/frontend/src/locales/fr_FR/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "Cloud",
   "no-files-in-category-hint": "Choisissez une autre catégorie depuis la barre latérale pour voir les autres fichiers de cette ROM.",
   "last-played": "Dernière partie",
+  "revision": "Revision",
   "load-save-or-state": "Charger une sauvegarde ou un état",
   "screenshots-uploaded-n": "{n} capture d'écran téléversée. | {n} captures d'écran téléversées.",
   "screenshots-uploaded-with-failed": "{n} capture d'écran téléversée, {failed} en échec. | {n} captures d'écran téléversées, {failed} en échec.",

--- a/frontend/src/locales/hu_HU/rom.json
+++ b/frontend/src/locales/hu_HU/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "Felhő",
   "no-files-in-category-hint": "Válts másik kategóriára az oldalsávon, hogy a ROM többi fájlját lásd.",
   "last-played": "Utoljára játszva",
+  "revision": "Revision",
   "load-save-or-state": "Mentés vagy állás betöltése",
   "screenshots-uploaded-n": "{n} képernyőkép feltöltve. | {n} képernyőkép feltöltve.",
   "screenshots-uploaded-with-failed": "{n} képernyőkép feltöltve, {failed} sikertelen. | {n} képernyőkép feltöltve, {failed} sikertelen.",

--- a/frontend/src/locales/it_IT/rom.json
+++ b/frontend/src/locales/it_IT/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "Cloud",
   "no-files-in-category-hint": "Passa a un'altra categoria dalla barra laterale per vedere gli altri file di questa ROM.",
   "last-played": "Ultima sessione",
+  "revision": "Revision",
   "load-save-or-state": "Carica salvataggio o stato",
   "screenshots-uploaded-n": "Caricato {n} screenshot. | Caricati {n} screenshot.",
   "screenshots-uploaded-with-failed": "Caricato {n} screenshot, {failed} falliti. | Caricati {n} screenshot, {failed} falliti.",

--- a/frontend/src/locales/ja_JP/rom.json
+++ b/frontend/src/locales/ja_JP/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "クラウド",
   "no-files-in-category-hint": "サイドバーから別のカテゴリに切り替えると、このROMの他のファイルを確認できます。",
   "last-played": "最終プレイ",
+  "revision": "Revision",
   "load-save-or-state": "セーブまたはステートセーブを読み込む",
   "screenshots-uploaded-n": "{n}件のスクリーンショットをアップロードしました。 | {n}件のスクリーンショットをアップロードしました。",
   "screenshots-uploaded-with-failed": "{n}件のスクリーンショットをアップロードしました。{failed}件失敗しました。 | {n}件のスクリーンショットをアップロードしました。{failed}件失敗しました。",

--- a/frontend/src/locales/ko_KR/rom.json
+++ b/frontend/src/locales/ko_KR/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "클라우드",
   "no-files-in-category-hint": "사이드바에서 다른 카테고리로 전환하여 이 ROM의 다른 파일을 확인하세요.",
   "last-played": "마지막 플레이",
+  "revision": "Revision",
   "load-save-or-state": "세이브 또는 상태 불러오기",
   "screenshots-uploaded-n": "{n}개 스크린샷을 업로드했습니다. | {n}개 스크린샷을 업로드했습니다.",
   "screenshots-uploaded-with-failed": "{n}개 스크린샷을 업로드했습니다, {failed}개 실패. | {n}개 스크린샷을 업로드했습니다, {failed}개 실패.",

--- a/frontend/src/locales/pl_PL/rom.json
+++ b/frontend/src/locales/pl_PL/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "Chmura",
   "no-files-in-category-hint": "Przełącz się na inną kategorię z paska bocznego, aby zobaczyć inne pliki tego ROM-u.",
   "last-played": "Ostatnio grane",
+  "revision": "Revision",
   "load-save-or-state": "Wczytaj zapis lub stan",
   "screenshots-uploaded-n": "Przesłano {n} zrzut ekranu. | Przesłano {n} zrzuty ekranu. | Przesłano {n} zrzutów ekranu.",
   "screenshots-uploaded-with-failed": "Przesłano {n} zrzut ekranu, {failed} niepowodzeń. | Przesłano {n} zrzuty ekranu, {failed} niepowodzeń.",

--- a/frontend/src/locales/pt_BR/rom.json
+++ b/frontend/src/locales/pt_BR/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "Nuvem",
   "no-files-in-category-hint": "Mude para outra categoria na barra lateral para ver os outros arquivos desta ROM.",
   "last-played": "Jogado por último",
+  "revision": "Revision",
   "load-save-or-state": "Carregar save ou state",
   "screenshots-uploaded-n": "{n} captura de tela enviada. | {n} capturas de tela enviadas.",
   "screenshots-uploaded-with-failed": "{n} captura de tela enviada, {failed} com falha. | {n} capturas de tela enviadas, {failed} com falha.",

--- a/frontend/src/locales/ro_RO/rom.json
+++ b/frontend/src/locales/ro_RO/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "Cloud",
   "no-files-in-category-hint": "Comută la altă categorie din bara laterală pentru a vedea celelalte fișiere ale acestui ROM.",
   "last-played": "Jucat ultima dată",
+  "revision": "Revision",
   "load-save-or-state": "Încarcă salvare sau stare",
   "screenshots-uploaded-n": "S-a încărcat {n} captură de ecran. | S-au încărcat {n} capturi de ecran.",
   "screenshots-uploaded-with-failed": "S-a încărcat {n} captură de ecran, {failed} au eșuat. | S-au încărcat {n} capturi de ecran, {failed} au eșuat.",

--- a/frontend/src/locales/ru_RU/rom.json
+++ b/frontend/src/locales/ru_RU/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "Облако",
   "no-files-in-category-hint": "Переключитесь на другую категорию в боковой панели, чтобы увидеть другие файлы этого ROM.",
   "last-played": "Последний раз играли",
+  "revision": "Revision",
   "load-save-or-state": "Загрузить сохранение или состояние",
   "screenshots-uploaded-n": "Загружен {n} скриншот. | Загружено {n} скриншотов.",
   "screenshots-uploaded-with-failed": "Загружен {n} скриншот, {failed} с ошибкой. | Загружено {n} скриншотов, {failed} с ошибкой.",

--- a/frontend/src/locales/tr_TR/rom.json
+++ b/frontend/src/locales/tr_TR/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "Bulut",
   "no-files-in-category-hint": "Bu ROM'un diğer dosyalarını görmek için kenar çubuğundan başka bir kategori seçin.",
   "last-played": "Son oynama",
+  "revision": "Revision",
   "load-save-or-state": "Kayıt veya durum kaydı yükle",
   "screenshots-uploaded-n": "{n} ekran görüntüsü yüklendi. | {n} ekran görüntüsü yüklendi.",
   "screenshots-uploaded-with-failed": "{n} ekran görüntüsü yüklendi, {failed} başarısız. | {n} ekran görüntüsü yüklendi, {failed} başarısız.",

--- a/frontend/src/locales/zh_CN/rom.json
+++ b/frontend/src/locales/zh_CN/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "云端",
   "no-files-in-category-hint": "从侧边栏切换到其他分类，以查看此 ROM 的其他文件。",
   "last-played": "最后游玩",
+  "revision": "Revision",
   "load-save-or-state": "加载存档或状态",
   "screenshots-uploaded-n": "已上传 {n} 张截图。 | 已上传 {n} 张截图。",
   "screenshots-uploaded-with-failed": "已上传 {n} 张截图，{failed} 张失败。 | 已上传 {n} 张截图，{failed} 张失败。",

--- a/frontend/src/locales/zh_TW/rom.json
+++ b/frontend/src/locales/zh_TW/rom.json
@@ -391,6 +391,7 @@
   "launchbox-cloud": "雲端",
   "no-files-in-category-hint": "從側邊欄切換到其他類別，以查看此 ROM 的其他檔案。",
   "last-played": "最後遊玩",
+  "revision": "Revision",
   "load-save-or-state": "載入存檔或即時存檔",
   "screenshots-uploaded-n": "已上傳 {n} 張螢幕截圖。 | 已上傳 {n} 張螢幕截圖。",
   "screenshots-uploaded-with-failed": "已上傳 {n} 張螢幕截圖，{failed} 張失敗。 | 已上傳 {n} 張螢幕截圖，{failed} 張失敗。",

--- a/frontend/src/v2/components/GameDetails/OverviewTab.vue
+++ b/frontend/src/v2/components/GameDetails/OverviewTab.vue
@@ -50,6 +50,7 @@ const props = defineProps<{
   userCollections: UserCollectionSchema[];
   hltb: RomHLTBMetadata | null | undefined;
   lastPlayed: string | null;
+  revision: string | null;
   screenshots: string[];
   expansions: IGDBRelatedGame[];
   dlcs: IGDBRelatedGame[];
@@ -162,14 +163,21 @@ const coverSource = computed(() => {
     <!-- 1. Summary -->
     <p v-if="summary" class="overview-tab__summary">{{ summary }}</p>
 
-    <!-- 2. Per-ROM fact rows (left-labelled). Last played + the
-         per-game characteristics — Players, Age rating, RomM
+    <!-- 2. Per-ROM fact rows (left-labelled). Revision, Last played +
+         the per-game characteristics — Players, Age rating, RomM
          collections — get a row each so each fact can render its own
          semantic widget instead of being flattened to a chip list. -->
     <div
-      v-if="lastPlayed || hasQuickFacts || userCollectionTiles.length"
+      v-if="
+        revision || lastPlayed || hasQuickFacts || userCollectionTiles.length
+      "
       class="overview-tab__facts"
     >
+      <div v-if="revision" class="overview-tab__row">
+        <div class="overview-tab__label">{{ t("rom.revision") }}</div>
+        <div class="overview-tab__field">{{ revision }}</div>
+      </div>
+
       <div v-if="lastPlayed" class="overview-tab__row">
         <div class="overview-tab__label">{{ t("rom.last-played") }}</div>
         <div class="overview-tab__field">{{ lastPlayed }}</div>

--- a/frontend/src/v2/views/GameDetails.vue
+++ b/frontend/src/v2/views/GameDetails.vue
@@ -276,6 +276,7 @@ const tabs = computed<RTabNavItem[]>(() => [
             :user-collections="userCollections"
             :hltb="currentRom.hltb_metadata"
             :last-played="lastPlayed"
+            :revision="currentRom.revision ?? null"
             :screenshots="currentRom.merged_screenshots ?? []"
             :expansions="expansions"
             :dlcs="dlcs"


### PR DESCRIPTION
**Description**

Adds support for displaying ROM revision information in the Game Details overview tab. This includes:

- New `revision` prop in `OverviewTab.vue` component to accept revision data
- Conditional rendering of revision as a labeled fact row (displayed before "Last played")
- Translation key `rom.revision` added to all 18 supported language files
- Wiring of `currentRom.revision` from the backend in `GameDetails.vue`

The revision field displays only when data is available, maintaining the existing layout behavior for the facts section.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments (updated fact rows comment to mention revision)
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A - straightforward data display addition following existing patterns

https://claude.ai/code/session_01TUiuFX615VBcwYT7xb6dsm