### PR TITLE
Support markdown manuals and enforce allowed file types

### DIFF
--- a/backend/endpoints/roms/manual.py
+++ b/backend/endpoints/roms/manual.py
@@ -57,7 +57,16 @@ async def add_rom_manuals(
     if not rom:
         raise RomNotFoundInDatabaseException(id)
 
-    # The stored filename is always `{rom.id}.pdf`; we only use `filename` as
+    if not _is_allowed_manual_file(filename):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Unsupported manual file type. Allowed: "
+                f"{', '.join(sorted(ALLOWED_MANUAL_EXTENSIONS))}"
+            ),
+        )
+
+    # The stored filename is always `{rom.id}{ext}`; we only use `filename` as
     # the form-field key, but normalise it to a safe basename first.
     try:
         safe_field_name = fs_resource_handler._sanitize_filename(filename)
@@ -67,11 +76,23 @@ async def add_rom_manuals(
             detail=f"Invalid upload filename: {exc}",
         ) from exc
 
+    ext = os.path.splitext(filename)[1].lower()
     manuals_path = f"{rom.fs_resources_path}/manual"
-    file_location = fs_resource_handler.validate_path(f"{manuals_path}/{rom.id}.pdf")
+    file_location = fs_resource_handler.validate_path(f"{manuals_path}/{rom.id}{ext}")
     log.info(f"Uploading manual to {hl(str(file_location))}")
 
     await fs_resource_handler.make_directory(manuals_path)
+
+    # Drop any prior manual stored under a different extension so the single
+    # primary manual stays unambiguous (the glob matches `{rom.id}.*`).
+    for allowed_ext in ALLOWED_MANUAL_EXTENSIONS:
+        if allowed_ext == ext:
+            continue
+        stale = fs_resource_handler.validate_path(
+            f"{manuals_path}/{rom.id}{allowed_ext}"
+        )
+        if stale.exists():
+            stale.unlink()
 
     parser = StreamingFormDataParser(headers=request.headers)
     parser.register("x-upload-platform", NullTarget())
@@ -99,7 +120,7 @@ async def add_rom_manuals(
     db_rom_handler.update_rom(
         id,
         {
-            "path_manual": f"{manuals_path}/{rom.id}.pdf",
+            "path_manual": f"{manuals_path}/{rom.id}{ext}",
         },
     )
 

--- a/backend/endpoints/roms/manual.py
+++ b/backend/endpoints/roms/manual.py
@@ -15,6 +15,7 @@ from exceptions.fs_exceptions import RomAlreadyExistsException
 from handler.auth.constants import Scope
 from handler.database import db_rom_handler
 from handler.filesystem import fs_resource_handler, fs_rom_handler
+from handler.filesystem.resources_handler import ALLOWED_MANUAL_EXTENSIONS
 from handler.rom_conversion import promote_single_file_to_folder
 from logger.formatter import BLUE
 from logger.formatter import highlight as hl
@@ -25,7 +26,6 @@ from utils.router import APIRouter
 router = APIRouter()
 
 MANUAL_FOLDER = "manual"
-ALLOWED_MANUAL_EXTENSIONS = frozenset({".pdf", ".md"})
 
 
 def _is_allowed_manual_file(file_name: str) -> bool:

--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -20,6 +20,8 @@ from .base_handler import CoverSize, FSHandler
 
 LOCAL_FILE_SCHEMES = ("file://", "launchbox-file://")
 
+ALLOWED_MANUAL_EXTENSIONS = frozenset({".pdf", ".md"})
+
 
 def _resolve_local_file_uri(uri: str) -> Path | None:
     """Resolve a local-file URI to an absolute Path, or None if unsafe/unknown.
@@ -402,9 +404,10 @@ class FSResourcesHandler(FSHandler):
             True if manual exists in filesystem else False
         """
         full_path = self.validate_path(f"{rom.fs_resources_path}/manual")
-        for _ in full_path.glob(f"{rom.id}.*"):
-            return True
-        return False
+        return any(
+            (full_path / f"{rom.id}{ext}").is_file()
+            for ext in ALLOWED_MANUAL_EXTENSIONS
+        )
 
     async def _store_manual(self, rom: Rom, url_manual: str):
         manual_path = f"{rom.fs_resources_path}/manual"
@@ -474,10 +477,19 @@ class FSResourcesHandler(FSHandler):
             rom: Rom object
         """
         full_path = self.validate_path(f"{rom.fs_resources_path}/manual")
-        for matched_file in full_path.glob(f"{rom.id}.*"):
-            return str(matched_file.relative_to(self.base_path))
+        candidates = [
+            candidate
+            for ext in ALLOWED_MANUAL_EXTENSIONS
+            if (candidate := full_path / f"{rom.id}{ext}").is_file()
+        ]
+        if not candidates:
+            return None
 
-        return None
+        # Multiple allowed manuals can coexist (e.g. an uploaded `.md` and a
+        # redownloaded `.pdf`). Pick the most recently written one, breaking
+        # mtime ties by name so the result is deterministic.
+        newest = max(candidates, key=lambda p: (p.stat().st_mtime, p.name))
+        return str(newest.relative_to(self.base_path))
 
     async def get_manual(
         self, rom: Rom, overwrite: bool, url_manual: str | None

--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -402,7 +402,7 @@ class FSResourcesHandler(FSHandler):
             True if manual exists in filesystem else False
         """
         full_path = self.validate_path(f"{rom.fs_resources_path}/manual")
-        for _ in full_path.glob(f"{rom.id}.pdf"):
+        for _ in full_path.glob(f"{rom.id}.*"):
             return True
         return False
 
@@ -474,7 +474,7 @@ class FSResourcesHandler(FSHandler):
             rom: Rom object
         """
         full_path = self.validate_path(f"{rom.fs_resources_path}/manual")
-        for matched_file in full_path.glob(f"{rom.id}.pdf"):
+        for matched_file in full_path.glob(f"{rom.id}.*"):
             return str(matched_file.relative_to(self.base_path))
 
         return None

--- a/backend/tests/endpoints/roms/test_manual.py
+++ b/backend/tests/endpoints/roms/test_manual.py
@@ -10,6 +10,7 @@ from handler.database import db_rom_handler
 from models.rom import Rom, RomFile, RomFileCategory
 
 PDF_BYTES = b"%PDF-1.4\n%mock pdf\n%%EOF"
+MD_BYTES = b"# Manual\n\nSome **markdown** content.\n"
 
 
 def _auth(token: str) -> dict[str, str]:
@@ -88,6 +89,63 @@ def test_upload_manual_to_resources_success(
     assert written.read_bytes() == PDF_BYTES
     refreshed = db_rom_handler.get_rom(rom.id)
     assert refreshed.path_manual == f"{rom.fs_resources_path}/manual/{rom.id}.pdf"
+
+
+def test_upload_markdown_manual_to_resources_preserves_extension(
+    client: TestClient,
+    access_token: str,
+    rom: Rom,
+    manual_fs_resources: Path,
+):
+    response = client.post(
+        f"/api/roms/{rom.id}/manuals",
+        headers={**_auth(access_token), "x-upload-filename": "README.md"},
+        files={"README.md": ("README.md", MD_BYTES, "text/markdown")},
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    written = manual_fs_resources / f"{rom.id}.md"
+    assert written.exists()
+    assert written.read_bytes() == MD_BYTES
+    refreshed = db_rom_handler.get_rom(rom.id)
+    assert refreshed.path_manual == f"{rom.fs_resources_path}/manual/{rom.id}.md"
+
+
+def test_upload_manual_to_resources_rejects_unsupported_extension(
+    client: TestClient,
+    access_token: str,
+    rom: Rom,
+    manual_fs_resources: Path,
+):
+    response = client.post(
+        f"/api/roms/{rom.id}/manuals",
+        headers={**_auth(access_token), "x-upload-filename": "manual.txt"},
+        files={"manual.txt": ("manual.txt", b"not allowed", "text/plain")},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Unsupported manual file type" in response.json()["detail"]
+
+
+def test_upload_manual_to_resources_drops_stale_other_extension(
+    client: TestClient,
+    access_token: str,
+    rom: Rom,
+    manual_fs_resources: Path,
+):
+    # A prior PDF manual exists; uploading a Markdown one should remove it so
+    # the single primary manual stays unambiguous.
+    (manual_fs_resources / f"{rom.id}.pdf").write_bytes(PDF_BYTES)
+
+    response = client.post(
+        f"/api/roms/{rom.id}/manuals",
+        headers={**_auth(access_token), "x-upload-filename": "README.md"},
+        files={"README.md": ("README.md", MD_BYTES, "text/markdown")},
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert (manual_fs_resources / f"{rom.id}.md").exists()
+    assert not (manual_fs_resources / f"{rom.id}.pdf").exists()
 
 
 def test_upload_manual_to_resources_rom_not_found(

--- a/backend/tests/handler/filesystem/test_resources_handler.py
+++ b/backend/tests/handler/filesystem/test_resources_handler.py
@@ -469,6 +469,37 @@ class TestFSResourcesHandler:
         result = handler._get_manual_path(rom)
         assert result == f"{rom.fs_resources_path}/manual/{rom.id}{ext}"
 
+    @pytest.mark.parametrize("ext", [".part", ".bak", ".tmp", ".txt"])
+    def test_manual_exists_ignores_disallowed_extensions(
+        self, handler: FSResourcesHandler, rom: Rom, tmp_path, ext: str
+    ):
+        """Files that aren't PDF or Markdown must not be treated as manuals."""
+        handler.base_path = tmp_path
+        manual_dir = tmp_path / rom.fs_resources_path / "manual"
+        manual_dir.mkdir(parents=True)
+        (manual_dir / f"{rom.id}{ext}").write_bytes(b"not a manual")
+
+        assert not handler.manual_exists(rom)
+        assert handler._get_manual_path(rom) is None
+
+    def test_get_manual_path_prefers_newest_when_multiple_exist(
+        self, handler: FSResourcesHandler, rom: Rom, tmp_path
+    ):
+        """When several allowed manuals coexist, the newest one wins."""
+        handler.base_path = tmp_path
+        manual_dir = tmp_path / rom.fs_resources_path / "manual"
+        manual_dir.mkdir(parents=True)
+
+        older = manual_dir / f"{rom.id}.md"
+        newer = manual_dir / f"{rom.id}.pdf"
+        older.write_bytes(b"old manual")
+        newer.write_bytes(b"new manual")
+        os.utime(older, (1000, 1000))
+        os.utime(newer, (2000, 2000))
+
+        result = handler._get_manual_path(rom)
+        assert result == f"{rom.fs_resources_path}/manual/{rom.id}.pdf"
+
     @pytest.mark.asyncio
     async def test_get_manual_no_url(self, handler: FSResourcesHandler, rom: Rom):
         """Test get_manual with no URL"""

--- a/backend/tests/handler/filesystem/test_resources_handler.py
+++ b/backend/tests/handler/filesystem/test_resources_handler.py
@@ -444,6 +444,31 @@ class TestFSResourcesHandler:
         result = handler._get_manual_path(rom)
         assert result is None
 
+    @pytest.mark.parametrize("ext", [".pdf", ".md"])
+    def test_manual_exists_finds_extension(
+        self, handler: FSResourcesHandler, rom: Rom, tmp_path, ext: str
+    ):
+        """manual_exists locates both PDF and Markdown manuals."""
+        handler.base_path = tmp_path
+        manual_dir = tmp_path / rom.fs_resources_path / "manual"
+        manual_dir.mkdir(parents=True)
+        (manual_dir / f"{rom.id}{ext}").write_bytes(b"manual")
+
+        assert handler.manual_exists(rom)
+
+    @pytest.mark.parametrize("ext", [".pdf", ".md"])
+    def test_get_manual_path_finds_extension(
+        self, handler: FSResourcesHandler, rom: Rom, tmp_path, ext: str
+    ):
+        """_get_manual_path returns the relative path for PDF and Markdown."""
+        handler.base_path = tmp_path
+        manual_dir = tmp_path / rom.fs_resources_path / "manual"
+        manual_dir.mkdir(parents=True)
+        (manual_dir / f"{rom.id}{ext}").write_bytes(b"manual")
+
+        result = handler._get_manual_path(rom)
+        assert result == f"{rom.fs_resources_path}/manual/{rom.id}{ext}"
+
     @pytest.mark.asyncio
     async def test_get_manual_no_url(self, handler: FSResourcesHandler, rom: Rom):
         """Test get_manual with no URL"""

--- a/frontend/src/locales/bg_BG/rom.json
+++ b/frontend/src/locales/bg_BG/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "Качен е {n} файл от ръководството, {failed} неуспешни. | Качени са {n} файла от ръководството, {failed} неуспешни.",
   "manual-match": "Ръчно разпознаване",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "Грешка при премахване на ръководството: {error}",
   "manual-removed": "Ръководството е премахнато успешно",

--- a/frontend/src/locales/cs_CZ/rom.json
+++ b/frontend/src/locales/cs_CZ/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "Nahráno {n} souborů manuálu, {failed} selhalo. | Nahrán {n} soubor manuálu, {failed} selhalo. | Nahrány {n} soubory manuálu, {failed} selhalo. | Nahráno {n} souborů manuálu, {failed} selhalo.",
   "manual-match": "Ruční přiřazení",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "Nepodařilo se odstranit manuál: {error}",
   "manual-removed": "Manuál úspěšně odstraněn",

--- a/frontend/src/locales/de_DE/rom.json
+++ b/frontend/src/locales/de_DE/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "{n} Handbuch-Datei hochgeladen, {failed} fehlgeschlagen. | {n} Handbuch-Dateien hochgeladen, {failed} fehlgeschlagen.",
   "manual-match": "Manuell zuweisen",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "Fehler beim Entfernen des Handbuchs: {error}",
   "manual-removed": "Handbuch erfolgreich entfernt",

--- a/frontend/src/locales/en_GB/rom.json
+++ b/frontend/src/locales/en_GB/rom.json
@@ -56,6 +56,7 @@
   "manual-files-upload-success": "{count} manual file uploaded successfully ({failed} skipped/failed). | {count} manual files uploaded successfully ({failed} skipped/failed).",
   "manual-match": "Manual match",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "Failed to remove manual: {error}",
   "manual-removed": "Manual removed successfully",

--- a/frontend/src/locales/en_US/rom.json
+++ b/frontend/src/locales/en_US/rom.json
@@ -57,6 +57,7 @@
   "manual-files-upload-success": "{count} manual file uploaded successfully ({failed} skipped/failed). | {count} manual files uploaded successfully ({failed} skipped/failed).",
   "manual-match": "Manual match",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "Failed to remove manual: {error}",
   "manual-removed": "Manual removed successfully",

--- a/frontend/src/locales/es_ES/rom.json
+++ b/frontend/src/locales/es_ES/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "{n} manual subido, {failed} con error | {n} manuales subidos, {failed} con error",
   "manual-match": "Identificación manual",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "Error al eliminar el manual: {error}",
   "manual-removed": "Manual eliminado con éxito",

--- a/frontend/src/locales/fr_FR/rom.json
+++ b/frontend/src/locales/fr_FR/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "{n} fichier de manuel téléversé, {failed} en échec. | {n} fichiers de manuel téléversés, {failed} en échec.",
   "manual-match": "Correspondance manuelle",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "Échec de la suppression du manuel : {error}",
   "manual-removed": "Manuel supprimé avec succès",

--- a/frontend/src/locales/hu_HU/rom.json
+++ b/frontend/src/locales/hu_HU/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "{n} kézikönyvfájl feltöltve, {failed} sikertelen. | {n} kézikönyvfájl feltöltve, {failed} sikertelen.",
   "manual-match": "Kézi egyeztetés",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "A kézikönyv eltávolítása sikertelen: {error}",
   "manual-removed": "A kézikönyv sikeresen eltávolítva",

--- a/frontend/src/locales/it_IT/rom.json
+++ b/frontend/src/locales/it_IT/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "Caricato {n} file manuale, {failed} falliti. | Caricati {n} file manuali, {failed} falliti.",
   "manual-match": "Associazione manuale",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "Errore durante la rimozione del manuale: {error}",
   "manual-removed": "Manuale rimosso con successo",

--- a/frontend/src/locales/ja_JP/rom.json
+++ b/frontend/src/locales/ja_JP/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "{n}件のマニュアルファイルをアップロードしました。{failed}件失敗しました。 | {n}件のマニュアルファイルをアップロードしました。{failed}件失敗しました。",
   "manual-match": "手動マッチ",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "マニュアルの削除に失敗しました: {error}",
   "manual-removed": "マニュアルが正常に削除されました",

--- a/frontend/src/locales/ko_KR/rom.json
+++ b/frontend/src/locales/ko_KR/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "{n}개 매뉴얼 파일을 업로드했습니다, {failed}개 실패. | {n}개 매뉴얼 파일을 업로드했습니다, {failed}개 실패.",
   "manual-match": "수동으로 DB 대응",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "매뉴얼 제거 실패: {error}",
   "manual-removed": "매뉴얼이 성공적으로 제거되었습니다",

--- a/frontend/src/locales/pl_PL/rom.json
+++ b/frontend/src/locales/pl_PL/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "Przesłano {n} plik instrukcji, {failed} niepowodzeń. | Przesłano {n} pliki instrukcji, {failed} niepowodzeń.",
   "manual-match": "Ręczne dopasowanie",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "Nie udało się usunąć instrukcji: {error}",
   "manual-removed": "Instrukcja została pomyślnie usunięta",

--- a/frontend/src/locales/pt_BR/rom.json
+++ b/frontend/src/locales/pt_BR/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "{n} arquivo de manual enviado, {failed} com falha. | {n} arquivos de manual enviados, {failed} com falha.",
   "manual-match": "Correspondência manual",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "Falha ao remover o manual: {error}",
   "manual-removed": "Manual removido com sucesso",

--- a/frontend/src/locales/ro_RO/rom.json
+++ b/frontend/src/locales/ro_RO/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "S-a încărcat {n} fișier de manual, {failed} au eșuat. | S-au încărcat {n} fișiere de manual, {failed} au eșuat.",
   "manual-match": "Potrivire manuală",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "Eliminarea manualului a eșuat: {error}",
   "manual-removed": "Manualul a fost eliminat cu succes",

--- a/frontend/src/locales/ru_RU/rom.json
+++ b/frontend/src/locales/ru_RU/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "Загружен {n} файл руководства, {failed} с ошибкой. | Загружено {n} файлов руководства, {failed} с ошибкой.",
   "manual-match": "Ручное совпадение",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "Не удалось удалить руководство: {error}",
   "manual-removed": "Руководство успешно удалено",

--- a/frontend/src/locales/tr_TR/rom.json
+++ b/frontend/src/locales/tr_TR/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "{n} kılavuz dosyası yüklendi, {failed} başarısız. | {n} kılavuz dosyası yüklendi, {failed} başarısız.",
   "manual-match": "Manuel eşleştirme",
   "manual-redownload-failed": "Kılavuz yeniden indirilemedi: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Kılavuz başarıyla yeniden indirildi",
   "manual-remove-failed": "Kılavuz kaldırılamadı: {error}",
   "manual-removed": "Kılavuz başarıyla kaldırıldı",

--- a/frontend/src/locales/zh_CN/rom.json
+++ b/frontend/src/locales/zh_CN/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "已上传 {n} 个手册文件，{failed} 个失败。 | 已上传 {n} 个手册文件，{failed} 个失败。",
   "manual-match": "手动匹配",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "删除手册失败：{error}",
   "manual-removed": "手册删除成功",

--- a/frontend/src/locales/zh_TW/rom.json
+++ b/frontend/src/locales/zh_TW/rom.json
@@ -152,6 +152,7 @@
   "manual-files-uploaded-with-failed": "已上傳 {n} 個手冊檔案，{failed} 個失敗。 | 已上傳 {n} 個手冊檔案，{failed} 個失敗。",
   "manual-match": "手動匹配",
   "manual-redownload-failed": "Failed to re-download manual: {error}",
+  "manual-load-failed": "Unable to load manual",
   "manual-redownloaded": "Manual re-downloaded successfully",
   "manual-remove-failed": "刪除手冊失敗：{error}",
   "manual-removed": "手冊刪除成功",

--- a/frontend/src/v2/components/GameDetails/FilesTab/FilesTab.vue
+++ b/frontend/src/v2/components/GameDetails/FilesTab/FilesTab.vue
@@ -624,7 +624,7 @@ const currentUploadState = computed<SubtabUploadState>(() => {
   <input
     ref="manualUploadInput"
     type="file"
-    accept="application/pdf,text/markdown"
+    accept="application/pdf,.md"
     multiple
     class="r-v2-files__file-input"
     :aria-label="t('rom.upload-manual-files')"

--- a/frontend/src/v2/components/GameDetails/FilesTab/FilesTab.vue
+++ b/frontend/src/v2/components/GameDetails/FilesTab/FilesTab.vue
@@ -624,7 +624,7 @@ const currentUploadState = computed<SubtabUploadState>(() => {
   <input
     ref="manualUploadInput"
     type="file"
-    accept="application/pdf"
+    accept="application/pdf,.md,text/markdown"
     multiple
     class="r-v2-files__file-input"
     :aria-label="t('rom.upload-manual-files')"

--- a/frontend/src/v2/components/GameDetails/FilesTab/FilesTab.vue
+++ b/frontend/src/v2/components/GameDetails/FilesTab/FilesTab.vue
@@ -624,7 +624,7 @@ const currentUploadState = computed<SubtabUploadState>(() => {
   <input
     ref="manualUploadInput"
     type="file"
-    accept="application/pdf,.md,text/markdown"
+    accept="application/pdf,text/markdown"
     multiple
     class="r-v2-files__file-input"
     :aria-label="t('rom.upload-manual-files')"

--- a/frontend/src/v2/components/GameDetails/MarkdownViewer.vue
+++ b/frontend/src/v2/components/GameDetails/MarkdownViewer.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+// MarkdownViewer (v2) — renders a Markdown (.md) manual with the same v2
+// chrome as PdfViewer. Manuals can be PDF or Markdown; MediaTab picks the
+// viewer by extension. The file is fetched as text and handed to MdPreview
+// (md-editor-v3), the same renderer used by NotesTab.
+import { RBtn, REmptyState, RIcon, RSpinner, RTooltip } from "@v2/lib";
+import { MdPreview } from "md-editor-v3";
+import "md-editor-v3/lib/style.css";
+import { computed, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { useThemeMode } from "@/v2/composables/useThemeMode";
+
+const props = defineProps<{
+  url: string;
+  /** Show a danger-tinted delete button at the end of the toolbar. */
+  deletable?: boolean;
+  /** Show a re-download button when a scraped source URL exists. */
+  redownloadable?: boolean;
+  /** Drive the re-download button's loading/disabled state. */
+  redownloading?: boolean;
+}>();
+
+const emit = defineEmits<{
+  delete: [];
+  redownload: [];
+}>();
+
+const { t } = useI18n();
+const { isLight } = useThemeMode();
+const mdTheme = computed<"light" | "dark">(() =>
+  isLight.value ? "light" : "dark",
+);
+
+// Filename for the download button — last path segment without the cache-bust
+// query, decoded back to its human form (e.g. `README.md`).
+const fileName = computed(() => {
+  const path = props.url.split("?")[0];
+  const last = path.substring(path.lastIndexOf("/") + 1);
+  try {
+    return decodeURIComponent(last) || "manual.md";
+  } catch {
+    return last || "manual.md";
+  }
+});
+
+const content = ref("");
+const loading = ref(false);
+const failed = ref(false);
+
+async function load() {
+  loading.value = true;
+  failed.value = false;
+  try {
+    const res = await fetch(props.url, { credentials: "include" });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    content.value = await res.text();
+  } catch (err) {
+    console.error("Failed to load markdown manual", err);
+    failed.value = true;
+  } finally {
+    loading.value = false;
+  }
+}
+
+watch(() => props.url, load, { immediate: true });
+</script>
+
+<template>
+  <div class="r-v2-mdv">
+    <div class="r-v2-mdv__toolbar">
+      <span class="r-v2-mdv__name">{{ fileName }}</span>
+
+      <span class="r-v2-mdv__spacer" />
+
+      <RTooltip :text="t('common.download')">
+        <template #activator="{ props: activator }">
+          <a
+            v-bind="activator"
+            :href="url"
+            :download="fileName"
+            class="r-v2-mdv__btn"
+          >
+            <RIcon icon="mdi-download" size="18" />
+          </a>
+        </template>
+      </RTooltip>
+
+      <RTooltip v-if="redownloadable" :text="t('rom.redownload')">
+        <template #activator="{ props: activator }">
+          <button
+            v-bind="activator"
+            type="button"
+            class="r-v2-mdv__btn"
+            :class="{ 'r-v2-mdv__btn--loading': redownloading }"
+            :disabled="redownloading"
+            @click="emit('redownload')"
+          >
+            <RIcon icon="mdi-cloud-download-outline" size="18" />
+          </button>
+        </template>
+      </RTooltip>
+
+      <RTooltip v-if="deletable" :text="t('common.delete')">
+        <template #activator="{ props: activator }">
+          <button
+            v-bind="activator"
+            type="button"
+            class="r-v2-mdv__btn r-v2-mdv__btn--danger"
+            @click="emit('delete')"
+          >
+            <RIcon icon="mdi-delete-outline" size="18" />
+          </button>
+        </template>
+      </RTooltip>
+    </div>
+
+    <div class="r-v2-mdv__viewer">
+      <div v-if="loading" class="r-v2-mdv__center">
+        <RSpinner :size="28" />
+      </div>
+      <REmptyState
+        v-else-if="failed"
+        icon="mdi-file-alert-outline"
+        :title="t('rom.manual-load-failed')"
+      >
+        <template #actions>
+          <RBtn variant="outlined" size="small" @click="load">
+            {{ t("common.try-again") }}
+          </RBtn>
+        </template>
+      </REmptyState>
+      <MdPreview
+        v-else
+        no-highlight
+        no-katex
+        no-mermaid
+        :model-value="content"
+        :theme="mdTheme"
+        language="en-US"
+        preview-theme="vuepress"
+        code-theme="github"
+        class="r-v2-mdv__preview"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.r-v2-mdv {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+/* Toolbar inherits the parent's bg-elevated — no separate background or
+   divider so the surface reads as one continuous panel (mirrors PdfViewer). */
+.r-v2-mdv__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 6px 10px;
+}
+.r-v2-mdv__name {
+  font-size: 12px;
+  color: var(--r-color-fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.r-v2-mdv__spacer {
+  flex: 1;
+}
+
+.r-v2-mdv__btn {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: var(--r-radius-md);
+  color: var(--r-color-fg-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: inherit;
+  transition:
+    background var(--r-motion-fast) var(--r-motion-ease-out),
+    color var(--r-motion-fast) var(--r-motion-ease-out);
+}
+.r-v2-mdv__btn:hover {
+  background: var(--r-color-surface-hover);
+  color: var(--r-color-fg);
+}
+.r-v2-mdv__btn--danger {
+  color: var(--r-color-danger);
+}
+.r-v2-mdv__btn--danger:hover {
+  background: color-mix(in srgb, var(--r-color-danger) 14%, transparent);
+  color: var(--r-color-danger);
+}
+.r-v2-mdv__btn--loading {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.r-v2-mdv__btn--loading:hover {
+  background: transparent;
+  color: var(--r-color-fg-secondary);
+}
+
+.r-v2-mdv__viewer {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+.r-v2-mdv__center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+/* MdPreview paints its own surface — blend it with the surrounding
+   bg-elevated container so there's no visible seam under the toolbar. */
+.r-v2-mdv__preview {
+  background: transparent;
+  padding: 0 16px 16px;
+}
+</style>

--- a/frontend/src/v2/components/GameDetails/MediaTab.vue
+++ b/frontend/src/v2/components/GameDetails/MediaTab.vue
@@ -426,7 +426,7 @@ async function deleteSoundtrack(fileId: number) {
           :hint="t('common.dropzone-hint')"
           :active-title="t('common.dropzone-drag-over')"
           :input-label="t('rom.upload-manual')"
-          accept="application/pdf,.md,text/markdown"
+          accept="application/pdf,text/markdown"
           multiple
           @files="handleManualFiles"
         >
@@ -450,7 +450,7 @@ async function deleteSoundtrack(fileId: number) {
           class="r-v2-media__fill"
           :release-label="t('common.dropzone-drag-over')"
           :input-label="t('rom.upload-manual')"
-          accept="application/pdf,.md,text/markdown"
+          accept="application/pdf,text/markdown"
           multiple
           @files="handleManualFiles"
         >

--- a/frontend/src/v2/components/GameDetails/MediaTab.vue
+++ b/frontend/src/v2/components/GameDetails/MediaTab.vue
@@ -426,7 +426,7 @@ async function deleteSoundtrack(fileId: number) {
           :hint="t('common.dropzone-hint')"
           :active-title="t('common.dropzone-drag-over')"
           :input-label="t('rom.upload-manual')"
-          accept="application/pdf,text/markdown"
+          accept="application/pdf,.md"
           multiple
           @files="handleManualFiles"
         >
@@ -450,7 +450,7 @@ async function deleteSoundtrack(fileId: number) {
           class="r-v2-media__fill"
           :release-label="t('common.dropzone-drag-over')"
           :input-label="t('rom.upload-manual')"
-          accept="application/pdf,text/markdown"
+          accept="application/pdf,.md"
           multiple
           @files="handleManualFiles"
         >

--- a/frontend/src/v2/components/GameDetails/MediaTab.vue
+++ b/frontend/src/v2/components/GameDetails/MediaTab.vue
@@ -31,6 +31,9 @@ import { useSnackbar } from "@/v2/composables/useSnackbar";
 const PdfViewer = defineAsyncComponent(
   () => import("@/v2/components/GameDetails/PdfViewer.vue"),
 );
+const MarkdownViewer = defineAsyncComponent(
+  () => import("@/v2/components/GameDetails/MarkdownViewer.vue"),
+);
 const SoundtrackPanel = defineAsyncComponent(
   () => import("@/v2/components/GameDetails/SoundtrackPanel.vue"),
 );
@@ -115,7 +118,11 @@ type ManualEntry = {
   label: string;
   url: string;
   isPrimary: boolean;
+  // Manuals can be PDF or Markdown; the viewer is picked by extension.
+  kind: "pdf" | "md";
 };
+
+const isMarkdown = (name: string) => /\.md$/i.test(name);
 
 const manualEntries = computed<ManualEntry[]>(() => {
   const entries: ManualEntry[] = [];
@@ -126,6 +133,7 @@ const manualEntries = computed<ManualEntry[]>(() => {
       label: t("rom.scraped-manual"),
       url: `${FRONTEND_RESOURCES_PATH}/${props.rom.path_manual}?v=${cacheBust}`,
       isPrimary: true,
+      kind: isMarkdown(props.rom.path_manual) ? "md" : "pdf",
     });
   }
   for (const file of props.rom.files ?? []) {
@@ -137,6 +145,7 @@ const manualEntries = computed<ManualEntry[]>(() => {
           file.file_name,
         )}?v=${cacheBust}`,
         isPrimary: false,
+        kind: isMarkdown(file.file_name) ? "md" : "pdf",
       });
     }
   }
@@ -417,7 +426,7 @@ async function deleteSoundtrack(fileId: number) {
           :hint="t('common.dropzone-hint')"
           :active-title="t('common.dropzone-drag-over')"
           :input-label="t('rom.upload-manual')"
-          accept="application/pdf"
+          accept="application/pdf,.md,text/markdown"
           multiple
           @files="handleManualFiles"
         >
@@ -441,21 +450,33 @@ async function deleteSoundtrack(fileId: number) {
           class="r-v2-media__fill"
           :release-label="t('common.dropzone-drag-over')"
           :input-label="t('rom.upload-manual')"
-          accept="application/pdf"
+          accept="application/pdf,.md,text/markdown"
           multiple
           @files="handleManualFiles"
         >
           <div class="r-v2-media__viewer">
-            <PdfViewer
-              v-if="selectedManual"
-              :key="`${selectedManual.id}-${rom.updated_at}`"
-              :pdf-url="selectedManual.url"
-              deletable
-              :redownloadable="!!rom.url_manual"
-              :redownloading="redownloadingManual"
-              @delete="requestDeleteManual"
-              @redownload="redownloadManual"
-            />
+            <template v-if="selectedManual">
+              <MarkdownViewer
+                v-if="selectedManual.kind === 'md'"
+                :key="`${selectedManual.id}-${rom.updated_at}`"
+                :url="selectedManual.url"
+                deletable
+                :redownloadable="!!rom.url_manual"
+                :redownloading="redownloadingManual"
+                @delete="requestDeleteManual"
+                @redownload="redownloadManual"
+              />
+              <PdfViewer
+                v-else
+                :key="`${selectedManual.id}-${rom.updated_at}`"
+                :pdf-url="selectedManual.url"
+                deletable
+                :redownloadable="!!rom.url_manual"
+                :redownloading="redownloadingManual"
+                @delete="requestDeleteManual"
+                @redownload="redownloadManual"
+              />
+            </template>
           </div>
         </RDropzone>
       </section>


### PR DESCRIPTION
**TL;DR**
This PR extends manual upload support beyond PDF to include Markdown files, adds validation to reject unsupported file types, and ensures only one manual file exists per ROM by cleaning up stale files when a new manual is uploaded with a different extension.

Fixes #3654

**What changed?**

- **Manual file type validation**: Added `_is_allowed_manual_file()` check to reject uploads with unsupported extensions, returning a 400 error with a list of allowed types
- **Dynamic file extension handling**: Changed manual storage from hardcoded `.pdf` to preserve the uploaded file's extension (e.g., `.md` for Markdown files)
- **Stale file cleanup**: When uploading a new manual, automatically removes any prior manual stored with a different extension to maintain a single unambiguous primary manual per ROM
- **Glob pattern updates**: Updated filesystem checks from `{rom.id}.pdf` to `{rom.id}.*` to detect manuals regardless of extension
- **Test coverage**: Added tests for:
  - Markdown manual upload preserving `.md` extension
  - Rejection of unsupported file types (e.g., `.txt`)
  - Stale PDF removal when uploading a Markdown replacement
  - Extension detection in both `manual_exists()` and `_get_manual_path()`
- **Localization**: Updated Bulgarian translation file (truncated in diff)

**Checklist**
- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*