### PR TITLE
fix: stop mapping Public Domain ROMs to Poland

### DIFF
--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -259,9 +259,6 @@ export function regionToEmoji(region: string) {
     case "no":
     case "norway":
       return "🇳🇴";
-    case "pd":
-    case "public domain":
-      return "🇵🇱";
     case "r":
     case "russia":
       return "🇷🇺";

--- a/frontend/test/utils.test.ts
+++ b/frontend/test/utils.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import { languageToEmoji, regionToEmoji } from "@/utils";
 
 describe("regionToEmoji", () => {

--- a/frontend/test/utils.test.ts
+++ b/frontend/test/utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { languageToEmoji, regionToEmoji } from "@/utils";
+
+describe("regionToEmoji", () => {
+  it("does not render Public Domain as the Poland flag", () => {
+    expect(regionToEmoji("PD")).toBe("PD");
+    expect(regionToEmoji("Public Domain")).toBe("Public Domain");
+  });
+});
+
+describe("languageToEmoji", () => {
+  it("keeps the Polish language flag mapping", () => {
+    expect(languageToEmoji("PL")).toBe("🇵🇱");
+    expect(languageToEmoji("Polish")).toBe("🇵🇱");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the display of ROMs tagged as `PD` / `Public Domain`.

The backend already parses the `PD` filename tag correctly as `Public Domain`, but `regionToEmoji()` incorrectly mapped both `PD` and `Public Domain` to the Poland flag. On platforms that render regional indicator emojis as flags, this caused Public Domain ROMs to appear as Polish.

## Changes

* Remove the incorrect Poland flag mapping for `PD` and `Public Domain`
* Allow the existing fallback to display the original region text
* Add regression tests for `PD` and `Public Domain`
* Verify that the Polish language flag mapping remains unchanged

## Testing

* `npm test -- test/utils.test.ts`
* `npm test` — 454 tests passed
* `npm run typecheck`
* `npm run build`

Fixes #3630

## AI assistance disclosure

I used ChatGPT to assist with codebase navigation, debugging, test planning, and drafting parts of the regression test. I manually reviewed the changes and ran the complete test, type-check, and build commands locally.
