### PR TITLE
fix(backend): correct M4A embedded cover extraction and validation

### DIFF
--- a/backend/endpoints/roms/soundtrack.py
+++ b/backend/endpoints/roms/soundtrack.py
@@ -205,7 +205,9 @@ async def add_rom_soundtracks(
             )
         else:
             log.error(f"[audio_tags] cover persist failed for {file_location}")
-            db_rom_handler.upsert_track_meta(saved.id, rom.id, {"has_embedded_cover": False})
+            db_rom_handler.upsert_track_meta(
+                saved.id, rom.id, {"has_embedded_cover": False}
+            )
 
     return Response(status_code=status.HTTP_201_CREATED)
 

--- a/backend/endpoints/roms/soundtrack.py
+++ b/backend/endpoints/roms/soundtrack.py
@@ -203,6 +203,9 @@ async def add_rom_soundtracks(
             db_rom_handler.upsert_track_meta(
                 saved.id, rom.id, {"cover_path": cover_path}
             )
+        else:
+            log.error(f"[audio_tags] cover persist failed for {file_location}")
+            db_rom_handler.upsert_track_meta(saved.id, rom.id, {"has_embedded_cover": False})
 
     return Response(status_code=status.HTTP_201_CREATED)
 

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -159,6 +159,11 @@ def persist_soundtrack_cover(rom_file: RomFile, rom: Rom) -> None:
         db_rom_handler.upsert_track_meta(
             rom_file.id, rom.id, {"cover_path": cover_path}
         )
+    else:
+        log.error(f"[audio_tags] cover persist failed for {abs_audio_path}")
+        db_rom_handler.upsert_track_meta(
+            rom_file.id, rom.id, {"has_embedded_cover": False}
+        )
 
 
 async def scan_platform(

--- a/backend/tests/utils/test_audio_tags.py
+++ b/backend/tests/utils/test_audio_tags.py
@@ -1,11 +1,14 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import pytest
 from mutagen.mp4 import MP4, MP4Cover
 
 from utils.audio_tags import (
+    _allowed_mime_types,
     _extract_picture_from_mp4,
     _parse_leading_int,
     _parse_year,
+    persist_embedded_cover,
     track_meta_columns,
 )
 
@@ -105,14 +108,14 @@ class TestExtractPictureFromMp4:
         return audio
 
     def test_jpeg_cover(self):
-        cover_data = b"\xff\xd8\xff fake jpeg"
+        cover_data = b"\xff\xd8\xff\xe0\x00\x10JFIF"
         audio = self._mp4_with_covers(
             [MP4Cover(cover_data, imageformat=MP4Cover.FORMAT_JPEG)]
         )
         assert _extract_picture_from_mp4(audio) == (cover_data, "image/jpeg")
 
     def test_png_cover(self):
-        cover_data = b"\x89PNG fake png"
+        cover_data = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
         audio = self._mp4_with_covers(
             [MP4Cover(cover_data, imageformat=MP4Cover.FORMAT_PNG)]
         )
@@ -126,3 +129,51 @@ class TestExtractPictureFromMp4:
     def test_empty_covr_list(self):
         audio = self._mp4_with_covers([])
         assert _extract_picture_from_mp4(audio) is None
+
+    def test_unknown_format_sniffs_jpeg(self):
+        cover_data = b"\xff\xd8\xff\xe0\x00\x10JFIF"
+        audio = self._mp4_with_covers([MP4Cover(cover_data)])
+        assert _extract_picture_from_mp4(audio) == (cover_data, "image/jpeg")
+
+    def test_rejects_gif_labeled_as_jpeg(self):
+        cover_data = b"GIF89a\x00\x00\x01\x00\x01"
+        audio = self._mp4_with_covers(
+            [MP4Cover(cover_data, imageformat=MP4Cover.FORMAT_JPEG)]
+        )
+        with pytest.raises(ValueError, match="JPEG or PNG"):
+            _extract_picture_from_mp4(audio)
+
+
+class TestAllowedMimeTypes:
+    def test_sniffs_png(self):
+        data = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+        assert _allowed_mime_types(data) == "image/png"
+
+    def test_sniffs_jpeg(self):
+        data = b"\xff\xd8\xff\xe0\x00\x10JFIF"
+        assert _allowed_mime_types(data) == "image/jpeg"
+
+    def test_rejects_gif(self):
+        with pytest.raises(ValueError, match="JPEG or PNG"):
+            _allowed_mime_types(b"GIF89a")
+
+
+class TestPersistEmbeddedCover:
+    def test_extraction_failure_returns_none_without_raising(self):
+        """A cover that fails to extract (e.g. unsupported format) must not
+        raise out of persist_embedded_cover, and must not be written to disk."""
+        with (
+            patch(
+                "utils.audio_tags.extract_embedded_cover",
+                side_effect=ValueError("embedded cover is not JPEG or PNG"),
+            ),
+            patch("builtins.open") as mock_open,
+        ):
+            result = persist_embedded_cover(
+                audio_full_path="/fake/track.m4a",
+                platform_id=1,
+                rom_id=1,
+                file_id=1,
+            )
+        assert result is None
+        mock_open.assert_not_called()

--- a/backend/tests/utils/test_audio_tags.py
+++ b/backend/tests/utils/test_audio_tags.py
@@ -1,4 +1,9 @@
+from unittest.mock import MagicMock
+
+from mutagen.mp4 import MP4, MP4Cover
+
 from utils.audio_tags import (
+    _extract_picture_from_mp4,
     _parse_leading_int,
     _parse_year,
     track_meta_columns,
@@ -91,3 +96,33 @@ class TestTrackMetaColumns:
         cols = track_meta_columns({"title": "x" * 1000, "genre": "y" * 1000})
         assert len(cols["title"]) == 512
         assert len(cols["genre"]) == 255
+
+
+class TestExtractPictureFromMp4:
+    def _mp4_with_covers(self, covers: list[MP4Cover] | None) -> MP4:
+        audio = MagicMock(spec=MP4)
+        audio.tags = {"covr": covers} if covers is not None else None
+        return audio
+
+    def test_jpeg_cover(self):
+        cover_data = b"\xff\xd8\xff fake jpeg"
+        audio = self._mp4_with_covers(
+            [MP4Cover(cover_data, imageformat=MP4Cover.FORMAT_JPEG)]
+        )
+        assert _extract_picture_from_mp4(audio) == (cover_data, "image/jpeg")
+
+    def test_png_cover(self):
+        cover_data = b"\x89PNG fake png"
+        audio = self._mp4_with_covers(
+            [MP4Cover(cover_data, imageformat=MP4Cover.FORMAT_PNG)]
+        )
+        assert _extract_picture_from_mp4(audio) == (cover_data, "image/png")
+
+    def test_no_covr_tag(self):
+        audio = MagicMock(spec=MP4)
+        audio.tags = None
+        assert _extract_picture_from_mp4(audio) is None
+
+    def test_empty_covr_list(self):
+        audio = self._mp4_with_covers([])
+        assert _extract_picture_from_mp4(audio) is None

--- a/backend/utils/audio_tags.py
+++ b/backend/utils/audio_tags.py
@@ -8,7 +8,7 @@ from typing import Any, TypedDict
 import mutagen
 from mutagen.flac import FLAC, Picture
 from mutagen.id3 import APIC, ID3
-from mutagen.mp4 import MP4
+from mutagen.mp4 import MP4, MP4Cover
 from mutagen.oggopus import OggOpus
 from mutagen.oggvorbis import OggVorbis
 
@@ -292,7 +292,7 @@ def _extract_picture_from_mp4(audio: MP4) -> tuple[bytes, str] | None:
         return None
     cover = covers[0]
     fmt = getattr(cover, "imageformat", None)
-    mime = "image/png" if fmt == MP4.Cover.FORMAT_PNG else "image/jpeg"
+    mime = "image/png" if fmt == MP4Cover.FORMAT_PNG else "image/jpeg"
     return bytes(cover), mime
 
 
@@ -355,20 +355,27 @@ def remove_persisted_cover(cover_path: str | None) -> None:
 
 
 def extract_embedded_cover(full_path: str) -> tuple[bytes, str] | None:
-    """Return (image_bytes, mime_type) for the first embedded picture, or None."""
+    """Return (image_bytes, mime_type) for the first embedded picture, or None.
+
+    Never raises — on any failure we log and return None so the upload path
+    keeps moving even when cover extraction fails.
+    """
     audio = _open_mutagen(full_path)
     if audio is None:
         return None
 
-    if isinstance(audio, FLAC):
-        return _extract_picture_from_flac(audio)
-    if isinstance(audio, (OggVorbis, OggOpus)):
-        return _extract_picture_from_ogg(audio)
-    if isinstance(audio, MP4):
-        return _extract_picture_from_mp4(audio)
+    try:
+        if isinstance(audio, FLAC):
+            return _extract_picture_from_flac(audio)
+        if isinstance(audio, (OggVorbis, OggOpus)):
+            return _extract_picture_from_ogg(audio)
+        if isinstance(audio, MP4):
+            return _extract_picture_from_mp4(audio)
 
-    tags = getattr(audio, "tags", None)
-    if isinstance(tags, ID3):
-        return _extract_picture_from_id3(tags)
+        tags = getattr(audio, "tags", None)
+        if isinstance(tags, ID3):
+            return _extract_picture_from_id3(tags)
+    except Exception as exc:
+        log.warning(f"[audio_tags] cover extract failed for {full_path}: {exc}")
 
     return None

--- a/backend/utils/audio_tags.py
+++ b/backend/utils/audio_tags.py
@@ -8,7 +8,7 @@ from typing import Any, TypedDict
 import mutagen
 from mutagen.flac import FLAC, Picture
 from mutagen.id3 import APIC, ID3
-from mutagen.mp4 import MP4, MP4Cover
+from mutagen.mp4 import MP4
 from mutagen.oggopus import OggOpus
 from mutagen.oggvorbis import OggVorbis
 
@@ -140,6 +140,15 @@ def _mp4_track_tuple(value: object) -> str | None:
     return str(first)
 
 
+def _allowed_mime_types(data: bytes) -> str:
+    """Return MIME type for embedded cover bytes; only JPEG and PNG are allowed."""
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    raise ValueError("embedded cover is not JPEG or PNG")
+
+
 # NOTE: the per-format tag and embedded-cover handling below (ID3 / MP4 /
 # Vorbis comments / FLAC pictures) was largely AI-generated against mutagen's
 # API — verify against real files when adding or changing a format.
@@ -261,14 +270,14 @@ def extract_audio_meta(full_path: str) -> AudioTags | None:
 def _extract_picture_from_id3(tags: ID3) -> tuple[bytes, str] | None:
     for frame in tags.values():
         if isinstance(frame, APIC):
-            return frame.data, frame.mime or "image/jpeg"
+            return frame.data, _allowed_mime_types(frame.data)
     return None
 
 
 def _extract_picture_from_flac(audio: FLAC) -> tuple[bytes, str] | None:
     if audio.pictures:
         pic = audio.pictures[0]
-        return pic.data, pic.mime or "image/jpeg"
+        return pic.data, _allowed_mime_types(pic.data)
     return None
 
 
@@ -282,7 +291,7 @@ def _extract_picture_from_ogg(audio: OggVorbis | OggOpus) -> tuple[bytes, str] |
         except Exception as exc:
             log.debug(f"[audio_tags] ogg picture decode failed: {exc}")
             continue
-        return pic.data, pic.mime or "image/jpeg"
+        return pic.data, _allowed_mime_types(pic.data)
     return None
 
 
@@ -291,9 +300,8 @@ def _extract_picture_from_mp4(audio: MP4) -> tuple[bytes, str] | None:
     if not covers:
         return None
     cover = covers[0]
-    fmt = getattr(cover, "imageformat", None)
-    mime = "image/png" if fmt == MP4Cover.FORMAT_PNG else "image/jpeg"
-    return bytes(cover), mime
+    data = bytes(cover)
+    return data, _allowed_mime_types(data)
 
 
 def _ext_for_mime(mime: str) -> str:
@@ -317,7 +325,11 @@ def persist_embedded_cover(
     track_meta.cover_path), or None if no cover or write failed."""
     from config import RESOURCES_BASE_PATH
 
-    cover = extract_embedded_cover(audio_full_path)
+    try:
+        cover = extract_embedded_cover(audio_full_path)
+    except Exception as exc:
+        log.error(f"[audio_tags] cover extract failed for {audio_full_path}: {exc}")
+        return None
     if cover is None:
         return None
 
@@ -355,27 +367,25 @@ def remove_persisted_cover(cover_path: str | None) -> None:
 
 
 def extract_embedded_cover(full_path: str) -> tuple[bytes, str] | None:
-    """Return (image_bytes, mime_type) for the first embedded picture, or None.
+    """Return (image_bytes, mime_type) for the first embedded picture, or None
+    if the file has no embedded cover.
 
-    Never raises — on any failure we log and return None so the upload path
-    keeps moving even when cover extraction fails.
+    Raises if a cover is present but cannot be read (e.g. an unsupported
+    image format) so callers can tell that failure apart from "no cover".
     """
     audio = _open_mutagen(full_path)
     if audio is None:
         return None
 
-    try:
-        if isinstance(audio, FLAC):
-            return _extract_picture_from_flac(audio)
-        if isinstance(audio, (OggVorbis, OggOpus)):
-            return _extract_picture_from_ogg(audio)
-        if isinstance(audio, MP4):
-            return _extract_picture_from_mp4(audio)
+    if isinstance(audio, FLAC):
+        return _extract_picture_from_flac(audio)
+    if isinstance(audio, (OggVorbis, OggOpus)):
+        return _extract_picture_from_ogg(audio)
+    if isinstance(audio, MP4):
+        return _extract_picture_from_mp4(audio)
 
-        tags = getattr(audio, "tags", None)
-        if isinstance(tags, ID3):
-            return _extract_picture_from_id3(tags)
-    except Exception as exc:
-        log.warning(f"[audio_tags] cover extract failed for {full_path}: {exc}")
+    tags = getattr(audio, "tags", None)
+    if isinstance(tags, ID3):
+        return _extract_picture_from_id3(tags)
 
     return None


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
When uploading a soundtrack in `.m4a` format, the embedded cover doesn't show up because has error extracting the cover.

This PR Fixes embedded soundtrack cover handling for `.m4a` and other audio formats.
1. **Broken M4A extraction** — `_extract_picture_from_mp4` referenced a non-existent `MP4.Cover` attribute, causing cover extraction to fail on valid M4A files. Cover MIME is now derived from the actual image bytes instead of broken or unreliable container metadata.
2. **Mislabeled cover bytes** — non-JPEG/PNG covers (e.g. GIF, or entries with missing/wrong format metadata) were persisted as `image/jpeg` with a `.jpg` extension, so clients could not render them. Embedded cover bytes are now validated via magic-byte sniffing; only JPEG and PNG are accepted.
3. **Silent cover drops** — when `has_embedded_cover` was true but extraction or persistence failed, the track was saved with missing cover art and incorrect metadata. Upload and scan callers now log the failure and set `has_embedded_cover=False`.



**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)
N/A (backend-only fix)

---

## AI assistance disclosure
This PR was developed with Cursor AI assistance (writing unit tests and MIME type detection). 
I verified the fix against real M4A, FLAC, MP3, OGG and WAV files.
