### PR TITLE
fix(platforms): stop platform variants from renaming the parent platform

### DIFF
--- a/backend/tests/utils/test_platforms.py
+++ b/backend/tests/utils/test_platforms.py
@@ -1,0 +1,25 @@
+from handler.database import db_platform_handler
+from models.platform import Platform
+from utils.platforms import get_supported_platforms
+
+
+def test_supported_platform_not_shadowed_by_variant():
+    """A variant/alias folder bound to a parent slug must not shadow the parent.
+
+    Regression for the bug where adding an "fbneo" folder as a variant of
+    "arcade" renamed the Arcade platform to "FBneo" in the platform picker.
+    """
+    # Canonical Arcade platform (folder name matches the slug).
+    db_platform_handler.add_platform(
+        Platform(name="Arcade", slug="arcade", fs_slug="arcade")
+    )
+    # Variant folder resolved to the same slug during scan.
+    db_platform_handler.add_platform(
+        Platform(name="FBneo", slug="arcade", fs_slug="fbneo")
+    )
+
+    supported = get_supported_platforms()
+    arcade = next(p for p in supported if p.slug == "arcade")
+
+    assert arcade.name == "Arcade"
+    assert arcade.fs_slug == "arcade"

--- a/backend/utils/platforms.py
+++ b/backend/utils/platforms.py
@@ -26,7 +26,16 @@ def get_supported_platforms() -> list[PlatformSchema]:
         Flashpoint, and HowLongToBeat.
     """
     db_platforms = db_platform_handler.get_platforms()
-    db_platforms_map = {p.slug: p for p in db_platforms}
+
+    # Multiple folders can resolve to the same slug (a folder alias or a
+    # platform variant bound to a parent platform). When that happens, prefer
+    # the canonical platform (the one whose fs_slug matches its slug) so a
+    # variant folder doesn't shadow the parent and rename it in the picker.
+    db_platforms_map: dict[str, Platform] = {}
+    for p in db_platforms:
+        existing = db_platforms_map.get(p.slug)
+        if existing is None or p.fs_slug == p.slug:
+            db_platforms_map[p.slug] = p
 
     now = datetime.now(timezone.utc)
     supported_platforms = []


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

When a folder is mapped as a **Platform Variant** (or Folder Alias) of an existing platform, the scanner resolves that folder to the parent's slug. The database then holds two platform rows sharing the same `slug` (e.g. the real `arcade` folder and an `fbneo` folder both with `slug="arcade"`).

`get_supported_platforms()` built its slug→platform map with a plain dict comprehension:

```python
db_platforms_map = {p.slug: p for p in db_platforms}
```

With two rows sharing a slug, whichever came last (platforms are ordered by name) silently overwrote the parent, so the platform picker and Folder Mappings page displayed the variant's name instead of the parent's. This is what caused Arcade to be "renamed" to FBneo, and the reported WiiWare/WiiVC case.

The fix prefers the **canonical** platform (the one whose `fs_slug` matches its `slug`) when building the map, so a variant/alias folder can no longer shadow its parent.

Note: variants remain their own platform row borrowing the parent's metadata, which is the documented intent of "Platform variant". This PR only fixes the naming collision.

Fixes #3157

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A (backend-only change)

---

**AI assistance disclosure**

This change was written with AI assistance (PostHog Code). The AI performed the investigation, implemented the fix, and wrote the accompanying test; the change has been reviewed before submission.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*