### PR TITLE
fix: allow NAT64-wrapped public IPs through SSRF filter

### DIFF
--- a/backend/tests/utils/test_ssrf.py
+++ b/backend/tests/utils/test_ssrf.py
@@ -65,13 +65,29 @@ class TestIsForbiddenIp:
             "fc00::1",
             "fe80::1",
             "ff02::1",
+            # NAT64-wrapped internal IPv4 must stay blocked (embedded IPv4 checked).
+            "64:ff9b::7f00:1",  # 127.0.0.1 loopback
+            "64:ff9b::a00:1",  # 10.0.0.1 private
+            "64:ff9b::c0a8:101",  # 192.168.1.1 private
+            "64:ff9b::a9fe:a9fe",  # 169.254.169.254 cloud metadata
+            # RFC 8215 local-use NAT64 prefix is private; not unwrapped, stays blocked.
+            "64:ff9b:1::8d5f:accd",
         ],
     )
     def test_forbidden(self, ip):
         assert is_forbidden_ip(ipaddress.ip_address(ip)) is True
 
     @pytest.mark.parametrize(
-        "ip", ["8.8.8.8", "1.1.1.1", "93.184.216.34", "2001:4860:4860::8888"]
+        "ip",
+        [
+            "8.8.8.8",
+            "1.1.1.1",
+            "93.184.216.34",
+            "2001:4860:4860::8888",
+            # NAT64-wrapped public IPv4 (DNS64) must be allowed. See issue #3668.
+            "64:ff9b::8d5f:accd",  # 141.95.172.205
+            "64:ff9b::808:808",  # 8.8.8.8
+        ],
     )
     def test_allowed(self, ip):
         assert is_forbidden_ip(ipaddress.ip_address(ip)) is False
@@ -111,6 +127,36 @@ class TestSSRFProtectedAsyncBackend:
         # That is what pins the address against DNS rebinding.
         assert calls[0][0][0] == "93.184.216.34"
         assert calls[0][0][1] == 443
+
+    async def test_nat64_wrapped_public_ip_connects(self, monkeypatch):
+        """DNS64 case (issue #3668): a NAT64-wrapped public IPv4 must be reachable."""
+        calls: list[ConnectCall] = []
+        inner = _stub_async_inner(calls)
+        backend = SSRFProtectedAsyncBackend(inner=inner)
+
+        async def fake_getaddrinfo(host, port, *args, **kwargs):
+            return _addr_info("64:ff9b::8d5f:accd", port)  # wraps 141.95.172.205
+
+        monkeypatch.setattr(asyncio.get_running_loop(), "getaddrinfo", fake_getaddrinfo)
+
+        await backend.connect_tcp("neoclone.screenscraper.fr", 443)
+
+        assert calls[0][0][0] == "64:ff9b::8d5f:accd"
+        assert calls[0][0][1] == 443
+
+    async def test_nat64_wrapped_private_ip_is_rejected(self, monkeypatch):
+        """A NAT64-wrapped private/loopback IPv4 must still be blocked."""
+        inner = _stub_async_inner([])
+        backend = SSRFProtectedAsyncBackend(inner=inner)
+
+        async def fake_getaddrinfo(host, port, *args, **kwargs):
+            return _addr_info("64:ff9b::7f00:1", port)  # wraps 127.0.0.1
+
+        monkeypatch.setattr(asyncio.get_running_loop(), "getaddrinfo", fake_getaddrinfo)
+
+        with pytest.raises(httpcore.ConnectError, match="forbidden IP"):
+            await backend.connect_tcp("nat64.rebind.example.com", 80)
+        inner.connect_tcp.assert_not_called()
 
     async def test_hostname_resolving_to_private_ip_is_rejected(self, monkeypatch):
         """DNS rebinding case: hostname resolves to 127.0.0.1 must fail."""

--- a/backend/utils/ssrf.py
+++ b/backend/utils/ssrf.py
@@ -44,9 +44,28 @@ from httpcore._backends.sync import SyncBackend
 from logger.logger import log
 from utils.validation import ValidationError
 
+# RFC 6052 well-known NAT64 prefix. DNS64 resolvers embed a public IPv4 in
+# the low 32 bits so IPv6-only clients can reach IPv4-only hosts. We must
+# judge such an address by its embedded IPv4, not the (reserved) wrapper.
+_NAT64_WELL_KNOWN_PREFIX = ipaddress.ip_network("64:ff9b::/96")
+
+
+def _nat64_embedded_ipv4(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> ipaddress.IPv4Address | None:
+    """Return the IPv4 embedded in a well-known NAT64 address, else None."""
+    if isinstance(ip, ipaddress.IPv6Address) and ip in _NAT64_WELL_KNOWN_PREFIX:
+        return ipaddress.IPv4Address(int(ip) & 0xFFFFFFFF)
+    return None
+
 
 def is_forbidden_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """Return True if the IP must not be reached from a server-side HTTP request."""
+    embedded = _nat64_embedded_ipv4(ip)
+    if embedded is not None:
+        # A NAT64-wrapped public IPv4 is a legitimate destination on DNS64
+        # networks; a wrapped private/internal IPv4 must still be blocked.
+        return is_forbidden_ip(embedded)
     return (
         ip.is_private
         or ip.is_loopback


### PR DESCRIPTION
## Summary

Fixes #3668. On DNS64/NAT64 networks (e.g. OPNsense + Tayga), the resolver synthesizes IPv6 answers by embedding a public IPv4 inside the RFC 6052 well-known NAT64 prefix `64:ff9b::/96`. For example `neoclone.screenscraper.fr` resolves to `64:ff9b::8d5f:accd`, which wraps the public IPv4 `141.95.172.205`.

RomM's SSRF classifier `is_forbidden_ip` rejected these because the well-known NAT64 range is classified as `is_reserved` (and `not is_global` on some Python versions), producing:

```
SSRF prevention: hostname 'neoclone.screenscraper.fr' resolves to forbidden IP 64:ff9b::8d5f:accd
Unable to fetch cover at https://neoclone.screenscraper.fr/...
```

This broke all outbound metadata and cover fetching on any NAT64-only deployment.

## Change

`is_forbidden_ip` now detects a NAT64-wrapped address, extracts the embedded IPv4, and runs the forbidden check against **that** IPv4:

- A wrapped **public** IPv4 (`64:ff9b::8d5f:accd` → `141.95.172.205`) is now allowed.
- A wrapped **private/internal** IPv4 (`64:ff9b::7f00:1` → `127.0.0.1`, `64:ff9b::a00:1` → `10.0.0.1`, cloud metadata, etc.) is still blocked.

Because `is_forbidden_ip` is the shared classifier used by both the DNS-resolution backends and the syntactic URL validator, this single change covers every code path. The RFC 8215 local-use prefix `64:ff9b:1::/48` is marked private by Python, so it is not unwrapped and remains blocked.

Scope: only the RFC 6052 well-known prefix `64:ff9b::/96` is unwrapped (the default used by the reporter and the vast majority of NAT64/DNS64 setups). No new configuration.

## Tests

- New `TestIsForbiddenIp` cases for NAT64-wrapped public (allowed) and private/loopback/link-local (blocked) addresses, plus an RFC 8215 sanity case.
- New async-backend regression tests: a hostname resolving to `64:ff9b::8d5f:accd` connects to the pinned NAT64 address; one resolving to `64:ff9b::7f00:1` still raises `ConnectError`.

`uv run pytest tests/utils/test_ssrf.py` → 62 passed. `trunk fmt` + `trunk check` clean. No API surface change, so no OpenAPI/type regen needed.

## AI assistance disclosure

This change was written with AI assistance (PostHog Code / Claude). The root-cause analysis, code changes, tests, and this description were AI-generated and reviewed before submission.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*