### PR TITLE
feat: Add ScreenScraper metadata proxy support via Hasheous

### DIFF
--- a/backend/handler/metadata/hasheous_handler.py
+++ b/backend/handler/metadata/hasheous_handler.py
@@ -8,7 +8,7 @@ from fastapi import HTTPException, status
 
 from config import DEV_MODE, HASHEOUS_API_ENABLED
 from logger.logger import log
-from models.rom import RomFile
+from models.rom import Rom, RomFile
 from utils import get_version
 from utils.context import ctx_httpx_client
 
@@ -20,6 +20,15 @@ from .igdb_handler import (
     IGDBMetadataPlatform,
 )
 from .ra_handler import RAMetadata
+from .ss_handler import (
+    ACCEPTABLE_FILE_EXTENSIONS_BY_PLATFORM_SLUG as SS_ACCEPTABLE_EXTS,
+)
+from .ss_handler import (
+    SSRom,
+    _get_rom_type,
+    _is_notgame,
+    build_ss_game,
+)
 
 
 class HasheousMetadata(TypedDict):
@@ -123,6 +132,9 @@ class HasheousHandler(MetadataHandler):
         self.proxy_igdb_game_endpoint = f"{self.BASE_URL}/MetadataProxy/IGDB/Game"
         self.proxy_igdb_cover_endpoint = f"{self.BASE_URL}/MetadataProxy/IGDB/Cover"
         self.proxy_ra_game_endpoint = f"{self.BASE_URL}/MetadataProxy/RA/Game"
+        self.proxy_ss_jeuinfos_endpoint = (
+            f"{self.BASE_URL}/MetadataProxy/ScreenScraper/jeuInfos.php"
+        )
         self.app_api_key = (
             "UUvh9ef_CddMM4xXO1iqxl9FqEt764v33LU-UiGFc0P34odXjMP9M6MTeE4JZRxZ"
             if DEV_MODE
@@ -406,6 +418,99 @@ class HasheousHandler(MetadataHandler):
             return hasheous_rom
 
         return hasheous_rom
+
+    def _jeu_to_ss_rom(self, rom: Rom, response: dict) -> SSRom:
+        jeu = response.get("response", {}).get("jeu", {})
+        if not jeu:
+            return SSRom(ss_id=None)
+        if _is_notgame(jeu):
+            log.warning(
+                "ScreenScraper (via Hasheous): received notgame entry, ignoring"
+            )
+            return SSRom(ss_id=None)
+        return build_ss_game(rom, jeu)
+
+    async def get_ss_game(
+        self, rom: Rom, platform_ss_id: int, files: list[RomFile]
+    ) -> SSRom:
+        """Fetch ScreenScraper metadata for a ROM through the Hasheous proxy.
+
+        Used as a credential-free fallback when the user has no ScreenScraper
+        account. Mirrors the native ScreenScraper hash lookup and reuses
+        ``build_ss_game`` to produce the same ``ss_id``/``ss_metadata`` shape.
+        """
+        if not self.is_enabled() or not platform_ss_id:
+            return SSRom(ss_id=None)
+
+        filtered_files = [
+            file
+            for file in files
+            if file.file_size_bytes > 0
+            and file.is_top_level
+            and (
+                UPS(rom.platform_slug) not in SS_ACCEPTABLE_EXTS
+                or file.file_extension in SS_ACCEPTABLE_EXTS[UPS(rom.platform_slug)]
+            )
+        ]
+
+        # Largest file is most likely the main ROM, giving the best hash match.
+        first_file = max(filtered_files, key=lambda f: f.file_size_bytes, default=None)
+        if first_file is None:
+            return SSRom(ss_id=None)
+
+        rom_name = (
+            first_file.archive_members[0]["name"].split("/")[-1]
+            if first_file.archive_members is not None
+            and len(first_file.archive_members) == 1
+            else first_file.file_name
+        )
+
+        if not (
+            first_file.md5_hash
+            or first_file.sha1_hash
+            or first_file.crc_hash
+            or rom_name
+        ):
+            log.info(
+                "No hashes or filename provided for Hasheous ScreenScraper lookup."
+            )
+            return SSRom(ss_id=None)
+
+        params: dict[str, str | int] = {"systemeid": platform_ss_id}
+        if first_file.md5_hash:
+            params["md5"] = first_file.md5_hash
+        if first_file.sha1_hash:
+            params["sha1"] = first_file.sha1_hash
+        if first_file.crc_hash:
+            params["crc"] = first_file.crc_hash
+        if first_file.file_size_bytes:
+            params["romtaille"] = first_file.file_size_bytes
+        if rom_name:
+            params["romnom"] = rom_name
+        params["romtype"] = _get_rom_type(first_file)
+
+        response = await self._request(
+            self.proxy_ss_jeuinfos_endpoint, params=params, method="GET"
+        )
+        if not response:
+            return SSRom(ss_id=None)
+
+        return self._jeu_to_ss_rom(rom, response)
+
+    async def get_ss_rom_by_id(self, rom: Rom, ss_id: int) -> SSRom:
+        """Refetch ScreenScraper metadata by game id through the Hasheous proxy."""
+        if not self.is_enabled() or not ss_id:
+            return SSRom(ss_id=None)
+
+        response = await self._request(
+            self.proxy_ss_jeuinfos_endpoint,
+            params={"gameid": ss_id},
+            method="GET",
+        )
+        if not response:
+            return SSRom(ss_id=None)
+
+        return self._jeu_to_ss_rom(rom, response)
 
 
 class SlugToHasheousId(TypedDict):

--- a/backend/handler/metadata/hasheous_handler.py
+++ b/backend/handler/metadata/hasheous_handler.py
@@ -24,6 +24,7 @@ from .ss_handler import (
     ACCEPTABLE_FILE_EXTENSIONS_BY_PLATFORM_SLUG as SS_ACCEPTABLE_EXTS,
 )
 from .ss_handler import (
+    SSMetadata,
     SSRom,
     _get_rom_type,
     _is_notgame,
@@ -61,6 +62,7 @@ class HasheousRom(BaseRom):
     ra_metadata: NotRequired[RAMetadata]
     tgdb_id: NotRequired[int | None]
     ss_id: NotRequired[int | None]
+    ss_metadata: NotRequired[SSMetadata]
     hasheous_metadata: NotRequired[HasheousMetadata]
 
 

--- a/backend/handler/metadata/hasheous_handler.py
+++ b/backend/handler/metadata/hasheous_handler.py
@@ -60,6 +60,7 @@ class HasheousRom(BaseRom):
     ra_id: NotRequired[int | None]
     ra_metadata: NotRequired[RAMetadata]
     tgdb_id: NotRequired[int | None]
+    ss_id: NotRequired[int | None]
     hasheous_metadata: NotRequired[HasheousMetadata]
 
 
@@ -431,7 +432,7 @@ class HasheousHandler(MetadataHandler):
         return build_ss_game(rom, jeu)
 
     async def get_ss_game(
-        self, rom: Rom, platform_ss_id: int, files: list[RomFile]
+        self, rom: Rom, platform_ss_id: int | None, files: list[RomFile]
     ) -> SSRom:
         """Fetch ScreenScraper metadata for a ROM through the Hasheous proxy.
 

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -444,7 +444,9 @@ async def scan_rom(
                 platform.slug, get_match_files()
             )
 
-        return HasheousRom(hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None)
+        return HasheousRom(
+            hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None, ss_id=None
+        )
 
     _added_rom = db_rom_handler.add_rom(Rom(**rom_attrs))
     _added_rom.is_identifying = True
@@ -640,17 +642,9 @@ async def scan_rom(
         return MobyGamesRom(moby_id=None)
 
     async def fetch_ss_rom(playmatch_rom: PlaymatchRomMatch) -> SSRom:
-        # When the user has no ScreenScraper credentials, fall back to fetching
-        # ScreenScraper metadata through the Hasheous proxy (credential-free).
-        ss_via_hasheous = (
-            not meta_ss_handler.is_enabled()
-            and meta_hasheous_handler.is_enabled()
-            and rom.platform_slug in HASHEOUS_PLATFORM_LIST
-        )
         if (
             MetadataSource.SS in metadata_sources
             and platform.ss_id
-            and (meta_ss_handler.is_enabled() or ss_via_hasheous)
             and (
                 newly_added
                 or scan_type == ScanType.COMPLETE
@@ -662,12 +656,12 @@ async def scan_rom(
                 )
             )
         ):
-            if ss_via_hasheous:
-                if scan_type == ScanType.UPDATE and rom.ss_id:
-                    return await meta_hasheous_handler.get_ss_rom_by_id(rom, rom.ss_id)
-                return await meta_hasheous_handler.get_ss_game(
-                    rom, platform.ss_id, get_match_files()
-                )
+            # if ss_via_hasheous:
+            #     if scan_type == ScanType.UPDATE and rom.ss_id:
+            #         return await meta_hasheous_handler.get_ss_rom_by_id(rom, rom.ss_id)
+            #     return await meta_hasheous_handler.get_ss_game(
+            #         rom, platform.ss_id, get_match_files()
+            #     )
 
             # Use the ID to refetch metadata
             if scan_type == ScanType.UPDATE and rom.ss_id:
@@ -815,20 +809,20 @@ async def scan_rom(
             (
                 igdb_game,
                 ra_game,
+                ss_game,
             ) = await asyncio.gather(
                 meta_hasheous_handler.get_igdb_game(hasheous_rom),
                 meta_hasheous_handler.get_ra_game(hasheous_rom),
+                meta_hasheous_handler.get_ss_game(
+                    rom, platform.ss_id, get_match_files()
+                ),
             )
 
-            return HasheousRom(
-                {
-                    **hasheous_rom,
-                    **ra_game,
-                    **igdb_game,
-                }
-            )
+            return HasheousRom({**hasheous_rom, **ra_game, **igdb_game, **ss_game})
 
-        return HasheousRom(hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None)
+        return HasheousRom(
+            hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None, ss_id=None
+        )
 
     # Run metadata fetches concurrently
     (

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -444,9 +444,7 @@ async def scan_rom(
                 platform.slug, get_match_files()
             )
 
-        return HasheousRom(
-            hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None, ss_id=None
-        )
+        return HasheousRom(hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None)
 
     _added_rom = db_rom_handler.add_rom(Rom(**rom_attrs))
     _added_rom.is_identifying = True
@@ -656,13 +654,6 @@ async def scan_rom(
                 )
             )
         ):
-            # if ss_via_hasheous:
-            #     if scan_type == ScanType.UPDATE and rom.ss_id:
-            #         return await meta_hasheous_handler.get_ss_rom_by_id(rom, rom.ss_id)
-            #     return await meta_hasheous_handler.get_ss_game(
-            #         rom, platform.ss_id, get_match_files()
-            #     )
-
             # Use the ID to refetch metadata
             if scan_type == ScanType.UPDATE and rom.ss_id:
                 return await meta_ss_handler.get_rom_by_id(rom, rom.ss_id)

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -640,9 +640,17 @@ async def scan_rom(
         return MobyGamesRom(moby_id=None)
 
     async def fetch_ss_rom(playmatch_rom: PlaymatchRomMatch) -> SSRom:
+        # When the user has no ScreenScraper credentials, fall back to fetching
+        # ScreenScraper metadata through the Hasheous proxy (credential-free).
+        ss_via_hasheous = (
+            not meta_ss_handler.is_enabled()
+            and meta_hasheous_handler.is_enabled()
+            and rom.platform_slug in HASHEOUS_PLATFORM_LIST
+        )
         if (
             MetadataSource.SS in metadata_sources
             and platform.ss_id
+            and (meta_ss_handler.is_enabled() or ss_via_hasheous)
             and (
                 newly_added
                 or scan_type == ScanType.COMPLETE
@@ -654,6 +662,13 @@ async def scan_rom(
                 )
             )
         ):
+            if ss_via_hasheous:
+                if scan_type == ScanType.UPDATE and rom.ss_id:
+                    return await meta_hasheous_handler.get_ss_rom_by_id(rom, rom.ss_id)
+                return await meta_hasheous_handler.get_ss_game(
+                    rom, platform.ss_id, get_match_files()
+                )
+
             # Use the ID to refetch metadata
             if scan_type == ScanType.UPDATE and rom.ss_id:
                 return await meta_ss_handler.get_rom_by_id(rom, rom.ss_id)

--- a/backend/tests/handler/metadata/test_hasheous_handler.py
+++ b/backend/tests/handler/metadata/test_hasheous_handler.py
@@ -1,0 +1,162 @@
+"""Tests for the Hasheous ScreenScraper proxy fallback."""
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from adapters.services.screenscraper_types import SSGame
+from config.config_manager import Config, MetadataMediaType
+from handler.metadata.hasheous_handler import HasheousHandler
+
+
+@pytest.fixture
+def handler() -> HasheousHandler:
+    return HasheousHandler()
+
+
+def _make_config() -> Config:
+    return Config(
+        EXCLUDED_PLATFORMS=[],
+        EXCLUDED_SINGLE_EXT=[],
+        EXCLUDED_SINGLE_FILES=[],
+        EXCLUDED_MULTI_FILES=[],
+        EXCLUDED_MULTI_PARTS_EXT=[],
+        EXCLUDED_MULTI_PARTS_FILES=[],
+        PLATFORMS_BINDING={},
+        PLATFORMS_VERSIONS={},
+        ROMS_FOLDER_NAME="roms",
+        FIRMWARE_FOLDER_NAME="bios",
+        SCAN_REGION_PRIORITY=[],
+        SCAN_LANGUAGE_PRIORITY=["en"],
+        SCAN_MEDIA=["box2d", "box3d", "screenshot"],
+        GAMELIST_MEDIA_THUMBNAIL=MetadataMediaType.BOX2D,
+        GAMELIST_MEDIA_IMAGE=MetadataMediaType.SCREENSHOT,
+    )
+
+
+def _make_rom() -> MagicMock:
+    rom = MagicMock()
+    rom.regions = []
+    rom.platform_slug = "snes"
+    rom.platform_id = 1
+    rom.id = 1
+    return rom
+
+
+def _make_file() -> MagicMock:
+    f = MagicMock()
+    f.file_size_bytes = 1024
+    f.is_top_level = True
+    f.file_extension = "sfc"
+    f.md5_hash = "abc123md5"
+    f.sha1_hash = "abc123sha1"
+    f.crc_hash = "deadbeef"
+    f.file_name = "Sonic (USA).sfc"
+    f.archive_members = None
+    return f
+
+
+def _jeu_response(game_id: str = "12345") -> dict:
+    return {
+        "response": {
+            "jeu": {
+                "id": game_id,
+                "noms": [{"region": "ss", "text": "Sonic the Hedgehog"}],
+                "synopsis": [{"langue": "en", "text": "A speedy platformer."}],
+            }
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_ss_game_populates_ssrom(handler: HasheousHandler):
+    with (
+        patch.object(HasheousHandler, "is_enabled", return_value=True),
+        patch("handler.metadata.ss_handler.cm.get_config", return_value=_make_config()),
+        patch.object(
+            handler, "_request", new=AsyncMock(return_value=_jeu_response())
+        ) as req,
+    ):
+        result = await handler.get_ss_game(_make_rom(), 4, [_make_file()])
+
+    assert result["ss_id"] == 12345
+    assert result["name"] == "Sonic the Hedgehog"
+    assert result["summary"] == "A speedy platformer."
+    assert result.get("ss_metadata") is not None
+
+    # jeuInfos is queried with the platform id and the file hashes.
+    _, kwargs = req.call_args
+    params = kwargs["params"]
+    assert params["systemeid"] == 4
+    assert params["md5"] == "abc123md5"
+    assert params["sha1"] == "abc123sha1"
+    assert params["crc"] == "deadbeef"
+    assert kwargs["method"] == "GET"
+
+
+@pytest.mark.asyncio
+async def test_get_ss_game_disabled_returns_empty(handler: HasheousHandler):
+    with patch.object(HasheousHandler, "is_enabled", return_value=False):
+        result = await handler.get_ss_game(_make_rom(), 4, [_make_file()])
+
+    assert result["ss_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_ss_game_no_platform_id_returns_empty(handler: HasheousHandler):
+    with patch.object(HasheousHandler, "is_enabled", return_value=True):
+        result = await handler.get_ss_game(_make_rom(), 0, [_make_file()])
+
+    assert result["ss_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_ss_game_notgame_returns_empty(handler: HasheousHandler):
+    notgame = _jeu_response()
+    notgame["response"]["jeu"]["notgame"] = "true"
+
+    with (
+        patch.object(HasheousHandler, "is_enabled", return_value=True),
+        patch("handler.metadata.ss_handler.cm.get_config", return_value=_make_config()),
+        patch.object(handler, "_request", new=AsyncMock(return_value=notgame)),
+    ):
+        result = await handler.get_ss_game(_make_rom(), 4, [_make_file()])
+
+    assert result["ss_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_ss_game_empty_response_returns_empty(handler: HasheousHandler):
+    with (
+        patch.object(HasheousHandler, "is_enabled", return_value=True),
+        patch.object(handler, "_request", new=AsyncMock(return_value={})),
+    ):
+        result = await handler.get_ss_game(_make_rom(), 4, [_make_file()])
+
+    assert result["ss_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_ss_rom_by_id_queries_gameid(handler: HasheousHandler):
+    with (
+        patch.object(HasheousHandler, "is_enabled", return_value=True),
+        patch("handler.metadata.ss_handler.cm.get_config", return_value=_make_config()),
+        patch.object(
+            handler, "_request", new=AsyncMock(return_value=_jeu_response("999"))
+        ) as req,
+    ):
+        result = await handler.get_ss_rom_by_id(_make_rom(), 999)
+
+    assert result["ss_id"] == 999
+    _, kwargs = req.call_args
+    assert kwargs["params"]["gameid"] == 999
+    assert kwargs["method"] == "GET"
+
+
+def test_notgame_helper_reused_from_ss_handler():
+    """The proxy path must reuse the native ScreenScraper notgame filter."""
+    from handler.metadata.hasheous_handler import _is_notgame
+
+    assert _is_notgame(cast(SSGame, {"notgame": "true"})) is True
+    assert _is_notgame(cast(SSGame, {"notgame": "false", "noms": []})) is False

--- a/frontend/src/stores/heartbeat.ts
+++ b/frontend/src/stores/heartbeat.ts
@@ -144,12 +144,9 @@ export default defineStore("heartbeat", {
           name: "Screenscraper",
           value: "ss",
           logo_path: "/assets/scrappers/ss.png",
-          // Usable with own credentials, or credential-free via the Hasheous proxy.
-          disabled:
-            !this.value.METADATA_SOURCES?.SS_API_ENABLED &&
-            !this.value.METADATA_SOURCES?.HASHEOUS_API_ENABLED
-              ? i18n.global.t("scan.api-key-missing")
-              : "",
+          disabled: !this.value.METADATA_SOURCES?.SS_API_ENABLED
+            ? i18n.global.t("scan.api-key-missing")
+            : "",
         },
         {
           name: "Mobygames",

--- a/frontend/src/stores/heartbeat.ts
+++ b/frontend/src/stores/heartbeat.ts
@@ -144,9 +144,12 @@ export default defineStore("heartbeat", {
           name: "Screenscraper",
           value: "ss",
           logo_path: "/assets/scrappers/ss.png",
-          disabled: !this.value.METADATA_SOURCES?.SS_API_ENABLED
-            ? i18n.global.t("scan.api-key-missing")
-            : "",
+          // Usable with own credentials, or credential-free via the Hasheous proxy.
+          disabled:
+            !this.value.METADATA_SOURCES?.SS_API_ENABLED &&
+            !this.value.METADATA_SOURCES?.HASHEOUS_API_ENABLED
+              ? i18n.global.t("scan.api-key-missing")
+              : "",
         },
         {
           name: "Mobygames",


### PR DESCRIPTION
**TL;DR**
Adds ScreenScraper metadata fetching through the Hasheous proxy as a credential-free fallback when users don't have their own ScreenScraper account. This leverages new Hasheous endpoints for game metadata lookups by hash or game ID.

**What changed?**

- **Hasheous Handler Enhancement**: Added `get_ss_game()` and `get_ss_rom_by_id()` methods to fetch ScreenScraper metadata through the Hasheous proxy endpoint (`/MetadataProxy/ScreenScraper/jeuInfos.php`)
  - `get_ss_game()` performs hash-based lookups (MD5, SHA1, CRC) with file size and name as fallbacks
  - `get_ss_rom_by_id()` refetches metadata by existing game ID
  - Both methods reuse existing ScreenScraper parsing logic via `build_ss_game()` to maintain consistent metadata structure

- **Scan Handler Integration**: Updated ROM scanning logic to fall back to Hasheous ScreenScraper proxy when:
  - ScreenScraper direct access is disabled (`meta_ss_handler` not enabled)
  - Hasheous is enabled and the platform is in the supported list
  - Prioritizes direct ScreenScraper if available, falls back to Hasheous proxy otherwise

- **File Filtering**: Implemented platform-specific file extension filtering for hash-based lookups, selecting the largest valid file as most likely to contain the main ROM

- **Test Coverage**: Added comprehensive unit tests for the Hasheous ScreenScraper proxy functionality

**Checklist**
- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*