### PR TITLE
fix(launchbox): import local media when matching via update_rom

### DIFF
--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -65,6 +65,7 @@ from handler.metadata import (
     meta_ra_handler,
     meta_ss_handler,
 )
+from handler.metadata.launchbox_handler.media import populate_rom_specific_paths
 from handler.metadata.ss_handler import add_ss_auth_to_url, get_preferred_media_types
 from handler.rom_conversion import promote_single_file_to_folder
 from logger.formatter import BLUE
@@ -1534,9 +1535,14 @@ async def update_rom(
         and int(cleaned_data["launchbox_id"]) != rom.launchbox_id
     ):
         launchbox_rom = await meta_launchbox_handler.get_rom_by_id(
-            cleaned_data["launchbox_id"]
+            cleaned_data["launchbox_id"],
+            fs_name=rom.fs_name,
+            platform_slug=rom.platform_slug,
         )
         if launchbox_rom.get("launchbox_id"):
+            metadata = launchbox_rom.get("launchbox_metadata")
+            if metadata:
+                populate_rom_specific_paths(metadata, rom)
             cleaned_data.update(launchbox_rom)
     elif rom.launchbox_id and not cleaned_data["launchbox_id"]:
         cleaned_data.update({"launchbox_id": None, "launchbox_metadata": {}})
@@ -1722,6 +1728,36 @@ async def update_rom(
             if media_path and media_url:
                 await fs_resource_handler.store_media_file(
                     add_ss_auth_to_url(media_url),
+                    media_path,
+                )
+
+    # Handle local media files from LaunchBox when the ID has changed
+    if (
+        cleaned_data["launchbox_id"]
+        and int(cleaned_data["launchbox_id"]) != rom.launchbox_id
+    ):
+        preferred_media_types = get_preferred_media_types()
+
+        for media_type in preferred_media_types:
+            # Remove old media files if the launchbox_id is changing
+            if rom.launchbox_metadata and rom.launchbox_metadata.get(
+                f"{media_type.value}_path"
+            ):
+                await fs_resource_handler.remove_media_resources_path(
+                    rom.platform_id,
+                    rom.id,
+                    media_type,
+                )
+
+            media_path = cleaned_data.get("launchbox_metadata", {}).get(
+                f"{media_type.value}_path"
+            )
+            media_url = cleaned_data.get("launchbox_metadata", {}).get(
+                f"{media_type.value}_url"
+            )
+            if media_path and media_url:
+                await fs_resource_handler.store_media_file(
+                    media_url,
                     media_path,
                 )
 

--- a/backend/tests/endpoints/roms/test_rom.py
+++ b/backend/tests/endpoints/roms/test_rom.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 from fastapi import status
 from fastapi.testclient import TestClient
 
+from config.config_manager import MetadataMediaType
 from handler.database import db_collection_handler, db_rom_handler
 from handler.filesystem.resources_handler import FSResourcesHandler
 from handler.filesystem.roms_handler import FSRomsHandler
@@ -892,6 +893,62 @@ class TestUpdateMetadataIDs:
         body = response.json()
         assert body["launchbox_id"] == MOCK_LAUNCHBOX_ID
         assert get_rom_by_id_mock.called
+
+    @patch.object(FSResourcesHandler, "store_media_file", new_callable=AsyncMock)
+    @patch(
+        "handler.metadata.launchbox_handler.media.get_preferred_media_types",
+        return_value=[MetadataMediaType.VIDEO],
+    )
+    @patch(
+        "endpoints.roms.get_preferred_media_types",
+        return_value=[MetadataMediaType.VIDEO],
+    )
+    @patch.object(
+        LaunchboxHandler,
+        "get_rom_by_id",
+        return_value=LaunchboxRom(
+            launchbox_id=MOCK_LAUNCHBOX_ID,
+            launchbox_metadata={  # type: ignore[typeddict-item]
+                "video_url": "launchbox-file://Videos/NES/Mario.mp4",
+            },
+        ),
+    )
+    def test_update_rom_launchbox_id_imports_local_video(
+        self,
+        get_rom_by_id_mock: AsyncMock,
+        _get_preferred_endpoint_mock: AsyncMock,
+        _get_preferred_media_mock: AsyncMock,
+        store_media_file_mock: AsyncMock,
+        client: TestClient,
+        access_token: str,
+        rom: Rom,
+    ):
+        """A LaunchBox match with a local video resolves a path and copies the file."""
+        response = client.put(
+            f"/api/roms/{rom.id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+            data={"launchbox_id": str(MOCK_LAUNCHBOX_ID)},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        body = response.json()
+        assert body["launchbox_id"] == MOCK_LAUNCHBOX_ID
+        # get_rom_by_id must receive fs_name/platform_slug so local media resolves
+        assert get_rom_by_id_mock.call_args.kwargs.get("fs_name") == rom.fs_name
+        assert (
+            get_rom_by_id_mock.call_args.kwargs.get("platform_slug")
+            == rom.platform_slug
+        )
+        # populate_rom_specific_paths must have set video_path
+        video_path = body["launchbox_metadata"].get("video_path", "")
+        assert video_path.endswith("/video.mp4")
+        # and the video file must have been copied into the resource store
+        store_media_file_mock.assert_awaited_once()
+        await_args = store_media_file_mock.await_args
+        assert await_args is not None
+        called_url, called_path = await_args.args
+        assert called_url == "launchbox-file://Videos/NES/Mario.mp4"
+        assert called_path == video_path
 
     @patch.object(
         LaunchboxHandler,


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Manually (re)matching a LaunchBox ID through the ROM edit dialog ("Update metadata") never imported any LaunchBox media (e.g. local videos), even with `video` in `scan.media`. Unlike the ScreenScraper block in the same handler, the LaunchBox branch of `update_rom`:

- fetched metadata via `get_rom_by_id` **without** `fs_name`/`platform_slug`, so local-media merging never ran;
- never called `populate_rom_specific_paths`, so no `{type}_path` (e.g. `video_path`) was generated;
- had **no** `store_media_file` loop, so nothing was ever copied into the resource store.

This PR fixes the LaunchBox branch of `update_rom` to:

1. Pass `fs_name`/`platform_slug` to `get_rom_by_id` so local LaunchBox media resolves.
2. Call `populate_rom_specific_paths` on the fetched metadata to generate media paths.
3. Add a `store_media_file` loop mirroring the ScreenScraper/scan blocks, which also clears stale media when the LaunchBox ID changes.

Note: the scan/rescan path already imports LaunchBox video correctly (`populate_rom_specific_paths` is called in `scan_handler.py` with a persisted ROM, and the scan socket store loop copies it). The gallery-art (non-video images) question raised in the issue is intentionally out of scope here, as it needs a product/UI decision plus a new frontend surface.

**AI assistance disclosure:** This change was written with AI assistance (PostHog Code / Claude). The investigation, code changes, and tests were AI-generated and reviewed before submission.

Fixes #3521

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A (backend-only change)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*