### PR TITLE
fix(scan): keep scanning when SteamGridDB or a hash-match provider fails

### DIFF
--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -1,6 +1,7 @@
 import asyncio
 import enum
 import functools
+from collections.abc import Awaitable, Sequence
 from typing import Any
 
 import socketio  # type: ignore
@@ -159,6 +160,34 @@ def persist_soundtrack_cover(rom_file: RomFile, rom: Rom) -> None:
         db_rom_handler.upsert_track_meta(
             rom_file.id, rom.id, {"cover_path": cover_path}
         )
+
+
+async def _gather_provider_fetches(
+    fetches: Sequence[tuple[Awaitable[Any], Any]],
+    fs_name: str,
+) -> list[Any]:
+    """Run provider fetches concurrently, swapping any that raise for their
+    fallback so one provider failing never discards the others' results."""
+    results = await asyncio.gather(
+        *(coro for coro, _ in fetches), return_exceptions=True
+    )
+
+    resolved: list[Any] = []
+    for (_, fallback), result in zip(fetches, results, strict=True):
+        if isinstance(result, BaseException):
+            # Never swallow cancellation or other non-Exception signals.
+            if not isinstance(result, Exception):
+                raise result
+            log.error(
+                f"Error fetching {hl(fallback.__class__.__name__)} metadata for "
+                f"{hl(fs_name)}: {result}",
+                extra=LOGGER_MODULE_NAME,
+            )
+            resolved.append(fallback)
+        else:
+            resolved.append(result)
+
+    return resolved
 
 
 async def scan_platform(
@@ -466,13 +495,36 @@ async def scan_rom(
             },
         )
 
-    # Run hash fetches concurrently
+    # Run hash fetches concurrently. One provider raising must not discard the
+    # other's result for this ROM, so each failure falls back to an empty match.
     (
         playmatch_hash_match,
         hasheous_hash_match,
-    ) = await asyncio.gather(
-        fetch_playmatch_hash_match(),
-        fetch_hasheous_hash_match(),
+    ) = await _gather_provider_fetches(
+        (
+            (
+                fetch_playmatch_hash_match(),
+                PlaymatchRomMatch(
+                    igdb_id=None,
+                    moby_id=None,
+                    ss_id=None,
+                    launchbox_id=None,
+                    sgdb_id=None,
+                    ra_id=None,
+                    hasheous_id=None,
+                    tgdb_id=None,
+                    flashpoint_id=None,
+                    hltb_id=None,
+                    libretro_id=None,
+                    gamelist_id=None,
+                ),
+            ),
+            (
+                fetch_hasheous_hash_match(),
+                HasheousRom(hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None),
+            ),
+        ),
+        str(rom_attrs["fs_name"]),
     )
 
     async def fetch_igdb_rom(
@@ -838,23 +890,9 @@ async def scan_rom(
         (fetch_gamelist_rom(), GamelistRom(gamelist_id=None)),
         (fetch_libretro_rom(), LibretroRom(libretro_id=None)),
     )
-    fetch_results = await asyncio.gather(
-        *(coro for coro, _ in provider_fetches), return_exceptions=True
+    resolved = await _gather_provider_fetches(
+        provider_fetches, str(rom_attrs["fs_name"])
     )
-
-    resolved: list[Any] = []
-    for (_, fallback), result in zip(provider_fetches, fetch_results, strict=True):
-        if isinstance(result, BaseException):
-            if not isinstance(result, Exception):
-                raise result
-            provider = fallback.__class__.__name__
-            log.error(
-                f"Error fetching {hl(provider)} metadata for {hl(rom_attrs['fs_name'])}: {result}",
-                extra=LOGGER_MODULE_NAME,
-            )
-            resolved.append(fallback)
-        else:
-            resolved.append(result)
 
     (
         igdb_handler_rom,
@@ -1084,7 +1122,12 @@ async def scan_rom(
 
         return SGDBRom(sgdb_id=None)
 
-    sgdb_hander_rom = await fetch_sgdb_details(playmatch_hash_match)
+    # SteamGridDB runs after the other providers (it reuses their resolved
+    # names), so a failure here must not discard the metadata already gathered.
+    (sgdb_hander_rom,) = await _gather_provider_fetches(
+        ((fetch_sgdb_details(playmatch_hash_match), SGDBRom(sgdb_id=None)),),
+        str(rom_attrs["fs_name"]),
+    )
     if sgdb_hander_rom.get("sgdb_id"):
         rom_attrs["sgdb_id"] = sgdb_hander_rom["sgdb_id"]
 

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -9,6 +9,7 @@ from handler.metadata import (
     meta_moby_handler,
     meta_playmatch_handler,
     meta_ra_handler,
+    meta_sgdb_handler,
     meta_ss_handler,
 )
 from handler.metadata.hasheous_handler import HasheousRom
@@ -625,3 +626,86 @@ async def test_scan_rom_provider_error_does_not_discard_others(
     # MobyGames blew up, but ScreenScraper's match survived.
     assert result.ss_id == 321
     assert result.moby_id is None
+
+
+@patch.object(meta_playmatch_handler, "is_enabled", return_value=False)
+@patch.object(meta_sgdb_handler, "get_details_by_names", new_callable=AsyncMock)
+@patch.object(meta_ss_handler, "lookup_rom", new_callable=AsyncMock)
+async def test_scan_rom_sgdb_error_does_not_abort_scan(
+    mock_ss_lookup, mock_sgdb_details, mock_playmatch_enabled
+):
+    """SteamGridDB runs after the other providers; a failure there (issue #2236)
+    must not abort the scan or discard the metadata already gathered."""
+    mock_ss_lookup.return_value = (SSRom(ss_id=321, name="Match"), False)
+    mock_sgdb_details.side_effect = ValueError("boom")
+
+    platform = _ss_quota_platform()
+    rom = db_rom_handler.add_rom(
+        Rom(platform_id=platform.id, fs_name="game.sfc", fs_path="snes", tags=[])
+    )
+
+    async with initialize_context():
+        result = await scan_rom(
+            platform=platform,
+            scan_type=ScanType.QUICK,
+            rom=rom,
+            fs_rom=_ss_quota_fs_rom("game.sfc"),
+            metadata_sources=[MetadataSource.SS, MetadataSource.SGDB],
+            newly_added=True,
+        )
+
+    # SteamGridDB was attempted and blew up, but the ROM kept ScreenScraper's match.
+    mock_sgdb_details.assert_awaited_once()
+    assert type(result) is Rom
+    assert result.ss_id == 321
+    assert result.sgdb_id is None
+
+
+@patch.object(meta_playmatch_handler, "is_enabled", return_value=False)
+@patch.object(meta_hasheous_handler, "get_ra_game", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "get_igdb_game", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "lookup_rom", new_callable=AsyncMock)
+@patch.object(meta_ss_handler, "lookup_rom", new_callable=AsyncMock)
+async def test_scan_rom_hash_match_error_does_not_abort_scan(
+    mock_ss_lookup,
+    mock_hasheous_lookup,
+    mock_hasheous_igdb,
+    mock_hasheous_ra,
+    mock_playmatch_enabled,
+):
+    """A failure in the concurrent hash-match step (e.g. Hasheous unreachable,
+    issue #2236) must not abort the scan for the ROM."""
+    mock_hasheous_lookup.side_effect = ValueError("boom")
+    mock_hasheous_igdb.return_value = {}
+    mock_hasheous_ra.return_value = {}
+    mock_ss_lookup.return_value = (SSRom(ss_id=321, name="Match"), False)
+
+    platform = db_platform_handler.add_platform(
+        Platform(
+            id=1,
+            slug="snes",
+            fs_slug="snes",
+            name="Super Nintendo",
+            ss_id=4,
+            hasheous_id=7,
+        )
+    )
+    rom = db_rom_handler.add_rom(
+        Rom(platform_id=platform.id, fs_name="game.sfc", fs_path="snes", tags=[])
+    )
+
+    async with initialize_context():
+        result = await scan_rom(
+            platform=platform,
+            scan_type=ScanType.QUICK,
+            rom=rom,
+            fs_rom=_ss_quota_fs_rom("game.sfc"),
+            metadata_sources=[MetadataSource.HASHEOUS, MetadataSource.SS],
+            newly_added=True,
+        )
+
+    # The Hasheous hash lookup raised, but ScreenScraper still identified the ROM.
+    mock_hasheous_lookup.assert_awaited_once()
+    assert type(result) is Rom
+    assert result.ss_id == 321
+    assert result.hasheous_id is None


### PR DESCRIPTION
**Description**

When a metadata provider request fails mid-scan, the whole ROM scan aborts instead of skipping that provider (#2236). The main per-ROM provider gather was made fault-tolerant in #3620, but two provider sites in `scan_rom` were still awaited without exception handling:

- The concurrent hash-match step (Playmatch + Hasheous).
- The SteamGridDB fetch, which runs after the other providers. Because it runs last, its failure also discarded every other provider's already-fetched metadata for that ROM, and repeated on every subsequent ROM.

Both now go through a shared `_gather_provider_fetches` helper that gathers with `return_exceptions=True` and falls back to an empty match on failure (logged at error level), so one provider failing never discards the others' results or interrupts the scan. Cancellation and other non-Exception signals are re-raised.

Fixes #2236

> This PR was written primarily by Claude Code (code and tests).

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes