### PR TITLE
fix(backend): load platform_id on siblings to avoid DetachedInstanceError

### DIFF
--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -218,6 +218,7 @@ def with_details(func):
                 load_only(
                     Rom.id,
                     Rom.name,
+                    Rom.platform_id,
                     Rom.fs_name_no_tags,
                     Rom.fs_name_no_ext,
                 ),


### PR DESCRIPTION
## Problem

`GET /api/roms/{id}/simple` (and `/{id}`) crashes with a `DetachedInstanceError`:

```
sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <Rom> is not bound to a
Session; deferred load operation of attribute 'platform_id' cannot proceed
```

The single-rom endpoints build `SiblingRomSchema` from the eager-loaded
`sibling_roms` relationship. `_visible_siblings` (`backend/endpoints/responses/rom.py`)
filters those siblings with `perms.can_see_rom(s.id, s.platform_id)`. The
`with_details` loader in `roms_handler.py` restricts the sibling columns via
`load_only(...)` and did not include `platform_id`, so the attribute was
deferred. By the time the response schema is serialized the session has closed,
and reading `s.platform_id` fires a lazy load against a detached instance.

## Fix

Add `Rom.platform_id` to the sibling `load_only` so the permission check reads
an already-loaded column. The list path (`with_query_filters`) loads siblings
without a column allowlist, so it already had `platform_id` and was unaffected.

## Testing

- `trunk fmt` / `trunk check` clean on the changed file.

## AI assistance

This change was written with AI assistance (Claude Code), including the root-cause
analysis and the one-line fix.