### PR TITLE
perf(v2): use static background SVG in Firefox to stop GPU repaint

### DIFF
--- a/frontend/src/v2/components/AppShell/BackgroundArt.vue
+++ b/frontend/src/v2/components/AppShell/BackgroundArt.vue
@@ -14,23 +14,19 @@ defineProps<{
 
 <template>
   <div class="r-v2-bg">
+    <!-- Fallback art (no cover) comes from the CSS `background-image` on
+         `.r-v2-bg__layer` so Firefox can swap it for the static variant via
+         `@-moz-document`; an inline style here would win over that override.
+         A real cover URL still sets the inline background-image. -->
     <div
       class="r-v2-bg__layer r-v2-bg__layer--a"
       :class="{ 'r-v2-bg__layer--active': activeLayer === 'a' }"
-      :style="
-        layerA
-          ? { backgroundImage: `url('${layerA}')` }
-          : { backgroundImage: `url('/assets/auth_background.svg')` }
-      "
+      :style="layerA ? { backgroundImage: `url('${layerA}')` } : {}"
     />
     <div
       class="r-v2-bg__layer r-v2-bg__layer--b"
       :class="{ 'r-v2-bg__layer--active': activeLayer === 'b' }"
-      :style="
-        layerB
-          ? { backgroundImage: `url('${layerB}')` }
-          : { backgroundImage: `url('/assets/auth_background.svg')` }
-      "
+      :style="layerB ? { backgroundImage: `url('${layerB}')` } : {}"
     />
   </div>
   <div class="r-v2-bg__overlay" />

--- a/frontend/src/v2/layouts/AuthLayout.vue
+++ b/frontend/src/v2/layouts/AuthLayout.vue
@@ -76,6 +76,15 @@ onMounted(installInputModality);
   z-index: 0;
 }
 
+/* Firefox: WebRender re-rasterizes the animated SVG every frame, pegging the
+   GPU. Swap to the static variant in Gecko only (the empty `url-prefix()`
+   hack matches all Firefox pages and stays enabled by default). */
+@-moz-document url-prefix() {
+  .r-v2-auth__bg {
+    background-image: url("/assets/auth_background_static.svg");
+  }
+}
+
 .r-v2-auth__stage {
   position: relative;
   z-index: 1;

--- a/frontend/src/v2/styles/global.css
+++ b/frontend/src/v2/styles/global.css
@@ -145,6 +145,9 @@ html[data-input="pad"] .r-v2 * {
 .r-v2-bg__layer {
   position: absolute;
   inset: 0;
+  /* Fallback art when no cover is set (settings, admin, etc.). Kept in CSS
+     rather than inline so Firefox can swap it for the static variant below. */
+  background-image: url("/assets/auth_background.svg");
   background-size: cover;
   background-position: center 20%;
   background-repeat: no-repeat;
@@ -152,6 +155,17 @@ html[data-input="pad"] .r-v2 * {
   transform: scale(1.08);
   transition: opacity 0.7s ease;
   will-change: opacity;
+}
+
+/* Firefox: the animated fallback SVG is re-rasterized every frame under the
+   28px blur (and re-sampled by every backdrop-filter surface), pegging the
+   WebRender backend. Use the static variant in Gecko only (the empty
+   `url-prefix()` hack matches all Firefox pages and stays enabled by
+   default). Cover art is raster, so it's unaffected. */
+@-moz-document url-prefix() {
+  .r-v2-bg__layer {
+    background-image: url("/assets/auth_background_static.svg");
+  }
 }
 
 .r-v2-bg__layer--a {

--- a/frontend/src/v2/views/DevicePairShell.vue
+++ b/frontend/src/v2/views/DevicePairShell.vue
@@ -52,6 +52,15 @@ import DevicePair from "@/v2/views/DevicePair.vue";
   z-index: 0;
 }
 
+/* Firefox: WebRender re-rasterizes the animated SVG every frame, pegging the
+   GPU. Swap to the static variant in Gecko only (the empty `url-prefix()`
+   hack matches all Firefox pages and stays enabled by default). */
+@-moz-document url-prefix() {
+  .r-v2-devpair-shell__bg {
+    background-image: url("/assets/auth_background_static.svg");
+  }
+}
+
 .r-v2-devpair-shell__stage {
   position: relative;
   z-index: 1;

--- a/frontend/src/v2/views/PairShell.vue
+++ b/frontend/src/v2/views/PairShell.vue
@@ -39,6 +39,15 @@ import Pair from "@/v2/views/Pair.vue";
   z-index: 0;
 }
 
+/* Firefox: WebRender re-rasterizes the animated SVG every frame, pegging the
+   GPU. Swap to the static variant in Gecko only (the empty `url-prefix()`
+   hack matches all Firefox pages and stays enabled by default). */
+@-moz-document url-prefix() {
+  .r-v2-pair-shell__bg {
+    background-image: url("/assets/auth_background_static.svg");
+  }
+}
+
 .r-v2-pair-shell__stage {
   position: relative;
   z-index: 1;


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

In Firefox, loading any v2 page pegged the renderer/GPU (WebRender backend saturated, continuous 80-100% peaks), worst on `/administration`.

Root cause: `assets/auth_background.svg` contains two infinite CSS animations (`leftMove`/`rightMove`, `15s ... infinite`). Rendered as a full-viewport `background-image` under a 28px blur and re-sampled by every `backdrop-filter` surface, Firefox's WebRender re-rasterizes the whole viewport every frame. It is worst on pages that fall back to this art (settings, administration) because they call `setBgArt(null)`, so both background layers show the animated SVG; other pages show static cover art. The animation never surfaced in `document.getAnimations()` because animations inside a `background-image` SVG live in a separate document.

Fix: swap to the already-existing static variant (`auth_background_static.svg`) in Firefox only, via the `@-moz-document url-prefix()` hack, the same pattern v1's `Auth.vue` already uses. Every other browser keeps the animation. Applied to all four v2 surfaces that use this art (app background, auth, pair, device-pair). The app background fallback is moved from an inline style into CSS so the Firefox override can take effect; cover art (raster) is unaffected.

Verified: `npm run typecheck` clean, `npm run build` succeeds and the `@-moz-document` blocks survive minification with the static (non-animated) SVG inlined, `trunk fmt` clean.

**AI assistance disclosure**: This change was investigated and implemented with the assistance of an AI agent (PostHog Code / Claude), including the profiling analysis, root-cause diagnosis, and the code changes, all reviewed by the author.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A (visual output is unchanged in Chrome/Safari; Firefox shows the static variant of the same artwork).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*