### PR TITLE
fix: make 1.8 migration re-entrant so fresh installs stop crash-looping on MariaDB

### DIFF
--- a/backend/alembic/versions/1.8_.py
+++ b/backend/alembic/versions/1.8_.py
@@ -48,8 +48,7 @@ def _create_platforms_table() -> None:
 
 
 def _copy_old_platforms() -> None:
-    op.execute(
-        """
+    op.execute("""
         INSERT INTO platforms(igdb_id, sgdb_id, slug, fs_slug, name, logo_path, n_roms)
         SELECT
             old_platforms.igdb_id,
@@ -63,8 +62,7 @@ def _copy_old_platforms() -> None:
         LEFT JOIN platforms AS existing_platforms
             ON existing_platforms.fs_slug = old_platforms.slug
         WHERE existing_platforms.fs_slug IS NULL
-        """
-    )
+        """)
 
 
 def _upgrade_platforms(connection: sa.Connection) -> None:
@@ -148,8 +146,7 @@ def _create_roms_table() -> None:
 
 
 def _copy_old_roms() -> None:
-    op.execute(
-        """
+    op.execute("""
         INSERT INTO roms(
             r_igdb_id, p_igdb_id, r_sgdb_id, p_sgdb_id,
             p_slug, p_name, file_name, file_name_no_tags,
@@ -189,8 +186,7 @@ def _copy_old_roms() -> None:
             ON existing_roms.p_slug = old_roms.p_slug
             AND existing_roms.file_name = old_roms.file_name
         WHERE existing_roms.id IS NULL
-        """
-    )
+        """)
 
 
 def _upgrade_roms_table(connection: sa.Connection) -> None:

--- a/backend/alembic/versions/1.8_.py
+++ b/backend/alembic/versions/1.8_.py
@@ -8,6 +8,7 @@ Create Date: 2023-04-17 12:03:19.163501
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy import inspect
 
 from utils.database import CustomJSON
 
@@ -18,28 +19,78 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade() -> None:
-    with op.batch_alter_table("platforms") as batch_op:
-        batch_op.execute("ALTER TABLE platforms RENAME TO old_platforms")
-        op.create_table(
-            "platforms",
-            sa.Column("igdb_id", sa.String(length=10), nullable=True),
-            sa.Column("sgdb_id", sa.String(length=10), nullable=True),
-            sa.Column("slug", sa.String(length=50), nullable=False),
-            sa.Column("fs_slug", sa.String(length=50), nullable=False),
-            sa.Column("name", sa.String(length=400), nullable=True),
-            sa.Column("logo_path", sa.String(length=1000), nullable=True),
-            sa.Column("n_roms", sa.Integer(), nullable=True),
-            sa.PrimaryKeyConstraint("fs_slug"),
-            if_not_exists=True,
-        )
-        batch_op.execute(
-            "INSERT INTO platforms(igdb_id, sgdb_id, slug, fs_slug, name, logo_path, n_roms) \
-                            SELECT igdb_id, sgdb_id, slug, slug, name, logo_path, n_roms \
-                            FROM old_platforms"
-        )
-        op.drop_table("old_platforms", if_exists=True)
+def _has_table(connection: sa.Connection, table_name: str) -> bool:
+    return inspect(connection).has_table(table_name)
 
+
+def _has_column(connection: sa.Connection, table_name: str, column_name: str) -> bool:
+    if not _has_table(connection, table_name):
+        return False
+
+    return column_name in {
+        column["name"] for column in inspect(connection).get_columns(table_name)
+    }
+
+
+def _create_platforms_table() -> None:
+    op.create_table(
+        "platforms",
+        sa.Column("igdb_id", sa.String(length=10), nullable=True),
+        sa.Column("sgdb_id", sa.String(length=10), nullable=True),
+        sa.Column("slug", sa.String(length=50), nullable=False),
+        sa.Column("fs_slug", sa.String(length=50), nullable=False),
+        sa.Column("name", sa.String(length=400), nullable=True),
+        sa.Column("logo_path", sa.String(length=1000), nullable=True),
+        sa.Column("n_roms", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("fs_slug"),
+        if_not_exists=True,
+    )
+
+
+def _copy_old_platforms() -> None:
+    op.execute(
+        """
+        INSERT INTO platforms(igdb_id, sgdb_id, slug, fs_slug, name, logo_path, n_roms)
+        SELECT
+            old_platforms.igdb_id,
+            old_platforms.sgdb_id,
+            old_platforms.slug,
+            old_platforms.slug,
+            old_platforms.name,
+            old_platforms.logo_path,
+            old_platforms.n_roms
+        FROM old_platforms
+        LEFT JOIN platforms AS existing_platforms
+            ON existing_platforms.fs_slug = old_platforms.slug
+        WHERE existing_platforms.fs_slug IS NULL
+        """
+    )
+
+
+def _upgrade_platforms(connection: sa.Connection) -> None:
+    if (
+        _has_table(connection, "platforms")
+        and not _has_column(connection, "platforms", "fs_slug")
+        and not _has_table(connection, "old_platforms")
+    ):
+        op.rename_table("platforms", "old_platforms")
+
+    if _has_table(connection, "old_platforms"):
+        if not _has_table(connection, "platforms"):
+            _create_platforms_table()
+
+        _copy_old_platforms()
+        op.drop_table("old_platforms", if_exists=True)
+    elif not _has_table(connection, "platforms"):
+        _create_platforms_table()
+
+
+def _upgrade_roms_columns(connection: sa.Connection) -> None:
+    if not _has_table(connection, "roms") or _has_column(connection, "roms", "id"):
+        return
+
+    has_name = _has_column(connection, "roms", "name")
+    has_r_name = _has_column(connection, "roms", "r_name")
     with op.batch_alter_table("roms") as batch_op:
         batch_op.add_column(
             sa.Column("p_name", sa.String(length=150), nullable=True),
@@ -48,89 +99,124 @@ def upgrade() -> None:
         batch_op.add_column(
             sa.Column("url_cover", sa.Text(), nullable=True), if_not_exists=True
         )
-        batch_op.alter_column(
-            "name",
-            new_column_name="r_name",
-            type_=sa.String(length=150),
-            existing_type=sa.String(length=150),
-        )
+        if has_name and not has_r_name:
+            batch_op.alter_column(
+                "name",
+                new_column_name="r_name",
+                type_=sa.String(length=150),
+                existing_type=sa.String(length=150),
+            )
         batch_op.alter_column(
             "p_slug", existing_type=sa.String(length=50), nullable=False
         )
         batch_op.alter_column(
             "file_name", existing_type=sa.String(length=450), nullable=False
         )
-    with op.batch_alter_table("roms") as batch_op:
-        batch_op.execute("ALTER TABLE roms RENAME TO old_roms")
-        op.create_table(
-            "roms",
-            sa.Column("id", sa.Integer(), autoincrement=True),
-            sa.Column("r_igdb_id", sa.String(length=10), nullable=True),
-            sa.Column("p_igdb_id", sa.String(length=10), nullable=True),
-            sa.Column("r_sgdb_id", sa.String(length=10), nullable=True),
-            sa.Column("p_sgdb_id", sa.String(length=10), nullable=True),
-            sa.Column("p_slug", sa.String(length=50), nullable=False),
-            sa.Column("p_name", sa.String(length=150), nullable=True),
-            sa.Column("file_name", sa.String(length=450), nullable=False),
-            sa.Column("file_name_no_tags", sa.String(length=450), nullable=False),
-            sa.Column("file_extension", sa.String(length=10), nullable=True),
-            sa.Column("file_path", sa.String(length=1000), nullable=True),
-            sa.Column("file_size", sa.Float(), nullable=True),
-            sa.Column("file_size_units", sa.String(length=10), nullable=True),
-            sa.Column("r_name", sa.String(length=350), nullable=True),
-            sa.Column("r_slug", sa.String(length=100), nullable=True),
-            sa.Column("summary", sa.Text(), nullable=True),
-            sa.Column("path_cover_s", sa.Text(), nullable=True),
-            sa.Column("path_cover_l", sa.Text(), nullable=True),
-            sa.Column("has_cover", sa.Boolean(), nullable=True),
-            sa.Column("region", sa.String(length=20), nullable=True),
-            sa.Column("revision", sa.String(length=20), nullable=True),
-            sa.Column("tags", CustomJSON(), nullable=True),
-            sa.Column("multi", sa.Boolean(), nullable=True),
-            sa.Column("files", CustomJSON(), nullable=True),
-            sa.Column("url_cover", sa.Text(), nullable=True),
-            sa.PrimaryKeyConstraint("id"),
-            if_not_exists=True,
+
+
+def _create_roms_table() -> None:
+    op.create_table(
+        "roms",
+        sa.Column("id", sa.Integer(), autoincrement=True),
+        sa.Column("r_igdb_id", sa.String(length=10), nullable=True),
+        sa.Column("p_igdb_id", sa.String(length=10), nullable=True),
+        sa.Column("r_sgdb_id", sa.String(length=10), nullable=True),
+        sa.Column("p_sgdb_id", sa.String(length=10), nullable=True),
+        sa.Column("p_slug", sa.String(length=50), nullable=False),
+        sa.Column("p_name", sa.String(length=150), nullable=True),
+        sa.Column("file_name", sa.String(length=450), nullable=False),
+        sa.Column("file_name_no_tags", sa.String(length=450), nullable=False),
+        sa.Column("file_extension", sa.String(length=10), nullable=True),
+        sa.Column("file_path", sa.String(length=1000), nullable=True),
+        sa.Column("file_size", sa.Float(), nullable=True),
+        sa.Column("file_size_units", sa.String(length=10), nullable=True),
+        sa.Column("r_name", sa.String(length=350), nullable=True),
+        sa.Column("r_slug", sa.String(length=100), nullable=True),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("path_cover_s", sa.Text(), nullable=True),
+        sa.Column("path_cover_l", sa.Text(), nullable=True),
+        sa.Column("has_cover", sa.Boolean(), nullable=True),
+        sa.Column("region", sa.String(length=20), nullable=True),
+        sa.Column("revision", sa.String(length=20), nullable=True),
+        sa.Column("tags", CustomJSON(), nullable=True),
+        sa.Column("multi", sa.Boolean(), nullable=True),
+        sa.Column("files", CustomJSON(), nullable=True),
+        sa.Column("url_cover", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        if_not_exists=True,
+    )
+
+
+def _copy_old_roms() -> None:
+    op.execute(
+        """
+        INSERT INTO roms(
+            r_igdb_id, p_igdb_id, r_sgdb_id, p_sgdb_id,
+            p_slug, p_name, file_name, file_name_no_tags,
+            file_extension, file_path, file_size,
+            file_size_units, r_name, r_slug,
+            summary, path_cover_s, path_cover_l,
+            has_cover, region, revision, tags,
+            multi, files, url_cover
         )
-        batch_op.execute("""
-            INSERT INTO roms(
-                r_igdb_id, p_igdb_id, r_sgdb_id, p_sgdb_id, 
-                p_slug, p_name, file_name, file_name_no_tags, 
-                file_extension, file_path, file_size, 
-                file_size_units, r_name, r_slug, 
-                summary, path_cover_s, path_cover_l, 
-                has_cover, region, revision, tags, 
-                multi, files, url_cover
-            ) 
-            SELECT 
-                r_igdb_id, 
-                p_igdb_id, 
-                r_sgdb_id, 
-                p_sgdb_id, 
-                p_slug, 
-                p_name, 
-                file_name, 
-                file_name_no_tags, 
-                file_extension, 
-                file_path, 
-                file_size, 
-                file_size_units, 
-                r_name, 
-                r_slug, 
-                summary, 
-                path_cover_s, 
-                path_cover_l, 
-                has_cover, 
-                region, 
-                revision, 
-                tags, 
-                multi, 
-                files, 
-                url_cover
-            FROM 
-                old_roms
-            """)
+        SELECT
+            old_roms.r_igdb_id,
+            old_roms.p_igdb_id,
+            old_roms.r_sgdb_id,
+            old_roms.p_sgdb_id,
+            old_roms.p_slug,
+            old_roms.p_name,
+            old_roms.file_name,
+            old_roms.file_name_no_tags,
+            old_roms.file_extension,
+            old_roms.file_path,
+            old_roms.file_size,
+            old_roms.file_size_units,
+            old_roms.r_name,
+            old_roms.r_slug,
+            old_roms.summary,
+            old_roms.path_cover_s,
+            old_roms.path_cover_l,
+            old_roms.has_cover,
+            old_roms.region,
+            old_roms.revision,
+            old_roms.tags,
+            old_roms.multi,
+            old_roms.files,
+            old_roms.url_cover
+        FROM old_roms
+        LEFT JOIN roms AS existing_roms
+            ON existing_roms.p_slug = old_roms.p_slug
+            AND existing_roms.file_name = old_roms.file_name
+        WHERE existing_roms.id IS NULL
+        """
+    )
+
+
+def _upgrade_roms_table(connection: sa.Connection) -> None:
+    if (
+        _has_table(connection, "roms")
+        and not _has_column(connection, "roms", "id")
+        and not _has_table(connection, "old_roms")
+    ):
+        op.rename_table("roms", "old_roms")
+
+    if _has_table(connection, "old_roms"):
+        if not _has_table(connection, "roms"):
+            _create_roms_table()
+
+        _copy_old_roms()
         op.drop_table("old_roms", if_exists=True)
+    elif not _has_table(connection, "roms"):
+        _create_roms_table()
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    _upgrade_platforms(connection)
+    _upgrade_roms_columns(connection)
+    _upgrade_roms_table(connection)
 
 
 def downgrade() -> None:

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -72,12 +72,12 @@ def migration_engine() -> Iterator[Engine]:
 
 def _run_1_8_upgrade(conn: Connection) -> None:
     context = MigrationContext.configure(conn, opts={"render_as_batch": True})
-    previous_op = getattr(migration_1_8, "op")
-    setattr(migration_1_8, "op", Operations(context))
+    previous_op = migration_1_8.op
+    migration_1_8.op = Operations(context)  # trunk-ignore(mypy/attr-defined)
     try:
-        getattr(migration_1_8, "upgrade")()
+        migration_1_8.upgrade()
     finally:
-        setattr(migration_1_8, "op", previous_op)
+        migration_1_8.op = previous_op  # trunk-ignore(mypy/attr-defined)
 
 
 def _columns(conn: Connection, table_name: str) -> set[str]:

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1,0 +1,378 @@
+import importlib.util
+import re
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import Connection, Engine
+
+from config import ROMM_DB_DRIVER
+from config.config_manager import ConfigManager
+from utils.database import CustomJSON
+
+
+def _load_migration() -> ModuleType:
+    migration_path = Path(__file__).parents[1] / "alembic/versions/1.8_.py"
+    spec = importlib.util.spec_from_file_location("migration_1_8", migration_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+migration_1_8 = _load_migration()
+
+
+@pytest.fixture
+def migration_engine() -> Iterator[Engine]:
+    url = ConfigManager.get_db_engine()
+    assert url.database
+
+    db_name = f"{url.database}_migration_{uuid.uuid4().hex[:8]}"
+    assert re.fullmatch(r"[A-Za-z0-9_]+", db_name)
+
+    if ROMM_DB_DRIVER in ("mariadb", "mysql"):
+        admin_engine = create_engine(url.set(database="information_schema"))
+        with admin_engine.begin() as conn:
+            conn.execute(text(f"CREATE DATABASE `{db_name}`"))
+
+        engine = create_engine(url.set(database=db_name))
+        try:
+            yield engine
+        finally:
+            engine.dispose()
+            with admin_engine.begin() as conn:
+                conn.execute(text(f"DROP DATABASE IF EXISTS `{db_name}`"))
+            admin_engine.dispose()
+    elif ROMM_DB_DRIVER == "postgresql":
+        admin_engine = create_engine(
+            url.set(database="postgres"), isolation_level="AUTOCOMMIT"
+        )
+        with admin_engine.connect() as conn:
+            conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+
+        engine = create_engine(url.set(database=db_name))
+        try:
+            yield engine
+        finally:
+            engine.dispose()
+            with admin_engine.connect() as conn:
+                conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+            admin_engine.dispose()
+    else:
+        pytest.fail(f"Unsupported database driver: {ROMM_DB_DRIVER}")
+
+
+def _run_1_8_upgrade(conn: Connection) -> None:
+    context = MigrationContext.configure(conn, opts={"render_as_batch": True})
+    previous_op = getattr(migration_1_8, "op")
+    setattr(migration_1_8, "op", Operations(context))
+    try:
+        getattr(migration_1_8, "upgrade")()
+    finally:
+        setattr(migration_1_8, "op", previous_op)
+
+
+def _columns(conn: Connection, table_name: str) -> set[str]:
+    return {column["name"] for column in inspect(conn).get_columns(table_name)}
+
+
+def _has_table(conn: Connection, table_name: str) -> bool:
+    return inspect(conn).has_table(table_name)
+
+
+def _count(conn: Connection, table_name: str) -> int:
+    table = sa.table(table_name)
+    return int(conn.execute(sa.select(sa.func.count()).select_from(table)).scalar_one())
+
+
+def _create_legacy_platforms(
+    conn: Connection, table_name: str = "platforms"
+) -> sa.Table:
+    table = sa.Table(
+        table_name,
+        sa.MetaData(),
+        sa.Column("igdb_id", sa.String(length=10), nullable=True),
+        sa.Column("sgdb_id", sa.String(length=10), nullable=True),
+        sa.Column("slug", sa.String(length=50), nullable=False),
+        sa.Column("name", sa.String(length=400), nullable=True),
+        sa.Column("logo_path", sa.String(length=1000), nullable=True),
+        sa.Column("n_roms", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("slug"),
+    )
+    table.create(conn)
+    return table
+
+
+def _create_final_platforms(conn: Connection) -> sa.Table:
+    table = sa.Table(
+        "platforms",
+        sa.MetaData(),
+        sa.Column("igdb_id", sa.String(length=10), nullable=True),
+        sa.Column("sgdb_id", sa.String(length=10), nullable=True),
+        sa.Column("slug", sa.String(length=50), nullable=False),
+        sa.Column("fs_slug", sa.String(length=50), nullable=False),
+        sa.Column("name", sa.String(length=400), nullable=True),
+        sa.Column("logo_path", sa.String(length=1000), nullable=True),
+        sa.Column("n_roms", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("fs_slug"),
+    )
+    table.create(conn)
+    return table
+
+
+def _create_legacy_roms(conn: Connection) -> sa.Table:
+    table = sa.Table(
+        "roms",
+        sa.MetaData(),
+        sa.Column("r_igdb_id", sa.String(length=10), nullable=True),
+        sa.Column("p_igdb_id", sa.String(length=10), nullable=True),
+        sa.Column("r_sgdb_id", sa.String(length=10), nullable=True),
+        sa.Column("p_sgdb_id", sa.String(length=10), nullable=True),
+        sa.Column("p_slug", sa.String(length=50), nullable=False),
+        sa.Column("file_name", sa.String(length=450), nullable=False),
+        sa.Column("file_name_no_tags", sa.String(length=450), nullable=True),
+        sa.Column("file_extension", sa.String(length=10), nullable=True),
+        sa.Column("file_path", sa.String(length=1000), nullable=True),
+        sa.Column("file_size", sa.Float(), nullable=True),
+        sa.Column("file_size_units", sa.String(length=10), nullable=True),
+        sa.Column("name", sa.String(length=350), nullable=True),
+        sa.Column("r_slug", sa.String(length=100), nullable=True),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("path_cover_s", sa.Text(), nullable=True),
+        sa.Column("path_cover_l", sa.Text(), nullable=True),
+        sa.Column("has_cover", sa.Boolean(), nullable=True),
+        sa.Column("region", sa.String(length=20), nullable=True),
+        sa.Column("revision", sa.String(length=20), nullable=True),
+        sa.Column("tags", CustomJSON(), nullable=True),
+        sa.Column("multi", sa.Boolean(), nullable=True),
+        sa.Column("files", CustomJSON(), nullable=True),
+        sa.PrimaryKeyConstraint("p_slug", "file_name"),
+    )
+    table.create(conn)
+    return table
+
+
+def _create_preswap_roms(conn: Connection, table_name: str = "roms") -> sa.Table:
+    table = sa.Table(
+        table_name,
+        sa.MetaData(),
+        sa.Column("r_igdb_id", sa.String(length=10), nullable=True),
+        sa.Column("p_igdb_id", sa.String(length=10), nullable=True),
+        sa.Column("r_sgdb_id", sa.String(length=10), nullable=True),
+        sa.Column("p_sgdb_id", sa.String(length=10), nullable=True),
+        sa.Column("p_slug", sa.String(length=50), nullable=False),
+        sa.Column("p_name", sa.String(length=150), nullable=True),
+        sa.Column("file_name", sa.String(length=450), nullable=False),
+        sa.Column("file_name_no_tags", sa.String(length=450), nullable=True),
+        sa.Column("file_extension", sa.String(length=10), nullable=True),
+        sa.Column("file_path", sa.String(length=1000), nullable=True),
+        sa.Column("file_size", sa.Float(), nullable=True),
+        sa.Column("file_size_units", sa.String(length=10), nullable=True),
+        sa.Column("r_name", sa.String(length=150), nullable=True),
+        sa.Column("r_slug", sa.String(length=100), nullable=True),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("path_cover_s", sa.Text(), nullable=True),
+        sa.Column("path_cover_l", sa.Text(), nullable=True),
+        sa.Column("has_cover", sa.Boolean(), nullable=True),
+        sa.Column("region", sa.String(length=20), nullable=True),
+        sa.Column("revision", sa.String(length=20), nullable=True),
+        sa.Column("tags", CustomJSON(), nullable=True),
+        sa.Column("multi", sa.Boolean(), nullable=True),
+        sa.Column("files", CustomJSON(), nullable=True),
+        sa.Column("url_cover", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("p_slug", "file_name"),
+    )
+    table.create(conn)
+    return table
+
+
+def _create_final_roms(conn: Connection) -> sa.Table:
+    table = sa.Table(
+        "roms",
+        sa.MetaData(),
+        sa.Column("id", sa.Integer(), autoincrement=True),
+        sa.Column("r_igdb_id", sa.String(length=10), nullable=True),
+        sa.Column("p_igdb_id", sa.String(length=10), nullable=True),
+        sa.Column("r_sgdb_id", sa.String(length=10), nullable=True),
+        sa.Column("p_sgdb_id", sa.String(length=10), nullable=True),
+        sa.Column("p_slug", sa.String(length=50), nullable=False),
+        sa.Column("p_name", sa.String(length=150), nullable=True),
+        sa.Column("file_name", sa.String(length=450), nullable=False),
+        sa.Column("file_name_no_tags", sa.String(length=450), nullable=False),
+        sa.Column("file_extension", sa.String(length=10), nullable=True),
+        sa.Column("file_path", sa.String(length=1000), nullable=True),
+        sa.Column("file_size", sa.Float(), nullable=True),
+        sa.Column("file_size_units", sa.String(length=10), nullable=True),
+        sa.Column("r_name", sa.String(length=350), nullable=True),
+        sa.Column("r_slug", sa.String(length=100), nullable=True),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("path_cover_s", sa.Text(), nullable=True),
+        sa.Column("path_cover_l", sa.Text(), nullable=True),
+        sa.Column("has_cover", sa.Boolean(), nullable=True),
+        sa.Column("region", sa.String(length=20), nullable=True),
+        sa.Column("revision", sa.String(length=20), nullable=True),
+        sa.Column("tags", CustomJSON(), nullable=True),
+        sa.Column("multi", sa.Boolean(), nullable=True),
+        sa.Column("files", CustomJSON(), nullable=True),
+        sa.Column("url_cover", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    table.create(conn)
+    return table
+
+
+def _insert_platform(table: sa.Table, conn: Connection, slug: str) -> None:
+    values = {
+        "igdb_id": "1",
+        "sgdb_id": "2",
+        "slug": slug,
+        "name": slug.upper(),
+        "logo_path": None,
+        "n_roms": 1,
+    }
+    if "fs_slug" in table.c:
+        values["fs_slug"] = slug
+
+    conn.execute(table.insert().values(values))
+
+
+def _rom_values(file_name: str, r_name: str) -> dict[str, object]:
+    return {
+        "r_igdb_id": "1",
+        "p_igdb_id": "2",
+        "r_sgdb_id": "3",
+        "p_sgdb_id": "4",
+        "p_slug": "snes",
+        "p_name": "SNES",
+        "file_name": file_name,
+        "file_name_no_tags": file_name,
+        "file_extension": "zip",
+        "file_path": "snes/roms",
+        "file_size": 1.0,
+        "file_size_units": "MB",
+        "r_name": r_name,
+        "r_slug": r_name.lower(),
+        "summary": None,
+        "path_cover_s": None,
+        "path_cover_l": None,
+        "has_cover": False,
+        "region": "USA",
+        "revision": None,
+        "tags": [],
+        "multi": False,
+        "files": [],
+        "url_cover": None,
+    }
+
+
+def _insert_legacy_rom(table: sa.Table, conn: Connection) -> None:
+    values = _rom_values("sonic.zip", "Sonic")
+    values["name"] = values.pop("r_name")
+    values.pop("p_name")
+    values.pop("url_cover")
+    conn.execute(table.insert().values(values))
+
+
+def _insert_rom(table: sa.Table, conn: Connection, file_name: str, r_name: str) -> None:
+    values = _rom_values(file_name, r_name)
+    conn.execute(table.insert().values(values))
+
+
+def test_1_8_upgrade_runs_from_1_7_schema(migration_engine: Engine):
+    with migration_engine.begin() as conn:
+        platforms = _create_legacy_platforms(conn)
+        roms = _create_legacy_roms(conn)
+        _insert_platform(platforms, conn, "snes")
+        _insert_legacy_rom(roms, conn)
+
+        _run_1_8_upgrade(conn)
+
+        assert not _has_table(conn, "old_platforms")
+        assert not _has_table(conn, "old_roms")
+        assert "fs_slug" in _columns(conn, "platforms")
+        assert "id" in _columns(conn, "roms")
+        assert "r_name" in _columns(conn, "roms")
+        assert "name" not in _columns(conn, "roms")
+        assert (
+            conn.execute(text("SELECT fs_slug FROM platforms")).scalar_one() == "snes"
+        )
+        assert conn.execute(text("SELECT r_name FROM roms")).scalar_one() == "Sonic"
+
+
+def test_1_8_upgrade_reenters_after_rom_name_rename(migration_engine: Engine):
+    with migration_engine.begin() as conn:
+        platforms = _create_final_platforms(conn)
+        roms = _create_preswap_roms(conn)
+        _insert_platform(platforms, conn, "snes")
+        _insert_rom(roms, conn, "sonic.zip", "Sonic")
+
+        _run_1_8_upgrade(conn)
+
+        assert not _has_table(conn, "old_roms")
+        assert "id" in _columns(conn, "roms")
+        assert "name" not in _columns(conn, "roms")
+        assert conn.execute(text("SELECT r_name FROM roms")).scalar_one() == "Sonic"
+
+
+def test_1_8_upgrade_reenters_mid_roms_swap(migration_engine: Engine):
+    with migration_engine.begin() as conn:
+        platforms = _create_final_platforms(conn)
+        old_roms = _create_preswap_roms(conn, "old_roms")
+        roms = _create_final_roms(conn)
+        _insert_platform(platforms, conn, "snes")
+        _insert_rom(old_roms, conn, "sonic.zip", "Sonic")
+        _insert_rom(old_roms, conn, "mario.zip", "Mario")
+        _insert_rom(roms, conn, "sonic.zip", "Sonic")
+
+        _run_1_8_upgrade(conn)
+
+        assert not _has_table(conn, "old_roms")
+        assert _count(conn, "roms") == 2
+        assert {
+            row.file_name
+            for row in conn.execute(text("SELECT file_name FROM roms")).fetchall()
+        } == {"sonic.zip", "mario.zip"}
+
+
+def test_1_8_upgrade_reenters_mid_platforms_swap(migration_engine: Engine):
+    with migration_engine.begin() as conn:
+        old_platforms = _create_legacy_platforms(conn, "old_platforms")
+        platforms = _create_final_platforms(conn)
+        roms = _create_final_roms(conn)
+        _insert_platform(old_platforms, conn, "snes")
+        _insert_platform(old_platforms, conn, "gba")
+        _insert_platform(platforms, conn, "snes")
+        _insert_rom(roms, conn, "sonic.zip", "Sonic")
+
+        _run_1_8_upgrade(conn)
+
+        assert not _has_table(conn, "old_platforms")
+        assert _count(conn, "platforms") == 2
+        assert {
+            row.fs_slug
+            for row in conn.execute(text("SELECT fs_slug FROM platforms")).fetchall()
+        } == {"snes", "gba"}
+
+
+def test_1_8_upgrade_is_idempotent_after_completion(migration_engine: Engine):
+    with migration_engine.begin() as conn:
+        platforms = _create_final_platforms(conn)
+        roms = _create_final_roms(conn)
+        _insert_platform(platforms, conn, "snes")
+        _insert_rom(roms, conn, "sonic.zip", "Sonic")
+
+        _run_1_8_upgrade(conn)
+        _run_1_8_upgrade(conn)
+
+        assert not _has_table(conn, "old_platforms")
+        assert not _has_table(conn, "old_roms")
+        assert _count(conn, "platforms") == 1
+        assert _count(conn, "roms") == 1


### PR DESCRIPTION
**Description**
<sup>Fresh installs on MariaDB no longer crash-loop when the `1.8_` migration dies partway through.</sup>

Fresh installs on Docker Desktop/WSL2 and Synology (reported across 4.7.0 through 4.9.2, most recently 2026-07-02) hit `mariadb.ProgrammingError: Unknown column 'name' in 'roms'` on `ALTER TABLE roms CHANGE name r_name ...`, the init script exits 1, and `restart: unless-stopped` retries forever. Root cause: MariaDB DDL is non-transactional, so when the chain dies partway through `1.8_.py` (slow first boot, connection drop, container restart), `alembic_version` still reads `1.7.1` while `roms.name` is already renamed - every retry then deterministically fails at the same `alter_column`. #2515 and #3208 are the same loop surfacing at different steps. @gantoine's earlier `if_not_exists=True` guards covered `create_table`/`add_column`, but renames and table swaps have no such flag.

This PR makes `upgrade()` in `1.8_.py` re-entrant using live schema inspection (`sqlalchemy.inspect(op.get_bind())`, the same pattern `0022_collections_.py` already uses): the `name -> r_name` rename only runs when `roms` still has `name`; the `platforms` rename/copy/drop block and the `roms -> old_roms` swap detect leftover intermediate state and resume the copy instead of re-running the rename. On a clean database every guard passes and the migration runs exactly as before.

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Local testing note: `backend/tests/test_migrations.py` (new) simulates the partial-application states (renamed column, leftover `old_*` tables, half-copied data) and re-invokes the guarded steps. I could not run it locally (the MariaDB connector needs system libs my machine lacks), so the `migrations.yml` workflow (fresh `alembic upgrade head` on MariaDB 10.11 + Postgres 15) is the verification gate.

#### Screenshots (if applicable)

N/A - migration fix, no UI change.

Fixes #3496, related to #2515 and #3208.

AI was used for assistance.
