### PR TITLE
fix: display selected firmware in player

### DIFF
--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -709,9 +709,10 @@ const selectedAsset = computed<SaveSchema | StateSchema | null>(() =>
             clearable
             hide-details
             :label="t('common.firmware')"
-            :items="
-              firmwareOptions.map((f) => ({ title: f.file_name, value: f }))
-            "
+            :items="firmwareOptions"
+            item-title="file_name"
+            item-value="id"
+            return-object
           />
           <RSwitch v-model="fullscreenOnPlay" :label="t('play.full-screen')" />
         </div>


### PR DESCRIPTION
## Summary

Fixes the firmware selector in the v2 EmulatorJS player so that the
selected firmware remains visible after selection.

The selector model stores a `FirmwareSchema` object, but the options were
wrapped as `{ title, value: firmware }`. This allowed the selected firmware
to be passed to the player, but prevented `RSelect` from resolving and
displaying the selected item correctly.

## Changes

- Pass firmware objects directly to `RSelect`
- Use `file_name` as the visible item title
- Use `id` as the stable item value
- Enable `return-object` so the player continues receiving a
  `FirmwareSchema` object

## Testing

- `npx prettier --check src/v2/views/Player/EmulatorJS.vue`
- `npm run typecheck`
- `npm test`
- `npm run build`

Fixes #3662

## AI assistance disclosure

I used ChatGPT to assist with codebase navigation, diagnosis of the
`RSelect` model-value mismatch, and review of the proposed fix. I manually
reviewed the final change and ran all listed checks locally.