### PR TITLE
fix(backend): serve PDF/Markdown manuals inline so the viewer can render them

### DIFF
--- a/backend/endpoints/roms/files.py
+++ b/backend/endpoints/roms/files.py
@@ -111,6 +111,11 @@ async def get_romfile_content(
         media_type = "application/octet-stream"
         disposition = "attachment"
 
+    # Inline files are served under an explicit, trusted Content-Type; nosniff
+    # keeps the browser from sniffing them into anything script-capable (e.g. a
+    # Markdown manual into HTML).
+    headers = {"X-Content-Type-Options": "nosniff"} if disposition == "inline" else {}
+
     # Serve the file directly in development mode for emulatorjs
     if DEV_MODE:
         rom_path = fs_rom_handler.validate_path(file.full_path)
@@ -121,6 +126,7 @@ async def get_romfile_content(
             filename=file.file_name,
             media_type=media_type,
             content_disposition_type=disposition,
+            headers=headers,
         )
 
     # Otherwise proxy through nginx (which parses Range itself via X-Accel-Redirect)
@@ -128,4 +134,5 @@ async def get_romfile_content(
         download_path=Path(f"/library/{file.full_path}"),
         disposition=disposition,
         media_type=media_type,
+        headers=headers,
     )

--- a/backend/endpoints/roms/files.py
+++ b/backend/endpoints/roms/files.py
@@ -18,7 +18,11 @@ from logger.formatter import highlight as hl
 from logger.logger import log
 from models.rom import RomFileCategory
 from utils.audio_tags import guess_audio_media_type
-from utils.media_types import guess_media_file_type, is_allowed_media_file
+from utils.media_types import (
+    guess_media_file_type,
+    is_allowed_document_file,
+    is_allowed_media_file,
+)
 from utils.nginx import FileRedirectResponse
 from utils.router import APIRouter
 
@@ -103,6 +107,14 @@ async def get_romfile_content(
     # details view can render and seek them; everything else downloads.
     if file.category == RomFileCategory.SOUNDTRACK:
         media_type = guess_audio_media_type(file.file_name)
+        disposition = "inline"
+    elif file.category == RomFileCategory.MANUAL and is_allowed_document_file(
+        file.file_name
+    ):
+        # Only manuals are served inline as documents so the in-page viewer can
+        # render them; a game/extra file that happens to end in .pdf/.md still
+        # downloads.
+        media_type = guess_media_file_type(file.file_name)
         disposition = "inline"
     elif is_allowed_media_file(file.file_name):
         media_type = guess_media_file_type(file.file_name)

--- a/backend/tests/endpoints/roms/test_files.py
+++ b/backend/tests/endpoints/roms/test_files.py
@@ -72,6 +72,41 @@ def test_video_file_served_inline(
     assert r.headers["content-disposition"].startswith("inline")
 
 
+def test_pdf_manual_served_inline(
+    client: TestClient, access_token: str, admin_user: User, platform: Platform
+):
+    rom = _make_rom(admin_user, platform)
+    file = _add_file(rom, "manual.pdf", RomFileCategory.MANUAL)
+
+    r = client.get(
+        f"/api/roms/{file.id}/files/content/manual.pdf",
+        headers=_auth(access_token),
+    )
+
+    assert r.status_code == status.HTTP_200_OK
+    assert r.headers["content-type"].startswith("application/pdf")
+    assert r.headers["content-disposition"].startswith("inline")
+    assert r.headers["x-content-type-options"] == "nosniff"
+
+
+def test_markdown_manual_served_inline(
+    client: TestClient, access_token: str, admin_user: User, platform: Platform
+):
+    rom = _make_rom(admin_user, platform)
+    file = _add_file(rom, "manual.md", RomFileCategory.MANUAL)
+
+    r = client.get(
+        f"/api/roms/{file.id}/files/content/manual.md",
+        headers=_auth(access_token),
+    )
+
+    assert r.status_code == status.HTTP_200_OK
+    assert r.headers["content-type"].startswith("text/markdown")
+    assert r.headers["content-disposition"].startswith("inline")
+    # nosniff keeps the browser from sniffing the Markdown into HTML.
+    assert r.headers["x-content-type-options"] == "nosniff"
+
+
 def test_rom_file_served_as_attachment(
     client: TestClient, access_token: str, admin_user: User, platform: Platform
 ):

--- a/backend/tests/endpoints/roms/test_files.py
+++ b/backend/tests/endpoints/roms/test_files.py
@@ -107,6 +107,24 @@ def test_markdown_manual_served_inline(
     assert r.headers["x-content-type-options"] == "nosniff"
 
 
+def test_non_manual_document_served_as_attachment(
+    client: TestClient, access_token: str, admin_user: User, platform: Platform
+):
+    # A game/extra file that happens to end in .pdf must still download; only
+    # manual-category documents are served inline.
+    rom = _make_rom(admin_user, platform)
+    file = _add_file(rom, "readme.pdf", RomFileCategory.GAME)
+
+    r = client.get(
+        f"/api/roms/{file.id}/files/content/readme.pdf",
+        headers=_auth(access_token),
+    )
+
+    assert r.status_code == status.HTTP_200_OK
+    assert r.headers["content-type"].startswith("application/octet-stream")
+    assert r.headers["content-disposition"].startswith("attachment")
+
+
 def test_rom_file_served_as_attachment(
     client: TestClient, access_token: str, admin_user: User, platform: Platform
 ):

--- a/backend/utils/media_types.py
+++ b/backend/utils/media_types.py
@@ -8,11 +8,14 @@ from typing import Final
 # browser) from the ROM download endpoint. Images and videos never execute
 # scripts, so serving them inline under an explicit, trusted Content-Type
 # avoids the content-sniffing/XSS risk that keeps arbitrary files served as
-# attachments.
+# attachments. Manuals (PDF/Markdown) are served inline too so the in-page
+# manual viewer can render them; the browser renders PDFs in a sandboxed
+# viewer and Markdown is served as text/markdown (never sniffed to HTML).
 ALLOWED_IMAGE_EXTENSIONS = frozenset(
     {".png", ".jpg", ".jpeg", ".webp", ".gif", ".tiff", ".tif", ".bmp", ".avif"}
 )
 ALLOWED_VIDEO_EXTENSIONS = frozenset({".mp4", ".webm", ".ogv", ".mov", ".m4v"})
+ALLOWED_DOCUMENT_EXTENSIONS = frozenset({".pdf", ".md"})
 
 # MIME types the stdlib mimetypes module guesses inconsistently (or not at
 # all) across platforms.
@@ -24,6 +27,8 @@ MEDIA_MIME_OVERRIDES = {
     ".webm": "video/webm",
     ".ogv": "video/ogg",
     ".mov": "video/quicktime",
+    ".pdf": "application/pdf",
+    ".md": "text/markdown",
 }
 
 # Image MIME types we trust to (a) accept as avatar uploads and (b) serve
@@ -50,9 +55,19 @@ def is_allowed_video_file(file_name: str) -> bool:
     return ext in ALLOWED_VIDEO_EXTENSIONS
 
 
+def is_allowed_document_file(file_name: str) -> bool:
+    """Whether a library file is a manual document the browser can render inline."""
+    ext = os.path.splitext(file_name)[1].lower()
+    return ext in ALLOWED_DOCUMENT_EXTENSIONS
+
+
 def is_allowed_media_file(file_name: str) -> bool:
-    """Whether a library file is an image/video the browser can render inline."""
-    return is_allowed_image_file(file_name) or is_allowed_video_file(file_name)
+    """Whether a library file is an image/video/document the browser can render inline."""
+    return (
+        is_allowed_image_file(file_name)
+        or is_allowed_video_file(file_name)
+        or is_allowed_document_file(file_name)
+    )
 
 
 def guess_media_file_type(file_name: str) -> str:

--- a/backend/utils/media_types.py
+++ b/backend/utils/media_types.py
@@ -62,12 +62,8 @@ def is_allowed_document_file(file_name: str) -> bool:
 
 
 def is_allowed_media_file(file_name: str) -> bool:
-    """Whether a library file is an image/video/document the browser can render inline."""
-    return (
-        is_allowed_image_file(file_name)
-        or is_allowed_video_file(file_name)
-        or is_allowed_document_file(file_name)
-    )
+    """Whether a library file is an image/video the browser can render inline."""
+    return is_allowed_image_file(file_name) or is_allowed_video_file(file_name)
 
 
 def guess_media_file_type(file_name: str) -> str:


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Uploaded manuals (a `RomFile` with `category="manual"`) are served from `GET /api/roms/{id}/files/content/{file_name}`. That endpoint only treated soundtracks and image/video files as inline media, so manuals fell through to `application/octet-stream` + `Content-Disposition: attachment`. The same URL is used for both viewing and downloading, so downloads and the nav chrome kept working while the in-page PDF/Markdown viewer got an octet-stream/attachment response and rendered a blank area.

This only affected manuals uploaded as extra files. Scraped/primary manuals (`rom.has_manual` + `rom.path_manual`) load from the static-asset path and were unaffected, which is why the bug reproduced for some libraries but not others.

Changes:

- Add `.pdf` and `.md` to `is_allowed_media_file` (via a new `ALLOWED_DOCUMENT_EXTENSIONS` / `is_allowed_document_file`), with explicit MIME overrides (`application/pdf`, `text/markdown`) so the content type is trustworthy across platforms. Manuals are now served inline.
- Set `X-Content-Type-Options: nosniff` on inline responses (both the dev `FileResponse` and the nginx `FileRedirectResponse`). SVG is deliberately kept out of the inline allowlist because it can carry script, so serving Markdown inline warrants the same care: `nosniff` prevents the browser from sniffing a `.md` manual into HTML.
- Add endpoint tests covering the previously-untested manual content path.

Fixes #3712

**AI assistance disclosure**
<sup>Per CONTRIBUTING.md.</sup>

This change was written with AI assistance (PostHog Code / Claude): investigation, code changes, and tests were AI-generated and human-reviewed.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
