### PR TITLE
fix(retroachievements): match MSX2 against RetroAchievements (#3644)

### DIFF
--- a/backend/adapters/services/rahasher.py
+++ b/backend/adapters/services/rahasher.py
@@ -102,7 +102,6 @@ PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID: dict[UPS, int] = {
     UPS.LYNX: 13,
     UPS.MEGA_DUCK_SLASH_COUGAR_BOY: 69,
     UPS.MSX: 29,
-    # RA groups MSX2 under the MSX console, ID 29 (issue #3644).
     UPS.MSX2: 29,
     UPS.N64: 2,
     UPS.NDS: 18,

--- a/backend/adapters/services/rahasher.py
+++ b/backend/adapters/services/rahasher.py
@@ -102,6 +102,8 @@ PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID: dict[UPS, int] = {
     UPS.LYNX: 13,
     UPS.MEGA_DUCK_SLASH_COUGAR_BOY: 69,
     UPS.MSX: 29,
+    # RA groups MSX2 under the MSX console, ID 29 (issue #3644).
+    UPS.MSX2: 29,
     UPS.N64: 2,
     UPS.NDS: 18,
     UPS.NEO_GEO_CD: 56,

--- a/backend/handler/metadata/ra_handler.py
+++ b/backend/handler/metadata/ra_handler.py
@@ -421,6 +421,9 @@ RA_PLATFORM_LIST: dict[UPS, SlugToRAId] = {
     UPS.JAGUAR: {"id": 17, "name": "Jaguar"},
     UPS.LYNX: {"id": 13, "name": "Lynx"},
     UPS.MSX: {"id": 29, "name": "MSX"},
+    # RetroAchievements has no separate MSX2 console; RA groups MSX2 under the
+    # MSX console, ID 29 (issue #3644).
+    UPS.MSX2: {"id": 29, "name": "MSX2"},
     UPS.MEGA_DUCK_SLASH_COUGAR_BOY: {
         "id": 69,
         "name": "Mega Duck/Cougar Boy",

--- a/backend/handler/metadata/ra_handler.py
+++ b/backend/handler/metadata/ra_handler.py
@@ -421,8 +421,6 @@ RA_PLATFORM_LIST: dict[UPS, SlugToRAId] = {
     UPS.JAGUAR: {"id": 17, "name": "Jaguar"},
     UPS.LYNX: {"id": 13, "name": "Lynx"},
     UPS.MSX: {"id": 29, "name": "MSX"},
-    # RetroAchievements has no separate MSX2 console; RA groups MSX2 under the
-    # MSX console, ID 29 (issue #3644).
     UPS.MSX2: {"id": 29, "name": "MSX2"},
     UPS.MEGA_DUCK_SLASH_COUGAR_BOY: {
         "id": 69,

--- a/backend/tests/adapters/services/test_rahasher.py
+++ b/backend/tests/adapters/services/test_rahasher.py
@@ -680,53 +680,6 @@ class TestRAHasherPspNativeHashing:
         mock_subprocess.assert_called_once()
 
 
-class TestRAHasherMSXPlatformMapping:
-    """MSX and MSX2 share RetroAchievements console ID 29, so both slugs must be
-    present in the slug->RA-id table and treated as buffer-hashable cartridge
-    platforms (GitHub issue #3644)."""
-
-    @pytest.fixture
-    def service(self):
-        return RAHasherService()
-
-    @pytest.mark.parametrize("ups", [UPS.MSX, UPS.MSX2])
-    def test_msx_slugs_map_to_console_29(self, ups):
-        assert PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[ups] == 29
-
-    def test_msx2_is_buffer_hashable(self):
-        # MSX cartridges are buffer-hashable, so MSX2 must not be treated as
-        # disc-based (which would skip RAHasher for archived ROMs).
-        assert UPS.MSX2 not in RA_BUFFER_HASH_UNSUPPORTED
-
-    @pytest.mark.asyncio
-    async def test_calculate_hash_runs_rahasher_for_msx2(
-        self, service: RAHasherService
-    ):
-        """An MSX2 cartridge file must actually reach RAHasher (issue #3644)."""
-        msx2_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.MSX2]
-
-        mock_proc = AsyncMock()
-        mock_proc.wait.return_value = 0
-        mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
-        mock_proc.stderr = None
-
-        with patch(
-            "asyncio.create_subprocess_exec", return_value=mock_proc
-        ) as mock_subprocess:
-            result = await service.calculate_hash(
-                {"ra_id": msx2_id, "slug": "msx2"}, "/roms/msx2/game.rom"
-            )
-
-        assert result == "a1b2c3d4e5f6789012345678901234ab"
-        mock_subprocess.assert_called_once_with(
-            "RAHasher",
-            str(msx2_id),
-            "/roms/msx2/game.rom",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-
-
 class TestRAHasherError:
     """Test the RAHasherError exception."""
 

--- a/backend/tests/adapters/services/test_rahasher.py
+++ b/backend/tests/adapters/services/test_rahasher.py
@@ -680,6 +680,53 @@ class TestRAHasherPspNativeHashing:
         mock_subprocess.assert_called_once()
 
 
+class TestRAHasherMSXPlatformMapping:
+    """MSX and MSX2 share RetroAchievements console ID 29, so both slugs must be
+    present in the slug->RA-id table and treated as buffer-hashable cartridge
+    platforms (GitHub issue #3644)."""
+
+    @pytest.fixture
+    def service(self):
+        return RAHasherService()
+
+    @pytest.mark.parametrize("ups", [UPS.MSX, UPS.MSX2])
+    def test_msx_slugs_map_to_console_29(self, ups):
+        assert PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[ups] == 29
+
+    def test_msx2_is_buffer_hashable(self):
+        # MSX cartridges are buffer-hashable, so MSX2 must not be treated as
+        # disc-based (which would skip RAHasher for archived ROMs).
+        assert UPS.MSX2 not in RA_BUFFER_HASH_UNSUPPORTED
+
+    @pytest.mark.asyncio
+    async def test_calculate_hash_runs_rahasher_for_msx2(
+        self, service: RAHasherService
+    ):
+        """An MSX2 cartridge file must actually reach RAHasher (issue #3644)."""
+        msx2_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.MSX2]
+
+        mock_proc = AsyncMock()
+        mock_proc.wait.return_value = 0
+        mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
+        mock_proc.stderr = None
+
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=mock_proc
+        ) as mock_subprocess:
+            result = await service.calculate_hash(
+                {"ra_id": msx2_id, "slug": "msx2"}, "/roms/msx2/game.rom"
+            )
+
+        assert result == "a1b2c3d4e5f6789012345678901234ab"
+        mock_subprocess.assert_called_once_with(
+            "RAHasher",
+            str(msx2_id),
+            "/roms/msx2/game.rom",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+
 class TestRAHasherError:
     """Test the RAHasherError exception."""
 

--- a/backend/tests/handler/metadata/test_ra_handler.py
+++ b/backend/tests/handler/metadata/test_ra_handler.py
@@ -1,0 +1,51 @@
+"""Tests for the RetroAchievements metadata handler platform mapping."""
+
+import pytest
+
+from handler.metadata.base_handler import UniversalPlatformSlug as UPS
+from handler.metadata.ra_handler import RA_PLATFORM_LIST, RAHandler
+
+# RetroAchievements groups MSX and MSX2 under a single console, "MSX"
+# (console ID 29). See GitHub issue #3644.
+RA_MSX_CONSOLE_ID = 29
+
+# RomM models MSX and MSX2 as separate platforms; RA lumps both into console 29.
+MSX_SLUGS_ON_CONSOLE_29 = ["msx", "msx2"]
+
+
+@pytest.fixture
+def handler() -> RAHandler:
+    return RAHandler()
+
+
+# ---------------------------------------------------------------------------
+# Platform resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("slug", MSX_SLUGS_ON_CONSOLE_29)
+def test_get_platform_msx_slugs_map_to_msx_console(handler: RAHandler, slug: str):
+    """MSX and MSX2 both resolve to RA's single MSX console (ID 29), so their
+    ROMs get an RA hash and can match (issue #3644)."""
+    platform = handler.get_platform(slug)
+    assert platform["ra_id"] == RA_MSX_CONSOLE_ID
+    assert platform["slug"] == slug
+
+
+def test_msx2_shares_the_msx_console_id(handler: RAHandler):
+    """msx2 must resolve to the same RA id as msx."""
+    msx_id = handler.get_platform("msx")["ra_id"]
+    assert msx_id == RA_MSX_CONSOLE_ID
+    assert handler.get_platform("msx2")["ra_id"] == msx_id
+
+
+def test_get_platform_unsupported_returns_none(handler: RAHandler):
+    platform = handler.get_platform("not-a-real-platform")
+    assert platform["ra_id"] is None
+    assert platform["slug"] == "not-a-real-platform"
+
+
+def test_platform_list_uses_ups_keys():
+    """Every entry in RA_PLATFORM_LIST should be a UniversalPlatformSlug."""
+    for key in RA_PLATFORM_LIST.keys():
+        assert isinstance(key, UPS)

--- a/backend/tests/handler/metadata/test_ra_handler.py
+++ b/backend/tests/handler/metadata/test_ra_handler.py
@@ -5,38 +5,10 @@ import pytest
 from handler.metadata.base_handler import UniversalPlatformSlug as UPS
 from handler.metadata.ra_handler import RA_PLATFORM_LIST, RAHandler
 
-# RetroAchievements groups MSX and MSX2 under a single console, "MSX"
-# (console ID 29). See GitHub issue #3644.
-RA_MSX_CONSOLE_ID = 29
-
-# RomM models MSX and MSX2 as separate platforms; RA lumps both into console 29.
-MSX_SLUGS_ON_CONSOLE_29 = ["msx", "msx2"]
-
 
 @pytest.fixture
 def handler() -> RAHandler:
     return RAHandler()
-
-
-# ---------------------------------------------------------------------------
-# Platform resolution
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("slug", MSX_SLUGS_ON_CONSOLE_29)
-def test_get_platform_msx_slugs_map_to_msx_console(handler: RAHandler, slug: str):
-    """MSX and MSX2 both resolve to RA's single MSX console (ID 29), so their
-    ROMs get an RA hash and can match (issue #3644)."""
-    platform = handler.get_platform(slug)
-    assert platform["ra_id"] == RA_MSX_CONSOLE_ID
-    assert platform["slug"] == slug
-
-
-def test_msx2_shares_the_msx_console_id(handler: RAHandler):
-    """msx2 must resolve to the same RA id as msx."""
-    msx_id = handler.get_platform("msx")["ra_id"]
-    assert msx_id == RA_MSX_CONSOLE_ID
-    assert handler.get_platform("msx2")["ra_id"] == msx_id
 
 
 def test_get_platform_unsupported_returns_none(handler: RAHandler):


### PR DESCRIPTION
**Description**

MSX2 games never matched against RetroAchievements: they never received an RA
hash during scanning and never linked to an RA game, so no achievements or
progress ever showed up. Plain MSX games worked fine.

The cause is a data gap. RetroAchievements has no separate MSX2 console; it
groups MSX2 under its single "MSX" console (console ID 29). RomM correctly
models MSX and MSX2 as distinct platforms (which is right for IGDB,
ScreenScraper, LaunchBox, etc.), but its RetroAchievements integration was only
told about the `msx` slug. Because the `msx2` platform had no RA ID:

1. During a scan, RomM saw no RA platform for MSX2 and skipped RA hashing
   entirely (RAHasher was never even invoked for MSX2 files).
2. Any later match attempt bailed out early because the platform had no RA ID.

This PR maps the `msx2` slug to the same RA console ID (29) that `msx` already
uses, in the two tables RomM keeps for RetroAchievements, mirroring the existing
`msx` entry. Fixes #3644.

**Scope note**

This intentionally covers `msx2` only. RetroAchievements documents console 29 as
"MSX / MSX2", so that mapping is confirmed. The related `msx2plus` (MSX2+) and
`msx-turbo` (MSX Turbo R) slugs are also unmapped, but RA does not explicitly
document them under console 29, so they are deliberately left out of this change
rather than mapped on assumption. They can be added later if RA coverage for
them is confirmed (console 29 would be the only possible target, since rcheevos
defines a single MSX console).

**Files changed**

- `backend/handler/metadata/ra_handler.py`
  Added `UPS.MSX2 -> {"id": 29, "name": "MSX2"}` to `RA_PLATFORM_LIST`. This is
  what makes `get_platform("msx2")` return a real `ra_id` (instead of `None`),
  so matching is no longer short-circuited.
- `backend/adapters/services/rahasher.py`
  Added `UPS.MSX2 -> 29` to `PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID`, so RAHasher
  actually runs for MSX2 ROMs during scanning. MSX2 is cartridge-based, so it is
  (correctly) left out of the disc-only `RA_BUFFER_HASH_UNSUPPORTED` set, exactly
  like `msx`.
- `backend/tests/handler/metadata/test_ra_handler.py` (new)
  Tests that `get_platform()` resolves both `msx` and `msx2` to console 29, that
  `msx2` shares the same id as `msx`, that unknown slugs still return
  `ra_id=None`, and that every key in `RA_PLATFORM_LIST` is a
  `UniversalPlatformSlug`.
- `backend/tests/adapters/services/test_rahasher.py`
  New `TestRAHasherMSXPlatformMapping` class verifying the `msx`/`msx2` slug->id
  entries, that `msx2` remains buffer-hashable, and that an MSX2 file actually
  reaches the RAHasher subprocess with the right arguments.

**Testing**

- Wrote the tests first: the new MSX2 assertions failed before the change and
  pass after it.
- Targeted run (`test_ra_handler.py` + `test_rahasher.py`): all green.
- Full backend test suite: passes with no failures.
- `trunk fmt` and `trunk check` on all changed files: no issues.
- No API response schema changed, so no OpenAPI/type regeneration is required;
  the frontend already reads `ra_id` from the generated platform schema.

**Notes for reviewers**

- The derived `RA_ID_TO_SLUG` reverse map (unused in the codebase) still maps
  id 29 to a single slug; adding `msx2` alongside `msx` mirrors the existing
  behavior for id 7 (`nes`/`famicom`) and id 3 (`snes`/`sfam`), so no behavior
  changes.
- Behavior change: MSX2 libraries will now incur RA hashing on scan, the same as
  MSX does today. This is the intended fix.

**AI assistance disclosure**

This change was implemented with AI assistance (Claude). The analysis, tests,
and implementation were AI-generated from the issue and the existing MSX
pattern, then reviewed and verified locally (full backend test suite + Trunk).
The scope was deliberately narrowed to the RA-documented `msx2` case after
verifying that MSX2+ / Turbo R are not explicitly covered by RA console 29.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
