### PR TITLE
fix(roms): enforce parent ROM visibility on direct file endpoints

### DIFF
--- a/backend/endpoints/roms/files.py
+++ b/backend/endpoints/roms/files.py
@@ -10,6 +10,7 @@ from config import DEV_MODE, DISABLE_DOWNLOAD_ENDPOINT_AUTH
 from decorators.auth import protected_route
 from endpoints.responses.rom import RomFileSchema
 from handler.auth.constants import Scope
+from handler.auth.dependencies import assert_rom_visible
 from handler.database import db_rom_handler
 from handler.filesystem import fs_rom_handler
 from logger.formatter import BLUE
@@ -42,6 +43,16 @@ async def get_romfile(
             detail="File not found",
         )
 
+    # Resolve back to the parent rom and enforce its visibility, so a file
+    # belonging to a hidden rom can't be read by direct RomFile.id.
+    rom = db_rom_handler.get_rom(file.rom_id)
+    if not rom:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="File not found",
+        )
+    assert_rom_visible(request, rom, not_found_detail="File not found")
+
     return RomFileSchema.model_validate(file)
 
 
@@ -68,6 +79,16 @@ async def get_romfile_content(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="File not found",
         )
+
+    # 404-mask file bytes of roms hidden from the caller: resolve the parent
+    # rom and apply its visibility before serving any content.
+    rom = db_rom_handler.get_rom(file.rom_id)
+    if not rom:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="File not found",
+        )
+    assert_rom_visible(request, rom, not_found_detail="File not found")
 
     log.info(
         f"User {hl(current_username, color=BLUE)} is downloading {hl(file.file_name)}"

--- a/backend/tests/endpoints/roms/test_rom.py
+++ b/backend/tests/endpoints/roms/test_rom.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from config.config_manager import MetadataMediaType
 from handler.database import db_collection_handler, db_rom_handler
+from handler.database.base_handler import sync_session
 from handler.filesystem.resources_handler import FSResourcesHandler
 from handler.filesystem.roms_handler import FSRomsHandler
 from handler.metadata.flashpoint_handler import FlashpointHandler, FlashpointRom
@@ -16,6 +17,7 @@ from handler.metadata.moby_handler import MobyGamesHandler, MobyGamesRom
 from handler.metadata.ra_handler import RAGameRom, RAHandler
 from handler.metadata.ss_handler import SSHandler, SSRom
 from models.collection import Collection
+from models.permission import HiddenEntity, PermEntity
 from models.platform import Platform
 from models.rom import Rom, RomFile, compute_name_sort_key
 from models.user import User
@@ -314,6 +316,50 @@ def test_get_rom_content_missing_rom_returns_404(client: TestClient, access_toke
         "/api/roms/999999/content/missing.zip",
         headers={"Authorization": f"Bearer {access_token}"},
         follow_redirects=False,
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def _hide_rom_for_user(rom_id: int, user_id: int) -> None:
+    with sync_session.begin() as s:
+        s.add(HiddenEntity(entity=PermEntity.ROMS, entity_id=rom_id, user_id=user_id))
+
+
+def test_get_romfile_content_visible_rom(
+    client: TestClient, viewer_access_token: str, rom: Rom, rom_file
+):
+    # Baseline: a rom the viewer can see is downloadable by direct RomFile.id.
+    response = client.get(
+        f"/api/roms/{rom_file.id}/files/content/whatever.bin",
+        headers={"Authorization": f"Bearer {viewer_access_token}"},
+        follow_redirects=False,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert "X-Accel-Redirect" in response.headers
+
+
+def test_get_romfile_content_hidden_rom_returns_404(
+    client: TestClient, viewer_access_token: str, viewer_user, rom: Rom, rom_file
+):
+    # A file belonging to a hidden rom must 404 even by direct RomFile.id,
+    # matching the ROM-level content endpoint (visibility-bypass regression).
+    _hide_rom_for_user(rom.id, viewer_user.id)
+    response = client.get(
+        f"/api/roms/{rom_file.id}/files/content/whatever.bin",
+        headers={"Authorization": f"Bearer {viewer_access_token}"},
+        follow_redirects=False,
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_get_romfile_hidden_rom_returns_404(
+    client: TestClient, viewer_access_token: str, viewer_user, rom: Rom, rom_file
+):
+    # The file metadata endpoint must not leak files of a hidden rom either.
+    _hide_rom_for_user(rom.id, viewer_user.id)
+    response = client.get(
+        f"/api/roms/{rom_file.id}/files",
+        headers={"Authorization": f"Bearer {viewer_access_token}"},
     )
     assert response.status_code == status.HTTP_404_NOT_FOUND
 


### PR DESCRIPTION
**Description**

The direct ROM-file endpoints in `backend/endpoints/roms/files.py` resolved a `RomFile` purely by its user-supplied `id` and never mapped it back to the parent `Rom`, so they skipped the hidden ROM/platform visibility policy:

- `GET /api/roms/{id}/files/content/{file_name}` (`get_romfile_content`) served the file bytes (via nginx `X-Accel-Redirect` in production).
- `GET /api/roms/{id}/files` (`get_romfile`) returned the file metadata.

An authenticated user with only `roms.read` could download or inspect a file belonging to a ROM hidden from them by knowing or guessing the `RomFile.id`, even though the ROM-level endpoints (`/api/roms/{id}`, `/api/roms/{id}/content/...`) correctly return 404 for hidden ROMs.

**Fix**

Both handlers now resolve the parent `Rom` and call `assert_rom_visible(request, rom, not_found_detail="File not found")` before returning anything. This is the same 404-masking guard the ROM-level content endpoints use, and it matches the pattern already present in `patch.py` (`_resolve_library_patch`). `assert_rom_visible` no-ops for unauthenticated callers, so the `DISABLE_DOWNLOAD_ENDPOINT_AUTH` download path is unaffected.

**Tests**

Added three regression tests in `tests/endpoints/roms/test_rom.py`:

- `test_get_romfile_content_visible_rom` - baseline, a viewer can download a visible ROM's file by `RomFile.id` (200 + `X-Accel-Redirect`).
- `test_get_romfile_content_hidden_rom_returns_404` - a hidden ROM's file bytes now 404 by direct `RomFile.id`.
- `test_get_romfile_hidden_rom_returns_404` - the metadata endpoint no longer leaks a hidden ROM's file.

All 137 tests in the roms + permissions-resolver suites pass, and `trunk check` is clean.

**AI assistance disclosure**

This change was authored with AI assistance (PostHog Code / Claude): investigation of the affected endpoints, the fix, and the regression tests were AI-generated and human-reviewed.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*