### PR TITLE
fix(retroachievements): hash GameCube and Wii RVZ/WIA images natively

### DIFF
--- a/backend/adapters/services/rahasher.py
+++ b/backend/adapters/services/rahasher.py
@@ -9,6 +9,11 @@ from logger.formatter import highlight as hl
 from logger.logger import log
 from utils.filesystem import COMPRESSED_FILE_EXTENSIONS
 from utils.psp_hasher import calculate_psp_ra_hash, is_psp_native_hash_file
+from utils.rvz_hasher import (
+    calculate_gamecube_ra_hash,
+    calculate_wii_ra_hash,
+    is_rvz_native_hash_file,
+)
 
 RAHASHER_VALID_HASH_REGEX = re.compile(r"[0-9a-f]{32}")
 
@@ -143,6 +148,8 @@ RA_BUFFER_HASH_UNSUPPORTED_IDS: frozenset[int] = frozenset(
 )
 
 PSP_RA_ID: int = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSP]
+NGC_RA_ID: int = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.NGC]
+WII_RA_ID: int = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.WII]
 
 
 class RAHasherError(Exception): ...
@@ -218,6 +225,26 @@ class RAHasherService:
                 log.debug(
                     f"Computed native {hl('RA', color=LIGHTMAGENTA)} hash for PSP "
                     f"container {hl(file_path)}"
+                )
+                return native_hash
+
+        # GameCube/Wii RVZ and WIA images can't be read by RAHasher ("Not a
+        # Gamecube disc" / "Not a supported Wii file"). Compute the RA hash
+        # natively instead, reconstructing only the disc byte ranges the hash
+        # covers. On failure we fall through to RAHasher (no worse than before).
+        if platform["ra_id"] in (NGC_RA_ID, WII_RA_ID) and is_rvz_native_hash_file(
+            file_path
+        ):
+            if platform["ra_id"] == NGC_RA_ID:
+                native_hash = await asyncio.to_thread(
+                    calculate_gamecube_ra_hash, file_path
+                )
+            else:
+                native_hash = await asyncio.to_thread(calculate_wii_ra_hash, file_path)
+            if native_hash:
+                log.debug(
+                    f"Computed native {hl('RA', color=LIGHTMAGENTA)} hash for "
+                    f"{platform['slug']} RVZ/WIA image {hl(file_path)}"
                 )
                 return native_hash
 

--- a/backend/adapters/services/rahasher.py
+++ b/backend/adapters/services/rahasher.py
@@ -235,12 +235,7 @@ class RAHasherService:
         if platform["ra_id"] in (NGC_RA_ID, WII_RA_ID) and is_rvz_native_hash_file(
             file_path
         ):
-            if platform["ra_id"] == NGC_RA_ID:
-                native_hash = await asyncio.to_thread(
-                    calculate_gamecube_ra_hash, file_path
-                )
-            else:
-                native_hash = await asyncio.to_thread(calculate_wii_ra_hash, file_path)
+           native_hash = await asyncio.to_thread(calculate_gamecube_ra_hash if platform["ra_id"] == NGC_RA_ID else calculate_wii_ra_hash, file_path)
             if native_hash:
                 log.debug(
                     f"Computed native {hl('RA', color=LIGHTMAGENTA)} hash for "

--- a/backend/adapters/services/rahasher.py
+++ b/backend/adapters/services/rahasher.py
@@ -235,7 +235,14 @@ class RAHasherService:
         if platform["ra_id"] in (NGC_RA_ID, WII_RA_ID) and is_rvz_native_hash_file(
             file_path
         ):
-           native_hash = await asyncio.to_thread(calculate_gamecube_ra_hash if platform["ra_id"] == NGC_RA_ID else calculate_wii_ra_hash, file_path)
+            native_hash = await asyncio.to_thread(
+                (
+                    calculate_gamecube_ra_hash
+                    if platform["ra_id"] == NGC_RA_ID
+                    else calculate_wii_ra_hash
+                ),
+                file_path,
+            )
             if native_hash:
                 log.debug(
                     f"Computed native {hl('RA', color=LIGHTMAGENTA)} hash for "

--- a/backend/tests/adapters/services/test_rahasher.py
+++ b/backend/tests/adapters/services/test_rahasher.py
@@ -680,6 +680,135 @@ class TestRAHasherPspNativeHashing:
         mock_subprocess.assert_called_once()
 
 
+class TestRAHasherRvzNativeHashing:
+    """GameCube and Wii .rvz/.wia disc images are hashed natively instead of
+    being handed to RAHasher, which can't read the RVZ container
+    (issues #3649 and #3650)."""
+
+    @pytest.fixture
+    def service(self):
+        return RAHasherService()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("ext", [".rvz", ".wia"])
+    @pytest.mark.parametrize(
+        "ups,slug,native_fn",
+        [
+            (UPS.NGC, "ngc", "calculate_gamecube_ra_hash"),
+            (UPS.WII, "wii", "calculate_wii_ra_hash"),
+        ],
+    )
+    async def test_native_hash_short_circuits_rahasher(
+        self, service: RAHasherService, ups, slug, native_fn, ext
+    ):
+        """A successful native hash returns without spawning RAHasher."""
+        platform_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[ups]
+
+        with (
+            patch(
+                f"adapters.services.rahasher.{native_fn}",
+                return_value="a1b2c3d4e5f6789012345678901234ab",
+            ) as mock_native,
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+        ):
+            result = await service.calculate_hash(
+                {"ra_id": platform_id, "slug": slug}, f"/roms/{slug}/game{ext}"
+            )
+
+        assert result == "a1b2c3d4e5f6789012345678901234ab"
+        mock_native.assert_called_once_with(f"/roms/{slug}/game{ext}")
+        mock_subprocess.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_rahasher_when_native_fails(
+        self, service: RAHasherService
+    ):
+        """If native hashing returns nothing, RAHasher is still attempted."""
+        ngc_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.NGC]
+
+        mock_proc = AsyncMock()
+        mock_proc.wait.return_value = 0
+        mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
+        mock_proc.stderr = None
+
+        with (
+            patch(
+                "adapters.services.rahasher.calculate_gamecube_ra_hash",
+                return_value="",
+            ) as mock_native,
+            patch(
+                "asyncio.create_subprocess_exec", return_value=mock_proc
+            ) as mock_subprocess,
+        ):
+            result = await service.calculate_hash(
+                {"ra_id": ngc_id, "slug": "ngc"}, "/roms/ngc/game.rvz"
+            )
+
+        assert result == "a1b2c3d4e5f6789012345678901234ab"
+        mock_native.assert_called_once()
+        mock_subprocess.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_native_hashing_skipped_for_other_platforms(
+        self, service: RAHasherService
+    ):
+        """An .rvz on a non-GameCube/Wii platform must not hash natively."""
+        psx_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSX]
+
+        mock_proc = AsyncMock()
+        mock_proc.wait.return_value = 0
+        mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
+        mock_proc.stderr = None
+
+        with (
+            patch(
+                "adapters.services.rahasher.calculate_gamecube_ra_hash"
+            ) as mock_gc_native,
+            patch(
+                "adapters.services.rahasher.calculate_wii_ra_hash"
+            ) as mock_wii_native,
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        ):
+            await service.calculate_hash(
+                {"ra_id": psx_id, "slug": "psx"}, "/roms/psx/game.rvz"
+            )
+
+        mock_gc_native.assert_not_called()
+        mock_wii_native.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("ups,slug", [(UPS.NGC, "ngc"), (UPS.WII, "wii")])
+    async def test_native_hashing_skipped_for_raw_iso(
+        self, service: RAHasherService, ups, slug
+    ):
+        """Plain .iso discs still go to RAHasher (it reads them fine)."""
+        platform_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[ups]
+
+        mock_proc = AsyncMock()
+        mock_proc.wait.return_value = 0
+        mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
+        mock_proc.stderr = None
+
+        with (
+            patch(
+                "adapters.services.rahasher.calculate_gamecube_ra_hash"
+            ) as mock_gc_native,
+            patch(
+                "adapters.services.rahasher.calculate_wii_ra_hash"
+            ) as mock_wii_native,
+            patch(
+                "asyncio.create_subprocess_exec", return_value=mock_proc
+            ) as mock_subprocess,
+        ):
+            await service.calculate_hash(
+                {"ra_id": platform_id, "slug": slug}, f"/roms/{slug}/game.iso"
+            )
+
+        mock_gc_native.assert_not_called()
+        mock_wii_native.assert_not_called()
+        mock_subprocess.assert_called_once()
+
+
 class TestRAHasherError:
     """Test the RAHasherError exception."""
 

--- a/backend/tests/utils/test_rvz_hasher.py
+++ b/backend/tests/utils/test_rvz_hasher.py
@@ -430,9 +430,8 @@ class RvzBuilder:
                     continue
 
                 except_lists = b""
-                # With chunks below 2 MiB (RVZ) there is exactly one list per
-                # group; larger chunks carry one list per 2 MiB of data. The
-                # builder puts all of a group's exceptions in the first list.
+                # One list per 2 MiB of chunk (a single list below 2 MiB);
+                # all of a group's exceptions go in the first list.
                 for list_ix in range(n_lists):
                     entries = group_exceptions if list_ix == 0 else []
                     except_lists += struct.pack(">H", len(entries))
@@ -810,18 +809,6 @@ class TestCalculateWiiRaHash:
 
         assert calculate_wii_ra_hash(str(path)) == reference_wii_hash(iso)
 
-    def test_hash_is_independent_of_container_compression(self, tmp_path):
-        _, plain_rvz = build_wii_disc_and_rvz(compression=COMPRESSION_NONE)
-        _, zstd_rvz = build_wii_disc_and_rvz(compression=COMPRESSION_ZSTD)
-        plain_path = tmp_path / "plain.rvz"
-        zstd_path = tmp_path / "zstd.rvz"
-        plain_path.write_bytes(plain_rvz)
-        zstd_path.write_bytes(zstd_rvz)
-
-        assert calculate_wii_ra_hash(str(plain_path)) == calculate_wii_ra_hash(
-            str(zstd_path)
-        )
-
     def test_hash_exceptions_are_applied_before_encryption(self, tmp_path):
         """Stored hash exceptions must replace the recalculated tree bytes."""
         exceptions = [
@@ -854,15 +841,6 @@ class TestCalculateWiiRaHash:
         path.write_bytes(RvzBuilder(bytes(disc), disc_type=1).build())
 
         assert calculate_wii_ra_hash(str(path)) == ""
-
-    def test_returns_empty_for_unknown_magic(self, tmp_path):
-        path = tmp_path / "game.rvz"
-        path.write_bytes(b"NOPE" + b"\x00" * 0x100)
-
-        assert calculate_wii_ra_hash(str(path)) == ""
-
-    def test_returns_empty_for_missing_file(self, tmp_path):
-        assert calculate_wii_ra_hash(str(tmp_path / "missing.rvz")) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/utils/test_rvz_hasher.py
+++ b/backend/tests/utils/test_rvz_hasher.py
@@ -1,0 +1,890 @@
+import bz2
+import hashlib
+import lzma
+import struct
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+import zstandard
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+from utils.rvz_hasher import (
+    RVZ_NATIVE_HASH_EXTENSIONS,
+    _LaggedFibonacci,
+    calculate_gamecube_ra_hash,
+    calculate_wii_ra_hash,
+    is_rvz_native_hash_file,
+)
+
+WII_SECTOR_SIZE = 0x8000
+WII_SECTOR_DATA_SIZE = 0x7C00
+WII_SECTOR_HASH_SIZE = 0x400
+
+# wia_disc_t compression codes.
+COMPRESSION_NONE = 0
+COMPRESSION_BZIP2 = 2
+COMPRESSION_LZMA = 3
+COMPRESSION_LZMA2 = 4
+COMPRESSION_ZSTD = 5
+
+# Fixed LZMA parameters used by the builder (and mirrored by the reader via
+# the compr_data bytes in the header).
+_LZMA1_FILTERS = [
+    {"id": lzma.FILTER_LZMA1, "dict_size": 1 << 16, "lc": 3, "lp": 0, "pb": 2}
+]
+_LZMA1_COMPR_DATA = bytes([(2 * 5 + 0) * 9 + 3]) + struct.pack("<I", 1 << 16)
+_LZMA2_FILTERS = [{"id": lzma.FILTER_LZMA2, "dict_size": 1 << 20}]
+_LZMA2_COMPR_DATA = bytes([18])  # (2 | 0) << (18 // 2 + 11) == 1 MiB
+
+
+# ---------------------------------------------------------------------------
+# Reference implementations, written from the specs (rcheevos hash_disc.c and
+# Dolphin's WiaAndRvz.md / wiibrew Wii disc docs) independently of the
+# production reader so the two meet only at the format boundary.
+# ---------------------------------------------------------------------------
+
+
+class SpecLfg:
+    """Lagged Fibonacci PRNG as described in Dolphin's WiaAndRvz.md spec."""
+
+    def __init__(self, seed: bytes) -> None:
+        words = list(struct.unpack(">17I", seed))
+        for i in range(17, 521):
+            words.append(
+                (((words[i - 17] << 23) & 0xFFFFFFFF) ^ (words[i - 16] >> 9))
+                ^ words[i - 1]
+            )
+        self._buf = words
+        for _ in range(4):
+            self._advance()
+        self._pos = 0
+
+    def _advance(self) -> None:
+        buf = self._buf
+        for i in range(32):
+            buf[i] ^= buf[i + 521 - 32]
+        for i in range(32, 521):
+            buf[i] ^= buf[i - 32]
+
+    def forward(self, count: int) -> None:
+        self._pos += count
+        while self._pos >= 521 * 4:
+            self._advance()
+            self._pos -= 521 * 4
+
+    def get_bytes(self, count: int) -> bytes:
+        out = bytearray()
+        while count > 0:
+            word = self._buf[self._pos // 4]
+            # The spec's output code shifts the second byte by 18, not 16.
+            quad = bytes(
+                [
+                    (word >> 24) & 0xFF,
+                    (word >> 18) & 0xFF,
+                    (word >> 8) & 0xFF,
+                    word & 0xFF,
+                ]
+            )
+            take = min(count, 4 - self._pos % 4)
+            out += quad[self._pos % 4 : self._pos % 4 + take]
+            self._pos += take
+            count -= take
+            if self._pos == 521 * 4:
+                self._advance()
+                self._pos = 0
+        return bytes(out)
+
+
+def _read_padded(data: bytes, offset: int, length: int) -> bytes:
+    chunk = data[offset : offset + length]
+    return chunk + b"\x00" * (length - len(chunk))
+
+
+def _be32(data: bytes, offset: int = 0) -> int:
+    return struct.unpack_from(">I", data, offset)[0]
+
+
+def reference_gamecube_hash(disc: bytes) -> str:
+    """Port of rcheevos rc_hash_gamecube operating on a flat disc image."""
+    assert _read_padded(disc, 0x1C, 4) == b"\xc2\x33\x9f\x3d"
+    md5 = hashlib.md5(usedforsecurity=False)
+
+    body = _be32(_read_padded(disc, 0x2454, 4))
+    trailer = _be32(_read_padded(disc, 0x2458, 4))
+    header_size = min(0x2440 + 0x20 + body + trailer, 1024 * 1024)
+    md5.update(_read_padded(disc, 0, header_size))
+
+    dol_offset = _be32(_read_padded(disc, 0x420, 4))
+    dol_header = _read_padded(disc, dol_offset, 0xD8)
+    for ix in range(18):
+        seg_offset = _be32(dol_header, ix * 4)
+        seg_size = _be32(dol_header, 0x90 + ix * 4)
+        if seg_size:
+            md5.update(_read_padded(disc, seg_offset, seg_size))
+    return md5.hexdigest()
+
+
+def reference_wii_hash(iso: bytes) -> str:
+    """Port of rcheevos rc_hash_wii_disc operating on a flat disc image.
+
+    Mirrors rcheevos exactly, including reading the partition data offset
+    field and then seeking with it as an absolute file offset.
+    """
+    assert _read_padded(iso, 0x18, 4) == b"\x5d\x1c\x9e\xa3"
+    md5 = hashlib.md5(usedforsecurity=False)
+
+    encrypted = _read_padded(iso, 0x61, 1) == b"\x00"
+    assert encrypted, "reference only implements the encrypted-disc path"
+
+    md5.update(_read_padded(iso, 0, 0x80))
+    md5.update(_read_padded(iso, 0x4E000, 4))
+
+    info = struct.unpack(">8I", _read_padded(iso, 0x40000, 32))
+    partitions: list[tuple[int, int]] = []
+    for j in range(0, 8, 2):
+        count, table_off4 = info[j], info[j + 1]
+        for i in range(count):
+            entry = _read_padded(iso, (table_off4 << 2) + i * 8, 8)
+            partitions.append(struct.unpack(">II", entry))
+    assert partitions
+
+    for part_off4, part_type in partitions:
+        if part_type == 1:  # update partition
+            continue
+        part_start = part_off4 << 2
+
+        tmd_size, tmd_off4 = struct.unpack(
+            ">II", _read_padded(iso, part_start + 0x2A4, 8)
+        )
+        tmd_size = min(tmd_size, WII_SECTOR_DATA_SIZE)
+        md5.update(_read_padded(iso, part_start + (tmd_off4 << 2), tmd_size))
+
+        data_off4, data_size4 = struct.unpack(
+            ">II", _read_padded(iso, part_start + 0x2B8, 8)
+        )
+        part_offset = data_off4 << 2
+        part_size = data_size4 << 2
+
+        clusters = min(part_size // WII_SECTOR_SIZE, 1024)
+        for ix in range(clusters):
+            md5.update(
+                _read_padded(
+                    iso,
+                    part_offset + ix * WII_SECTOR_SIZE + WII_SECTOR_HASH_SIZE,
+                    WII_SECTOR_DATA_SIZE,
+                )
+            )
+    return md5.hexdigest()
+
+
+def _aes_cbc_encrypt(key: bytes, iv: bytes, data: bytes) -> bytes:
+    encryptor = Cipher(algorithms.AES(key), modes.CBC(iv)).encryptor()
+    return encryptor.update(data) + encryptor.finalize()
+
+
+def encrypt_wii_partition_data(
+    data: bytes, key: bytes, hash_patches: list[tuple[int, int, bytes]]
+) -> bytes:
+    """Rebuild the encrypted on-disc bytes of a Wii partition's data area.
+
+    ``data`` is the decrypted, hashless partition data (a multiple of 0x7C00).
+    ``hash_patches`` are (sector, offset, digest) replacements applied to the
+    recalculated hash tables before encryption (the wia_except_list_t model).
+    """
+    n_sectors = len(data) // WII_SECTOR_DATA_SIZE
+    out = bytearray()
+    for group_start in range(0, n_sectors, 64):
+        blocks = []
+        for b in range(64):
+            s = group_start + b
+            if s < n_sectors:
+                blocks.append(
+                    data[s * WII_SECTOR_DATA_SIZE : (s + 1) * WII_SECTOR_DATA_SIZE]
+                )
+            else:
+                blocks.append(b"\x00" * WII_SECTOR_DATA_SIZE)
+
+        h0_tables = [
+            b"".join(
+                hashlib.sha1(
+                    blocks[b][j * 0x400 : (j + 1) * 0x400], usedforsecurity=False
+                ).digest()
+                for j in range(31)
+            )
+            for b in range(64)
+        ]
+        h1_tables = [
+            b"".join(
+                hashlib.sha1(h0_tables[sub * 8 + k], usedforsecurity=False).digest()
+                for k in range(8)
+            )
+            for sub in range(8)
+        ]
+        h2_table = b"".join(
+            hashlib.sha1(h1_tables[sub], usedforsecurity=False).digest()
+            for sub in range(8)
+        )
+
+        headers = []
+        for b in range(64):
+            header = bytearray(WII_SECTOR_HASH_SIZE)
+            header[0:0x26C] = h0_tables[b]
+            header[0x280:0x320] = h1_tables[b // 8]
+            header[0x340:0x3E0] = h2_table
+            headers.append(header)
+
+        for sector, offset, digest in hash_patches:
+            if group_start <= sector < group_start + 64:
+                headers[sector - group_start][offset : offset + len(digest)] = digest
+
+        for b in range(64):
+            if group_start + b >= n_sectors:
+                break
+            enc_header = _aes_cbc_encrypt(key, b"\x00" * 16, bytes(headers[b]))
+            enc_data = _aes_cbc_encrypt(key, enc_header[0x3D0:0x3E0], blocks[b])
+            out += enc_header + enc_data
+    return bytes(out)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic RVZ / WIA container builder.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class JunkRun:
+    """A disc byte range stored as RVZ-packed junk instead of literal data."""
+
+    disc_offset: int
+    size: int
+    seed: bytes
+
+
+@dataclass
+class WiiPartitionImage:
+    """Decrypted partition data destined for wia_part_t storage."""
+
+    data_offset: int  # absolute disc offset where the encrypted data area starts
+    key: bytes
+    data: bytes  # decrypted, hashless; a multiple of 0x7C00
+    # (group_index, offset_within_group_hash_area, digest) exception entries
+    exceptions: list[tuple[int, int, bytes]] = field(default_factory=list)
+
+
+class RvzBuilder:
+    """Build a minimal but spec-conformant RVZ or WIA file for tests."""
+
+    def __init__(
+        self,
+        disc: bytes,
+        *,
+        disc_type: int,
+        compression: int = COMPRESSION_ZSTD,
+        chunk_size: int = 0x8000,
+        wia: bool = False,
+        partitions: list[WiiPartitionImage] | None = None,
+        junk_runs: list[JunkRun] | None = None,
+        store_groups_raw: bool = False,
+    ) -> None:
+        self.disc = disc
+        self.disc_type = disc_type
+        self.compression = compression
+        self.chunk_size = chunk_size
+        self.wia = wia
+        self.partitions = partitions or []
+        self.junk_runs = junk_runs or []
+        self.store_groups_raw = store_groups_raw
+        if wia:
+            assert not self.junk_runs and not store_groups_raw
+
+    def _compress(self, data: bytes) -> bytes:
+        if self.compression == COMPRESSION_NONE:
+            return data
+        if self.compression == COMPRESSION_BZIP2:
+            return bz2.compress(data)
+        if self.compression == COMPRESSION_LZMA:
+            return lzma.compress(data, format=lzma.FORMAT_RAW, filters=_LZMA1_FILTERS)
+        if self.compression == COMPRESSION_LZMA2:
+            return lzma.compress(data, format=lzma.FORMAT_RAW, filters=_LZMA2_FILTERS)
+        if self.compression == COMPRESSION_ZSTD:
+            return zstandard.ZstdCompressor(level=3).compress(data)
+        raise ValueError(f"unsupported compression {self.compression}")
+
+    @property
+    def _compr_data(self) -> bytes:
+        if self.compression == COMPRESSION_LZMA:
+            return _LZMA1_COMPR_DATA
+        if self.compression == COMPRESSION_LZMA2:
+            return _LZMA2_COMPR_DATA
+        return b""
+
+    def _pack_group_payload(self, plain: bytes, group_disc_start: int) -> tuple[
+        bytes,
+        int,
+    ]:
+        """RVZ-pack a group's data, encoding any overlapping junk runs.
+
+        Returns (payload, rvz_packed_size); rvz_packed_size is 0 when the
+        group has no junk runs (payload stored unpacked).
+        """
+        runs = sorted(
+            (r for r in self.junk_runs if group_disc_start <= r.disc_offset),
+            key=lambda r: r.disc_offset,
+        )
+        runs = [
+            r for r in runs if r.disc_offset + r.size <= group_disc_start + len(plain)
+        ]
+        if not runs:
+            return plain, 0
+
+        packed = bytearray()
+        pos = 0
+        for run in runs:
+            rel = run.disc_offset - group_disc_start
+            if rel > pos:
+                packed += struct.pack(">I", rel - pos) + plain[pos:rel]
+            packed += struct.pack(">I", run.size | 0x80000000) + run.seed
+            pos = rel + run.size
+        if pos < len(plain):
+            packed += struct.pack(">I", len(plain) - pos) + plain[pos:]
+        return bytes(packed), len(packed)
+
+    def build(self) -> bytes:
+        chunk = self.chunk_size
+        iso_size = len(self.disc)
+
+        part_ranges = [
+            (
+                p.data_offset,
+                p.data_offset + len(p.data) // WII_SECTOR_DATA_SIZE * WII_SECTOR_SIZE,
+            )
+            for p in self.partitions
+        ]
+        part_ranges.sort()
+
+        # Raw data areas: the complement of the partition data areas.
+        raw_ranges: list[tuple[int, int]] = []
+        cursor = 0
+        for start, end in part_ranges:
+            if start > cursor:
+                raw_ranges.append((cursor, start))
+            cursor = end
+        if cursor < iso_size:
+            raw_ranges.append((cursor, iso_size))
+
+        group_entries: list[tuple[int, int, int]] = []  # (off4, size_field, packed)
+        group_blobs: list[bytes] = []
+
+        def add_group(stream: bytes, compressible: bool, packed_size: int) -> None:
+            if not stream:
+                group_entries.append((0, 0, 0))
+                group_blobs.append(b"")
+                return
+            if compressible and not self.store_groups_raw:
+                blob = self._compress(stream)
+                compressed = self.compression != COMPRESSION_NONE
+            else:
+                blob = stream
+                compressed = False
+            size_field = len(blob)
+            if not self.wia and compressed:
+                size_field |= 0x80000000
+            group_entries.append((len(blob), size_field, packed_size))
+            group_blobs.append(blob)
+
+        raw_entries: list[tuple[int, int, int, int]] = []
+        for range_start, range_end in raw_ranges:
+            entry_off = max(range_start, 0x80)
+            entry_size = range_end - entry_off
+            aligned_start = entry_off - (entry_off % WII_SECTOR_SIZE)
+            aligned_size = entry_size + (entry_off % WII_SECTOR_SIZE)
+            first_group = len(group_entries)
+            n_groups = -(-aligned_size // chunk)
+            for i in range(n_groups):
+                start = aligned_start + i * chunk
+                size = min(chunk, aligned_start + aligned_size - start)
+                plain = _read_padded(self.disc, start, size)
+                if plain.count(0) == len(plain):
+                    add_group(b"", True, 0)
+                    continue
+                payload, packed_size = self._pack_group_payload(plain, start)
+                add_group(payload, True, packed_size)
+            raw_entries.append((entry_off, entry_size, first_group, n_groups))
+
+        chunk_hashless = chunk // WII_SECTOR_SIZE * WII_SECTOR_DATA_SIZE
+        part_entries: list[bytes] = []
+        for part in self.partitions:
+            n_sectors = len(part.data) // WII_SECTOR_DATA_SIZE
+            first_group = len(group_entries)
+            n_groups = -(-len(part.data) // chunk_hashless)
+            n_lists = max(1, chunk // 0x200000) if not self.wia else chunk // 0x200000
+            for i in range(n_groups):
+                start = i * chunk_hashless
+                plain = part.data[start : start + chunk_hashless]
+                group_exceptions = [
+                    (offset, digest) for g, offset, digest in part.exceptions if g == i
+                ]
+                if not group_exceptions and plain.count(0) == len(plain):
+                    add_group(b"", True, 0)
+                    continue
+
+                except_lists = b""
+                # With chunks below 2 MiB (RVZ) there is exactly one list per
+                # group; larger chunks carry one list per 2 MiB of data. The
+                # builder puts all of a group's exceptions in the first list.
+                for list_ix in range(n_lists):
+                    entries = group_exceptions if list_ix == 0 else []
+                    except_lists += struct.pack(">H", len(entries))
+                    for offset, digest in entries:
+                        except_lists += struct.pack(">H", offset) + digest
+
+                if self.compression == COMPRESSION_NONE:
+                    padding = (-len(except_lists)) % 4
+                    stream = except_lists + b"\x00" * padding + plain
+                    add_group(stream, True, 0)
+                else:
+                    add_group(except_lists + plain, True, 0)
+            part_entries.append(
+                part.key
+                + struct.pack(
+                    ">IIII",
+                    part.data_offset // WII_SECTOR_SIZE,
+                    n_sectors,
+                    first_group,
+                    n_groups,
+                )
+                + struct.pack(">IIII", 0, 0, 0, 0)
+            )
+
+        part_blob = b"".join(part_entries)
+        raw_blob = self._compress(
+            b"".join(struct.pack(">QQII", *entry) for entry in raw_entries)
+        )
+
+        # Layout: header 1, header 2, partition entries, group data, raw data
+        # entry table, group entry table. Group data offsets must be known
+        # before the group table is serialized, so group data comes first.
+        part_off = 0x48 + 0xDC
+        data_pos = part_off + len(part_blob)
+        placed_entries: list[bytes] = []
+        body = bytearray()
+        for (_blob_size, size_field, packed_size), blob in zip(
+            group_entries, group_blobs, strict=True
+        ):
+            if not blob:
+                placed_entries.append(
+                    struct.pack(">III" if not self.wia else ">II", 0, 0, 0)[
+                        : 12 if not self.wia else 8
+                    ]
+                )
+                continue
+            padding = (-data_pos) % 4
+            body += b"\x00" * padding
+            data_pos += padding
+            entry_fields = [data_pos >> 2, size_field]
+            if not self.wia:
+                entry_fields.append(packed_size)
+            placed_entries.append(
+                struct.pack(">III" if not self.wia else ">II", *entry_fields)
+            )
+            body += blob
+            data_pos += len(blob)
+
+        group_blob = self._compress(b"".join(placed_entries))
+        raw_off = data_pos
+        group_off = raw_off + len(raw_blob)
+        file_size = group_off + len(group_blob)
+
+        header_2 = struct.pack(
+            ">IIiI",
+            self.disc_type,
+            self.compression,
+            0,
+            chunk,
+        )
+        header_2 += _read_padded(self.disc, 0, 0x80)
+        header_2 += struct.pack(">II", len(self.partitions), 0x30)
+        header_2 += struct.pack(">Q", part_off)
+        header_2 += hashlib.sha1(part_blob, usedforsecurity=False).digest()
+        header_2 += struct.pack(">IQI", len(raw_entries), raw_off, len(raw_blob))
+        header_2 += struct.pack(">IQI", len(group_entries), group_off, len(group_blob))
+        compr_data = self._compr_data
+        header_2 += bytes([len(compr_data)]) + compr_data.ljust(7, b"\x00")
+        assert len(header_2) == 0xDC
+
+        magic = b"WIA\x01" if self.wia else b"RVZ\x01"
+        version = 0x01000000
+        version_compatible = 0x00090000 if self.wia else 0x00030000
+        header_1 = magic + struct.pack(
+            ">III", version, version_compatible, len(header_2)
+        )
+        header_1 += hashlib.sha1(header_2, usedforsecurity=False).digest()
+        header_1 += struct.pack(">QQ", iso_size, file_size)
+        header_1 += hashlib.sha1(header_1, usedforsecurity=False).digest()
+        assert len(header_1) == 0x48
+
+        return bytes(header_1 + header_2 + part_blob + body + raw_blob + group_blob)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic disc fixtures.
+# ---------------------------------------------------------------------------
+
+
+def build_gamecube_disc(size: int = 0x40000) -> bytearray:
+    """A tiny GameCube disc with a boot header, apploader and main.dol."""
+    disc = bytearray((i * 31 + 7) & 0xFF for i in range(size))
+    disc[0:6] = b"GTST01"
+    disc[0x1C:0x20] = b"\xc2\x33\x9f\x3d"
+    struct.pack_into(">I", disc, 0x420, 0x10000)  # main.dol offset
+    struct.pack_into(">I", disc, 0x2454, 0x600)  # apploader body size
+    struct.pack_into(">I", disc, 0x2458, 0x80)  # apploader trailer size
+
+    # main.dol header: two code segments and one data segment; rcheevos reads
+    # the segment offsets as partition-relative, so these point at disc space.
+    dol = 0x10000
+    disc[dol : dol + 0xD8] = b"\x00" * 0xD8
+    struct.pack_into(">I", disc, dol + 0x00, 0x11000)  # code segment 0 offset
+    struct.pack_into(">I", disc, dol + 0x90, 0x900)  # code segment 0 size
+    struct.pack_into(">I", disc, dol + 0x04, 0x18000)  # code segment 1 offset
+    struct.pack_into(">I", disc, dol + 0x94, 0x1004)  # code segment 1 size
+    struct.pack_into(">I", disc, dol + 0x1C, 0x2A000)  # data segment 0 offset
+    struct.pack_into(">I", disc, dol + 0xBC, 0x800)  # data segment 0 size
+    return disc
+
+
+def build_wii_disc_and_rvz(
+    *,
+    compression: int = COMPRESSION_NONE,
+    chunk_size: int = 0x20000,
+    tmd_size: int = 0x1F4,
+    exceptions: list[tuple[int, int, bytes]] | None = None,
+) -> tuple[bytes, bytes]:
+    """Build a synthetic Wii disc; returns (reference encrypted ISO, RVZ)."""
+    iso_size = 0x460000
+    disc = bytearray((i * 53 + 11) & 0xFF for i in range(iso_size))
+    disc[0:6] = b"RTST01"
+    disc[0x18:0x1C] = b"\x5d\x1c\x9e\xa3"
+    disc[0x61] = 0x00  # encrypted disc
+
+    game_part = 0x30000
+    update_part = 0x38000
+    data_offset = 0x20000  # partition-relative data offset field
+    part_data_abs = game_part + data_offset  # 0x50000
+    n_sectors = 128
+    data_size = n_sectors * WII_SECTOR_SIZE
+
+    # Partition info table: one table with an update and a game partition.
+    disc[0x40000:0x40030] = b"\x00" * 0x30
+    struct.pack_into(">II", disc, 0x40000, 2, 0x40020 >> 2)
+    struct.pack_into(">II", disc, 0x40020, update_part >> 2, 1)
+    struct.pack_into(">II", disc, 0x40028, game_part >> 2, 0)
+    disc[0x4E000:0x4E004] = b"\x00\x00\x00\x01"
+
+    # Game partition header: TMD location/size and data area location/size.
+    struct.pack_into(">II", disc, game_part + 0x2A4, tmd_size, 0x2C0 >> 2)
+    struct.pack_into(">II", disc, game_part + 0x2B8, data_offset >> 2, data_size >> 2)
+
+    # Update partition header carries plausible fields; rcheevos must skip it
+    # entirely (type 1), so none of these bytes may reach the hash.
+    struct.pack_into(">II", disc, update_part + 0x2A4, 0x200, 0x2C0 >> 2)
+    struct.pack_into(">II", disc, update_part + 0x2B8, data_offset >> 2, 0x8000 >> 2)
+
+    key = bytes(range(16))
+    part_data = bytes(
+        (i * 97 + 29) & 0xFF for i in range(n_sectors * WII_SECTOR_DATA_SIZE)
+    )
+    # Zero the partition data area in the raw disc; it is stored (and later
+    # reconstructed) through wia_part_t, not through the raw data ranges.
+    disc[part_data_abs : part_data_abs + data_size] = b"\x00" * data_size
+
+    exceptions = exceptions or []
+    sectors_per_group = chunk_size // WII_SECTOR_SIZE
+    hash_patches = [
+        (g * sectors_per_group + offset // 0x400, offset % 0x400, digest)
+        for g, offset, digest in exceptions
+    ]
+
+    iso = bytearray(disc)
+    iso[part_data_abs : part_data_abs + data_size] = encrypt_wii_partition_data(
+        part_data, key, hash_patches
+    )
+
+    rvz = RvzBuilder(
+        bytes(disc),
+        disc_type=2,
+        compression=compression,
+        chunk_size=chunk_size,
+        partitions=[
+            WiiPartitionImage(
+                data_offset=part_data_abs,
+                key=key,
+                data=part_data,
+                exceptions=exceptions,
+            )
+        ],
+    ).build()
+    return bytes(iso), rvz
+
+
+# ---------------------------------------------------------------------------
+# GameCube tests (issue #3649).
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateGamecubeRaHash:
+    """Native hashing of GameCube .rvz / .wia images."""
+
+    @pytest.mark.parametrize(
+        "compression",
+        [
+            COMPRESSION_NONE,
+            COMPRESSION_BZIP2,
+            COMPRESSION_LZMA,
+            COMPRESSION_LZMA2,
+            COMPRESSION_ZSTD,
+        ],
+    )
+    def test_rvz_matches_reference_hash_for_each_codec(self, tmp_path, compression):
+        disc = build_gamecube_disc()
+        path = tmp_path / "game.rvz"
+        path.write_bytes(
+            RvzBuilder(bytes(disc), disc_type=1, compression=compression).build()
+        )
+
+        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(disc)
+
+    def test_wia_container_matches_reference_hash(self, tmp_path):
+        """WIA (chunk >= 2 MiB, 8-byte group entries) hashes like its RVZ twin."""
+        disc = build_gamecube_disc()
+        path = tmp_path / "game.wia"
+        path.write_bytes(
+            RvzBuilder(
+                bytes(disc),
+                disc_type=1,
+                compression=COMPRESSION_LZMA,
+                chunk_size=0x200000,
+                wia=True,
+            ).build()
+        )
+
+        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(disc)
+
+    def test_groups_stored_raw_despite_compressed_codec(self, tmp_path):
+        """RVZ groups without the MSB flag are stored raw even in a zstd file."""
+        disc = build_gamecube_disc()
+        path = tmp_path / "game.rvz"
+        path.write_bytes(
+            RvzBuilder(
+                bytes(disc),
+                disc_type=1,
+                compression=COMPRESSION_ZSTD,
+                store_groups_raw=True,
+            ).build()
+        )
+
+        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(disc)
+
+    def test_zero_groups_decode_as_zeroes(self, tmp_path):
+        """An all-zero chunk is stored with data_size 0 and must read as zeroes."""
+        disc = build_gamecube_disc()
+        # Zero a whole chunk inside data segment 0 (0x2A000 + 0x800).
+        disc[0x28000:0x30000] = b"\x00" * 0x8000
+        path = tmp_path / "game.rvz"
+        path.write_bytes(RvzBuilder(bytes(disc), disc_type=1).build())
+
+        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(disc)
+
+    def test_rvz_packed_junk_regenerates_original_bytes(self, tmp_path):
+        """A junk-packed run must regenerate the PRNG bytes the disc held."""
+        disc = build_gamecube_disc()
+        seed = bytes((i * 17 + 3) & 0xFF for i in range(68))
+        junk = SpecLfg(seed).get_bytes(0x4000)
+        # Junk sector inside data segment 0's read range, starting 0x8000 into
+        # its 0x10000 chunk so the PRNG starts at a sector boundary.
+        disc[0x28000 : 0x28000 + 0x4000] = junk
+        # Widen data segment 0 to cover literal + junk + literal transitions.
+        struct.pack_into(">I", disc, 0x10000 + 0x1C, 0x27000)
+        struct.pack_into(">I", disc, 0x10000 + 0xBC, 0x6000)
+
+        path = tmp_path / "game.rvz"
+        path.write_bytes(
+            RvzBuilder(
+                bytes(disc),
+                disc_type=1,
+                chunk_size=0x10000,
+                junk_runs=[JunkRun(disc_offset=0x28000, size=0x4000, seed=seed)],
+            ).build()
+        )
+
+        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(disc)
+
+    def test_returns_empty_for_non_gamecube_disc(self, tmp_path):
+        """A Wii disc in the GameCube hasher fails the magic check."""
+        _, rvz = build_wii_disc_and_rvz()
+        path = tmp_path / "game.rvz"
+        path.write_bytes(rvz)
+
+        assert calculate_gamecube_ra_hash(str(path)) == ""
+
+    def test_returns_empty_for_unknown_magic(self, tmp_path):
+        path = tmp_path / "game.rvz"
+        path.write_bytes(b"NOPE" + b"\x00" * 0x100)
+
+        assert calculate_gamecube_ra_hash(str(path)) == ""
+
+    def test_returns_empty_for_missing_file(self, tmp_path):
+        assert calculate_gamecube_ra_hash(str(tmp_path / "missing.rvz")) == ""
+
+    def test_returns_empty_for_truncated_container(self, tmp_path):
+        disc = build_gamecube_disc()
+        rvz = RvzBuilder(bytes(disc), disc_type=1).build()
+        path = tmp_path / "game.rvz"
+        path.write_bytes(rvz[: len(rvz) // 2])
+
+        assert calculate_gamecube_ra_hash(str(path)) == ""
+
+
+# ---------------------------------------------------------------------------
+# Wii tests (issue #3650).
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateWiiRaHash:
+    """Native hashing of Wii .rvz images: hash tree + AES re-encryption."""
+
+    def test_uncompressed_rvz_matches_reference_hash(self, tmp_path):
+        iso, rvz = build_wii_disc_and_rvz(compression=COMPRESSION_NONE)
+        path = tmp_path / "game.rvz"
+        path.write_bytes(rvz)
+
+        assert calculate_wii_ra_hash(str(path)) == reference_wii_hash(iso)
+
+    def test_zstd_rvz_matches_reference_hash(self, tmp_path):
+        iso, rvz = build_wii_disc_and_rvz(compression=COMPRESSION_ZSTD)
+        path = tmp_path / "game.rvz"
+        path.write_bytes(rvz)
+
+        assert calculate_wii_ra_hash(str(path)) == reference_wii_hash(iso)
+
+    def test_hash_is_independent_of_container_compression(self, tmp_path):
+        _, plain_rvz = build_wii_disc_and_rvz(compression=COMPRESSION_NONE)
+        _, zstd_rvz = build_wii_disc_and_rvz(compression=COMPRESSION_ZSTD)
+        plain_path = tmp_path / "plain.rvz"
+        zstd_path = tmp_path / "zstd.rvz"
+        plain_path.write_bytes(plain_rvz)
+        zstd_path.write_bytes(zstd_rvz)
+
+        assert calculate_wii_ra_hash(str(plain_path)) == calculate_wii_ra_hash(
+            str(zstd_path)
+        )
+
+    def test_hash_exceptions_are_applied_before_encryption(self, tmp_path):
+        """Stored hash exceptions must replace the recalculated tree bytes."""
+        exceptions = [
+            (0, 0x10, b"\xab" * 20),  # sector 0, inside its H0 table
+            (2, 0x400 + 0x290, b"\xcd" * 20),  # group 2, sector 9, H1 area
+        ]
+        iso, rvz = build_wii_disc_and_rvz(
+            compression=COMPRESSION_ZSTD, exceptions=exceptions
+        )
+        baseline_iso, _ = build_wii_disc_and_rvz(compression=COMPRESSION_ZSTD)
+        path = tmp_path / "game.rvz"
+        path.write_bytes(rvz)
+
+        expected = reference_wii_hash(iso)
+        assert expected != reference_wii_hash(baseline_iso)
+        assert calculate_wii_ra_hash(str(path)) == expected
+
+    def test_tmd_size_is_capped_like_rcheevos(self, tmp_path):
+        """A TMD size field above 0x7C00 hashes only the first 0x7C00 bytes."""
+        iso, rvz = build_wii_disc_and_rvz(tmd_size=0x9000)
+        path = tmp_path / "game.rvz"
+        path.write_bytes(rvz)
+
+        assert calculate_wii_ra_hash(str(path)) == reference_wii_hash(iso)
+
+    def test_returns_empty_for_non_wii_disc(self, tmp_path):
+        """A GameCube disc in the Wii hasher fails the magic check."""
+        disc = build_gamecube_disc()
+        path = tmp_path / "game.rvz"
+        path.write_bytes(RvzBuilder(bytes(disc), disc_type=1).build())
+
+        assert calculate_wii_ra_hash(str(path)) == ""
+
+    def test_returns_empty_for_unknown_magic(self, tmp_path):
+        path = tmp_path / "game.rvz"
+        path.write_bytes(b"NOPE" + b"\x00" * 0x100)
+
+        assert calculate_wii_ra_hash(str(path)) == ""
+
+    def test_returns_empty_for_missing_file(self, tmp_path):
+        assert calculate_wii_ra_hash(str(tmp_path / "missing.rvz")) == ""
+
+
+# ---------------------------------------------------------------------------
+# Production PRNG vs the spec implementation.
+# ---------------------------------------------------------------------------
+
+
+class TestLaggedFibonacci:
+    """The production junk-data PRNG against an independent spec port."""
+
+    def test_stream_matches_spec_implementation(self):
+        seed = bytes((i * 41 + 5) & 0xFF for i in range(68))
+        spec = SpecLfg(seed)
+        prod = _LaggedFibonacci(seed)
+
+        # Cross several 2084-byte buffer refills to exercise the advance step.
+        assert prod.get_bytes(9000) == spec.get_bytes(9000)
+
+    def test_forward_matches_spec_implementation(self):
+        seed = bytes((i * 7 + 1) & 0xFF for i in range(68))
+        spec = SpecLfg(seed)
+        prod = _LaggedFibonacci(seed)
+        spec.forward(0x7123)
+        prod.forward(0x7123)
+
+        assert prod.get_bytes(600) == spec.get_bytes(600)
+
+
+# ---------------------------------------------------------------------------
+# Real-ROM integration tests. The expected hashes were verified against both
+# the RetroAchievements hash database (API_GetGameList) and the shipped
+# RAHasher 1.8.3 binary run on the reconstructed disc images.
+# ---------------------------------------------------------------------------
+
+_MOCK_ROMS = Path(__file__).parents[3] / "romm_mock" / "library" / "roms"
+_REAL_NGC_RVZ = _MOCK_ROMS / "ngc" / "Mario Kart - Double Dash!! (USA).rvz"
+_REAL_WII_RVZ = _MOCK_ROMS / "wii" / "Super Mario Galaxy (USA) (En,Fr,Es).rvz"
+
+
+@pytest.mark.skipif(not _REAL_NGC_RVZ.exists(), reason="mock GameCube RVZ not present")
+def test_real_gamecube_rvz_matches_retroachievements_hash():
+    """Mario Kart: Double Dash!! (USA), RetroAchievements game 7693."""
+    assert (
+        calculate_gamecube_ra_hash(str(_REAL_NGC_RVZ))
+        == "adad8934d2586d27ec4b653bae52e47b"
+    )
+
+
+@pytest.mark.skipif(not _REAL_WII_RVZ.exists(), reason="mock Wii RVZ not present")
+def test_real_wii_rvz_matches_retroachievements_hash():
+    """Super Mario Galaxy (USA), RetroAchievements game 189."""
+    assert (
+        calculate_wii_ra_hash(str(_REAL_WII_RVZ)) == "4e0d0d2f2c5d3c13d758b027bbcc059f"
+    )
+
+
+class TestIsRvzNativeHashFile:
+    def test_recognizes_native_extensions(self):
+        for ext in RVZ_NATIVE_HASH_EXTENSIONS:
+            assert is_rvz_native_hash_file(f"/roms/ngc/game{ext}")
+            assert is_rvz_native_hash_file(f"/roms/wii/game{ext.upper()}")
+
+    def test_rejects_other_extensions(self):
+        assert not is_rvz_native_hash_file("/roms/ngc/game.iso")
+        assert not is_rvz_native_hash_file("/roms/ngc/game.gcm")
+        assert not is_rvz_native_hash_file("/roms/wii/game.wbfs")
+        assert not is_rvz_native_hash_file("/roms/wii/game.zip")

--- a/backend/tests/utils/test_rvz_hasher.py
+++ b/backend/tests/utils/test_rvz_hasher.py
@@ -745,6 +745,38 @@ class TestCalculateGamecubeRaHash:
 
         assert calculate_gamecube_ra_hash(str(path)) == ""
 
+    def test_returns_empty_for_corrupt_zstd_group(self, tmp_path):
+        """A corrupted compressed group must fail softly, not raise."""
+        disc = build_gamecube_disc()
+        rvz = bytearray(RvzBuilder(bytes(disc), disc_type=1).build())
+        # Group data starts right after the two headers (no partition
+        # entries); clobber the first group's zstd frame magic.
+        data_start = 0x48 + 0xDC
+        rvz[data_start : data_start + 4] = b"\xde\xad\xbe\xef"
+        path = tmp_path / "game.rvz"
+        path.write_bytes(bytes(rvz))
+
+        assert calculate_gamecube_ra_hash(str(path)) == ""
+
+    def test_returns_empty_for_oversized_chunk_size(self, tmp_path):
+        """A crafted chunk size is rejected before any buffer allocation."""
+        disc = build_gamecube_disc()
+        rvz = bytearray(RvzBuilder(bytes(disc), disc_type=1).build())
+        struct.pack_into(">I", rvz, 0x48 + 0x0C, 0x40000000)  # 1 GiB chunks
+        path = tmp_path / "game.rvz"
+        path.write_bytes(bytes(rvz))
+
+        assert calculate_gamecube_ra_hash(str(path)) == ""
+
+    def test_returns_empty_for_dol_segment_past_disc_end(self, tmp_path):
+        """A corrupt main.dol segment size must not stall the scan."""
+        disc = build_gamecube_disc()
+        struct.pack_into(">I", disc, 0x10000 + 0x90, 0xFFFFFF00)
+        path = tmp_path / "game.rvz"
+        path.write_bytes(RvzBuilder(bytes(disc), disc_type=1).build())
+
+        assert calculate_gamecube_ra_hash(str(path)) == ""
+
 
 # ---------------------------------------------------------------------------
 # Wii tests (issue #3650).
@@ -763,6 +795,16 @@ class TestCalculateWiiRaHash:
 
     def test_zstd_rvz_matches_reference_hash(self, tmp_path):
         iso, rvz = build_wii_disc_and_rvz(compression=COMPRESSION_ZSTD)
+        path = tmp_path / "game.rvz"
+        path.write_bytes(rvz)
+
+        assert calculate_wii_ra_hash(str(path)) == reference_wii_hash(iso)
+
+    def test_small_chunk_zstd_rvz_matches_reference_hash(self, tmp_path):
+        """32 KiB chunks: one hash group spans many groups, one list each."""
+        iso, rvz = build_wii_disc_and_rvz(
+            compression=COMPRESSION_ZSTD, chunk_size=0x8000
+        )
         path = tmp_path / "game.rvz"
         path.write_bytes(rvz)
 

--- a/backend/utils/rvz_hasher.py
+++ b/backend/utils/rvz_hasher.py
@@ -32,6 +32,7 @@ Format references:
 
 import bz2
 import hashlib
+import io
 import lzma
 import os
 import struct
@@ -72,6 +73,17 @@ _MAX_GC_HEADER_SIZE = 1024 * 1024
 _MAX_WII_CLUSTERS = 1024
 _HASH_CHUNK_SIZE = 1024 * 1024
 
+# Real encoders use 32 KiB - 2 MiB chunks; the cap only rejects crafted
+# headers that would otherwise force multi-GB per-group allocations.
+_MAX_CHUNK_SIZE = 64 * 1024 * 1024
+# Dolphin's reader accepts at most 52*64 exceptions per list; used to bound
+# how much decompressed group output can precede the payload.
+_MAX_EXCEPTIONS_PER_LIST = 3328
+_MAX_EXCEPTION_LIST_BYTES = 2 + _MAX_EXCEPTIONS_PER_LIST * 22
+# Generous allowance for RVZ packing descriptors (4-byte run headers plus
+# 68-byte junk seeds) on top of the unpacked payload size.
+_RVZ_PACK_STREAM_SLACK = 0x100000
+
 _PARSE_ERRORS = (
     OSError,
     ValueError,
@@ -79,6 +91,7 @@ _PARSE_ERRORS = (
     EOFError,
     struct.error,
     lzma.LZMAError,
+    zstandard.ZstdError,
 )
 
 
@@ -234,7 +247,10 @@ class _RvzReader:
             _COMPRESSION_ZSTD,
         ):
             raise RvzHashError(f"unknown compression method {self.compression}")
-        if self.chunk_size == 0 or self.chunk_size % _WII_SECTOR_SIZE:
+        if (
+            not _WII_SECTOR_SIZE <= self.chunk_size <= _MAX_CHUNK_SIZE
+            or self.chunk_size % _WII_SECTOR_SIZE
+        ):
             raise RvzHashError("invalid chunk size")
 
         self.disc_header = header_2[0x10:0x90]
@@ -245,7 +261,7 @@ class _RvzReader:
         compr_data_len = header_2[0xD4]
         self._compr_data = header_2[0xD5 : 0xD5 + min(compr_data_len, 7)]
 
-        if n_part > 0x100 or n_raw > 0x10000 or n_groups > 0x1000000:
+        if n_part > 0x100 or n_raw > 0x10000 or n_groups > 0x100000:
             raise RvzHashError("implausible entry counts")
 
         # Partition entries are stored uncompressed. Entries smaller than
@@ -299,7 +315,14 @@ class _RvzReader:
         self._sectors_per_chunk = self.chunk_size // _WII_SECTOR_SIZE
         self._chunk_data_size = self._sectors_per_chunk * _WII_SECTOR_DATA_SIZE
 
-        self._group_cache: dict[int, tuple[bytes, list[tuple[int, int, bytes]]]] = {}
+        # Sized so one Wii hash group's chunks stay cached across the data
+        # and exception passes of _encrypted_hash_group.
+        self._group_cache_capacity = max(
+            16, _WII_SECTORS_PER_HASH_GROUP // self._sectors_per_chunk + 8
+        )
+        self._group_cache: dict[
+            tuple[int, int, int, bool], tuple[bytes, list[tuple[int, int, bytes]]]
+        ] = {}
         self._hash_group_cache: dict[tuple[int, int], bytes] = {}
 
     def close(self) -> None:
@@ -310,26 +333,38 @@ class _RvzReader:
 
     # -- container plumbing -------------------------------------------------
 
-    def _decompress(self, blob: bytes) -> bytes:
+    def _decompress(self, blob: bytes, max_output: int) -> bytes:
+        """Decompress at most ``max_output`` bytes; extra output is discarded.
+
+        The cap keeps a crafted group blob from expanding into a
+        memory-exhausting buffer (decompression bomb) during a scan.
+        """
         if self.compression == _COMPRESSION_NONE:
-            return blob
+            return blob[:max_output]
         if self.compression == _COMPRESSION_BZIP2:
-            return bz2.decompress(blob)
+            return bz2.BZ2Decompressor().decompress(blob, max_length=max_output)
         if self.compression in (_COMPRESSION_LZMA, _COMPRESSION_LZMA2):
             filters = _decode_lzma_filters(
                 self.compression == _COMPRESSION_LZMA2, self._compr_data
             )
             return lzma.LZMADecompressor(
                 format=lzma.FORMAT_RAW, filters=filters
-            ).decompress(blob)
-        return zstandard.ZstdDecompressor().decompressobj().decompress(blob)
+            ).decompress(blob, max_length=max_output)
+        reader = zstandard.ZstdDecompressor().stream_reader(io.BytesIO(blob))
+        out = bytearray()
+        while len(out) < max_output:
+            chunk = reader.read(min(1 << 20, max_output - len(out)))
+            if not chunk:
+                break
+            out += chunk
+        return bytes(out)
 
     def _decompress_blob(self, offset: int, size: int, expected: int) -> bytes:
         self._fh.seek(offset)
         blob = self._fh.read(size)
         if len(blob) < size:
             raise RvzHashError("truncated entry table")
-        out = self._decompress(blob)
+        out = self._decompress(blob, expected)
         if len(out) < expected:
             raise RvzHashError("entry table shorter than expected")
         return out
@@ -391,7 +426,8 @@ class _RvzReader:
         self, index: int, expected: int, data_offset: int, with_exceptions: bool
     ) -> tuple[bytes, list[tuple[int, int, bytes]]]:
         """Decode one group into (data, hash exceptions), zero-padded/cached."""
-        cached = self._group_cache.get(index)
+        cache_key = (index, expected, data_offset, with_exceptions)
+        cached = self._group_cache.get(cache_key)
         if cached is not None:
             return cached
 
@@ -414,7 +450,16 @@ class _RvzReader:
             if len(blob) < stored_size:
                 raise RvzHashError("truncated group data")
 
-            stream = self._decompress(blob) if compressed else blob
+            if self.is_rvz and packed_size:
+                payload_cap = min(packed_size, expected + _RVZ_PACK_STREAM_SLACK)
+            else:
+                payload_cap = expected
+            max_output = payload_cap
+            if with_exceptions:
+                max_output += (
+                    self._except_lists_per_group * _MAX_EXCEPTION_LIST_BYTES + 4
+                )
+            stream = self._decompress(blob, max_output) if compressed else blob
             exceptions: list[tuple[int, int, bytes]] = []
             if with_exceptions:
                 # Uncompressed exception lists are padded to a 4-byte
@@ -432,9 +477,9 @@ class _RvzReader:
                 data = data + b"\x00" * (expected - len(data))
             result = (data, exceptions)
 
-        if len(self._group_cache) >= 16:
+        if len(self._group_cache) >= self._group_cache_capacity:
             self._group_cache.clear()
-        self._group_cache[index] = result
+        self._group_cache[cache_key] = result
         return result
 
     # -- raw (non-partition) data -------------------------------------------
@@ -668,6 +713,11 @@ def _hash_nintendo_disc_partition(
         seg_offset = _be32(dol_header, ix * 4) << wii_shift
         seg_size = _be32(dol_header, 0x90 + ix * 4) << wii_shift
         if seg_size:
+            # A valid disc keeps every segment inside the image; a corrupt
+            # one claiming gigabytes would stall the scan hashing zero-fill
+            # (and could never match RA's database anyway).
+            if part_offset + seg_offset + seg_size > reader.iso_size:
+                raise RvzHashError("main.dol segment extends past the disc end")
             # rcheevos seeks these relative to the partition, not the DOL.
             _hash_chunked(md5, reader, part_offset + seg_offset, seg_size)
 

--- a/backend/utils/rvz_hasher.py
+++ b/backend/utils/rvz_hasher.py
@@ -71,6 +71,8 @@ _MAX_EXCEPTIONS_PER_LIST = 3328
 _MAX_EXCEPTION_LIST_BYTES = 2 + _MAX_EXCEPTIONS_PER_LIST * 22
 # Allowance for RVZ packing descriptors on top of the unpacked payload size.
 _RVZ_PACK_STREAM_SLACK = 0x100000
+# Minimum decoded-group cache budget in bytes; see _group_cache_budget.
+_GROUP_CACHE_MIN_BUDGET = 8 * 1024 * 1024
 
 _PARSE_ERRORS = (
     OSError,
@@ -211,7 +213,7 @@ class _RvzReader:
             raise RvzHashError("truncated file header")
         magic = header_1[:4]
         if magic not in (_RVZ_MAGIC, _WIA_MAGIC):
-            raise RvzHashError(f"unrecognized container magic {magic[:4]!r}")
+            raise RvzHashError(f"unrecognized container magic {magic!r}")
         self.is_rvz = magic == _RVZ_MAGIC
 
         header_2_size = struct.unpack_from(">I", header_1, 0x0C)[0]
@@ -303,11 +305,12 @@ class _RvzReader:
         self._sectors_per_chunk = self.chunk_size // _WII_SECTOR_SIZE
         self._chunk_data_size = self._sectors_per_chunk * _WII_SECTOR_DATA_SIZE
 
-        # Sized so one Wii hash group's chunks stay cached across the data
-        # and exception passes of _encrypted_hash_group.
-        self._group_cache_capacity = max(
-            16, _WII_SECTORS_PER_HASH_GROUP // self._sectors_per_chunk + 8
-        )
+        # Byte-bounded so a crafted chunk_size can't pin gigabytes of decoded
+        # groups; still fits the chunks covering one Wii hash group (plus a
+        # raw chunk) so _encrypted_hash_group's data and exception passes
+        # stay cached.
+        self._group_cache_budget = max(_GROUP_CACHE_MIN_BUDGET, 2 * self.chunk_size)
+        self._group_cache_bytes = 0
         self._group_cache: dict[
             tuple[int, int, int, bool], tuple[bytes, list[tuple[int, int, bytes]]]
         ] = {}
@@ -390,13 +393,16 @@ class _RvzReader:
                 raise RvzHashError("truncated hash exception list")
             (count,) = struct.unpack_from(">H", stream, pos)
             pos += 2
-            if count > 3328:
+            if count > _MAX_EXCEPTIONS_PER_LIST:
                 raise RvzHashError("implausible hash exception count")
             for _ in range(count):
                 if pos + 22 > len(stream):
                     raise RvzHashError("truncated hash exception entry")
                 (offset,) = struct.unpack_from(">H", stream, pos)
-                sector = list_ix * 64 + offset // _WII_SECTOR_HASH_SIZE
+                sector = (
+                    list_ix * _WII_SECTORS_PER_HASH_GROUP
+                    + offset // _WII_SECTOR_HASH_SIZE
+                )
                 exceptions.append(
                     (
                         sector,
@@ -464,9 +470,11 @@ class _RvzReader:
                 data = data + b"\x00" * (expected - len(data))
             result = (data, exceptions)
 
-        if len(self._group_cache) >= self._group_cache_capacity:
+        if self._group_cache_bytes + len(result[0]) > self._group_cache_budget:
             self._group_cache.clear()
+            self._group_cache_bytes = 0
         self._group_cache[cache_key] = result
+        self._group_cache_bytes += len(result[0])
         return result
 
     # -- raw (non-partition) data -------------------------------------------

--- a/backend/utils/rvz_hasher.py
+++ b/backend/utils/rvz_hasher.py
@@ -1,28 +1,18 @@
 """Native RetroAchievements hashing for GameCube/Wii RVZ and WIA disc images.
 
-RAHasher (RALibretro/rcheevos) reads raw ``.iso``/``.gcm`` GameCube and Wii
-discs, but not the block-compressed RVZ/WIA containers Dolphin creates. For
-those it fails with "Not a Gamecube disc" / "Not a supported Wii file" and the
-game is left without a RetroAchievements match (issues #3649 and #3650).
+RAHasher (RALibretro/rcheevos) can't read the block-compressed RVZ/WIA
+containers Dolphin creates, leaving those games without a RetroAchievements
+match (issues #3649 and #3650). Neither console's RA hash covers the whole
+disc: GameCube hashes the boot header, apploader and main.dol segments; Wii
+hashes the main header, region code and, per non-update partition, the TMD
+plus up to 1024 encrypted clusters (~32 MB). RVZ/WIA is group-indexed, so
+those ranges are rebuilt with random access, decompressing only the groups a
+range touches.
 
-Neither console's RA hash depends on the whole disc. Per rcheevos:
-
-- GameCube: ``MD5(boot/partition header incl. apploader + the up to 18
-  main.dol segments referenced by the boot header)``, a few MB near the disc
-  start.
-- Wii: ``MD5(main header + region code + per non-update partition: the TMD
-  (capped at 0x7C00) and up to 1024 encrypted 0x7C00-byte clusters)``, roughly
-  32 MB per partition.
-
-RVZ/WIA files are group-indexed, so those byte ranges can be reconstructed
-with random access, decompressing only the groups a range touches, with no
-subprocess and no multi-GB temporary ISO. Wii partition data is stored
-decrypted and with the hash tree stripped, and RA hashes the encrypted disc
-bytes, so the reconstruction recalculates the H0/H1/H2 hash tree, applies the
-container's stored hash exceptions and re-encrypts the clusters with the
-partition's embedded title key (AES-128-CBC). This reproduces the identical
-bytes of the original disc, so the resulting hash matches RA's database (and
-what Dolphin computes when playing the same file).
+Wii partition data is stored decrypted with the hash tree stripped, while RA
+hashes the encrypted disc bytes; the reader recalculates the H0/H1/H2 hash
+tree, applies the stored hash exceptions and re-encrypts clusters with the
+embedded title key (AES-128-CBC), reproducing the exact retail disc bytes.
 
 Format references:
 - https://github.com/dolphin-emu/dolphin/blob/master/docs/WiaAndRvz.md
@@ -73,15 +63,13 @@ _MAX_GC_HEADER_SIZE = 1024 * 1024
 _MAX_WII_CLUSTERS = 1024
 _HASH_CHUNK_SIZE = 1024 * 1024
 
-# Real encoders use 32 KiB - 2 MiB chunks; the cap only rejects crafted
-# headers that would otherwise force multi-GB per-group allocations.
+# Real encoders use 32 KiB - 2 MiB chunks; the cap blocks crafted headers
+# that would force multi-GB per-group allocations.
 _MAX_CHUNK_SIZE = 64 * 1024 * 1024
-# Dolphin's reader accepts at most 52*64 exceptions per list; used to bound
-# how much decompressed group output can precede the payload.
+# Dolphin's reader accepts at most 52*64 exceptions per list.
 _MAX_EXCEPTIONS_PER_LIST = 3328
 _MAX_EXCEPTION_LIST_BYTES = 2 + _MAX_EXCEPTIONS_PER_LIST * 22
-# Generous allowance for RVZ packing descriptors (4-byte run headers plus
-# 68-byte junk seeds) on top of the unpacked payload size.
+# Allowance for RVZ packing descriptors on top of the unpacked payload size.
 _RVZ_PACK_STREAM_SLACK = 0x100000
 
 _PARSE_ERRORS = (
@@ -336,8 +324,7 @@ class _RvzReader:
     def _decompress(self, blob: bytes, max_output: int) -> bytes:
         """Decompress at most ``max_output`` bytes; extra output is discarded.
 
-        The cap keeps a crafted group blob from expanding into a
-        memory-exhausting buffer (decompression bomb) during a scan.
+        The cap defuses decompression bombs in crafted group blobs.
         """
         if self.compression == _COMPRESSION_NONE:
             return blob[:max_output]
@@ -713,9 +700,8 @@ def _hash_nintendo_disc_partition(
         seg_offset = _be32(dol_header, ix * 4) << wii_shift
         seg_size = _be32(dol_header, 0x90 + ix * 4) << wii_shift
         if seg_size:
-            # A valid disc keeps every segment inside the image; a corrupt
-            # one claiming gigabytes would stall the scan hashing zero-fill
-            # (and could never match RA's database anyway).
+            # Corrupt sizes would stall hashing zero-fill; valid discs keep
+            # every segment inside the image.
             if part_offset + seg_offset + seg_size > reader.iso_size:
                 raise RvzHashError("main.dol segment extends past the disc end")
             # rcheevos seeks these relative to the partition, not the DOL.

--- a/backend/utils/rvz_hasher.py
+++ b/backend/utils/rvz_hasher.py
@@ -1,0 +1,796 @@
+"""Native RetroAchievements hashing for GameCube/Wii RVZ and WIA disc images.
+
+RAHasher (RALibretro/rcheevos) reads raw ``.iso``/``.gcm`` GameCube and Wii
+discs, but not the block-compressed RVZ/WIA containers Dolphin creates. For
+those it fails with "Not a Gamecube disc" / "Not a supported Wii file" and the
+game is left without a RetroAchievements match (issues #3649 and #3650).
+
+Neither console's RA hash depends on the whole disc. Per rcheevos:
+
+- GameCube: ``MD5(boot/partition header incl. apploader + the up to 18
+  main.dol segments referenced by the boot header)``, a few MB near the disc
+  start.
+- Wii: ``MD5(main header + region code + per non-update partition: the TMD
+  (capped at 0x7C00) and up to 1024 encrypted 0x7C00-byte clusters)``, roughly
+  32 MB per partition.
+
+RVZ/WIA files are group-indexed, so those byte ranges can be reconstructed
+with random access, decompressing only the groups a range touches, with no
+subprocess and no multi-GB temporary ISO. Wii partition data is stored
+decrypted and with the hash tree stripped, and RA hashes the encrypted disc
+bytes, so the reconstruction recalculates the H0/H1/H2 hash tree, applies the
+container's stored hash exceptions and re-encrypts the clusters with the
+partition's embedded title key (AES-128-CBC). This reproduces the identical
+bytes of the original disc, so the resulting hash matches RA's database (and
+what Dolphin computes when playing the same file).
+
+Format references:
+- https://github.com/dolphin-emu/dolphin/blob/master/docs/WiaAndRvz.md
+- https://wiibrew.org/wiki/Wii_Disc
+- rcheevos ``src/rhash/hash_disc.c`` (``rc_hash_gamecube`` / ``rc_hash_wii``)
+"""
+
+import bz2
+import hashlib
+import lzma
+import os
+import struct
+from typing import BinaryIO
+
+import zstandard
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+from logger.formatter import LIGHTMAGENTA
+from logger.formatter import highlight as hl
+from logger.logger import log
+
+# Container extensions RAHasher can't read but which we can hash natively. The
+# real container is still detected by magic; the extension only gates whether
+# we attempt native hashing before falling back to RAHasher.
+RVZ_NATIVE_HASH_EXTENSIONS: tuple[str, ...] = (".rvz", ".wia")
+
+_RVZ_MAGIC = b"RVZ\x01"
+_WIA_MAGIC = b"WIA\x01"
+
+# wia_disc_t compression codes.
+_COMPRESSION_NONE = 0
+_COMPRESSION_PURGE = 1
+_COMPRESSION_BZIP2 = 2
+_COMPRESSION_LZMA = 3
+_COMPRESSION_LZMA2 = 4
+_COMPRESSION_ZSTD = 5
+
+_WII_SECTOR_SIZE = 0x8000
+_WII_SECTOR_DATA_SIZE = 0x7C00
+_WII_SECTOR_HASH_SIZE = 0x400
+_WII_SECTORS_PER_HASH_GROUP = 64
+
+_GC_MAGIC = b"\xc2\x33\x9f\x3d"  # at disc offset 0x1C
+_WII_MAGIC = b"\x5d\x1c\x9e\xa3"  # at disc offset 0x18
+_GC_BASE_HEADER_SIZE = 0x2440
+_MAX_GC_HEADER_SIZE = 1024 * 1024
+_MAX_WII_CLUSTERS = 1024
+_HASH_CHUNK_SIZE = 1024 * 1024
+
+_PARSE_ERRORS = (
+    OSError,
+    ValueError,
+    IndexError,
+    EOFError,
+    struct.error,
+    lzma.LZMAError,
+)
+
+
+class RvzHashError(Exception):
+    """Raised when an RVZ/WIA container can't be parsed for native hashing."""
+
+
+class _LaggedFibonacci:
+    """The PRNG GameCube/Wii discs use for junk padding (f=xor, j=32, k=521).
+
+    RVZ stores junk ranges as a 68-byte seed plus a length; regenerating the
+    stream reproduces the original disc bytes. Mirrors Dolphin's
+    LaggedFibonacciGenerator, including the console's "shift by 18 instead of
+    16" output quirk, which is baked into the buffer words up front.
+    """
+
+    _K = 521
+    _J = 32
+    _BUFFER_BYTES = _K * 4
+
+    def __init__(self, seed: bytes) -> None:
+        if len(seed) < 68:
+            raise RvzHashError("truncated junk PRNG seed")
+        words = list(struct.unpack(">17I", seed[:68]))
+        for i in range(17, self._K):
+            words.append(
+                ((words[i - 17] << 23) & 0xFFFFFFFF)
+                ^ (words[i - 16] >> 9)
+                ^ words[i - 1]
+            )
+        self._words = [(w & 0xFF00FFFF) | ((w >> 2) & 0x00FF0000) for w in words]
+        for _ in range(4):
+            self._advance()
+        self._pos = 0
+        self._buffer: bytes | None = None
+
+    def _advance(self) -> None:
+        words = self._words
+        for i in range(self._J):
+            words[i] ^= words[i + self._K - self._J]
+        for i in range(self._J, self._K):
+            words[i] ^= words[i - self._J]
+        self._buffer = None
+
+    def _bytes(self) -> bytes:
+        if self._buffer is None:
+            self._buffer = struct.pack(f">{self._K}I", *self._words)
+        return self._buffer
+
+    def forward(self, count: int) -> None:
+        self._pos += count
+        while self._pos >= self._BUFFER_BYTES:
+            self._advance()
+            self._pos -= self._BUFFER_BYTES
+
+    def get_bytes(self, count: int) -> bytes:
+        out = bytearray()
+        while count > 0:
+            buffer = self._bytes()
+            take = min(count, self._BUFFER_BYTES - self._pos)
+            out += buffer[self._pos : self._pos + take]
+            self._pos += take
+            count -= take
+            if self._pos == self._BUFFER_BYTES:
+                self._advance()
+                self._pos = 0
+        return bytes(out)
+
+
+def _decode_lzma_filters(lzma2: bool, compr_data: bytes) -> list[dict]:
+    """Convert the 7-Zip-SDK properties stored in the header to lzma filters."""
+    if lzma2:
+        if len(compr_data) < 1:
+            raise RvzHashError("missing LZMA2 properties")
+        prop = compr_data[0]
+        if prop > 40:
+            raise RvzHashError("invalid LZMA2 dictionary size")
+        dict_size = 0xFFFFFFFF if prop == 40 else (2 | (prop & 1)) << (prop // 2 + 11)
+        return [{"id": lzma.FILTER_LZMA2, "dict_size": max(dict_size, 1 << 12)}]
+
+    if len(compr_data) < 5:
+        raise RvzHashError("missing LZMA properties")
+    d = compr_data[0]
+    if d >= 9 * 5 * 5:
+        raise RvzHashError("invalid LZMA properties")
+    lc = d % 9
+    d //= 9
+    pb = d // 5
+    lp = d % 5
+    dict_size = struct.unpack_from("<I", compr_data, 1)[0]
+    return [
+        {
+            "id": lzma.FILTER_LZMA1,
+            "dict_size": max(dict_size, 1 << 12),
+            "lc": lc,
+            "lp": lp,
+            "pb": pb,
+        }
+    ]
+
+
+class _WiiPartition:
+    """A wia_part_t entry: title key plus up to two group-backed data ranges."""
+
+    __slots__ = ("key", "segments", "base_sector")
+
+    def __init__(self, key: bytes, segments: list[tuple[int, int, int, int]]) -> None:
+        self.key = key
+        # (first_sector, n_sectors, group_index, n_groups), empty ones dropped
+        self.segments = [seg for seg in segments if seg[1] > 0]
+        if not self.segments:
+            raise RvzHashError("Wii partition without data segments")
+        self.base_sector = min(seg[0] for seg in self.segments)
+
+
+class _RvzReader:
+    """Random access over the reconstructed disc bytes of an RVZ/WIA image.
+
+    ``read_at`` serves any byte range of the original disc: non-partition
+    ranges come from the raw-data groups, Wii partition data is rebuilt into
+    its encrypted on-disc form (hash tree + hash exceptions + AES-128-CBC),
+    and unmapped ranges read as zeroes.
+    """
+
+    def __init__(self, fh: BinaryIO) -> None:
+        self._fh = fh
+        header_1 = fh.read(0x48)
+        if len(header_1) < 0x48:
+            raise RvzHashError("truncated file header")
+        magic = header_1[:4]
+        if magic not in (_RVZ_MAGIC, _WIA_MAGIC):
+            raise RvzHashError(f"unrecognized container magic {magic[:4]!r}")
+        self.is_rvz = magic == _RVZ_MAGIC
+
+        header_2_size = struct.unpack_from(">I", header_1, 0x0C)[0]
+        self.iso_size = struct.unpack_from(">Q", header_1, 0x24)[0]
+        if not 0xDC <= header_2_size <= 0x400:
+            raise RvzHashError("invalid disc header size")
+        header_2 = fh.read(header_2_size)
+        if len(header_2) < 0xDC:
+            raise RvzHashError("truncated disc header")
+
+        self.disc_type, self.compression, _level, self.chunk_size = struct.unpack_from(
+            ">IIiI", header_2, 0
+        )
+        if self.compression == _COMPRESSION_PURGE:
+            raise RvzHashError("PURGE compression is not supported")
+        if self.compression not in (
+            _COMPRESSION_NONE,
+            _COMPRESSION_BZIP2,
+            _COMPRESSION_LZMA,
+            _COMPRESSION_LZMA2,
+            _COMPRESSION_ZSTD,
+        ):
+            raise RvzHashError(f"unknown compression method {self.compression}")
+        if self.chunk_size == 0 or self.chunk_size % _WII_SECTOR_SIZE:
+            raise RvzHashError("invalid chunk size")
+
+        self.disc_header = header_2[0x10:0x90]
+        n_part, part_t_size = struct.unpack_from(">II", header_2, 0x90)
+        part_off = struct.unpack_from(">Q", header_2, 0x98)[0]
+        n_raw, raw_off, raw_size = struct.unpack_from(">IQI", header_2, 0xB4)
+        n_groups, group_off, group_size = struct.unpack_from(">IQI", header_2, 0xC4)
+        compr_data_len = header_2[0xD4]
+        self._compr_data = header_2[0xD5 : 0xD5 + min(compr_data_len, 7)]
+
+        if n_part > 0x100 or n_raw > 0x10000 or n_groups > 0x1000000:
+            raise RvzHashError("implausible entry counts")
+
+        # Partition entries are stored uncompressed. Entries smaller than
+        # 0x30 bytes are zero-padded per the spec.
+        self.partitions: list[_WiiPartition] = []
+        if n_part:
+            if part_t_size > 0x400:
+                raise RvzHashError("invalid partition entry size")
+            fh.seek(part_off)
+            blob = fh.read(n_part * part_t_size)
+            if len(blob) < n_part * part_t_size:
+                raise RvzHashError("truncated partition entries")
+            for i in range(n_part):
+                entry = blob[i * part_t_size : (i + 1) * part_t_size].ljust(
+                    0x30, b"\x00"
+                )
+                segments = [
+                    struct.unpack_from(">IIII", entry, base) for base in (0x10, 0x20)
+                ]
+                self.partitions.append(_WiiPartition(entry[:16], segments))
+
+        # Raw-data and group entry tables are stored compressed.
+        raw_blob = self._decompress_blob(raw_off, raw_size, n_raw * 0x18)
+        self._raw_entries: list[tuple[int, int, int, int]] = []
+        for i in range(n_raw):
+            data_off, data_size, group_index, entry_groups = struct.unpack_from(
+                ">QQII", raw_blob, i * 0x18
+            )
+            # The first entry claims to start at 0x80; align entries down to a
+            # sector boundary (the group data actually covers from there).
+            skew = data_off % _WII_SECTOR_SIZE
+            self._raw_entries.append(
+                (data_off - skew, data_size + skew, group_index, entry_groups)
+            )
+
+        entry_size = 0x0C if self.is_rvz else 0x08
+        group_blob = self._decompress_blob(group_off, group_size, n_groups * entry_size)
+        self._groups: list[tuple[int, int, int]] = []
+        for i in range(n_groups):
+            if self.is_rvz:
+                self._groups.append(
+                    struct.unpack_from(">III", group_blob, i * entry_size)
+                )
+            else:
+                off4, size_field = struct.unpack_from(">II", group_blob, i * entry_size)
+                self._groups.append((off4, size_field, 0))
+
+        # Per-group hash-exception lists for Wii partition data. One list per
+        # 2 MiB of chunk, or a single list for RVZ chunks below 2 MiB.
+        self._except_lists_per_group = max(1, self.chunk_size // 0x200000)
+        self._sectors_per_chunk = self.chunk_size // _WII_SECTOR_SIZE
+        self._chunk_data_size = self._sectors_per_chunk * _WII_SECTOR_DATA_SIZE
+
+        self._group_cache: dict[int, tuple[bytes, list[tuple[int, int, bytes]]]] = {}
+        self._hash_group_cache: dict[tuple[int, int], bytes] = {}
+
+    def close(self) -> None:
+        try:
+            self._fh.close()
+        except OSError:
+            pass
+
+    # -- container plumbing -------------------------------------------------
+
+    def _decompress(self, blob: bytes) -> bytes:
+        if self.compression == _COMPRESSION_NONE:
+            return blob
+        if self.compression == _COMPRESSION_BZIP2:
+            return bz2.decompress(blob)
+        if self.compression in (_COMPRESSION_LZMA, _COMPRESSION_LZMA2):
+            filters = _decode_lzma_filters(
+                self.compression == _COMPRESSION_LZMA2, self._compr_data
+            )
+            return lzma.LZMADecompressor(
+                format=lzma.FORMAT_RAW, filters=filters
+            ).decompress(blob)
+        return zstandard.ZstdDecompressor().decompressobj().decompress(blob)
+
+    def _decompress_blob(self, offset: int, size: int, expected: int) -> bytes:
+        self._fh.seek(offset)
+        blob = self._fh.read(size)
+        if len(blob) < size:
+            raise RvzHashError("truncated entry table")
+        out = self._decompress(blob)
+        if len(out) < expected:
+            raise RvzHashError("entry table shorter than expected")
+        return out
+
+    def _unpack_rvz(self, packed: bytes, data_offset: int, expected: int) -> bytes:
+        """Decode RVZ packing: literal runs plus PRNG-generated junk runs."""
+        out = bytearray()
+        pos = 0
+        while pos + 4 <= len(packed) and len(out) < expected:
+            size = struct.unpack_from(">I", packed, pos)[0]
+            pos += 4
+            if size & 0x80000000:
+                size &= 0x7FFFFFFF
+                lfg = _LaggedFibonacci(packed[pos : pos + 68])
+                pos += 68
+                lfg.forward((data_offset + len(out)) % _WII_SECTOR_SIZE)
+                out += lfg.get_bytes(min(size, expected - len(out)))
+            else:
+                out += packed[pos : pos + size]
+                pos += size
+        return bytes(out)
+
+    def _parse_exception_lists(
+        self, stream: bytes, align: bool
+    ) -> tuple[list[tuple[int, int, bytes]], int]:
+        """Parse the group's wia_except_list_t structs.
+
+        Returns (exceptions, bytes consumed); each exception is
+        (sector offset within the group, offset in that sector's hash area,
+        20-byte replacement digest).
+        """
+        exceptions: list[tuple[int, int, bytes]] = []
+        pos = 0
+        for list_ix in range(self._except_lists_per_group):
+            if pos + 2 > len(stream):
+                raise RvzHashError("truncated hash exception list")
+            (count,) = struct.unpack_from(">H", stream, pos)
+            pos += 2
+            if count > 3328:
+                raise RvzHashError("implausible hash exception count")
+            for _ in range(count):
+                if pos + 22 > len(stream):
+                    raise RvzHashError("truncated hash exception entry")
+                (offset,) = struct.unpack_from(">H", stream, pos)
+                sector = list_ix * 64 + offset // _WII_SECTOR_HASH_SIZE
+                exceptions.append(
+                    (
+                        sector,
+                        offset % _WII_SECTOR_HASH_SIZE,
+                        stream[pos + 2 : pos + 22],
+                    )
+                )
+                pos += 22
+        if align:
+            pos += (-pos) % 4
+        return exceptions, pos
+
+    def _decode_group(
+        self, index: int, expected: int, data_offset: int, with_exceptions: bool
+    ) -> tuple[bytes, list[tuple[int, int, bytes]]]:
+        """Decode one group into (data, hash exceptions), zero-padded/cached."""
+        cached = self._group_cache.get(index)
+        if cached is not None:
+            return cached
+
+        if index >= len(self._groups):
+            raise RvzHashError("group index out of range")
+        data_off4, size_field, packed_size = self._groups[index]
+        if self.is_rvz:
+            compressed = bool(size_field & 0x80000000)
+            stored_size = size_field & 0x7FFFFFFF
+        else:
+            compressed = self.compression != _COMPRESSION_NONE
+            stored_size = size_field
+
+        result: tuple[bytes, list[tuple[int, int, bytes]]]
+        if stored_size == 0:
+            result = (b"\x00" * expected, [])
+        else:
+            self._fh.seek(data_off4 << 2)
+            blob = self._fh.read(stored_size)
+            if len(blob) < stored_size:
+                raise RvzHashError("truncated group data")
+
+            stream = self._decompress(blob) if compressed else blob
+            exceptions: list[tuple[int, int, bytes]] = []
+            if with_exceptions:
+                # Uncompressed exception lists are padded to a 4-byte
+                # boundary; compressed ones are not.
+                exceptions, consumed = self._parse_exception_lists(
+                    stream, align=not compressed
+                )
+                stream = stream[consumed:]
+
+            if self.is_rvz and packed_size:
+                data = self._unpack_rvz(stream[:packed_size], data_offset, expected)
+            else:
+                data = stream[:expected]
+            if len(data) < expected:
+                data = data + b"\x00" * (expected - len(data))
+            result = (data, exceptions)
+
+        if len(self._group_cache) >= 16:
+            self._group_cache.clear()
+        self._group_cache[index] = result
+        return result
+
+    # -- raw (non-partition) data -------------------------------------------
+
+    def _read_raw_into(self, out: bytearray, offset: int, length: int) -> None:
+        end = offset + length
+        for entry_start, entry_size, group_index, entry_groups in self._raw_entries:
+            entry_end = entry_start + entry_size
+            lo = max(offset, entry_start)
+            hi = min(end, entry_end)
+            while lo < hi:
+                g = (lo - entry_start) // self.chunk_size
+                if g >= entry_groups:
+                    break
+                group_start = entry_start + g * self.chunk_size
+                expected = min(self.chunk_size, entry_end - group_start)
+                data, _ = self._decode_group(
+                    group_index + g, expected, g * self.chunk_size, False
+                )
+                skip = lo - group_start
+                take = min(hi - lo, expected - skip)
+                if take <= 0:
+                    break
+                out[lo - offset : lo - offset + take] = data[skip : skip + take]
+                lo += take
+
+    # -- Wii partition data --------------------------------------------------
+
+    def _read_partition_decrypted(
+        self, partition: _WiiPartition, offset: int, length: int
+    ) -> bytes:
+        """Read the decrypted, hashless partition data address space."""
+        out = bytearray(length)
+        end = offset + length
+        for first_sector, n_sectors, group_index, seg_groups in partition.segments:
+            seg_start = (first_sector - partition.base_sector) * _WII_SECTOR_DATA_SIZE
+            seg_size = n_sectors * _WII_SECTOR_DATA_SIZE
+            seg_end = seg_start + seg_size
+            lo = max(offset, seg_start)
+            hi = min(end, seg_end)
+            while lo < hi:
+                g = (lo - seg_start) // self._chunk_data_size
+                if g >= seg_groups:
+                    break
+                group_start = seg_start + g * self._chunk_data_size
+                expected = min(self._chunk_data_size, seg_end - group_start)
+                data, _ = self._decode_group(
+                    group_index + g, expected, g * self._chunk_data_size, True
+                )
+                skip = lo - group_start
+                take = min(hi - lo, expected - skip)
+                if take <= 0:
+                    break
+                out[lo - offset : lo - offset + take] = data[skip : skip + take]
+                lo += take
+        return bytes(out)
+
+    def _partition_exceptions(
+        self, partition: _WiiPartition, sector_lo: int, sector_hi: int
+    ) -> list[tuple[int, int, bytes]]:
+        """Hash exceptions for partition-relative sectors [lo, hi)."""
+        exceptions: list[tuple[int, int, bytes]] = []
+        for first_sector, n_sectors, group_index, seg_groups in partition.segments:
+            seg_sector_base = first_sector - partition.base_sector
+            seg_size = n_sectors * _WII_SECTOR_DATA_SIZE
+            for g in range(seg_groups):
+                group_sector = seg_sector_base + g * self._sectors_per_chunk
+                if group_sector >= sector_hi:
+                    break
+                if group_sector + self._sectors_per_chunk <= sector_lo:
+                    continue
+                expected = min(
+                    self._chunk_data_size, seg_size - g * self._chunk_data_size
+                )
+                _, group_exceptions = self._decode_group(
+                    group_index + g, expected, g * self._chunk_data_size, True
+                )
+                for sector_in_group, hash_offset, digest in group_exceptions:
+                    sector = group_sector + sector_in_group
+                    if sector_lo <= sector < sector_hi:
+                        exceptions.append((sector, hash_offset, digest))
+        return exceptions
+
+    def _encrypted_hash_group(self, partition_index: int, hash_group: int) -> bytes:
+        """Rebuild one 64-sector hash group (2 MiB) of encrypted disc bytes."""
+        cache_key = (partition_index, hash_group)
+        cached = self._hash_group_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        partition = self.partitions[partition_index]
+        sector_lo = hash_group * _WII_SECTORS_PER_HASH_GROUP
+        blocks = [
+            self._read_partition_decrypted(
+                partition,
+                (sector_lo + b) * _WII_SECTOR_DATA_SIZE,
+                _WII_SECTOR_DATA_SIZE,
+            )
+            for b in range(_WII_SECTORS_PER_HASH_GROUP)
+        ]
+
+        # H0: 31 SHA-1 digests per sector, one per 0x400 bytes of data.
+        h0_tables = [
+            b"".join(
+                hashlib.sha1(
+                    block[j * 0x400 : (j + 1) * 0x400], usedforsecurity=False
+                ).digest()
+                for j in range(31)
+            )
+            for block in blocks
+        ]
+        # H1: per 8-sector subgroup, the SHA-1 of each member's H0 table.
+        h1_tables = [
+            b"".join(
+                hashlib.sha1(h0_tables[sub * 8 + k], usedforsecurity=False).digest()
+                for k in range(8)
+            )
+            for sub in range(8)
+        ]
+        # H2: the SHA-1 of each subgroup's H1 table, shared by all 64 sectors.
+        h2_table = b"".join(
+            hashlib.sha1(h1_tables[sub], usedforsecurity=False).digest()
+            for sub in range(8)
+        )
+
+        headers = []
+        for b in range(_WII_SECTORS_PER_HASH_GROUP):
+            header = bytearray(_WII_SECTOR_HASH_SIZE)
+            header[0x000:0x26C] = h0_tables[b]
+            header[0x280:0x320] = h1_tables[b // 8]
+            header[0x340:0x3E0] = h2_table
+            headers.append(header)
+
+        for sector, hash_offset, digest in self._partition_exceptions(
+            partition, sector_lo, sector_lo + _WII_SECTORS_PER_HASH_GROUP
+        ):
+            local = headers[sector - sector_lo]
+            local[hash_offset : hash_offset + len(digest)] = digest[
+                : _WII_SECTOR_HASH_SIZE - hash_offset
+            ]
+
+        out = bytearray()
+        for b in range(_WII_SECTORS_PER_HASH_GROUP):
+            hash_cipher = Cipher(
+                algorithms.AES(partition.key), modes.CBC(b"\x00" * 16)
+            ).encryptor()
+            enc_header = hash_cipher.update(bytes(headers[b])) + hash_cipher.finalize()
+            # The data IV is the encrypted hash area's bytes at 0x3D0.
+            data_cipher = Cipher(
+                algorithms.AES(partition.key), modes.CBC(enc_header[0x3D0:0x3E0])
+            ).encryptor()
+            out += enc_header + data_cipher.update(blocks[b]) + data_cipher.finalize()
+
+        if len(self._hash_group_cache) >= 2:
+            self._hash_group_cache.clear()
+        self._hash_group_cache[cache_key] = bytes(out)
+        return bytes(out)
+
+    def _read_partition_encrypted_into(
+        self, out: bytearray, offset: int, length: int, partition_index: int
+    ) -> None:
+        partition = self.partitions[partition_index]
+        end = offset + length
+        group_bytes = _WII_SECTORS_PER_HASH_GROUP * _WII_SECTOR_SIZE
+        for first_sector, n_sectors, _, _ in partition.segments:
+            seg_start = first_sector * _WII_SECTOR_SIZE
+            seg_end = seg_start + n_sectors * _WII_SECTOR_SIZE
+            lo = max(offset, seg_start)
+            hi = min(end, seg_end)
+            data_start = partition.base_sector * _WII_SECTOR_SIZE
+            while lo < hi:
+                hash_group = (lo - data_start) // group_bytes
+                group_start = data_start + hash_group * group_bytes
+                data = self._encrypted_hash_group(partition_index, hash_group)
+                skip = lo - group_start
+                take = min(hi - lo, group_bytes - skip)
+                out[lo - offset : lo - offset + take] = data[skip : skip + take]
+                lo += take
+
+    # -- public API -----------------------------------------------------------
+
+    def read_at(self, offset: int, length: int) -> bytes:
+        """Reconstructed disc bytes at [offset, offset+length), zero-filled."""
+        out = bytearray(length)
+        self._read_raw_into(out, offset, length)
+        for i in range(len(self.partitions)):
+            self._read_partition_encrypted_into(out, offset, length, i)
+        if offset < 0x80:
+            take = min(0x80 - offset, length)
+            out[0:take] = self.disc_header[offset : offset + take]
+        return bytes(out)
+
+
+def _open_reader(file_path: str) -> _RvzReader:
+    fh = open(file_path, "rb")  # noqa: SIM115 - ownership passes to the reader
+    try:
+        return _RvzReader(fh)
+    except BaseException:
+        fh.close()
+        raise
+
+
+def _be32(data: bytes, offset: int = 0) -> int:
+    return struct.unpack_from(">I", data, offset)[0]
+
+
+def _hash_chunked(md5, reader: _RvzReader, offset: int, size: int) -> None:
+    """Feed [offset, offset+size) to the hash in bounded chunks."""
+    pos = offset
+    remaining = size
+    while remaining > 0:
+        take = min(remaining, _HASH_CHUNK_SIZE)
+        md5.update(reader.read_at(pos, take))
+        pos += take
+        remaining -= take
+
+
+def _hash_nintendo_disc_partition(
+    md5, reader: _RvzReader, part_offset: int, wii_shift: int
+) -> None:
+    """Mirror of rcheevos rc_hash_nintendo_disc_partition."""
+    body, trailer = struct.unpack(
+        ">II", reader.read_at(part_offset + _GC_BASE_HEADER_SIZE + 0x14, 8)
+    )
+    header_size = min(_GC_BASE_HEADER_SIZE + 0x20 + body + trailer, _MAX_GC_HEADER_SIZE)
+    _hash_chunked(md5, reader, part_offset, header_size)
+
+    dol_offset = _be32(reader.read_at(part_offset + 0x420, 4)) << wii_shift
+    dol_header = reader.read_at(part_offset + dol_offset, 0xD8)
+    for ix in range(18):
+        seg_offset = _be32(dol_header, ix * 4) << wii_shift
+        seg_size = _be32(dol_header, 0x90 + ix * 4) << wii_shift
+        if seg_size:
+            # rcheevos seeks these relative to the partition, not the DOL.
+            _hash_chunked(md5, reader, part_offset + seg_offset, seg_size)
+
+
+def calculate_gamecube_ra_hash(file_path: str) -> str:
+    """Compute the RetroAchievements GameCube hash from an RVZ/WIA image.
+
+    Returns the 32-char MD5 hex digest, or an empty string if the container
+    can't be parsed or doesn't hold a GameCube disc (the caller then falls
+    back to RAHasher).
+    """
+    try:
+        reader = _open_reader(file_path)
+    except (OSError, RvzHashError) as exc:
+        log.warning(
+            f"Could not open RVZ/WIA container {hl(file_path)} for native "
+            f"{hl('RA', color=LIGHTMAGENTA)} hashing: {exc}"
+        )
+        return ""
+
+    try:
+        if reader.read_at(0x1C, 4) != _GC_MAGIC:
+            log.warning(
+                f"{hl(file_path)} does not hold a GameCube disc; can't compute "
+                f"native {hl('RA', color=LIGHTMAGENTA)} hash"
+            )
+            return ""
+        md5 = hashlib.md5(usedforsecurity=False)
+        _hash_nintendo_disc_partition(md5, reader, 0, 0)
+        return md5.hexdigest()
+    except (RvzHashError, *_PARSE_ERRORS) as exc:
+        log.warning(
+            f"Failed to read GameCube disc data from {hl(file_path)} for native "
+            f"{hl('RA', color=LIGHTMAGENTA)} hashing: {exc}"
+        )
+        return ""
+    finally:
+        reader.close()
+
+
+def _hash_wii_disc(md5, reader: _RvzReader) -> None:
+    """Mirror of rcheevos rc_hash_wii_disc for encrypted retail discs."""
+    if reader.read_at(0x61, 1) != b"\x00":
+        raise RvzHashError("decrypted Wii disc images are not supported")
+
+    md5.update(reader.read_at(0, 0x80))
+    md5.update(reader.read_at(0x4E000, 4))
+
+    info = struct.unpack(">8I", reader.read_at(0x40000, 32))
+    partitions: list[tuple[int, int]] = []
+    for j in range(0, 8, 2):
+        count, table_off4 = info[j], info[j + 1]
+        if count > 0x100:
+            raise RvzHashError("implausible partition count")
+        for i in range(count):
+            entry = reader.read_at((table_off4 << 2) + i * 8, 8)
+            partitions.append(struct.unpack(">II", entry))
+    if not partitions:
+        raise RvzHashError("no partitions found")
+
+    for part_off4, part_type in partitions:
+        if part_type == 1:  # update partition
+            continue
+        part_start = part_off4 << 2
+
+        tmd_size, tmd_off4 = struct.unpack(">II", reader.read_at(part_start + 0x2A4, 8))
+        tmd_size = min(tmd_size, _WII_SECTOR_DATA_SIZE)
+        md5.update(reader.read_at(part_start + (tmd_off4 << 2), tmd_size))
+
+        data_off4, data_size4 = struct.unpack(
+            ">II", reader.read_at(part_start + 0x2B8, 8)
+        )
+        # rcheevos reads the partition-relative data offset field and then
+        # seeks with it as an absolute file offset; mirror that exactly.
+        part_offset = data_off4 << 2
+        part_size = data_size4 << 2
+
+        clusters = min(part_size // _WII_SECTOR_SIZE, _MAX_WII_CLUSTERS)
+        for ix in range(clusters):
+            md5.update(
+                reader.read_at(
+                    part_offset + ix * _WII_SECTOR_SIZE + _WII_SECTOR_HASH_SIZE,
+                    _WII_SECTOR_DATA_SIZE,
+                )
+            )
+
+
+def calculate_wii_ra_hash(file_path: str) -> str:
+    """Compute the RetroAchievements Wii hash from an RVZ/WIA image.
+
+    Returns the 32-char MD5 hex digest, or an empty string if the container
+    can't be parsed or doesn't hold an encrypted Wii disc (the caller then
+    falls back to RAHasher).
+    """
+    try:
+        reader = _open_reader(file_path)
+    except (OSError, RvzHashError) as exc:
+        log.warning(
+            f"Could not open RVZ/WIA container {hl(file_path)} for native "
+            f"{hl('RA', color=LIGHTMAGENTA)} hashing: {exc}"
+        )
+        return ""
+
+    try:
+        if reader.read_at(0x18, 4) != _WII_MAGIC:
+            log.warning(
+                f"{hl(file_path)} does not hold a Wii disc; can't compute "
+                f"native {hl('RA', color=LIGHTMAGENTA)} hash"
+            )
+            return ""
+        md5 = hashlib.md5(usedforsecurity=False)
+        _hash_wii_disc(md5, reader)
+        return md5.hexdigest()
+    except (RvzHashError, *_PARSE_ERRORS) as exc:
+        log.warning(
+            f"Failed to read Wii disc data from {hl(file_path)} for native "
+            f"{hl('RA', color=LIGHTMAGENTA)} hashing: {exc}"
+        )
+        return ""
+    finally:
+        reader.close()
+
+
+def is_rvz_native_hash_file(file_path: str) -> bool:
+    """Whether ``file_path`` is an RVZ/WIA image we hash natively (by extension)."""
+    return os.path.splitext(file_path)[1].lower() in RVZ_NATIVE_HASH_EXTENSIONS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "anyio ~= 4.4",
   "authlib ~= 1.6.12",
   "colorama ~= 0.4",
+  "cryptography ~= 49.0",
   "defusedxml ~= 0.7",
   "fastapi-pagination[sqlalchemy] ~= 0.15",
   "fastapi[standard-no-fastapi-cloud-cli] ~= 0.134.0",
@@ -60,6 +61,7 @@ dependencies = [
   "watchfiles ~= 1.1",
   "yarl ~= 1.14",
   "zipfile-inflate64 ~= 0.1",
+  "zstandard ~= 0.25",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2200,6 +2200,7 @@ dependencies = [
     { name = "authlib" },
     { name = "bcrypt" },
     { name = "colorama" },
+    { name = "cryptography" },
     { name = "defusedxml" },
     { name = "fastapi", extra = ["standard-no-fastapi-cloud-cli"] },
     { name = "fastapi-pagination", extra = ["sqlalchemy"] },
@@ -2239,6 +2240,7 @@ dependencies = [
     { name = "watchfiles" },
     { name = "yarl" },
     { name = "zipfile-inflate64" },
+    { name = "zstandard" },
 ]
 
 [package.optional-dependencies]
@@ -2274,6 +2276,7 @@ requires-dist = [
     { name = "authlib", specifier = "~=1.6.12" },
     { name = "bcrypt", specifier = "<5" },
     { name = "colorama", specifier = "~=0.4" },
+    { name = "cryptography", specifier = "~=49.0" },
     { name = "defusedxml", specifier = "~=0.7" },
     { name = "fakeredis", marker = "extra == 'test'", specifier = "~=2.21" },
     { name = "fastapi", extras = ["standard-no-fastapi-cloud-cli"], specifier = "~=0.134.0" },
@@ -2331,6 +2334,7 @@ requires-dist = [
     { name = "watchfiles", specifier = "~=1.1" },
     { name = "yarl", specifier = "~=1.14" },
     { name = "zipfile-inflate64", specifier = "~=0.1" },
+    { name = "zstandard", specifier = "~=0.25" },
 ]
 provides-extras = ["dev", "test"]
 
@@ -2999,4 +3003,44 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]


### PR DESCRIPTION
**Description**

Fixes #3649 and #3650.

GameCube and Wii games stored as `.rvz`/`.wia` (the compressed disc format Dolphin
creates) never matched on RetroAchievements: the external `RAHasher` binary cannot
read the RVZ container and fails with `Not a Gamecube disc` /
`Not a supported Wii file`, so scans left those games without an RA link even
though the same files unlock achievements in Dolphin.

Neither console's RA hash depends on the whole disc, so this PR computes the hash
natively, in-process, with no subprocess and no temporary multi-GB ISO:

- A random-access RVZ/WIA reader decompresses only the groups a byte range
  touches. All codecs are supported (NONE, bzip2, LZMA, LZMA2, Zstandard), plus
  RVZ packing (junk regeneration via the lagged-Fibonacci PRNG) and stored hash
  exceptions. PURGE (legacy WIA) is rejected and falls back.
- **GameCube** (#3649): MD5 of the boot header, apploader, and the up-to-18
  `main.dol` segments, mirroring rcheevos `rc_hash_gamecube`.
- **Wii** (#3650): RA hashes *encrypted* disc bytes, but RVZ stores partition data
  decrypted with the hash tree stripped. The reader recalculates the H0/H1/H2
  hash tree, applies the container's hash exceptions, and re-encrypts clusters
  with the embedded title key (AES-128-CBC, data IV taken from the encrypted
  hash block at 0x3D0), reproducing the exact retail disc bytes rcheevos hashes.
- `RAHasherService.calculate_hash()` tries the native path for `.rvz`/`.wia` on
  the GameCube/Wii platforms and falls back to `RAHasher` on any failure, same
  shape as the PSP `.cso` native path (#3600).

**Files changed**

| File | Change |
| --- | --- |
| `backend/utils/rvz_hasher.py` | New: RVZ/WIA container reader + native GameCube/Wii RA hash implementations. |
| `backend/adapters/services/rahasher.py` | Native-hash gate for NGC/Wii `.rvz`/`.wia` before spawning `RAHasher`, with fallback. |
| `backend/tests/utils/test_rvz_hasher.py` | New: synthetic RVZ/WIA builder, spec-based reference implementations, 27 tests incl. real-ROM integration tests (skip when the dumps are absent). |
| `backend/tests/adapters/services/test_rahasher.py` | 9 new service tests: native path short-circuits the subprocess, falls back on failure, and is not triggered for other platforms or raw `.iso`. |
| `pyproject.toml` / `uv.lock` | Add `zstandard ~= 0.25`; promote `cryptography` (already transitive via joserfc/authlib) to a direct dependency for AES. |

**Testing**

- Synthetic tests cover every codec, WIA containers, groups stored raw, zero
  groups, RVZ junk packing, Wii hash exceptions, the rcheevos TMD cap, and
  update-partition skipping. The expected hashes come from independent
  reference implementations written from the specs (rcheevos `hash_disc.c`,
  Dolphin's `WiaAndRvz.md`, wiibrew), so the production reader and the tests
  meet only at the format boundary.
- Real dumps: *Mario Kart: Double Dash!! (USA)* `.rvz` hashes to
  `adad8934d2586d27ec4b653bae52e47b` and *Super Mario Galaxy (USA)* `.rvz` to
  `4e0d0d2f2c5d3c13d758b027bbcc059f`; both verified present in RA's official
  hash lists (games 7693 and 189) via `API_GetGameList`.
- Cross-check against the shipped binary: `RAHasher` 1.8.3 produces identical
  hashes when run on disc images reconstructed by this same reader, so there is
  no version-skew risk between the native path and the subprocess path.
- Timing on real files: ~0.06 s for the GameCube `.rvz` (zstd-19), ~0.42 s for
  the 3.5 GB Wii `.rvz`.
- Full backend suite: 1929 passed, no regressions.

**Notes for reviewers**

- Two rcheevos quirks are mirrored **deliberately** (matching Dolphin and
  RAHasher, and therefore RA's database): `rc_hash_wii_disc` reads the
  partition-relative data-offset field but seeks with it as an *absolute* file
  offset, and GameCube `main.dol` segment offsets are seeked relative to the
  partition, not the DOL. Both are commented in the code; "fixing" either
  breaks matching.
- The Wii encrypted-byte reconstruction (hash-tree layout, exception mapping,
  IV derivation) is the highest-risk logic; the real-ROM tests and the
  RAHasher cross-check are the strongest evidence it is byte-exact.
- Failure contract: both hash functions log and return `""` on any parse
  failure, and the service falls through to `RAHasher` (no worse than before).
- Decrypted Wii images (header byte 0x61 != 0) are explicitly not supported and
  fall back; retail RVZ dumps are always encrypted-original.
- Malformed containers are handled defensively: chunk size and entry counts are
  bounded, per-group decompression output is capped (decompression-bomb guard),
  and corrupt data (bad zstd frames, out-of-range DOL segments) fails softly to
  the RAHasher fallback rather than raising into the scan.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

---

> **AI assistance disclosure:** This PR was written primarily by Claude Code
> (Claude Fable 5): implementation, tests, and the validation tooling used to
> check the hashes against the RetroAchievements database and the RAHasher
> binary. Direction, test ROMs, and review were provided by the human operator.
> PR responses may also be drafted with AI assistance and will be disclosed as
> such.
