### PR TITLE
Fix typo in core mapping from 'zsx' to 'zxs'

### DIFF
--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -531,7 +531,7 @@ const _EJS_CORES_MAP: Record<string, string[]> = {
   wonderswan: ["mednafen_wswan"],
   swancrystal: ["mednafen_wswan"],
   "wonderswan-color": ["mednafen_wswan"],
-  zsx: ["fuse"],
+  zxs: ["fuse"],
 } as const;
 
 // TODO: Merge with _EJS_CORES_MAP next emukatorjs release (post 4.2.3)


### PR DESCRIPTION


<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
The EJS core mapping in frontend/src/utils/index.ts keyed the ZX Spectrum entry as zsx instead of the canonical platform slug zxs (as defined by UniversalPlatformSlug.ZXS in backend/handler/metadata/base_handler.py).

Renaming the key to zxs restores in-browser play for ZX Spectrum.
**Checklist**
<sup>Please check all that apply.</sup>

- [X] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)
