### PR TITLE
Fix 3D box size calculation for landscape spine images

### DIFF
--- a/frontend/src/v2/lib/media/RBox3D/RBox3D.stories.ts
+++ b/frontend/src/v2/lib/media/RBox3D/RBox3D.stories.ts
@@ -17,6 +17,9 @@ const face = (label: string, w: number, h: number, color: string) =>
 const front = face("FRONT", 286, 400, "rebeccapurple");
 const back = face("BACK", 286, 400, "darkslateblue");
 const spine = face("SPINE", 48, 400, "indigo");
+// A landscape spine scan (N64's side art arrives this way). Its raw w/h would
+// drive an absurd depth; the box must clamp it instead of blowing up.
+const wideSpine = face("SPINE", 400, 48, "indigo");
 
 const meta: Meta<typeof RBox3D> = {
   title: "Media/RBox3D",
@@ -65,6 +68,12 @@ export const Static: Story = {
 export const SpineForward: Story = {
   name: "Spine forward",
   args: { autoSpin: false, initialYaw: 82, initialPitch: 0 },
+};
+
+// ── Landscape spine (N64): depth clamps instead of exploding the box ──
+export const LandscapeSpine: Story = {
+  name: "Landscape spine (N64)",
+  args: { autoSpin: false, initialYaw: 36, initialPitch: -8, spine: wideSpine },
 };
 
 // ── Interaction: arrow keys (and thus gamepad D-pad) rotate it ──

--- a/frontend/src/v2/lib/media/RBox3D/RBox3D.vue
+++ b/frontend/src/v2/lib/media/RBox3D/RBox3D.vue
@@ -64,6 +64,11 @@ const MOMENTUM_FRAMES = 12; //        how far a flick coasts (× last-frame velo
 const MOMENTUM_MAX = 540; //          cap the coast so a hard flick can't whirl forever
 const DEFAULT_FRONT_RATIO = 0.715; // typical box face w/h until measured
 const DEFAULT_SPINE_RATIO = 0.12; //  depth/height until measured
+// Depth is the spine's w/h, which assumes a tall, thin spine scan. Some side
+// scans arrive landscape (N64's, notably), measuring far above any real box
+// depth and blowing the box up toward the camera. Cap it at a chunky-but-sane
+// depth so a malformed spine can't explode the geometry.
+const MAX_SPINE_RATIO = 0.3;
 
 const rootEl = ref<HTMLElement | null>(null);
 const frontImg = ref<HTMLImageElement | null>(null);
@@ -248,15 +253,19 @@ function tick() {
 // The box mirrors the real artwork: the front (box-2D) natural ratio drives
 // the box width/height, the spine's drives the depth. Defaults only stand in
 // until the bytes are decoded.
-function measureRatio(img: HTMLImageElement | null, target: Ref<number>) {
+function measureRatio(
+  img: HTMLImageElement | null,
+  target: Ref<number>,
+  max = Infinity,
+) {
   if (img && img.naturalWidth > 0 && img.naturalHeight > 0) {
-    target.value = img.naturalWidth / img.naturalHeight;
+    target.value = Math.min(img.naturalWidth / img.naturalHeight, max);
   }
 }
 const onFrontLoad = (e: Event) =>
   measureRatio(e.target as HTMLImageElement, frontRatio);
 const onSpineLoad = (e: Event) =>
-  measureRatio(e.target as HTMLImageElement, spineRatio);
+  measureRatio(e.target as HTMLImageElement, spineRatio, MAX_SPINE_RATIO);
 
 let ro: ResizeObserver | null = null;
 onMounted(() => {
@@ -287,7 +296,7 @@ onMounted(() => {
   // A cached cover can already be decoded before the load listener binds —
   // read its dimensions now so the box adopts box-2D's ratio immediately.
   measureRatio(frontImg.value, frontRatio);
-  measureRatio(spineImg.value, spineRatio);
+  measureRatio(spineImg.value, spineRatio, MAX_SPINE_RATIO);
   rafId = requestAnimationFrame(tick);
 });
 onBeforeUnmount(() => {


### PR DESCRIPTION
**TL;DR**
Add clamping to the spine ratio calculation to prevent landscape-oriented spine images (like those from N64 artwork) from inflating the box depth to unrealistic proportions. This fixes a display issue where certain game artwork causes the 3D box to render at an incorrect size.

**What changed?**

- Added `MAX_SPINE_RATIO` constant (0.3) to cap the spine's width/height ratio, preventing malformed or landscape-oriented spine scans from driving excessive box depth
- Updated `measureRatio()` function to accept an optional `max` parameter for clamping calculated ratios
- Applied the `MAX_SPINE_RATIO` cap when measuring spine images in both the load event handler and initial measurement on mount
- Added a new "Landscape spine (N64)" story variant to the RBox3D Storybook component to demonstrate and test the fix with a horizontal spine image

The fix ensures that landscape spine images (which have inverted width/height compared to typical tall spine scans) are clamped to a sensible depth range rather than being allowed to scale the 3D box geometry toward the camera.

**Checklist**

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*