### PR TITLE
feat: default UI language to browser language when available

### DIFF
--- a/frontend/src/RomM.vue
+++ b/frontend/src/RomM.vue
@@ -29,11 +29,11 @@ const languageStore = storeLanguage();
 const consoleStore = storeConsole();
 const vuetifyTheme = useTheme();
 const { consoleMode } = storeToRefs(consoleStore);
-const { defaultLanguage, languages } = storeToRefs(languageStore);
+const { languages } = storeToRefs(languageStore);
 const storedLocale = useLocalStorage("settings.locale", "");
 const selectedLanguage = ref(
   languages.value.find((lang) => lang.value === storedLocale.value) ||
-    defaultLanguage.value,
+    languageStore.detectBrowserLanguage(),
 );
 locale.value = selectedLanguage.value.value;
 languageStore.setLanguage(selectedLanguage.value);

--- a/frontend/src/stores/language.ts
+++ b/frontend/src/stores/language.ts
@@ -32,6 +32,29 @@ export default defineStore("language", {
     setLanguage(lang: { value: string; name: string }) {
       this.selectedLanguage = lang;
     },
+    // Match the browser's preferred languages against the available locales,
+    // falling back to the default (en_US) when none line up. Tries an exact
+    // match first (e.g. "en-US" -> "en_US"), then a language-only match
+    // (e.g. "fr" -> "fr_FR"). See rommapp/romm#3139.
+    detectBrowserLanguage() {
+      const preferred = navigator.languages?.length
+        ? navigator.languages
+        : [navigator.language];
+      for (const pref of preferred) {
+        if (!pref) continue;
+        const normalized = pref.replace("-", "_").toLowerCase();
+        const exact = this.languages.find(
+          (lang) => lang.value.toLowerCase() === normalized,
+        );
+        if (exact) return exact;
+        const base = normalized.split("_")[0];
+        const partial = this.languages.find(
+          (lang) => lang.value.toLowerCase().split("_")[0] === base,
+        );
+        if (partial) return partial;
+      }
+      return this.defaultLanguage;
+    },
     reset() {
       Object.assign(this, { ...defaultLanguageState });
     },

--- a/frontend/src/stores/language.ts
+++ b/frontend/src/stores/language.ts
@@ -35,13 +35,9 @@ export default defineStore("language", {
     // Match the browser's preferred languages against the available locales,
     // falling back to the default (en_US) when none line up. Tries an exact
     // match first (e.g. "en-US" -> "en_US"), then a language-only match
-    // (e.g. "fr" -> "fr_FR"). See rommapp/romm#3139.
+    // (e.g. "fr" -> "fr_FR").
     detectBrowserLanguage() {
-      const preferred = navigator.languages?.length
-        ? navigator.languages
-        : [navigator.language];
-      for (const pref of preferred) {
-        if (!pref) continue;
+      for (const pref of navigator.languages) {
         const normalized = pref.replace("-", "_").toLowerCase();
         const exact = this.languages.find(
           (lang) => lang.value.toLowerCase() === normalized,


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

On first visit RomM always started in English (`en_US`), ignoring the browser's preferred language even when a matching locale was available. This PR makes the app default to the browser language when it maps to one of the shipped locales.

Precedence on startup is now:
1. **Saved preference** — `localStorage["settings.locale"]` (or a logged-in user's `ui_settings.locale`). Unchanged, still wins.
2. **Browser language** (new) — `navigator.languages` matched against the available locales.
3. **`en_US`** — final fallback when nothing matches.

Matching tries an exact match first (`en-US` -> `en_US`, normalizing the separator and casing) then a language-only match (`fr` -> `fr_FR`), walking `navigator.languages` in preference order. A returning user's explicit choice is never overridden. This applies to both v1 and v2 since they share the same `RomM.vue` bootstrap and language store.

Fixes #3139

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

_N/A — behavioral change only._

---

**AI assistance disclosure:** This change was implemented with AI assistance (PostHog Code / Claude). The browser-language detection logic, the wiring in `RomM.vue`, and this PR description were AI-generated, then reviewed by a human. Verified locally with `npm run typecheck` and `trunk check`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*