### PR TITLE
feat(roms): serve and display media files inline in details tab

### DIFF
--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -312,7 +312,6 @@ class RomSchema(BaseModel):
     url_cover: str | None
 
     has_manual: bool
-    has_manual_files: bool
     has_soundtrack: bool
     path_manual: str | None
     url_manual: str | None

--- a/backend/endpoints/roms/files.py
+++ b/backend/endpoints/roms/files.py
@@ -17,6 +17,7 @@ from logger.formatter import highlight as hl
 from logger.logger import log
 from models.rom import RomFileCategory
 from utils.audio_tags import guess_audio_media_type
+from utils.media_types import guess_media_file_type, is_inline_media_file
 from utils.nginx import FileRedirectResponse
 from utils.router import APIRouter
 
@@ -77,13 +78,17 @@ async def get_romfile_content(
     # record, never from the client-supplied file_name path param — otherwise a
     # caller could request the same bytes with an arbitrary extension to force a
     # mismatched Content-Type while served inline (content-sniffing/XSS).
-    is_audio = file.category == RomFileCategory.SOUNDTRACK
-    media_type = (
-        guess_audio_media_type(file.file_name)
-        if is_audio
-        else "application/octet-stream"
-    )
-    disposition = "inline" if is_audio else "attachment"
+    # Audio, images and videos are served inline so <audio>/<video>/<img> in the
+    # details view can render and seek them; everything else downloads.
+    if file.category == RomFileCategory.SOUNDTRACK:
+        media_type = guess_audio_media_type(file.file_name)
+        disposition = "inline"
+    elif is_inline_media_file(file.file_name):
+        media_type = guess_media_file_type(file.file_name)
+        disposition = "inline"
+    else:
+        media_type = "application/octet-stream"
+        disposition = "attachment"
 
     # Serve the file directly in development mode for emulatorjs
     if DEV_MODE:

--- a/backend/endpoints/roms/files.py
+++ b/backend/endpoints/roms/files.py
@@ -17,7 +17,7 @@ from logger.formatter import highlight as hl
 from logger.logger import log
 from models.rom import RomFileCategory
 from utils.audio_tags import guess_audio_media_type
-from utils.media_types import guess_media_file_type, is_inline_media_file
+from utils.media_types import guess_media_file_type, is_allowed_media_file
 from utils.nginx import FileRedirectResponse
 from utils.router import APIRouter
 
@@ -83,7 +83,7 @@ async def get_romfile_content(
     if file.category == RomFileCategory.SOUNDTRACK:
         media_type = guess_audio_media_type(file.file_name)
         disposition = "inline"
-    elif is_inline_media_file(file.file_name):
+    elif is_allowed_media_file(file.file_name):
         media_type = guess_media_file_type(file.file_name)
         disposition = "inline"
     else:

--- a/backend/endpoints/roms/screenshot.py
+++ b/backend/endpoints/roms/screenshot.py
@@ -20,11 +20,11 @@ from logger.formatter import BLUE
 from logger.formatter import highlight as hl
 from logger.logger import log
 from models.rom import RomFile, RomFileCategory
-from utils.router import APIRouter
-from utils.screenshots import (
-    ALLOWED_SCREENSHOT_EXTENSIONS,
-    is_allowed_screenshot_file,
+from utils.media_types import (
+    ALLOWED_IMAGE_EXTENSIONS,
+    is_inline_media_file,
 )
+from utils.router import APIRouter
 
 router = APIRouter()
 
@@ -79,12 +79,12 @@ async def add_rom_screenshots(
             detail="Upload filename must be a plain file name, not a path",
         )
 
-    if not is_allowed_screenshot_file(safe_filename):
+    if not is_inline_media_file(safe_filename):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(
                 f"Unsupported image file type. Allowed: "
-                f"{', '.join(sorted(ALLOWED_SCREENSHOT_EXTENSIONS))}"
+                f"{', '.join(sorted(ALLOWED_IMAGE_EXTENSIONS))}"
             ),
         )
 

--- a/backend/endpoints/roms/screenshot.py
+++ b/backend/endpoints/roms/screenshot.py
@@ -22,7 +22,7 @@ from logger.logger import log
 from models.rom import RomFile, RomFileCategory
 from utils.media_types import (
     ALLOWED_IMAGE_EXTENSIONS,
-    is_inline_media_file,
+    is_allowed_image_file,
 )
 from utils.router import APIRouter
 
@@ -79,7 +79,7 @@ async def add_rom_screenshots(
             detail="Upload filename must be a plain file name, not a path",
         )
 
-    if not is_inline_media_file(safe_filename):
+    if not is_allowed_image_file(safe_filename):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(

--- a/backend/endpoints/screenshots.py
+++ b/backend/endpoints/screenshots.py
@@ -17,11 +17,11 @@ from logger.formatter import BLUE
 from logger.formatter import highlight as hl
 from logger.logger import log
 from utils.filesystem import sanitize_filename
-from utils.router import APIRouter
-from utils.screenshots import (
-    ALLOWED_SCREENSHOT_EXTENSIONS,
-    is_allowed_screenshot_file,
+from utils.media_types import (
+    ALLOWED_IMAGE_EXTENSIONS,
+    is_inline_media_file,
 )
+from utils.router import APIRouter
 
 router = APIRouter(
     prefix="/screenshots",
@@ -69,12 +69,12 @@ async def add_screenshot(
             detail=f"Invalid screenshot filename: {str(exc)}",
         ) from exc
 
-    if not is_allowed_screenshot_file(sanitized_screenshot_filename):
+    if not is_inline_media_file(sanitized_screenshot_filename):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(
                 f"Unsupported image file type. Allowed: "
-                f"{', '.join(sorted(ALLOWED_SCREENSHOT_EXTENSIONS))}"
+                f"{', '.join(sorted(ALLOWED_IMAGE_EXTENSIONS))}"
             ),
         )
 

--- a/backend/endpoints/screenshots.py
+++ b/backend/endpoints/screenshots.py
@@ -19,7 +19,7 @@ from logger.logger import log
 from utils.filesystem import sanitize_filename
 from utils.media_types import (
     ALLOWED_IMAGE_EXTENSIONS,
-    is_inline_media_file,
+    is_allowed_image_file,
 )
 from utils.router import APIRouter
 
@@ -69,7 +69,7 @@ async def add_screenshot(
             detail=f"Invalid screenshot filename: {str(exc)}",
         ) from exc
 
-    if not is_inline_media_file(sanitized_screenshot_filename):
+    if not is_allowed_image_file(sanitized_screenshot_filename):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -236,7 +236,6 @@ def with_details(func):
             selectinload(Rom.notes),
             undefer(Rom.multi_file),
             undefer(Rom.top_level_file_count),
-            undefer(Rom.has_manual_files),
             undefer(Rom.has_soundtrack),
         )
         return func(*args, **kwargs)
@@ -876,7 +875,6 @@ class DBRomsHandler(DBBaseHandler):
             query = query.options(
                 undefer(Rom.multi_file),
                 undefer(Rom.top_level_file_count),
-                undefer(Rom.has_manual_files),
                 undefer(Rom.has_soundtrack),
             )
 

--- a/backend/handler/filesystem/assets_handler.py
+++ b/backend/handler/filesystem/assets_handler.py
@@ -4,7 +4,6 @@ import threading
 import zipfile
 from mimetypes import guess_type
 from pathlib import Path
-from typing import Final
 
 import magic
 from fastapi import HTTPException, UploadFile, status
@@ -13,17 +12,9 @@ from fastapi.responses import FileResponse
 from config import ASSETS_BASE_PATH
 from logger.logger import log
 from models.user import User
+from utils.media_types import IMAGE_EXT_BY_MIME_TYPE
 
 from .base_handler import FSHandler
-
-# Image MIME types we trust to (a) accept as avatar uploads and (b) serve
-# inline from the raw asset endpoint
-SAFE_IMAGE_MIME_TYPES: Final[dict[str, str]] = {
-    "image/png": "png",
-    "image/jpeg": "jpg",
-    "image/webp": "webp",
-    "image/gif": "gif",
-}
 
 # libmagic loads its database on construction (~few MB read from disk), so we
 # share a single Magic instance across requests. The underlying magic_t handle
@@ -38,7 +29,7 @@ def validate_image_upload(upload: UploadFile, *, label: str = "Image") -> str:
 
     Sniffs the leading bytes with libmagic and returns the trusted extension
     matching the detected MIME type. Raises HTTPException(400) if the file
-    is not a recognized PNG/JPEG/WebP/GIF, or if MIME sniffing fails.
+    is not a recognized image, or if MIME sniffing fails.
     Leaves the file cursor at 0.
     """
     upload.file.seek(0)
@@ -55,7 +46,7 @@ def validate_image_upload(upload: UploadFile, *, label: str = "Image") -> str:
             detail=f"Could not determine {label.lower()} file type",
         ) from exc
 
-    safe_extension = SAFE_IMAGE_MIME_TYPES.get(detected_mime)
+    safe_extension = IMAGE_EXT_BY_MIME_TYPE.get(detected_mime)
     if not safe_extension:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -76,7 +67,7 @@ def build_asset_file_response(
     avatar) can't execute as stored XSS."""
     download_name = filename or resolved_path.name
     guessed_type, _ = guess_type(download_name)
-    if guessed_type in SAFE_IMAGE_MIME_TYPES:
+    if guessed_type in IMAGE_EXT_BY_MIME_TYPE:
         return FileResponse(
             path=str(resolved_path),
             filename=download_name,

--- a/backend/handler/metadata/launchbox_handler/media.py
+++ b/backend/handler/metadata/launchbox_handler/media.py
@@ -30,7 +30,17 @@ from .utils import (
     sanitize_filename,
 )
 
-VIDEO_EXTS: tuple[str, ...] = (".mp4", ".webm", ".avi", ".mkv", ".mov", ".wmv")
+# Video container extensions recognized when probing for local LaunchBox media
+# and when validating a metadata video URL's suffix. A tuple because the probe
+# order is a preference order.
+RECOGNIZED_VIDEO_EXTENSIONS: tuple[str, ...] = (
+    ".mp4",
+    ".webm",
+    ".avi",
+    ".mkv",
+    ".mov",
+    ".wmv",
+)
 
 
 def local_media_req(
@@ -356,7 +366,7 @@ def _get_video(req: MediaRequest) -> str | None:
         return None
 
     for stem in ctx["stems"]:
-        for ext in VIDEO_EXTS:
+        for ext in RECOGNIZED_VIDEO_EXTENSIONS:
             candidate = ctx["base"] / f"{stem}{ext}"
             if candidate.is_file():
                 return file_uri_for_local_path(candidate)
@@ -553,7 +563,7 @@ def populate_rom_specific_paths(
             rom.platform_id, rom.id, MetadataMediaType.VIDEO
         )
         ext = Path(metadata["video_url"]).suffix.lower()
-        if ext not in VIDEO_EXTS:
+        if ext not in RECOGNIZED_VIDEO_EXTENSIONS:
             ext = ".mp4"
         metadata["video_path"] = f"{base}/video{ext}"
     return metadata

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -443,30 +443,6 @@ class Rom(BaseModel):
     def has_manual(self) -> bool:
         return bool(self.path_manual)
 
-    # `has_manual_files` and `has_soundtrack` come from correlated
-    # `EXISTS` subqueries against rom_files filtered by category.
-    # `@declared_attr` lets us define the column_property inside the
-    # class while still referencing `cls.id` (resolved after the
-    # mapping is built). Deferred + opt-in via `undefer` from the
-    # gallery query so we don't force a `Rom.files` load (the
-    # relationship is `lazy="raise"` for that endpoint).
-    @declared_attr
-    def has_manual_files(cls) -> Mapped[bool]:
-        return column_property(
-            select(RomFile.id)
-            .where(
-                and_(
-                    RomFile.rom_id == cls.id,
-                    RomFile.category == RomFileCategory.MANUAL,
-                )
-            )
-            .correlate_except(RomFile)
-            .exists()
-            .select()
-            .scalar_subquery(),
-            deferred=True,
-        )
-
     @declared_attr
     def has_soundtrack(cls) -> Mapped[bool]:
         return column_property(

--- a/backend/tasks/scheduled/convert_images_to_webp.py
+++ b/backend/tasks/scheduled/convert_images_to_webp.py
@@ -14,6 +14,7 @@ from config import (
 )
 from logger.logger import log
 from tasks.tasks import PeriodicTask, TaskType, update_job_meta
+from utils.media_types import ALLOWED_IMAGE_EXTENSIONS
 
 
 @dataclass
@@ -29,9 +30,6 @@ class ConversionResult:
 
 class ImageConverter:
     """Handles image format conversion to WebP."""
-
-    # Supported image formats
-    SUPPORTED_EXTENSIONS = {".png", ".jpg", ".jpeg", ".bmp", ".tiff", ".tif", ".gif"}
 
     # Image mode conversion mapping
     MODE_CONVERSIONS = {
@@ -147,7 +145,8 @@ class ConvertImagesToWebPTask(PeriodicTask):
             for p in self.resources_path.rglob("**/cover/*")
             if p.is_file()
             and not p.is_symlink()
-            and p.suffix.lower() in ImageConverter.SUPPORTED_EXTENSIONS
+            and p.suffix.lower() in ALLOWED_IMAGE_EXTENSIONS
+            and p.suffix.lower() != ".webp"
             and not p.with_suffix(".webp").exists()
         ]
 

--- a/backend/tests/endpoints/roms/test_files.py
+++ b/backend/tests/endpoints/roms/test_files.py
@@ -1,0 +1,106 @@
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from handler.database import db_rom_handler
+from models.platform import Platform
+from models.rom import Rom, RomFile, RomFileCategory
+from models.user import User
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _add_file(rom: Rom, name: str, category: RomFileCategory | None) -> RomFile:
+    return db_rom_handler.add_rom_file(
+        RomFile(
+            rom_id=rom.id,
+            file_name=name,
+            file_path=f"{rom.fs_path}/{rom.fs_name}",
+            file_size_bytes=10,
+            category=category,
+        )
+    )
+
+
+def _make_rom(admin_user: User, platform: Platform) -> Rom:
+    rom = db_rom_handler.add_rom(
+        Rom(
+            platform_id=platform.id,
+            name="media_rom",
+            slug="media_rom_slug",
+            fs_name="media_rom",
+            fs_name_no_tags="media_rom",
+            fs_name_no_ext="media_rom",
+            fs_extension="",
+            fs_path=f"{platform.slug}/roms",
+        )
+    )
+    db_rom_handler.add_rom_user(rom_id=rom.id, user_id=admin_user.id)
+    return rom
+
+
+def test_image_file_served_inline(
+    client: TestClient, access_token: str, admin_user: User, platform: Platform
+):
+    rom = _make_rom(admin_user, platform)
+    file = _add_file(rom, "trailer_thumb.png", RomFileCategory.GAME)
+
+    r = client.get(
+        f"/api/roms/{file.id}/files/content/trailer_thumb.png",
+        headers=_auth(access_token),
+    )
+
+    assert r.status_code == status.HTTP_200_OK
+    assert r.headers["content-type"].startswith("image/png")
+    assert r.headers["content-disposition"].startswith("inline")
+
+
+def test_video_file_served_inline(
+    client: TestClient, access_token: str, admin_user: User, platform: Platform
+):
+    rom = _make_rom(admin_user, platform)
+    file = _add_file(rom, "trailer.mp4", RomFileCategory.GAME)
+
+    r = client.get(
+        f"/api/roms/{file.id}/files/content/trailer.mp4",
+        headers=_auth(access_token),
+    )
+
+    assert r.status_code == status.HTTP_200_OK
+    assert r.headers["content-type"].startswith("video/mp4")
+    assert r.headers["content-disposition"].startswith("inline")
+
+
+def test_rom_file_served_as_attachment(
+    client: TestClient, access_token: str, admin_user: User, platform: Platform
+):
+    rom = _make_rom(admin_user, platform)
+    file = _add_file(rom, "game.bin", RomFileCategory.GAME)
+
+    r = client.get(
+        f"/api/roms/{file.id}/files/content/game.bin",
+        headers=_auth(access_token),
+    )
+
+    assert r.status_code == status.HTTP_200_OK
+    assert r.headers["content-type"].startswith("application/octet-stream")
+    assert r.headers["content-disposition"].startswith("attachment")
+
+
+def test_content_type_derived_from_db_not_path_param(
+    client: TestClient, access_token: str, admin_user: User, platform: Platform
+):
+    # A caller must not be able to force an inline image content-type on a
+    # non-media file by tacking a fake extension onto the URL path param.
+    rom = _make_rom(admin_user, platform)
+    file = _add_file(rom, "game.bin", RomFileCategory.GAME)
+
+    r = client.get(
+        f"/api/roms/{file.id}/files/content/game.bin.png",
+        headers=_auth(access_token),
+    )
+
+    assert r.status_code == status.HTTP_200_OK
+    assert r.headers["content-type"].startswith("application/octet-stream")
+    assert r.headers["content-disposition"].startswith("attachment")

--- a/backend/utils/audio_tags.py
+++ b/backend/utils/audio_tags.py
@@ -13,6 +13,7 @@ from mutagen.oggopus import OggOpus
 from mutagen.oggvorbis import OggVorbis
 
 from logger.logger import log
+from utils.media_types import IMAGE_EXT_BY_MIME_TYPE
 
 ALLOWED_AUDIO_EXTENSIONS = frozenset(
     {".mp3", ".ogg", ".oga", ".opus", ".m4a", ".aac", ".wav", ".flac"}
@@ -295,17 +296,8 @@ def _extract_picture_from_mp4(audio: MP4) -> tuple[bytes, str] | None:
     return bytes(cover), mime
 
 
-_COVER_EXT_BY_MIME = {
-    "image/jpeg": "jpg",
-    "image/jpg": "jpg",
-    "image/png": "png",
-    "image/webp": "webp",
-    "image/gif": "gif",
-}
-
-
 def _ext_for_mime(mime: str) -> str:
-    return _COVER_EXT_BY_MIME.get(mime.lower().split(";")[0].strip(), "bin")
+    return IMAGE_EXT_BY_MIME_TYPE.get(mime.lower().split(";")[0].strip(), "bin")
 
 
 def soundtrack_cover_dir(platform_id: int, rom_id: int) -> str:

--- a/backend/utils/media_types.py
+++ b/backend/utils/media_types.py
@@ -38,10 +38,21 @@ IMAGE_EXT_BY_MIME_TYPE: Final[dict[str, str]] = {
 }
 
 
-def is_inline_media_file(file_name: str) -> bool:
-    """Whether a library file is an image/video the browser can render inline."""
+def is_allowed_image_file(file_name: str) -> bool:
+    """Whether a library file is an image the browser can render inline."""
     ext = os.path.splitext(file_name)[1].lower()
-    return ext in ALLOWED_IMAGE_EXTENSIONS or ext in ALLOWED_VIDEO_EXTENSIONS
+    return ext in ALLOWED_IMAGE_EXTENSIONS
+
+
+def is_allowed_video_file(file_name: str) -> bool:
+    """Whether a library file is a video the browser can render inline."""
+    ext = os.path.splitext(file_name)[1].lower()
+    return ext in ALLOWED_VIDEO_EXTENSIONS
+
+
+def is_allowed_media_file(file_name: str) -> bool:
+    """Whether a library file is an image/video the browser can render inline."""
+    return is_allowed_image_file(file_name) or is_allowed_video_file(file_name)
 
 
 def guess_media_file_type(file_name: str) -> str:

--- a/backend/utils/media_types.py
+++ b/backend/utils/media_types.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import mimetypes
+import os
+
+# File extensions that are safe to serve inline (rendered/streamed by the
+# browser) from the ROM download endpoint. Images and videos never execute
+# scripts, so serving them inline under an explicit, trusted Content-Type
+# avoids the content-sniffing/XSS risk that keeps arbitrary files served as
+# attachments.
+ALLOWED_IMAGE_EXTENSIONS = frozenset(
+    {".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp", ".avif"}
+)
+ALLOWED_VIDEO_EXTENSIONS = frozenset({".mp4", ".webm", ".ogv", ".mov", ".m4v"})
+
+# MIME types the stdlib mimetypes module guesses inconsistently (or not at
+# all) across platforms.
+MEDIA_MIME_OVERRIDES = {
+    ".avif": "image/avif",
+    ".webp": "image/webp",
+    ".mp4": "video/mp4",
+    ".m4v": "video/mp4",
+    ".webm": "video/webm",
+    ".ogv": "video/ogg",
+    ".mov": "video/quicktime",
+}
+
+
+def is_inline_media_file(file_name: str) -> bool:
+    """Whether a library file is an image/video the browser can render inline."""
+    ext = os.path.splitext(file_name)[1].lower()
+    return ext in ALLOWED_IMAGE_EXTENSIONS or ext in ALLOWED_VIDEO_EXTENSIONS
+
+
+def guess_media_file_type(file_name: str) -> str:
+    ext = os.path.splitext(file_name)[1].lower()
+    if ext in MEDIA_MIME_OVERRIDES:
+        return MEDIA_MIME_OVERRIDES[ext]
+    guessed, _ = mimetypes.guess_type(file_name)
+    return guessed or "application/octet-stream"

--- a/backend/utils/media_types.py
+++ b/backend/utils/media_types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import mimetypes
 import os
+from typing import Final
 
 # File extensions that are safe to serve inline (rendered/streamed by the
 # browser) from the ROM download endpoint. Images and videos never execute
@@ -9,7 +10,7 @@ import os
 # avoids the content-sniffing/XSS risk that keeps arbitrary files served as
 # attachments.
 ALLOWED_IMAGE_EXTENSIONS = frozenset(
-    {".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp", ".avif"}
+    {".png", ".jpg", ".jpeg", ".webp", ".gif", ".tiff", ".tif", ".bmp", ".avif"}
 )
 ALLOWED_VIDEO_EXTENSIONS = frozenset({".mp4", ".webm", ".ogv", ".mov", ".m4v"})
 
@@ -23,6 +24,17 @@ MEDIA_MIME_OVERRIDES = {
     ".webm": "video/webm",
     ".ogv": "video/ogg",
     ".mov": "video/quicktime",
+}
+
+# Image MIME types we trust to (a) accept as avatar uploads and (b) serve
+# inline from the raw asset endpoint. Maps each trusted MIME type to its
+# canonical file extension.
+IMAGE_EXT_BY_MIME_TYPE: Final[dict[str, str]] = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/webp": "webp",
+    "image/gif": "gif",
 }
 
 

--- a/backend/utils/screenshots.py
+++ b/backend/utils/screenshots.py
@@ -1,20 +1,6 @@
-import os
-
 from config import FRONTEND_RESOURCES_PATH
 from models.assets import Save
 from models.rom import Rom
-
-# Image formats every modern browser can decode. Shared by the per-ROM
-# (endpoints/roms/screenshot.py) and per-user (endpoints/screenshots.py)
-# screenshot upload endpoints.
-ALLOWED_SCREENSHOT_EXTENSIONS = frozenset(
-    {".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp", ".avif"}
-)
-
-
-def is_allowed_screenshot_file(file_name: str) -> bool:
-    _, ext = os.path.splitext(file_name)
-    return ext.lower() in ALLOWED_SCREENSHOT_EXTENSIONS
 
 
 def continue_playing_screenshot(rom: Rom, latest_save: Save | None) -> str | None:

--- a/frontend/src/__generated__/models/DetailedRomSchema.ts
+++ b/frontend/src/__generated__/models/DetailedRomSchema.ts
@@ -69,7 +69,6 @@ export type DetailedRomSchema = {
     path_cover_large: (string | null);
     url_cover: (string | null);
     has_manual: boolean;
-    has_manual_files: boolean;
     has_soundtrack: boolean;
     path_manual: (string | null);
     url_manual: (string | null);

--- a/frontend/src/__generated__/models/SimpleRomSchema.ts
+++ b/frontend/src/__generated__/models/SimpleRomSchema.ts
@@ -61,7 +61,6 @@ export type SimpleRomSchema = {
     path_cover_large: (string | null);
     url_cover: (string | null);
     has_manual: boolean;
-    has_manual_files: boolean;
     has_soundtrack: boolean;
     path_manual: (string | null);
     url_manual: (string | null);

--- a/frontend/src/v2/components/GameDetails/ArtworkSubtab.vue
+++ b/frontend/src/v2/components/GameDetails/ArtworkSubtab.vue
@@ -22,10 +22,6 @@ const { t } = useI18n();
 const artwork = computed(() => resolveRomArtwork(props.rom));
 const images = computed(() => artwork.value.filter((a) => !a.isVideo));
 
-// Scraped assets carry an i18n key; library files carry their own name.
-const labelOf = (entry: RomArtworkEntry) =>
-  entry.label ?? (entry.labelKey ? t(entry.labelKey) : "");
-
 // Lightbox indexes into the image-only list, so map a clicked card to its
 // position there (videos are skipped).
 const lightboxIndex = ref(0);
@@ -70,13 +66,13 @@ function close() {
           v-else
           type="button"
           class="r-v2-art__btn"
-          :aria-label="t('rom.artwork-open', { name: labelOf(entry) })"
+          :aria-label="t('rom.artwork-open', { name: entry.label })"
           @click="openImage(entry)"
         >
           <img
             class="r-v2-art__media"
             :src="entry.url"
-            :alt="labelOf(entry)"
+            :alt="entry.label"
             loading="lazy"
           />
         </button>
@@ -87,7 +83,7 @@ function close() {
             "
             size="13"
           />
-          {{ labelOf(entry) }}
+          {{ entry.label }}
         </figcaption>
       </figure>
     </section>
@@ -104,13 +100,13 @@ function close() {
       <template #default="{ item }">
         <img
           :src="(item as RomArtworkEntry).url"
-          :alt="labelOf(item as RomArtworkEntry)"
+          :alt="(item as RomArtworkEntry).label"
         />
       </template>
       <template #thumbnail="{ item }">
         <img
           :src="(item as RomArtworkEntry).url"
-          :alt="labelOf(item as RomArtworkEntry)"
+          :alt="(item as RomArtworkEntry).label"
         />
       </template>
     </RCarousel>

--- a/frontend/src/v2/components/GameDetails/ArtworkSubtab.vue
+++ b/frontend/src/v2/components/GameDetails/ArtworkSubtab.vue
@@ -98,16 +98,10 @@ function close() {
       @close="close"
     >
       <template #default="{ item }">
-        <img
-          :src="(item as RomArtworkEntry).url"
-          :alt="(item as RomArtworkEntry).label"
-        />
+        <img :src="item.url" :alt="item.label" />
       </template>
       <template #thumbnail="{ item }">
-        <img
-          :src="(item as RomArtworkEntry).url"
-          :alt="(item as RomArtworkEntry).label"
-        />
+        <img :src="item.url" :alt="item.label" />
       </template>
     </RCarousel>
   </div>

--- a/frontend/src/v2/components/GameDetails/ArtworkSubtab.vue
+++ b/frontend/src/v2/components/GameDetails/ArtworkSubtab.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 // ArtworkSubtab — the Media tab's Artwork panel. A read-only gallery of every
-// scraped art asset that doesn't already get its own surface (covers live on
-// the page, screenshots have their own subtab, manual + soundtrack their own
-// subtabs). Surfaces bezel / logo / marquee / box art / fan art / mix images /
-// title screen plus the scraped videos, which the V2 GUI otherwise hid.
+// art asset that doesn't already get its own surface (covers live on the page,
+// screenshots have their own subtab, manual + soundtrack their own subtabs).
+// Surfaces bezel / logo / marquee / box art / fan art / mix images / title
+// screen plus the scraped videos, which the V2 GUI otherwise hid, and any
+// image/video files sitting in the game folder in the library.
 //
 // Each asset is a labelled card. Images are contained (not cropped) since the
 // set spans wildly different aspect ratios (wide marquees, tall box art) and
@@ -20,6 +21,10 @@ const { t } = useI18n();
 
 const artwork = computed(() => resolveRomArtwork(props.rom));
 const images = computed(() => artwork.value.filter((a) => !a.isVideo));
+
+// Scraped assets carry an i18n key; library files carry their own name.
+const labelOf = (entry: RomArtworkEntry) =>
+  entry.label ?? (entry.labelKey ? t(entry.labelKey) : "");
 
 // Lightbox indexes into the image-only list, so map a clicked card to its
 // position there (videos are skipped).
@@ -65,13 +70,13 @@ function close() {
           v-else
           type="button"
           class="r-v2-art__btn"
-          :aria-label="t('rom.artwork-open', { name: t(entry.labelKey) })"
+          :aria-label="t('rom.artwork-open', { name: labelOf(entry) })"
           @click="openImage(entry)"
         >
           <img
             class="r-v2-art__media"
             :src="entry.url"
-            :alt="t(entry.labelKey)"
+            :alt="labelOf(entry)"
             loading="lazy"
           />
         </button>
@@ -82,7 +87,7 @@ function close() {
             "
             size="13"
           />
-          {{ t(entry.labelKey) }}
+          {{ labelOf(entry) }}
         </figcaption>
       </figure>
     </section>
@@ -99,13 +104,13 @@ function close() {
       <template #default="{ item }">
         <img
           :src="(item as RomArtworkEntry).url"
-          :alt="t((item as RomArtworkEntry).labelKey)"
+          :alt="labelOf(item as RomArtworkEntry)"
         />
       </template>
       <template #thumbnail="{ item }">
         <img
           :src="(item as RomArtworkEntry).url"
-          :alt="t((item as RomArtworkEntry).labelKey)"
+          :alt="labelOf(item as RomArtworkEntry)"
         />
       </template>
     </RCarousel>

--- a/frontend/src/v2/components/GameDetails/OverviewTab.vue
+++ b/frontend/src/v2/components/GameDetails/OverviewTab.vue
@@ -86,8 +86,9 @@ const { t } = useI18n();
 const collectionsStore = storeCollections();
 const { toWebp } = useWebpSupport();
 
-// Scraped videos surface on the overview (the rest of the art lives in the
-// Media tab's Artwork subtab). Same resolver, filtered to videos.
+// Videos surface on the overview (the rest of the art lives in the Media tab's
+// Artwork subtab). Same resolver, filtered to videos: scraped clips plus any
+// video files in the game folder.
 const videos = computed(() =>
   resolveRomArtwork(props.rom).filter((a) => a.isVideo),
 );

--- a/frontend/src/v2/components/GameDetails/RelatedGameCard.vue
+++ b/frontend/src/v2/components/GameDetails/RelatedGameCard.vue
@@ -128,7 +128,6 @@ const syntheticRom = computed<SimpleRom>(() => ({
   path_cover_large: null,
   url_cover: props.game.cover_url ?? null,
   has_manual: false,
-  has_manual_files: false,
   has_soundtrack: false,
   path_manual: null,
   url_manual: null,

--- a/frontend/src/v2/components/GameDetails/ScreenshotsTab.vue
+++ b/frontend/src/v2/components/GameDetails/ScreenshotsTab.vue
@@ -153,16 +153,10 @@ function canToggle(shot: ScreenshotItem): boolean {
     @close="close"
   >
     <template #default="{ item, index }">
-      <img
-        :src="item as string"
-        :alt="t('rom.screenshot-num', { n: index + 1 })"
-      />
+      <img :src="item" :alt="t('rom.screenshot-num', { n: index + 1 })" />
     </template>
     <template #thumbnail="{ item, index }">
-      <img
-        :src="item as string"
-        :alt="t('rom.screenshot-num-thumb', { n: index + 1 })"
-      />
+      <img :src="item" :alt="t('rom.screenshot-num-thumb', { n: index + 1 })" />
     </template>
   </RCarousel>
 </template>

--- a/frontend/src/v2/lib/overlays/RCarousel/RCarousel.stories.ts
+++ b/frontend/src/v2/lib/overlays/RCarousel/RCarousel.stories.ts
@@ -1,8 +1,17 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
 import { expect, fn, userEvent, within } from "storybook/test";
-import { ref } from "vue";
+import { type Component, ref } from "vue";
 import RBtn from "@/v2/lib/primitives/RBtn/RBtn.vue";
 import RCarousel from "./RCarousel.vue";
+
+// RCarousel is generic (`<T>`), so its component-typed shape doesn't fit
+// Storybook's `component` slot or `Meta<typeof RCarousel>` — Vue narrows T
+// to `unknown` here. The casts below are narrow + intentional.
+//
+// The generic's fixed named slots also don't reconcile with Storybook's
+// `components` map (which types each entry as a plain `Component`), so the
+// render stories register the carousel through this cast alias.
+const RCarouselStory = RCarousel as unknown as Component;
 
 // Sample images — picsum is deterministic by seed and works offline through
 // the Storybook CDN cache.
@@ -14,9 +23,9 @@ const SAMPLES = [
   "https://picsum.photos/seed/r-carousel-5/1280/720",
 ];
 
-const meta: Meta<typeof RCarousel> = {
+const meta: Meta = {
   title: "Overlays/RCarousel",
-  component: RCarousel,
+  component: RCarousel as never,
   argTypes: {
     fullscreen: { control: "boolean" },
     loop: { control: "boolean" },
@@ -32,7 +41,7 @@ const meta: Meta<typeof RCarousel> = {
 
 export default meta;
 
-type Story = StoryObj<typeof RCarousel>;
+type Story = StoryObj;
 
 export const Inline: Story = {
   args: {
@@ -42,7 +51,7 @@ export const Inline: Story = {
     ariaLabel: "Image carousel",
   },
   render: (args) => ({
-    components: { RCarousel },
+    components: { RCarousel: RCarouselStory },
     setup() {
       const index = ref(0);
       return { args, index };
@@ -108,7 +117,7 @@ export const InlineLight: Story = {
     showThumbnails: true,
   },
   render: (args) => ({
-    components: { RCarousel },
+    components: { RCarousel: RCarouselStory },
     setup() {
       const index = ref(0);
       return { args, index };
@@ -141,7 +150,7 @@ export const Fullscreen: Story = {
     ariaLabel: "Screenshot lightbox",
   },
   render: (args) => ({
-    components: { RCarousel, RBtn },
+    components: { RCarousel: RCarouselStory, RBtn },
     setup() {
       const index = ref<number | null>(null);
       const onClose = fn(() => (index.value = null));
@@ -174,7 +183,7 @@ export const NoLoop: Story = {
     loop: false,
   },
   render: (args) => ({
-    components: { RCarousel },
+    components: { RCarousel: RCarouselStory },
     setup() {
       const index = ref(0);
       return { args, index };
@@ -200,7 +209,7 @@ export const SingleItem: Story = {
     items: SAMPLES.slice(0, 1),
   },
   render: (args) => ({
-    components: { RCarousel },
+    components: { RCarousel: RCarouselStory },
     setup() {
       const index = ref(0);
       return { args, index };

--- a/frontend/src/v2/lib/overlays/RCarousel/RCarousel.vue
+++ b/frontend/src/v2/lib/overlays/RCarousel/RCarousel.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+<script setup lang="ts" generic="T">
 // RCarousel — slide-through viewer for an array of items.
 //
 // Two modes:
@@ -32,41 +32,11 @@ import {
 } from "vue";
 import RBtn from "@/v2/lib/primitives/RBtn/RBtn.vue";
 import RIcon from "@/v2/lib/primitives/RIcon/RIcon.vue";
+import type { RCarouselProps } from "./types";
 
 defineOptions({ inheritAttrs: false });
 
-// Items are typed as `unknown` so the primitive stays free of any
-// product-domain knowledge (premise II.criterion-2). Consumers narrow the
-// slot payload with `v-slot="{ item }"` and an explicit cast or local
-// generic component.
-type CarouselItem = unknown;
-
-interface Props {
-  /** Active item index. */
-  modelValue: number;
-  /** Items array — the slot decides how each one is rendered. */
-  items: readonly CarouselItem[];
-  /** Render as a viewport-filling overlay with scrim and close button. */
-  fullscreen?: boolean;
-  /** Wrap from last → first and first → last. */
-  loop?: boolean;
-  /** Show "n / total" counter. Defaults to true when `items.length > 1`. */
-  showCounter?: boolean;
-  /** Show prev/next arrows. Defaults to true when `items.length > 1`. */
-  showArrows?: boolean;
-  /** Show a thumbnail strip below the active item. */
-  showThumbnails?: boolean;
-  /** Localised label for the close button. */
-  closeLabel?: string;
-  /** Localised label for the prev button. */
-  prevLabel?: string;
-  /** Localised label for the next button. */
-  nextLabel?: string;
-  /** Accessibility label for the carousel region. */
-  ariaLabel?: string;
-}
-
-const props = withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<RCarouselProps<T>>(), {
   fullscreen: false,
   loop: true,
   showCounter: undefined,
@@ -86,16 +56,8 @@ const emit = defineEmits<{
 }>();
 
 defineSlots<{
-  default(slotProps: {
-    item: CarouselItem;
-    index: number;
-    active: boolean;
-  }): unknown;
-  thumbnail(slotProps: {
-    item: CarouselItem;
-    index: number;
-    active: boolean;
-  }): unknown;
+  default(slotProps: { item: T; index: number; active: boolean }): unknown;
+  thumbnail(slotProps: { item: T; index: number; active: boolean }): unknown;
   empty(): unknown;
   counter(slotProps: { index: number; total: number }): unknown;
 }>();
@@ -117,9 +79,7 @@ const safeIndex = computed(() => {
   const i = Math.max(0, Math.min(props.modelValue, total.value - 1));
   return i;
 });
-const activeItem = computed<CarouselItem | undefined>(
-  () => props.items[safeIndex.value],
-);
+const activeItem = computed<T | undefined>(() => props.items[safeIndex.value]);
 
 // `direction` drives the slide direction of the <Transition> below. Updated
 // before we emit a new index so the transition class on the way out matches

--- a/frontend/src/v2/lib/overlays/RCarousel/index.ts
+++ b/frontend/src/v2/lib/overlays/RCarousel/index.ts
@@ -1,1 +1,2 @@
 export { default as RCarousel } from "./RCarousel.vue";
+export type { RCarouselProps } from "./types";

--- a/frontend/src/v2/lib/overlays/RCarousel/types.ts
+++ b/frontend/src/v2/lib/overlays/RCarousel/types.ts
@@ -1,0 +1,28 @@
+// Props for RCarousel. Kept in its own module (not inline in the SFC) because
+// RCarousel is a generic component (`<T>`) — an inline `interface Props` leaks
+// into the compiled default export as a private name (TS4082), and `export`
+// isn't allowed inside `<script setup>`.
+export interface RCarouselProps<TItem> {
+  /** Active item index. */
+  modelValue: number;
+  /** Items array — the slot decides how each one is rendered. */
+  items: readonly TItem[];
+  /** Render as a viewport-filling overlay with scrim and close button. */
+  fullscreen?: boolean;
+  /** Wrap from last → first and first → last. */
+  loop?: boolean;
+  /** Show "n / total" counter. Defaults to true when `items.length > 1`. */
+  showCounter?: boolean;
+  /** Show prev/next arrows. Defaults to true when `items.length > 1`. */
+  showArrows?: boolean;
+  /** Show a thumbnail strip below the active item. */
+  showThumbnails?: boolean;
+  /** Localised label for the close button. */
+  closeLabel?: string;
+  /** Localised label for the prev button. */
+  prevLabel?: string;
+  /** Localised label for the next button. */
+  nextLabel?: string;
+  /** Accessibility label for the carousel region. */
+  ariaLabel?: string;
+}

--- a/frontend/src/v2/utils/romArtwork.test.ts
+++ b/frontend/src/v2/utils/romArtwork.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import type { RomFileSchema } from "@/__generated__";
+import type { DetailedRom } from "@/stores/roms";
+import { resolveRomArtwork } from "./romArtwork";
+
+function makeFile(overrides: Partial<RomFileSchema>): RomFileSchema {
+  return {
+    id: 1,
+    rom_id: 1,
+    file_name: "file.bin",
+    file_path: "platform/roms/game",
+    file_size_bytes: 10,
+    full_path: "platform/roms/game/file.bin",
+    is_top_level: true,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    last_modified: "2024-01-01T00:00:00Z",
+    crc_hash: null,
+    md5_hash: null,
+    sha1_hash: null,
+    ra_hash: null,
+    chd_sha1_hash: null,
+    archive_members: null,
+    category: "game",
+    ...overrides,
+  };
+}
+
+function makeRom(files: RomFileSchema[]): DetailedRom {
+  return {
+    updated_at: "2024-01-01T00:00:00Z",
+    ss_metadata: null,
+    gamelist_metadata: null,
+    path_video: null,
+    files,
+  } as DetailedRom;
+}
+
+describe("resolveRomArtwork — library media files", () => {
+  it("includes image files as non-video entries pointing at the content endpoint", () => {
+    const rom = makeRom([makeFile({ id: 7, file_name: "artwork.png" })]);
+    const entries = resolveRomArtwork(rom);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].isVideo).toBe(false);
+    expect(entries[0].label).toBe("artwork");
+    expect(entries[0].url).toContain("/api/roms/7/files/content/artwork.png");
+  });
+
+  it("includes video files as video entries", () => {
+    const rom = makeRom([makeFile({ id: 3, file_name: "trailer.mp4" })]);
+    const entries = resolveRomArtwork(rom);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].isVideo).toBe(true);
+    expect(entries[0].label).toBe("trailer");
+  });
+
+  it("ignores files that are not a known media type", () => {
+    const rom = makeRom([
+      makeFile({ id: 1, file_name: "game.bin" }),
+      makeFile({ id: 2, file_name: "notes.txt" }),
+    ]);
+    expect(resolveRomArtwork(rom)).toHaveLength(0);
+  });
+
+  it("skips categories that have their own surface", () => {
+    const rom = makeRom([
+      makeFile({ id: 1, file_name: "shot.png", category: "screenshot" }),
+      makeFile({ id: 2, file_name: "track.mp4", category: "soundtrack" }),
+      makeFile({ id: 3, file_name: "book.png", category: "manual" }),
+      makeFile({ id: 4, file_name: "keep.png", category: "game" }),
+    ]);
+    const entries = resolveRomArtwork(rom);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].label).toBe("keep");
+  });
+
+  it("orders image files before video files", () => {
+    const rom = makeRom([
+      makeFile({ id: 1, file_name: "clip.mp4" }),
+      makeFile({ id: 2, file_name: "pic.jpg" }),
+    ]);
+    const entries = resolveRomArtwork(rom);
+
+    expect(entries.map((e) => e.isVideo)).toEqual([false, true]);
+  });
+});

--- a/frontend/src/v2/utils/romArtwork.ts
+++ b/frontend/src/v2/utils/romArtwork.ts
@@ -12,7 +12,7 @@
 //
 // Covers, screenshots, the manual and the soundtrack are intentionally left
 // out: they each have their own surface elsewhere in the details view.
-import { useI18n } from "vue-i18n";
+import i18n from "@/locales";
 import type { DetailedRom } from "@/stores/roms";
 import { FRONTEND_RESOURCES_PATH } from "@/utils";
 
@@ -43,8 +43,6 @@ const LIBRARY_VIDEO_EXTENSIONS = new Set(["mp4", "webm", "ogv", "mov", "m4v"]);
 const SURFACED_ELSEWHERE = new Set(["screenshot", "soundtrack", "manual"]);
 
 export function resolveRomArtwork(rom: DetailedRom): RomArtworkEntry[] {
-  const { t } = useI18n();
-
   const ss = rom.ss_metadata;
   const gl = rom.gamelist_metadata;
   const cacheBust = encodeURIComponent(rom.updated_at);
@@ -55,64 +53,68 @@ export function resolveRomArtwork(rom: DetailedRom): RomArtworkEntry[] {
     [
       {
         key: "title_screen",
-        label: t("rom.media-title-screen"),
+        label: i18n.global.t("rom.media-title-screen"),
         url: ss?.title_screen_path ?? null,
       },
-      { key: "logo", label: t("rom.media-logo"), url: ss?.logo_path ?? null },
+      {
+        key: "logo",
+        label: i18n.global.t("rom.media-logo"),
+        url: ss?.logo_path ?? null,
+      },
       {
         key: "marquee",
-        label: t("rom.media-marquee"),
+        label: i18n.global.t("rom.media-marquee"),
         url: ss?.marquee_path ?? gl?.marquee_path ?? null,
       },
       {
         key: "bezel",
-        label: t("rom.media-bezel"),
+        label: i18n.global.t("rom.media-bezel"),
         url: ss?.bezel_path ?? null,
       },
       {
         key: "fanart",
-        label: t("rom.media-fanart"),
+        label: i18n.global.t("rom.media-fanart"),
         url: ss?.fanart_path ?? null,
       },
       {
         key: "box3d",
-        label: t("rom.media-box3d"),
+        label: i18n.global.t("rom.media-box3d"),
         url: ss?.box3d_path ?? gl?.box3d_path ?? null,
       },
       {
         key: "box2d_back",
-        label: t("rom.media-box2d-back"),
+        label: i18n.global.t("rom.media-box2d-back"),
         url: ss?.box2d_back_path ?? null,
       },
       {
         key: "box2d_side",
-        label: t("rom.media-box2d-side"),
+        label: i18n.global.t("rom.media-box2d-side"),
         url: ss?.box2d_side_path ?? null,
       },
       {
         key: "physical",
-        label: t("rom.media-physical"),
+        label: i18n.global.t("rom.media-physical"),
         url: ss?.physical_path ?? gl?.physical_path ?? null,
       },
       {
         key: "miximage",
-        label: t("rom.media-miximage"),
+        label: i18n.global.t("rom.media-miximage"),
         url: ss?.miximage_path ?? gl?.miximage_path ?? null,
       },
       {
         key: "miximage_v2",
-        label: t("rom.media-miximage-v2"),
+        label: i18n.global.t("rom.media-miximage-v2"),
         url: ss?.miximage_v2_path ?? null,
       },
       {
         key: "video",
-        label: t("rom.media-video"),
+        label: i18n.global.t("rom.media-video"),
         url: rom.path_video ?? null,
         isVideo: true,
       },
       {
         key: "video_normalized",
-        label: t("rom.media-video-normalized"),
+        label: i18n.global.t("rom.media-video-normalized"),
         url: ss?.video_normalized_path ?? null,
         isVideo: true,
       },

--- a/frontend/src/v2/utils/romArtwork.ts
+++ b/frontend/src/v2/utils/romArtwork.ts
@@ -1,21 +1,46 @@
-// Resolves the scraped art assets attached to a ROM into a flat, display-ready
-// list. Shared by the Media tab's Artwork subtab (full gallery) and the
-// Overview tab (videos only) so both stay in sync.
+// Resolves the art assets attached to a ROM into a flat, display-ready list.
+// Shared by the Media tab's Artwork subtab (full gallery) and the Overview tab
+// (videos only) so both stay in sync.
+//
+// Two sources feed the list:
+//   1. Scraped resources — ScreenScraper is the richest and wins; gamelist
+//      fills in for the few types it also scrapes (mirrors v1's MediaCarousel
+//      fallbacks).
+//   2. Library media files — images/videos that live in the game folder on
+//      disk (rom.files), so a trailer or artwork dropped next to the ROM shows
+//      up here too.
 //
 // Covers, screenshots, the manual and the soundtrack are intentionally left
 // out: they each have their own surface elsewhere in the details view.
-// ScreenScraper is the richest source and wins; gamelist fills in for the few
-// types it also scrapes (mirrors v1's MediaCarousel fallbacks).
 import type { DetailedRom } from "@/stores/roms";
 import { FRONTEND_RESOURCES_PATH } from "@/utils";
 
 export type RomArtworkEntry = {
   key: string;
-  /** i18n key (under the `rom` namespace) for the asset's display label. */
-  labelKey: string;
+  /** i18n key (under the `rom` namespace) for a scraped asset's label. */
+  labelKey?: string;
+  /** Ready-to-display label for a library file (its name, extension stripped). */
+  label?: string;
   url: string;
   isVideo: boolean;
 };
+
+// Library file extensions the browser can render inline. Kept in sync with the
+// backend download endpoint (utils/media_types.py), which serves these inline.
+const LIBRARY_IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "webp",
+  "gif",
+  "bmp",
+  "avif",
+]);
+const LIBRARY_VIDEO_EXTENSIONS = new Set(["mp4", "webm", "ogv", "mov", "m4v"]);
+
+// File categories that already have their own surface in the details view, so
+// they must not be duplicated into the artwork gallery.
+const SURFACED_ELSEWHERE = new Set(["screenshot", "soundtrack", "manual"]);
 
 export function resolveRomArtwork(rom: DetailedRom): RomArtworkEntry[] {
   const ss = rom.ss_metadata;
@@ -96,7 +121,29 @@ export function resolveRomArtwork(rom: DetailedRom): RomArtworkEntry[] {
     }
   };
 
+  // Media files sitting in the game folder. Skip anything that already has its
+  // own surface (screenshots / soundtrack / manual); everything else with a
+  // known image/video extension is shown alongside the scraped assets.
+  const libraryImages: RomArtworkEntry[] = [];
+  const libraryVideos: RomArtworkEntry[] = [];
+  for (const file of rom.files ?? []) {
+    if (file.category && SURFACED_ELSEWHERE.has(file.category)) continue;
+    const ext = file.file_name.split(".").pop()?.toLowerCase() ?? "";
+    const isVideo = LIBRARY_VIDEO_EXTENSIONS.has(ext);
+    if (!isVideo && !LIBRARY_IMAGE_EXTENSIONS.has(ext)) continue;
+    (isVideo ? libraryVideos : libraryImages).push({
+      key: `file-${file.id}`,
+      label: file.file_name.replace(/\.[^.]+$/, ""),
+      url: `/api/roms/${file.id}/files/content/${encodeURIComponent(
+        file.file_name,
+      )}?v=${cacheBust}`,
+      isVideo,
+    });
+  }
+
   collect(images, false);
+  out.push(...libraryImages);
   collect(videos, true);
+  out.push(...libraryVideos);
   return out;
 }

--- a/frontend/src/v2/utils/romArtwork.ts
+++ b/frontend/src/v2/utils/romArtwork.ts
@@ -134,7 +134,9 @@ export function resolveRomArtwork(rom: DetailedRom): RomArtworkEntry[] {
         isVideo,
       };
     })
-    .filter((entry) => entry !== null);
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+    // Images before videos; sort is stable so original order holds within each group.
+    .sort((a, b) => Number(a.isVideo) - Number(b.isVideo));
 
   for (const def of artworkDefs) {
     if (!def.url || seen.has(def.url)) continue;

--- a/frontend/src/v2/utils/romArtwork.ts
+++ b/frontend/src/v2/utils/romArtwork.ts
@@ -12,17 +12,15 @@
 //
 // Covers, screenshots, the manual and the soundtrack are intentionally left
 // out: they each have their own surface elsewhere in the details view.
+import { useI18n } from "vue-i18n";
 import type { DetailedRom } from "@/stores/roms";
 import { FRONTEND_RESOURCES_PATH } from "@/utils";
 
 export type RomArtworkEntry = {
   key: string;
-  /** i18n key (under the `rom` namespace) for a scraped asset's label. */
-  labelKey?: string;
-  /** Ready-to-display label for a library file (its name, extension stripped). */
-  label?: string;
+  label: string;
   url: string;
-  isVideo: boolean;
+  isVideo?: boolean;
 };
 
 // Library file extensions the browser can render inline. Kept in sync with the
@@ -33,6 +31,8 @@ const LIBRARY_IMAGE_EXTENSIONS = new Set([
   "jpeg",
   "webp",
   "gif",
+  "tiff",
+  "tif",
   "bmp",
   "avif",
 ]);
@@ -43,107 +43,107 @@ const LIBRARY_VIDEO_EXTENSIONS = new Set(["mp4", "webm", "ogv", "mov", "m4v"]);
 const SURFACED_ELSEWHERE = new Set(["screenshot", "soundtrack", "manual"]);
 
 export function resolveRomArtwork(rom: DetailedRom): RomArtworkEntry[] {
+  const { t } = useI18n();
+
   const ss = rom.ss_metadata;
   const gl = rom.gamelist_metadata;
   const cacheBust = encodeURIComponent(rom.updated_at);
-
-  const images: { key: string; labelKey: string; path?: string | null }[] = [
-    {
-      key: "title_screen",
-      labelKey: "rom.media-title-screen",
-      path: ss?.title_screen_path,
-    },
-    { key: "logo", labelKey: "rom.media-logo", path: ss?.logo_path },
-    {
-      key: "marquee",
-      labelKey: "rom.media-marquee",
-      path: ss?.marquee_path ?? gl?.marquee_path,
-    },
-    { key: "bezel", labelKey: "rom.media-bezel", path: ss?.bezel_path },
-    { key: "fanart", labelKey: "rom.media-fanart", path: ss?.fanart_path },
-    {
-      key: "box3d",
-      labelKey: "rom.media-box3d",
-      path: ss?.box3d_path ?? gl?.box3d_path,
-    },
-    {
-      key: "box2d_back",
-      labelKey: "rom.media-box2d-back",
-      path: ss?.box2d_back_path,
-    },
-    {
-      key: "box2d_side",
-      labelKey: "rom.media-box2d-side",
-      path: ss?.box2d_side_path,
-    },
-    {
-      key: "physical",
-      labelKey: "rom.media-physical",
-      path: ss?.physical_path ?? gl?.physical_path,
-    },
-    {
-      key: "miximage",
-      labelKey: "rom.media-miximage",
-      path: ss?.miximage_path ?? gl?.miximage_path,
-    },
-    {
-      key: "miximage_v2",
-      labelKey: "rom.media-miximage-v2",
-      path: ss?.miximage_v2_path,
-    },
-  ];
-
-  const videos: { key: string; labelKey: string; path?: string | null }[] = [
-    { key: "video", labelKey: "rom.media-video", path: rom.path_video },
-    {
-      key: "video_normalized",
-      labelKey: "rom.media-video-normalized",
-      path: ss?.video_normalized_path,
-    },
-  ];
-
-  const out: RomArtworkEntry[] = [];
   const seen = new Set<string>();
+  const out: RomArtworkEntry[] = [];
 
-  const collect = (
-    defs: { key: string; labelKey: string; path?: string | null }[],
-    isVideo: boolean,
-  ) => {
-    for (const def of defs) {
-      if (!def.path || seen.has(def.path)) continue;
-      seen.add(def.path);
-      out.push({
-        key: def.key,
-        labelKey: def.labelKey,
-        url: `${FRONTEND_RESOURCES_PATH}/${def.path}?v=${cacheBust}`,
+  const artworkDefs: (Omit<RomArtworkEntry, "url"> & { url: string | null })[] =
+    [
+      {
+        key: "title_screen",
+        label: t("rom.media-title-screen"),
+        url: ss?.title_screen_path ?? null,
+      },
+      { key: "logo", label: t("rom.media-logo"), url: ss?.logo_path ?? null },
+      {
+        key: "marquee",
+        label: t("rom.media-marquee"),
+        url: ss?.marquee_path ?? gl?.marquee_path ?? null,
+      },
+      {
+        key: "bezel",
+        label: t("rom.media-bezel"),
+        url: ss?.bezel_path ?? null,
+      },
+      {
+        key: "fanart",
+        label: t("rom.media-fanart"),
+        url: ss?.fanart_path ?? null,
+      },
+      {
+        key: "box3d",
+        label: t("rom.media-box3d"),
+        url: ss?.box3d_path ?? gl?.box3d_path ?? null,
+      },
+      {
+        key: "box2d_back",
+        label: t("rom.media-box2d-back"),
+        url: ss?.box2d_back_path ?? null,
+      },
+      {
+        key: "box2d_side",
+        label: t("rom.media-box2d-side"),
+        url: ss?.box2d_side_path ?? null,
+      },
+      {
+        key: "physical",
+        label: t("rom.media-physical"),
+        url: ss?.physical_path ?? gl?.physical_path ?? null,
+      },
+      {
+        key: "miximage",
+        label: t("rom.media-miximage"),
+        url: ss?.miximage_path ?? gl?.miximage_path ?? null,
+      },
+      {
+        key: "miximage_v2",
+        label: t("rom.media-miximage-v2"),
+        url: ss?.miximage_v2_path ?? null,
+      },
+      {
+        key: "video",
+        label: t("rom.media-video"),
+        url: rom.path_video ?? null,
+        isVideo: true,
+      },
+      {
+        key: "video_normalized",
+        label: t("rom.media-video-normalized"),
+        url: ss?.video_normalized_path ?? null,
+        isVideo: true,
+      },
+    ];
+
+  const libraryMedia = rom.files
+    .filter((file) => !file.category || !SURFACED_ELSEWHERE.has(file.category))
+    .map((file) => {
+      const ext = file.file_name.split(".").pop()?.toLowerCase() ?? "";
+      const isVideo = LIBRARY_VIDEO_EXTENSIONS.has(ext);
+      if (!isVideo && !LIBRARY_IMAGE_EXTENSIONS.has(ext)) return null;
+
+      return {
+        key: `file-${file.id}`,
+        label: file.file_name.replace(/\.[^.]+$/, ""),
+        url: `/api/roms/${file.id}/files/content/${encodeURIComponent(file.file_name)}?v=${cacheBust}`,
         isVideo,
-      });
-    }
-  };
+      };
+    })
+    .filter((entry) => entry !== null);
 
-  // Media files sitting in the game folder. Skip anything that already has its
-  // own surface (screenshots / soundtrack / manual); everything else with a
-  // known image/video extension is shown alongside the scraped assets.
-  const libraryImages: RomArtworkEntry[] = [];
-  const libraryVideos: RomArtworkEntry[] = [];
-  for (const file of rom.files ?? []) {
-    if (file.category && SURFACED_ELSEWHERE.has(file.category)) continue;
-    const ext = file.file_name.split(".").pop()?.toLowerCase() ?? "";
-    const isVideo = LIBRARY_VIDEO_EXTENSIONS.has(ext);
-    if (!isVideo && !LIBRARY_IMAGE_EXTENSIONS.has(ext)) continue;
-    (isVideo ? libraryVideos : libraryImages).push({
-      key: `file-${file.id}`,
-      label: file.file_name.replace(/\.[^.]+$/, ""),
-      url: `/api/roms/${file.id}/files/content/${encodeURIComponent(
-        file.file_name,
-      )}?v=${cacheBust}`,
-      isVideo,
+  for (const def of artworkDefs) {
+    if (!def.url || seen.has(def.url)) continue;
+    seen.add(def.url);
+    out.push({
+      key: def.key,
+      label: def.label,
+      url: `${FRONTEND_RESOURCES_PATH}/${def.url}?v=${cacheBust}`,
+      isVideo: def.isVideo ?? false,
     });
   }
 
-  collect(images, false);
-  out.push(...libraryImages);
-  collect(videos, true);
-  out.push(...libraryVideos);
-  return out;
+  return [...out, ...libraryMedia];
 }


### PR DESCRIPTION
## TL;DR

Enable images and videos stored in the library to be displayed inline in the game details view. This adds media type detection utilities, updates the file serving endpoint to serve images/videos with inline disposition, and extends the artwork gallery UI to render library media files alongside scraped assets.

## What changed?

### Backend changes

- **New utility module** (`backend/utils/media_types.py`):
  - Added `is_inline_media_file()` function to identify images and videos by file extension
  - Added `guess_media_file_type()` function to determine MIME types with platform-consistent overrides for `.avif`, `.webp`, `.mp4`, `.m4v`, `.webm`, `.ogv`, `.mov`
  - Supported image extensions: `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.bmp`, `.avif`
  - Supported video extensions: `.mp4`, `.webm`, `.ogv`, `.mov`, `.m4v`

- **Updated file serving endpoint** (`backend/endpoints/roms/files.py`):
  - Refactored media type and disposition logic to handle audio, images, and videos
  - Images and videos now served with `inline` disposition (previously only audio files)
  - Other file types continue to download as `attachment`
  - Security preserved: Content-Type derived from database record, not client-supplied path parameter

- **New test coverage** (`backend/tests/endpoints/roms/test_files.py`):
  - Test for PNG images served inline with correct MIME type
  - Test for MP4 videos served inline with correct MIME type
  - Test for non-media files served as attachments
  - Security test verifying Content-Type cannot be spoofed via fake file extensions in URL

### Frontend changes

- **Updated artwork gallery** (`frontend/src/v2/components/GameDetails/ArtworkSubtab.vue`):
  - Extended to display library media files alongside scraped artwork assets
  - Gallery now includes images and videos from the game's file collection

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*