### PR TITLE
docs(claude): add PR linking and template conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,8 @@ These live in `.claude/skills/` and carry the detailed rules. Invoke the one tha
 **Never commit secrets.** Never commit secrets (API keys, passwords, tokens, etc.) to the repo. Use environment variables or secret management tools instead.
 **Don't explain a change.** Avoid comments that explain why a change was made to the code. Focus instead on the current behaviour of the code and how it works.
 **Python tools live in `backend/tools/`.** Standalone dev/test utilities and scripts (not part of the app runtime) go in `backend/tools/`, not scattered across `backend/`.
+**Link PRs to issues.** In the PR description, use `Fixes #XXXX` for issue/bug fixes and `Closes #XXXX` for feature implementations.
+**Use the PR template.** Base every PR description on `.github/PULL_REQUEST_TEMPLATE.md`.
 
 ---
 


### PR DESCRIPTION
**TL;DR**
Add documentation guidelines for Claude to follow when creating pull requests, including proper issue linking conventions and the requirement to use the repository's PR template.

**What changed?**
- Added guidance on linking PRs to issues using `Fixes #XXXX` for bug fixes and `Closes #XXXX` for feature implementations
- Added requirement to base PR descriptions on the existing `.github/PULL_REQUEST_TEMPLATE.md`

**Checklist**
- [x] Changes are documented in CLAUDE.md

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*