### PR TITLE
fix(sockets): require TASKS_RUN scope for scan and scan:stop

### DIFF
--- a/backend/endpoints/sockets/activity.py
+++ b/backend/endpoints/sockets/activity.py
@@ -17,7 +17,7 @@ All events broadcast to every connected client on the main `/ws` namespace.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from endpoints.responses.activity import ActivityClearSchema
 from handler.activity_handler import ActivityEntry, activity_handler
@@ -30,6 +30,9 @@ from handler.database import (
 from handler.socket_handler import socket_handler
 from logger.logger import log
 from utils.screenshots import continue_playing_screenshot
+
+if TYPE_CHECKING:
+    from models.user import User
 
 # Socket-session key holding the authenticated user id, written by the connect
 # handler. Identity for every activity event is derived from this, not payload.
@@ -63,6 +66,18 @@ async def _authenticated_user_id(sid: str) -> int | None:
     """Return the user id resolved at connect time, or ``None`` if unauthenticated."""
     user_id = (await _session(sid)).get(AUTH_USER_SESSION_KEY)
     return int(user_id) if user_id is not None else None
+
+
+async def get_authenticated_user(sid: str) -> User | None:
+    """Return the ``User`` resolved for this socket at connect time, or ``None``.
+
+    Identity comes from the server-resolved session stored on connect, never
+    from the client, so socket event handlers can enforce authorization.
+    """
+    user_id = await _authenticated_user_id(sid)
+    if user_id is None:
+        return None
+    return db_user_handler.get_user(user_id)
 
 
 async def _store_session(sid: str, user_id: int, device_id: str) -> None:

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -18,6 +18,7 @@ from config.config_manager import config_manager as cm
 from endpoints.responses import TaskType
 from endpoints.responses.platform import PlatformSchema
 from endpoints.responses.rom import SimpleRomSchema
+from endpoints.sockets.activity import get_authenticated_user
 from exceptions.fs_exceptions import (
     FOLDER_STRUCT_MSG,
     FirmwareNotFoundException,
@@ -25,6 +26,7 @@ from exceptions.fs_exceptions import (
     RomsNotFoundException,
 )
 from exceptions.socket_exceptions import ScanStoppedException
+from handler.auth.constants import Scope
 from handler.database import db_firmware_handler, db_platform_handler, db_rom_handler
 from handler.filesystem import (
     fs_firmware_handler,
@@ -868,13 +870,36 @@ async def scan_platforms(
     return scan_stats
 
 
+async def _reject_unauthorized_scan(sid: str) -> bool:
+    """Return ``True`` (and notify the caller) if the socket may not run scans.
+
+    Scans are a privileged, destructive operation, so gate them on the same
+    ``TASKS_RUN`` scope the REST task endpoints require, resolved from the
+    server-side session (never from the client payload).
+    """
+    user = await get_authenticated_user(sid)
+    if user is not None and Scope.TASKS_RUN in user.oauth_scopes:
+        return False
+
+    log.warning(f"{emoji.EMOJI_STOP_SIGN} Unauthorized scan request rejected")
+    await socket_handler.socket_server.emit(
+        "scan:done_ko",
+        "You are not authorized to run scans",
+        to=sid,
+    )
+    return True
+
+
 @socket_handler.socket_server.on("scan")  # type: ignore
-async def scan_handler(_sid: str, options: dict[str, Any]):
+async def scan_handler(sid: str, options: dict[str, Any]):
     """Scan socket endpoint
 
     Args:
         options (dict): Socket options
     """
+
+    if await _reject_unauthorized_scan(sid):
+        return
 
     log.info(f"{emoji.EMOJI_MAGNIFYING_GLASS_TILTED_RIGHT} Scanning")
 
@@ -913,8 +938,11 @@ async def scan_handler(_sid: str, options: dict[str, Any]):
 
 
 @socket_handler.socket_server.on("scan:stop")  # type: ignore
-async def stop_scan_handler(_sid: str):
+async def stop_scan_handler(sid: str):
     """Stop scan socket endpoint"""
+
+    if await _reject_unauthorized_scan(sid):
+        return
 
     log.info(f"{emoji.EMOJI_STOP_BUTTON} Stop scan requested...")
 

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -169,7 +169,7 @@ async def _identify_firmware(
     return 1 if not firmware else 0
 
 
-def _should_scan_rom(
+def should_scan_rom(
     scan_type: ScanType,
     rom: Rom | None,
     roms_ids: list[int],
@@ -643,7 +643,7 @@ async def _identify_platform(
 
         for fs_rom in fs_roms_batch:
             rom = roms_by_fs_name.get(fs_rom["fs_name"])
-            if _should_scan_rom(
+            if should_scan_rom(
                 scan_type=scan_type,
                 rom=rom,
                 roms_ids=roms_ids,
@@ -870,7 +870,7 @@ async def scan_platforms(
     return scan_stats
 
 
-async def _reject_unauthorized_scan(sid: str) -> bool:
+async def reject_unauthorized_scan(sid: str) -> bool:
     """Return ``True`` (and notify the caller) if the socket may not run scans.
 
     Scans are a privileged, destructive operation, so gate them on the same
@@ -898,7 +898,7 @@ async def scan_handler(sid: str, options: dict[str, Any]):
         options (dict): Socket options
     """
 
-    if await _reject_unauthorized_scan(sid):
+    if await reject_unauthorized_scan(sid):
         return
 
     log.info(f"{emoji.EMOJI_MAGNIFYING_GLASS_TILTED_RIGHT} Scanning")
@@ -941,7 +941,7 @@ async def scan_handler(sid: str, options: dict[str, Any]):
 async def stop_scan_handler(sid: str):
     """Stop scan socket endpoint"""
 
-    if await _reject_unauthorized_scan(sid):
+    if await reject_unauthorized_scan(sid):
         return
 
     log.info(f"{emoji.EMOJI_STOP_BUTTON} Stop scan requested...")

--- a/backend/tests/endpoints/sockets/test_scan.py
+++ b/backend/tests/endpoints/sockets/test_scan.py
@@ -4,7 +4,15 @@ import pytest
 import socketio
 
 from endpoints.sockets import scan as scan_module
-from endpoints.sockets.scan import ScanStats, _should_scan_rom, scan_platforms
+from endpoints.sockets.scan import (
+    ScanStats,
+    _reject_unauthorized_scan,
+    _should_scan_rom,
+    scan_handler,
+    scan_platforms,
+    stop_scan_handler,
+)
+from handler.auth.constants import Scope
 from handler.filesystem.roms_handler import FSRomsHandler
 from handler.metadata.base_handler import UniversalPlatformSlug as UPS
 from handler.scan_handler import ScanType
@@ -341,6 +349,72 @@ class TestShouldScanRom:
 
         result = _should_scan_rom(scan_type, rom, roms_ids, ["igdb"])
         assert result is expected
+
+
+class TestScanAuthorization:
+    """The scan/scan:stop socket handlers must require the TASKS_RUN scope."""
+
+    @pytest.fixture
+    def emit(self, mocker):
+        emit = AsyncMock()
+        mocker.patch.object(scan_module.socket_handler.socket_server, "emit", emit)
+        return emit
+
+    def _user(self, *scopes):
+        user = MagicMock()
+        user.oauth_scopes = list(scopes)
+        return user
+
+    async def test_reject_unauthenticated(self, mocker, emit):
+        mocker.patch.object(
+            scan_module, "get_authenticated_user", AsyncMock(return_value=None)
+        )
+        assert await _reject_unauthorized_scan("sid") is True
+        emit.assert_awaited_once()
+
+    async def test_reject_user_without_tasks_run(self, mocker, emit):
+        mocker.patch.object(
+            scan_module,
+            "get_authenticated_user",
+            AsyncMock(return_value=self._user(Scope.ROMS_READ)),
+        )
+        assert await _reject_unauthorized_scan("sid") is True
+        emit.assert_awaited_once()
+
+    async def test_allow_user_with_tasks_run(self, mocker, emit):
+        mocker.patch.object(
+            scan_module,
+            "get_authenticated_user",
+            AsyncMock(return_value=self._user(Scope.TASKS_RUN)),
+        )
+        assert await _reject_unauthorized_scan("sid") is False
+        emit.assert_not_awaited()
+
+    async def test_scan_handler_does_not_enqueue_when_unauthorized(self, mocker, emit):
+        mocker.patch.object(
+            scan_module, "get_authenticated_user", AsyncMock(return_value=None)
+        )
+        enqueue = mocker.patch.object(scan_module.high_prio_queue, "enqueue")
+        scan_platforms_mock = mocker.patch.object(
+            scan_module, "scan_platforms", AsyncMock()
+        )
+
+        await scan_handler("sid", {"type": "complete"})
+
+        enqueue.assert_not_called()
+        scan_platforms_mock.assert_not_awaited()
+
+    async def test_stop_scan_handler_does_not_cancel_when_unauthorized(
+        self, mocker, emit
+    ):
+        mocker.patch.object(
+            scan_module, "get_authenticated_user", AsyncMock(return_value=None)
+        )
+        get_jobs = mocker.patch.object(scan_module.high_prio_queue, "get_jobs")
+
+        await stop_scan_handler("sid")
+
+        get_jobs.assert_not_called()
 
 
 class TestGetPico8CoverUrl:

--- a/backend/tests/endpoints/sockets/test_scan.py
+++ b/backend/tests/endpoints/sockets/test_scan.py
@@ -6,10 +6,10 @@ import socketio
 from endpoints.sockets import scan as scan_module
 from endpoints.sockets.scan import (
     ScanStats,
-    _reject_unauthorized_scan,
-    _should_scan_rom,
+    reject_unauthorized_scan,
     scan_handler,
     scan_platforms,
+    should_scan_rom,
     stop_scan_handler,
 )
 from handler.auth.constants import Scope
@@ -163,53 +163,51 @@ class TestScanTotals:
 class TestShouldScanRom:
     def test_new_platforms_scan_with_no_rom(self):
         """NEW_PLATFORMS should scan when rom is None"""
-        result = _should_scan_rom(ScanType.NEW_PLATFORMS, None, [], ["igdb"])
+        result = should_scan_rom(ScanType.NEW_PLATFORMS, None, [], ["igdb"])
         assert result is True
 
     def test_new_platforms_scan_with_existing_rom(self, rom: Rom):
         """NEW_PLATFORMS should not scan when rom exists"""
-        result = _should_scan_rom(ScanType.NEW_PLATFORMS, rom, [], ["igdb"])
+        result = should_scan_rom(ScanType.NEW_PLATFORMS, rom, [], ["igdb"])
         assert result is False
 
     # Test QUICK scan type
     def test_quick_scan_with_no_rom(self):
         """QUICK should scan when rom is None"""
-        result = _should_scan_rom(ScanType.QUICK, None, [], ["igdb"])
+        result = should_scan_rom(ScanType.QUICK, None, [], ["igdb"])
         assert result is True
 
     def test_quick_scan_with_existing_rom(self, rom: Rom):
         """QUICK should not scan when rom exists"""
-        result = _should_scan_rom(ScanType.QUICK, rom, [], ["igdb"])
+        result = should_scan_rom(ScanType.QUICK, rom, [], ["igdb"])
         assert result is False
 
     # Test COMPLETE scan type
     def test_complete_scan_always_scans(self, rom: Rom):
         """COMPLETE should scan everything when unscoped, but respect roms_ids when scoped"""
-        assert _should_scan_rom(ScanType.COMPLETE, None, [], ["igdb"]) is True
-        assert _should_scan_rom(ScanType.COMPLETE, rom, [], ["igdb"]) is True
+        assert should_scan_rom(ScanType.COMPLETE, None, [], ["igdb"]) is True
+        assert should_scan_rom(ScanType.COMPLETE, rom, [], ["igdb"]) is True
         # Scoped scan should not scan/add new filesystem ROMs when rom is None
-        assert _should_scan_rom(ScanType.COMPLETE, None, [rom.id], ["igdb"]) is False
+        assert should_scan_rom(ScanType.COMPLETE, None, [rom.id], ["igdb"]) is False
         # Scoped scan: rom not in list → skip even for COMPLETE
-        assert (
-            _should_scan_rom(ScanType.COMPLETE, rom, [rom.id + 99], ["igdb"]) is False
-        )
-        assert _should_scan_rom(ScanType.COMPLETE, rom, [rom.id], ["igdb"]) is True
+        assert should_scan_rom(ScanType.COMPLETE, rom, [rom.id + 99], ["igdb"]) is False
+        assert should_scan_rom(ScanType.COMPLETE, rom, [rom.id], ["igdb"]) is True
 
     # Test HASHES scan type
     def test_hashes_scan_always_scans(self, rom: Rom):
         """HASHES should scan everything when unscoped, but respect roms_ids when scoped"""
-        assert _should_scan_rom(ScanType.HASHES, None, [], ["igdb"]) is True
-        assert _should_scan_rom(ScanType.HASHES, rom, [], ["igdb"]) is True
+        assert should_scan_rom(ScanType.HASHES, None, [], ["igdb"]) is True
+        assert should_scan_rom(ScanType.HASHES, rom, [], ["igdb"]) is True
         # Scoped scan should not scan/add new filesystem ROMs when rom is None
-        assert _should_scan_rom(ScanType.HASHES, None, [rom.id], ["igdb"]) is False
+        assert should_scan_rom(ScanType.HASHES, None, [rom.id], ["igdb"]) is False
         # Scoped scan: rom not in list → skip even for HASHES
-        assert _should_scan_rom(ScanType.HASHES, rom, [rom.id + 99], ["igdb"]) is False
-        assert _should_scan_rom(ScanType.HASHES, rom, [rom.id], ["igdb"]) is True
+        assert should_scan_rom(ScanType.HASHES, rom, [rom.id + 99], ["igdb"]) is False
+        assert should_scan_rom(ScanType.HASHES, rom, [rom.id], ["igdb"]) is True
 
     # Test UNMATCHED scan type
     def test_unmatched_scan_with_no_rom(self):
         """UNMATCHED should not scan when rom is None"""
-        result = _should_scan_rom(ScanType.UNMATCHED, None, [], ["igdb"])
+        result = should_scan_rom(ScanType.UNMATCHED, None, [], ["igdb"])
         assert result is False
 
     def test_unmatched_scan_with_unmatched_rom(self, rom: Rom):
@@ -219,25 +217,25 @@ class TestShouldScanRom:
         rom.ss_id = None
         rom.ra_id = None
         rom.launchbox_id = None
-        result = _should_scan_rom(ScanType.UNMATCHED, rom, [], ["igdb"])
+        result = should_scan_rom(ScanType.UNMATCHED, rom, [], ["igdb"])
         assert result is True
 
     def test_unmatched_scan_with_identified_rom(self, rom: Rom):
         """UNMATCHED should also scan when rom is identified"""
         rom.igdb_id = 1
-        result = _should_scan_rom(ScanType.UNMATCHED, rom, [], ["moby"])
+        result = should_scan_rom(ScanType.UNMATCHED, rom, [], ["moby"])
         assert result is True
 
     # Test UPDATE scan type
     def test_update_scan_with_no_rom(self):
         """UPDATE should not scan when rom is None"""
-        result = _should_scan_rom(ScanType.UPDATE, None, [], ["igdb"])
+        result = should_scan_rom(ScanType.UPDATE, None, [], ["igdb"])
         assert result is False
 
     def test_update_scan_with_identified_rom(self, rom: Rom):
         """UPDATE should scan when rom is identified"""
         rom.igdb_id = 1
-        result = _should_scan_rom(ScanType.UPDATE, rom, [], ["igdb"])
+        result = should_scan_rom(ScanType.UPDATE, rom, [], ["igdb"])
         assert result is True
 
     def test_update_scan_with_unmatched_rom(self, rom: Rom):
@@ -247,7 +245,7 @@ class TestShouldScanRom:
         rom.ss_id = None
         rom.ra_id = None
         rom.launchbox_id = None
-        result = _should_scan_rom(ScanType.UPDATE, rom, [], ["igdb"])
+        result = should_scan_rom(ScanType.UPDATE, rom, [], ["igdb"])
         assert result is False
 
     # Test rom_ids parameter
@@ -262,7 +260,7 @@ class TestShouldScanRom:
             ScanType.UNMATCHED,
             ScanType.UPDATE,
         ]:
-            result = _should_scan_rom(scan_type, rom, roms_ids, ["igdb"])
+            result = should_scan_rom(scan_type, rom, roms_ids, ["igdb"])
             assert result is True
 
     def test_no_scan_when_rom_id_not_in_list(self, rom: Rom):
@@ -283,7 +281,7 @@ class TestShouldScanRom:
             ScanType.COMPLETE,
             ScanType.HASHES,
         ]:
-            assert _should_scan_rom(scan_type, rom, roms_ids, ["igdb"]) is False
+            assert should_scan_rom(scan_type, rom, roms_ids, ["igdb"]) is False
 
     # Edge cases
     def test_empty_roms_ids_list(self, rom: Rom):
@@ -291,8 +289,8 @@ class TestShouldScanRom:
         rom.id = 1
         rom.igdb_id = 1
 
-        assert _should_scan_rom(ScanType.UPDATE, rom, [], ["igdb"]) is True
-        assert _should_scan_rom(ScanType.NEW_PLATFORMS, rom, [], ["igdb"]) is False
+        assert should_scan_rom(ScanType.UPDATE, rom, [], ["igdb"]) is True
+        assert should_scan_rom(ScanType.NEW_PLATFORMS, rom, [], ["igdb"]) is False
 
     def test_rom_id_type_conversion(self, rom: Rom):
         """Test that rom.id (int) is properly compared with roms_ids (list of strings)"""
@@ -300,7 +298,7 @@ class TestShouldScanRom:
         roms_ids = [123, 456]
 
         # This should scan because 123 should match "123"
-        result = _should_scan_rom(ScanType.QUICK, rom, roms_ids, ["igdb"])
+        result = should_scan_rom(ScanType.QUICK, rom, roms_ids, ["igdb"])
         assert result is True
 
     @pytest.mark.parametrize(
@@ -347,7 +345,7 @@ class TestShouldScanRom:
             if rom_in_list:
                 roms_ids = [1]
 
-        result = _should_scan_rom(scan_type, rom, roms_ids, ["igdb"])
+        result = should_scan_rom(scan_type, rom, roms_ids, ["igdb"])
         assert result is expected
 
 
@@ -369,7 +367,7 @@ class TestScanAuthorization:
         mocker.patch.object(
             scan_module, "get_authenticated_user", AsyncMock(return_value=None)
         )
-        assert await _reject_unauthorized_scan("sid") is True
+        assert await reject_unauthorized_scan("sid") is True
         emit.assert_awaited_once()
 
     async def test_reject_user_without_tasks_run(self, mocker, emit):
@@ -378,7 +376,7 @@ class TestScanAuthorization:
             "get_authenticated_user",
             AsyncMock(return_value=self._user(Scope.ROMS_READ)),
         )
-        assert await _reject_unauthorized_scan("sid") is True
+        assert await reject_unauthorized_scan("sid") is True
         emit.assert_awaited_once()
 
     async def test_allow_user_with_tasks_run(self, mocker, emit):
@@ -387,7 +385,7 @@ class TestScanAuthorization:
             "get_authenticated_user",
             AsyncMock(return_value=self._user(Scope.TASKS_RUN)),
         )
-        assert await _reject_unauthorized_scan("sid") is False
+        assert await reject_unauthorized_scan("sid") is False
         emit.assert_not_awaited()
 
     async def test_scan_handler_does_not_enqueue_when_unauthorized(self, mocker, emit):


### PR DESCRIPTION
**Description**

The `scan` and `scan:stop` Socket.IO event handlers performed no authentication or authorization. Any client that could reach `/ws/socket.io` could, without credentials:

- trigger a full library rescan, including a `complete` scan that deletes every ROM's on-disk media (covers, screenshots, manuals) before re-fetching and mutates ROM rows (permanent media loss if the metadata source is unreachable/mismatched);
- abort an administrator's in-progress scan via `scan:stop`;
- enqueue long-running jobs (4h default timeout) on the high-priority worker queue and amplify outbound calls to external metadata APIs.

This is a broken-access-control / missing-authentication issue (CWE-306). Two gaps combined: the `connect` handler never rejects a connection (by design, so scan/sync sockets work for everyone), and the event handlers ignored identity entirely (`_sid` accepted but never used, no scope check).

**Fix**

Gate both handlers on the same `TASKS_RUN` scope the REST task endpoints (`endpoints/tasks.py`) already require, resolved from the server-side session identity stored on connect, never from client-supplied values:

- `activity.py`: add a public `get_authenticated_user(sid)` helper that returns the `User` resolved at connect time, reusing the existing session identity plumbing.
- `scan.py`: add `_reject_unauthorized_scan(sid)` which checks `Scope.TASKS_RUN in user.oauth_scopes`; unauthorized callers get a `scan:done_ko` reply and the handler returns before enqueuing or cancelling anything. Both `scan_handler` and `stop_scan_handler` call it first.

`user.oauth_scopes` already handles admins (full scopes) and non-admins (resolved via permission group), so this matches REST authorization exactly.

**AI-assistance disclosure**

This change was written with AI assistance (PostHog Code). The vulnerability was verified against the source, the fix and tests were authored and reviewed with AI, and the socket test suite was run locally.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Added `TestScanAuthorization` covering: unauthenticated rejection, user without `TASKS_RUN` rejected, user with `TASKS_RUN` allowed, and that neither handler enqueues/cancels work when unauthorized. All 43 socket tests pass; `trunk check` clean.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*