### PR TITLE
Use parsed filename for unmatched ROM titles instead of raw filename

### DIFF
--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -283,7 +283,7 @@ async def _identify_rom(
                     languages=parsed_tags.languages,
                     tags=parsed_tags.other_tags,
                     platform_id=platform.id,
-                    name=fs_rom["fs_name"],
+                    name=fs_rom_handler.get_file_name_with_no_tags(fs_rom["fs_name"]),
                     url_cover="",
                     url_manual="",
                     url_screenshots=[],

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -969,14 +969,17 @@ async def scan_rom(
         fs_name_no_tags = fs_rom_handler.get_file_name_with_no_tags(
             rom_attrs["fs_name"]
         )
-        is_placeholder = rom.name in (None, "", rom.fs_name, fs_name_no_tags)
-        existing_name = None if is_placeholder else rom.name
+        # Both the existing name and the seeded rom_attrs name can hold the
+        # placeholder (rom_attrs["name"] is seeded from rom.name earlier, and is
+        # only overwritten when a provider actually matched). Discard either when
+        # it's a placeholder so the parsed filename fallback can win.
+        placeholders = (None, "", rom.fs_name, fs_name_no_tags)
+        existing_name = None if rom.name in placeholders else rom.name
+        matched_name = rom_attrs.get("name")
+        matched_name = None if matched_name in placeholders else matched_name
         rom_attrs.update(
             {
-                "name": existing_name
-                or rom_attrs.get("name")
-                or fs_name_no_tags
-                or None,
+                "name": existing_name or matched_name or fs_name_no_tags or None,
                 "summary": rom.summary or rom_attrs.get("summary") or None,
                 # Don't overwrite existing manually uploaded cover image
                 "url_cover": (

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -963,16 +963,13 @@ async def scan_rom(
     ):
         # A ROM's name defaults to a filename-derived placeholder when first
         # created. Treat that placeholder as "no name" so a freshly matched provider
-        # name replaces it (while preserving user-edited names). When still unmatched,
-        # fall back to the parsed filename (tags and extension stripped) rather than
-        # keeping the raw filename as the title.
+        # name replaces it (while preserving user-edited names).
         fs_name_no_tags = fs_rom_handler.get_file_name_with_no_tags(
             rom_attrs["fs_name"]
         )
         # Both the existing name and the seeded rom_attrs name can hold the
-        # placeholder (rom_attrs["name"] is seeded from rom.name earlier, and is
-        # only overwritten when a provider actually matched). Discard either when
-        # it's a placeholder so the parsed filename fallback can win.
+        # placeholder. Discard either when it's a placeholder so the parsed
+        # filename fallback can win.
         placeholders = (None, "", rom.fs_name, fs_name_no_tags)
         existing_name = None if rom.name in placeholders else rom.name
         matched_name = rom_attrs.get("name")

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -961,14 +961,22 @@ async def scan_rom(
     if not newly_added and (
         scan_type == ScanType.UNMATCHED or scan_type == ScanType.UPDATE
     ):
-        # A ROM's name defaults to its raw filename (extension included) when first
+        # A ROM's name defaults to a filename-derived placeholder when first
         # created. Treat that placeholder as "no name" so a freshly matched provider
-        # name replaces it, instead of keeping the filename (with its extension) as
-        # the title.
-        existing_name = rom.name if rom.name != rom.fs_name else None
+        # name replaces it (while preserving user-edited names). When still unmatched,
+        # fall back to the parsed filename (tags and extension stripped) rather than
+        # keeping the raw filename as the title.
+        fs_name_no_tags = fs_rom_handler.get_file_name_with_no_tags(
+            rom_attrs["fs_name"]
+        )
+        is_placeholder = rom.name in (None, "", rom.fs_name, fs_name_no_tags)
+        existing_name = None if is_placeholder else rom.name
         rom_attrs.update(
             {
-                "name": existing_name or rom_attrs.get("name") or rom.name or None,
+                "name": existing_name
+                or rom_attrs.get("name")
+                or fs_name_no_tags
+                or None,
                 "summary": rom.summary or rom_attrs.get("summary") or None,
                 # Don't overwrite existing manually uploaded cover image
                 "url_cover": (

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -438,6 +438,66 @@ async def test_scan_rom_unmatched_preserves_custom_name(
     assert result.name == "My Custom Title"
 
 
+@patch.object(meta_playmatch_handler, "is_enabled", return_value=False)
+@patch.object(meta_hasheous_handler, "get_ra_game", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "get_igdb_game", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "lookup_rom", new_callable=AsyncMock)
+async def test_scan_rom_unmatched_no_match_uses_parsed_name(
+    mock_lookup, mock_get_igdb, mock_get_ra, mock_playmatch_enabled
+):
+    """UNMATCHED scan that still finds no provider match must heal a raw-filename
+    placeholder into the parsed name (tags and extension stripped), so the title
+    is clean and a follow-up search uses the parsed name."""
+    no_match = HasheousRom(
+        hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None, name=None
+    )
+    mock_lookup.return_value = no_match
+    mock_get_igdb.return_value = no_match
+    mock_get_ra.return_value = no_match
+
+    platform = Platform(
+        id=1, slug="n64", fs_slug="n64", name="Nintendo 64", igdb_id=4, hasheous_id=64
+    )
+    platform = db_platform_handler.add_platform(platform)
+
+    # Legacy ROM created before the fix: name holds the raw filename.
+    rom = Rom(
+        platform_id=platform.id,
+        fs_name="Snow Brothers (USA).zip",
+        fs_name_no_tags="Snow Brothers",
+        fs_name_no_ext="Snow Brothers (USA)",
+        fs_extension="zip",
+        fs_path="n64/Snow Brothers (USA)",
+        name="Snow Brothers (USA).zip",
+        fs_size_bytes=1024,
+        tags=[],
+    )
+    rom = db_rom_handler.add_rom(rom)
+
+    async with initialize_context():
+        result = await scan_rom(
+            platform=platform,
+            scan_type=ScanType.UNMATCHED,
+            rom=rom,
+            fs_rom={
+                "fs_name": "Snow Brothers (USA).zip",
+                "flat": True,
+                "nested": False,
+                "files": [],
+                "crc_hash": "",
+                "md5_hash": "",
+                "sha1_hash": "",
+                "ra_hash": "",
+            },
+            metadata_sources=[MetadataSource.HASHEOUS],
+            newly_added=False,
+        )
+
+    assert result.hasheous_id is None
+    # The raw filename placeholder must be replaced by the parsed name.
+    assert result.name == "Snow Brothers"
+
+
 def _top_level_rom_file(**kwargs) -> RomFile:
     """Build a RomFile whose `is_top_level` cached_property is pre-seeded to
     True, so it passes lookup_rom's filtering without a persisted rom."""

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -448,9 +448,7 @@ async def test_scan_rom_unmatched_no_match_uses_parsed_name(
     """UNMATCHED scan that still finds no provider match must heal a raw-filename
     placeholder into the parsed name (tags and extension stripped), so the title
     is clean and a follow-up search uses the parsed name."""
-    no_match = HasheousRom(
-        hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None, name=None
-    )
+    no_match = HasheousRom(hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None)
     mock_lookup.return_value = no_match
     mock_get_igdb.return_value = no_match
     mock_get_ra.return_value = no_match


### PR DESCRIPTION
**TL;DR**
When a ROM scan finds no metadata match, the title should fall back to the parsed filename (with tags and extension stripped) rather than keeping the raw filename as a placeholder. This ensures unmatched ROMs have clean, readable titles for subsequent searches.

Fixes #3665

**What changed?**

- **Updated ROM creation for unmatched matches** (`scan.py`): Changed the `name` field to use `fs_rom_handler.get_file_name_with_no_tags()` instead of the raw filename when creating an unmatched ROM entry.

- **Improved placeholder detection logic** (`scan_handler.py`): Enhanced the logic that determines whether a ROM's existing name is a placeholder:
  - Expanded placeholder detection to recognize both the raw filename and the parsed filename (without tags) as placeholders
  - When updating an unmatched ROM, now falls back to the parsed filename instead of the raw filename if no user-edited name exists
  - Preserves user-edited names while replacing auto-generated placeholders

- **Added test coverage** (`test_fastapi.py`): New test `test_scan_rom_unmatched_no_match_uses_parsed_name` verifies that:
  - A legacy ROM with a raw filename placeholder gets healed to use the parsed name
  - The parsed name (tags and extension stripped) becomes the fallback title when no metadata match is found

**Checklist**
- [x] Changes tested with new unit test
- [x] Updated relevant comments explaining the placeholder behavior
- [x] Logic preserves existing user-edited ROM names

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*