### PR TITLE
feat(player): remember emulator core per-game

### DIFF
--- a/frontend/src/console/views/Play.vue
+++ b/frontend/src/console/views/Play.vue
@@ -49,6 +49,7 @@ const createPlayerStorage = (romId: number, platformSlug: string) => ({
     null as string | null,
   ),
   disc: useLocalStorage(`player:${romId}:disc`, null as string | null),
+  gameCore: useLocalStorage(`player:${romId}:core`, null as string | null),
   core: useLocalStorage(`player:${platformSlug}:core`, null as string | null),
   biosId: useLocalStorage(
     `player:${platformSlug}:bios_id`,
@@ -409,9 +410,12 @@ async function boot() {
     rom.platform_slug,
     configStore.config.EJS_NETPLAY_ENABLED,
   );
+  // Prefer the core saved for this game, falling back to the platform default
+  const preferredCore =
+    playerStorage.gameCore.value ?? playerStorage.core.value;
   const core =
-    playerStorage.core.value && supported.includes(playerStorage.core.value)
-      ? playerStorage.core.value
+    preferredCore && supported.includes(preferredCore)
+      ? preferredCore
       : supported[0];
 
   const coreOptions = configStore.getEJSCoreOptions(core);

--- a/frontend/src/console/views/Play.vue
+++ b/frontend/src/console/views/Play.vue
@@ -410,13 +410,12 @@ async function boot() {
     rom.platform_slug,
     configStore.config.EJS_NETPLAY_ENABLED,
   );
-  // Prefer the core saved for this game, falling back to the platform default
-  const preferredCore =
-    playerStorage.gameCore.value ?? playerStorage.core.value;
+  // Prefer the core saved for this game, then the platform default, validating
+  // each candidate so a stale entry falls through instead of masking the next
   const core =
-    preferredCore && supported.includes(preferredCore)
-      ? preferredCore
-      : supported[0];
+    [playerStorage.gameCore.value, playerStorage.core.value].find(
+      (c): c is string => !!c && supported.includes(c),
+    ) ?? supported[0];
 
   const coreOptions = configStore.getEJSCoreOptions(core);
   window.EJS_core = core;

--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -406,15 +406,16 @@ onMounted(async () => {
     selectedDisc.value = rom.value.files[0]?.id ?? null;
   }
 
-  // Prefer the core saved for this game, falling back to the platform default
-  const storedCore =
-    localStorage.getItem(`player:${rom.value.id}:core`) ??
-    localStorage.getItem(`player:${rom.value.platform_slug}:core`);
-  if (storedCore && supportedCores.value.includes(storedCore)) {
-    selectedCore.value = storedCore;
-  } else {
-    selectedCore.value = supportedCores.value[0];
-  }
+  // Prefer the core saved for this game, then the platform default, validating
+  // each candidate so a stale entry falls through instead of masking the next
+  const gameCore = localStorage.getItem(`player:${rom.value.id}:core`);
+  const platformCore = localStorage.getItem(
+    `player:${rom.value.platform_slug}:core`,
+  );
+  selectedCore.value =
+    [gameCore, platformCore].find(
+      (core): core is string => !!core && supportedCores.value.includes(core),
+    ) ?? supportedCores.value[0];
 
   const coreOptions = configStore.getEJSCoreOptions(selectedCore.value);
   const storedBiosID = localStorage.getItem(

--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -406,10 +406,11 @@ onMounted(async () => {
     selectedDisc.value = rom.value.files[0]?.id ?? null;
   }
 
-  const storedCore = localStorage.getItem(
-    `player:${rom.value.platform_slug}:core`,
-  );
-  if (storedCore) {
+  // Prefer the core saved for this game, falling back to the platform default
+  const storedCore =
+    localStorage.getItem(`player:${rom.value.id}:core`) ??
+    localStorage.getItem(`player:${rom.value.platform_slug}:core`);
+  if (storedCore && supportedCores.value.includes(storedCore)) {
     selectedCore.value = storedCore;
   } else {
     selectedCore.value = supportedCores.value[0];

--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -199,11 +199,14 @@ onMounted(() => {
   }
 
   if (props.core) {
+    // Remember the core per-game, and per-platform as the fallback default
+    localStorage.setItem(`player:${romRef.value.id}:core`, props.core);
     localStorage.setItem(
       `player:${romRef.value.platform_slug}:core`,
       props.core,
     );
   } else {
+    localStorage.removeItem(`player:${romRef.value.id}:core`);
     localStorage.removeItem(`player:${romRef.value.platform_slug}:core`);
   }
 


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Just like the selected emulator core is saved in localStorage per-platform, this now also saves the selected core **per-game**, and falls back to the per-platform core when a game has no saved core.

Fallback chain: **per-game core → per-platform core → first supported core**.

Closes #2042

Changes:
- **`Player.vue`** (write, shared by v1 + v2): when a core is chosen, writes both `player:${rom.id}:core` (per-game) and `player:${rom.platform_slug}:core` (per-platform, kept as the default for new games on that platform). Removal clears both.
- **`v2/views/Player/EmulatorJS.vue`** (read): reads the per-game core first, falls back to the per-platform core, then the first supported core. Added a `supportedCores` validity check so a stale/unsupported saved core can't stick.
- **`console/views/Play.vue`** (read): added a `gameCore` storage ref and prefers it over the platform core, both validated against the supported list.

The v1 `Base.vue` read is intentionally left untouched to honor the v1 freeze; it still reads the per-platform key (unchanged behavior). The feature is fully functional in v2 and the console.

**AI assistance disclosure**: This change was implemented with AI assistance (PostHog Code / Claude). All code was reviewed before submission.

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*