### PR TITLE
fix(scan): make Hasheous and SteamGridDB scan lookups fault-tolerant in the metadata handlers

### DIFF
--- a/backend/handler/metadata/hasheous_handler.py
+++ b/backend/handler/metadata/hasheous_handler.py
@@ -232,6 +232,12 @@ class HasheousHandler(MetadataHandler):
         )
 
     async def lookup_rom(self, platform_slug: str, files: list[RomFile]) -> HasheousRom:
+        """Identify a ROM by its file hashes.
+
+        Returns a HasheousRom with the matched IDs, or an empty match if the
+        lookup fails. The lookup is best-effort and never raises to the caller,
+        so an unreachable Hasheous can't abort a scan.
+        """
         fallback_rom = HasheousRom(
             hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None
         )
@@ -280,14 +286,18 @@ class HasheousHandler(MetadataHandler):
             )
             return fallback_rom
 
-        hasheous_game = await self._request(
-            self.games_endpoint,
-            params={
-                "returnAllSources": "true",
-                "returnFields": "Signatures, Metadata, Attributes",
-            },
-            data=data,
-        )
+        try:
+            hasheous_game = await self._request(
+                self.games_endpoint,
+                params={
+                    "returnAllSources": "true",
+                    "returnFields": "Signatures, Metadata, Attributes",
+                },
+                data=data,
+            )
+        except Exception as exc:
+            log.error("Hasheous hash lookup failed, skipping: %s", exc)
+            return fallback_rom
 
         if not hasheous_game:
             return fallback_rom

--- a/backend/handler/metadata/sgdb_handler.py
+++ b/backend/handler/metadata/sgdb_handler.py
@@ -96,50 +96,64 @@ class SGDBBaseHandler(MetadataHandler):
         return list(filter(None, results))
 
     async def get_details_by_names(self, game_names: list[str]) -> SGDBRom:
+        """Get ROM details by candidate game names.
+
+        Returns an empty match if the lookup fails. The lookup is best-effort
+        and never raises to the caller, so an unreachable SteamGridDB can't
+        abort a scan.
+        """
         if not self.is_enabled():
             return SGDBRom(sgdb_id=None)
 
-        for game_name in game_names:
-            search_term = self.normalize_search_term(game_name, remove_articles=False)
-            games = await self.sgdb_service.search_games(term=search_term)
-            if not games:
-                log.debug(f"Could not find '{search_term}' on SteamGridDB")
-                continue
+        try:
+            for game_name in game_names:
+                search_term = self.normalize_search_term(
+                    game_name, remove_articles=False
+                )
+                games = await self.sgdb_service.search_games(term=search_term)
+                if not games:
+                    log.debug(f"Could not find '{search_term}' on SteamGridDB")
+                    continue
 
-            games_by_name: dict[str, SGDBGame] = {}
-            for game in games:
-                if (
-                    game["name"] not in games_by_name
-                    or game["id"] < games_by_name[game["name"]]["id"]
-                ):
-                    games_by_name[game["name"]] = game
+                games_by_name: dict[str, SGDBGame] = {}
+                for game in games:
+                    if (
+                        game["name"] not in games_by_name
+                        or game["id"] < games_by_name[game["name"]]["id"]
+                    ):
+                        games_by_name[game["name"]] = game
 
-            best_match, best_score = self.find_best_match(
-                search_term,
-                list(games_by_name.keys()),
-                min_similarity_score=self.min_similarity_score,
+                best_match, best_score = self.find_best_match(
+                    search_term,
+                    list(games_by_name.keys()),
+                    min_similarity_score=self.min_similarity_score,
+                )
+                if best_match:
+                    game_details = await self._get_game_covers(
+                        game_id=games_by_name[best_match]["id"],
+                        game_name=games_by_name[best_match]["name"],
+                        types=(SGDBType.STATIC,),
+                        is_nsfw=False,
+                        is_humor=False,
+                        is_epilepsy=False,
+                    )
+
+                    first_resource = next(
+                        (res for res in game_details["resources"] if res["url"]), None
+                    )
+                    if first_resource:
+                        log.debug(
+                            f"Found match for '{search_term}' -> '{best_match}' (score: {best_score:.3f})"
+                        )
+                        return SGDBRom(
+                            sgdb_id=games_by_name[best_match]["id"],
+                            url_cover=first_resource["url"],
+                        )
+        except Exception as e:
+            log.error(
+                f"Failed to fetch SteamGridDB details for '{', '.join(game_names)}': {e}"
             )
-            if best_match:
-                game_details = await self._get_game_covers(
-                    game_id=games_by_name[best_match]["id"],
-                    game_name=games_by_name[best_match]["name"],
-                    types=(SGDBType.STATIC,),
-                    is_nsfw=False,
-                    is_humor=False,
-                    is_epilepsy=False,
-                )
-
-                first_resource = next(
-                    (res for res in game_details["resources"] if res["url"]), None
-                )
-                if first_resource:
-                    log.debug(
-                        f"Found match for '{search_term}' -> '{best_match}' (score: {best_score:.3f})"
-                    )
-                    return SGDBRom(
-                        sgdb_id=games_by_name[best_match]["id"],
-                        url_cover=first_resource["url"],
-                    )
+            return SGDBRom(sgdb_id=None)
 
         log.debug(f"No good match found for '{', '.join(game_names)}' on SteamGridDB")
         return SGDBRom(sgdb_id=None)

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi import HTTPException, status
 
 from handler.database import db_platform_handler, db_rom_handler
 from handler.filesystem.roms_handler import FSRom
@@ -9,6 +10,7 @@ from handler.metadata import (
     meta_moby_handler,
     meta_playmatch_handler,
     meta_ra_handler,
+    meta_sgdb_handler,
     meta_ss_handler,
 )
 from handler.metadata.hasheous_handler import HasheousRom
@@ -625,3 +627,96 @@ async def test_scan_rom_provider_error_does_not_discard_others(
     # MobyGames blew up, but ScreenScraper's match survived.
     assert result.ss_id == 321
     assert result.moby_id is None
+
+
+@patch.object(meta_playmatch_handler, "is_enabled", return_value=False)
+@patch.object(meta_sgdb_handler, "is_enabled", return_value=True)
+@patch.object(meta_sgdb_handler.sgdb_service, "search_games", new_callable=AsyncMock)
+@patch.object(meta_ss_handler, "lookup_rom", new_callable=AsyncMock)
+async def test_scan_rom_sgdb_error_does_not_abort_scan(
+    mock_ss_lookup, mock_sgdb_search, mock_sgdb_enabled, mock_playmatch_enabled
+):
+    """SteamGridDB runs after the other providers; a failure there (issue #2236)
+    must resolve to an empty match in the handler instead of aborting the scan
+    or discarding the metadata already gathered."""
+    mock_ss_lookup.return_value = (SSRom(ss_id=321, name="Match"), False)
+    mock_sgdb_search.side_effect = ValueError("boom")
+
+    platform = _ss_quota_platform()
+    rom = db_rom_handler.add_rom(
+        Rom(platform_id=platform.id, fs_name="game.sfc", fs_path="snes", tags=[])
+    )
+
+    async with initialize_context():
+        result = await scan_rom(
+            platform=platform,
+            scan_type=ScanType.QUICK,
+            rom=rom,
+            fs_rom=_ss_quota_fs_rom("game.sfc"),
+            metadata_sources=[MetadataSource.SS, MetadataSource.SGDB],
+            newly_added=True,
+        )
+
+    # SteamGridDB was attempted and blew up, but the ROM kept ScreenScraper's match.
+    mock_sgdb_search.assert_awaited_once()
+    assert type(result) is Rom
+    assert result.ss_id == 321
+    assert result.sgdb_id is None
+
+
+@patch.object(meta_playmatch_handler, "is_enabled", return_value=False)
+@patch.object(meta_hasheous_handler, "is_enabled", return_value=True)
+@patch.object(meta_hasheous_handler, "_request", new_callable=AsyncMock)
+@patch.object(meta_ss_handler, "lookup_rom", new_callable=AsyncMock)
+async def test_scan_rom_hash_match_error_does_not_abort_scan(
+    mock_ss_lookup,
+    mock_hasheous_request,
+    mock_hasheous_enabled,
+    mock_playmatch_enabled,
+):
+    """A failure in the concurrent hash-match step (e.g. Hasheous unreachable,
+    issue #2236) must resolve to an empty match in the handler instead of
+    aborting the scan for the ROM."""
+    mock_hasheous_request.side_effect = HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Can't connect to Hasheous, check your internet connection",
+    )
+    mock_ss_lookup.return_value = (SSRom(ss_id=321, name="Match"), False)
+
+    platform = db_platform_handler.add_platform(
+        Platform(
+            id=1,
+            slug="snes",
+            fs_slug="snes",
+            name="Super Nintendo",
+            ss_id=4,
+            hasheous_id=7,
+        )
+    )
+    rom = db_rom_handler.add_rom(
+        Rom(platform_id=platform.id, fs_name="game.sfc", fs_path="snes", tags=[])
+    )
+    fs_rom = _ss_quota_fs_rom("game.sfc")
+    fs_rom["files"] = [
+        _top_level_rom_file(
+            file_name="game.sfc",
+            file_size_bytes=1024,
+            md5_hash="somemd5hash",
+        )
+    ]
+
+    async with initialize_context():
+        result = await scan_rom(
+            platform=platform,
+            scan_type=ScanType.QUICK,
+            rom=rom,
+            fs_rom=fs_rom,
+            metadata_sources=[MetadataSource.HASHEOUS, MetadataSource.SS],
+            newly_added=True,
+        )
+
+    # The Hasheous hash lookup raised, but ScreenScraper still identified the ROM.
+    mock_hasheous_request.assert_awaited_once()
+    assert type(result) is Rom
+    assert result.ss_id == 321
+    assert result.hasheous_id is None


### PR DESCRIPTION
**Description**

Follow-up to #3711, taking @gantoine's review direction to handle this in the metadata handler instead of gathering in the scan handler. Thanks for the pointer!

When a metadata provider request fails mid-scan, the whole scan aborts instead of skipping that provider (#2236). The main per-ROM provider phase already resolves failures per provider (#3620), but two calls in `scan_rom` still let provider exceptions propagate:

- The concurrent hash-match step: `HasheousHandler.lookup_rom` raises (its `_request` re-raises network errors as an `HTTPException` 503), while Playmatch's `lookup_rom` is already documented best-effort and never raises.
- The SteamGridDB step, which runs after the other providers: `SGDBBaseHandler.get_details_by_names` raises, and because it runs last, its failure also discarded every other provider's already-fetched metadata for that ROM (this is the exact traceback in #2236).

This PR moves the fault tolerance into the metadata handlers themselves, extending the pattern the handlers already use (`PlaymatchHandler.lookup_rom` and `SGDBBaseHandler.get_rom_by_id` both catch internally and return an empty match):

- `HasheousHandler.lookup_rom` catches request failures, logs at error level, and returns the empty match.
- `SGDBBaseHandler.get_details_by_names` does the same.

No `scan_handler` changes are needed. `asyncio.CancelledError` is not swallowed since it doesn't inherit from `Exception`.

**Other call sites reviewed**

- `HasheousHandler.lookup_rom` is only called from `scan_rom`.
- `SGDBBaseHandler.get_details_by_names` is also called by `GET /search/roms` (per-name SGDB cover enrichment). Previously an SGDB outage there raised a 500 for the whole search response even when IGDB/SS/Moby returned matches; it now degrades to results without SGDB covers. `GET /search/cover`, which deliberately surfaces SGDB errors to the user (401 on an invalid API key), uses `get_details` and is unchanged.
- Manual-match flows (`update_rom`, search by ID/name) use `get_rom_by_id` / `get_matched_rom*` and are unchanged, so those still surface provider errors to the UI.

**Tests**

Adapted the two regression tests from #3711 to inject failures at the service/request layer (`sgdb_service.search_games`, Hasheous `_request`) so the handler guards are exercised end-to-end through `scan_rom`. Both fail without the handler changes and pass with them. Full backend suite passes (2037 passed, 2 skipped).

Fixes #2236
Supersedes #3711

> This PR was written primarily by Claude Code (code and tests), directed and reviewed by a human.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
