### PR TITLE
docs(sync): clarify slot pairing behavior in negotiate OpenAPI spec

### DIFF
--- a/backend/endpoints/responses/sync.py
+++ b/backend/endpoints/responses/sync.py
@@ -1,21 +1,48 @@
 from typing import Literal
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, Field
 
 from .base import BaseModel, UTCDatetime
 from .play_session import PlaySessionIngestResponse
 
 
 class SyncOperationSchema(BaseModel):
-    action: Literal["upload", "download", "conflict", "no_op"]
-    rom_id: int
-    save_id: int | None = None
-    file_name: str
-    slot: str | None = None
-    emulator: str | None = None
-    reason: str
-    server_updated_at: UTCDatetime | None = None
-    server_content_hash: str | None = None
+    action: Literal["upload", "download", "conflict", "no_op"] = Field(
+        description=(
+            "Operation the client should perform. 'upload' when the client has a "
+            "save the server lacks (including any null-slot save, which is never "
+            "paired with server saves), 'download' when the server has a newer or "
+            "unknown save, 'conflict' when both sides changed independently, and "
+            "'no_op' when no action is needed."
+        )
+    )
+    rom_id: int = Field(description="ID of the ROM this operation applies to.")
+    save_id: int | None = Field(
+        default=None,
+        description="ID of the server save, if one exists (null for uploads).",
+    )
+    file_name: str = Field(description="Name of the save file.")
+    slot: str | None = Field(
+        default=None,
+        description=(
+            "Slot the operation applies to. Echoes the client slot for uploads; "
+            "for downloads and conflicts it is the server save's slot."
+        ),
+    )
+    emulator: str | None = Field(
+        default=None, description="Emulator associated with the save, if known."
+    )
+    reason: str = Field(
+        description="Human-readable explanation of why this operation was chosen."
+    )
+    server_updated_at: UTCDatetime | None = Field(
+        default=None,
+        description="Last-modified timestamp of the server save, when applicable.",
+    )
+    server_content_hash: str | None = Field(
+        default=None,
+        description="Content hash of the server save, when applicable.",
+    )
 
 
 class SyncNegotiateResponse(BaseModel):

--- a/backend/endpoints/sync.py
+++ b/backend/endpoints/sync.py
@@ -40,18 +40,45 @@ router = APIRouter(
 
 
 class ClientSaveState(BaseModel):
-    rom_id: int
-    file_name: str
-    slot: str | None = None
-    emulator: str | None = None
-    content_hash: str | None = None
-    updated_at: datetime
-    file_size_bytes: int
+    rom_id: int = Field(description="ID of the ROM this save belongs to.")
+    file_name: str = Field(description="Name of the save file on the client.")
+    slot: str | None = Field(
+        default=None,
+        description=(
+            "Save slot name. Saves are paired between client and server on "
+            "(rom_id, slot), so provide a stable slot name (e.g. 'autosave') to "
+            "keep a save in sync across negotiations. A null slot is treated as "
+            "an archival, manual-upload save: it is never paired with slotted "
+            "server saves, so a null-slot client save always negotiates as an "
+            "'upload' even when an identical file already exists on the server "
+            "under a slot."
+        ),
+    )
+    emulator: str | None = Field(
+        default=None, description="Emulator that produced the save, if known."
+    )
+    content_hash: str | None = Field(
+        default=None,
+        description="Hash of the save contents, used to detect identical saves.",
+    )
+    updated_at: datetime = Field(
+        description="Last-modified timestamp of the save on the client."
+    )
+    file_size_bytes: int = Field(description="Size of the save file in bytes.")
 
 
 class SyncNegotiatePayload(BaseModel):
-    device_id: str | None = None
-    saves: list[ClientSaveState]
+    device_id: str | None = Field(
+        default=None,
+        description=(
+            "ID of the syncing device. Optional when the request uses a "
+            "device-bound client token, in which case the device is inferred "
+            "from the token."
+        ),
+    )
+    saves: list[ClientSaveState] = Field(
+        description="Current save state on the client."
+    )
 
 
 class SyncPlaySessionEntry(BaseModel):
@@ -85,6 +112,14 @@ def negotiate_sync(
 
     The client sends its current save state, and the server returns a list of
     operations (upload, download, conflict, no_op) to bring both sides in sync.
+
+    Saves are paired on (rom_id, slot). Clients that want a save to stay in sync
+    should send a stable, non-null slot name (e.g. "autosave"). Null-slot saves
+    are treated as archival, manual uploads: they are excluded from pairing, so a
+    null-slot client save always negotiates as an "upload" even when an identical
+    file (same content_hash) already exists on the server under a slot. This is
+    intentional, since saves can be cloned across slots and null slots overlap
+    with manual uploads.
     """
     device_id: str | None = payload.device_id or getattr(
         request.state, "device_id", None

--- a/frontend/src/__generated__/models/ClientSaveState.ts
+++ b/frontend/src/__generated__/models/ClientSaveState.ts
@@ -3,12 +3,33 @@
 /* tslint:disable */
 /* eslint-disable */
 export type ClientSaveState = {
+    /**
+     * ID of the ROM this save belongs to.
+     */
     rom_id: number;
+    /**
+     * Name of the save file on the client.
+     */
     file_name: string;
+    /**
+     * Save slot name. Saves are paired between client and server on (rom_id, slot), so provide a stable slot name (e.g. 'autosave') to keep a save in sync across negotiations. A null slot is treated as an archival, manual-upload save: it is never paired with slotted server saves, so a null-slot client save always negotiates as an 'upload' even when an identical file already exists on the server under a slot.
+     */
     slot?: (string | null);
+    /**
+     * Emulator that produced the save, if known.
+     */
     emulator?: (string | null);
+    /**
+     * Hash of the save contents, used to detect identical saves.
+     */
     content_hash?: (string | null);
+    /**
+     * Last-modified timestamp of the save on the client.
+     */
     updated_at: string;
+    /**
+     * Size of the save file in bytes.
+     */
     file_size_bytes: number;
 };
 

--- a/frontend/src/__generated__/models/SyncNegotiatePayload.ts
+++ b/frontend/src/__generated__/models/SyncNegotiatePayload.ts
@@ -4,7 +4,13 @@
 /* eslint-disable */
 import type { ClientSaveState } from './ClientSaveState';
 export type SyncNegotiatePayload = {
+    /**
+     * ID of the syncing device. Optional when the request uses a device-bound client token, in which case the device is inferred from the token.
+     */
     device_id?: (string | null);
+    /**
+     * Current save state on the client.
+     */
     saves: Array<ClientSaveState>;
 };
 

--- a/frontend/src/__generated__/models/SyncOperationSchema.ts
+++ b/frontend/src/__generated__/models/SyncOperationSchema.ts
@@ -3,14 +3,41 @@
 /* tslint:disable */
 /* eslint-disable */
 export type SyncOperationSchema = {
+    /**
+     * Operation the client should perform. 'upload' when the client has a save the server lacks (including any null-slot save, which is never paired with server saves), 'download' when the server has a newer or unknown save, 'conflict' when both sides changed independently, and 'no_op' when no action is needed.
+     */
     action: 'upload' | 'download' | 'conflict' | 'no_op';
+    /**
+     * ID of the ROM this operation applies to.
+     */
     rom_id: number;
+    /**
+     * ID of the server save, if one exists (null for uploads).
+     */
     save_id?: (number | null);
+    /**
+     * Name of the save file.
+     */
     file_name: string;
+    /**
+     * Slot the operation applies to. Echoes the client slot for uploads; for downloads and conflicts it is the server save's slot.
+     */
     slot?: (string | null);
+    /**
+     * Emulator associated with the save, if known.
+     */
     emulator?: (string | null);
+    /**
+     * Human-readable explanation of why this operation was chosen.
+     */
     reason: string;
+    /**
+     * Last-modified timestamp of the server save, when applicable.
+     */
     server_updated_at?: (string | null);
+    /**
+     * Content hash of the server save, when applicable.
+     */
     server_content_hash?: (string | null);
 };
 


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3697.

The `/api/sync/negotiate` endpoint pairs client and server saves on `(rom_id, slot)` and deliberately excludes null-slot server saves from pairing (they are treated as archival / manual uploads). As a result, a client save sent with `slot=null` never matches an existing server save and always negotiates as an `upload`, even when an identical file (same `content_hash`) already exists on the server under a slot.

This is intentional (saves can be cloned across slots, and null slots overlap with manual uploads), but it was undocumented, so it read as a bug to API consumers (see #3697).

This PR documents the behavior in the OpenAPI spec, no logic changes:

- Add `Field(description=...)` to `ClientSaveState` and `SyncNegotiatePayload`. The `slot` description explains the pairing rule and recommends sending a stable slot name (e.g. `"autosave"`) for saves that should stay in sync.
- Add `Field(description=...)` to `SyncOperationSchema`, including what each `action` value means and the null-slot caveat.
- Expand the `negotiate_sync` docstring (surfaced as the OpenAPI operation description).
- Regenerate the frontend types so the generated client carries the new descriptions.

**AI assistance disclosure**
This PR was written with AI assistance (PostHog Code). The change was fully AI-authored, then reviewed and verified locally by the author.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

<sup>Docs-only change; existing `tests/endpoints/test_sync.py` (34 tests) still passes and covers the negotiate behavior.</sup>

#### Screenshots (if applicable)

N/A

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*