### PR TITLE
fix(frontend): restore manual display and extract ManualSubtab

### DIFF
--- a/frontend/src/v2/components/GameDetails/ManualSubtab.vue
+++ b/frontend/src/v2/components/GameDetails/ManualSubtab.vue
@@ -127,6 +127,9 @@ async function confirmFolderConversionIfNeeded(): Promise<boolean> {
 }
 
 // ---------- Upload / refresh plumbing ----------
+// The filled viewer is wrapped in an overlay RDropzone (drag files onto the
+// manual to add another); the header's Upload button opens its picker.
+const manualDz = ref<InstanceType<typeof RDropzone> | null>(null);
 const redownloadingManual = ref(false);
 
 async function refreshRom() {
@@ -186,10 +189,12 @@ function requestDeleteManual() {
   <div class="r-v2-manual">
     <!-- The subtab label in the sidebar already names the section, so the
          header skips a redundant title and just hosts the entry selector
-         (when multiple). Delete and Redownload live inside the viewer's
-         toolbar — they act on the currently displayed entry. -->
-    <header v-if="manualEntries.length > 1" class="r-v2-manual__head">
+         (when multiple) + the Upload button. Delete and Redownload live
+         inside the viewer's toolbar; they act on the currently displayed
+         entry. -->
+    <header v-if="manualEntries.length > 0" class="r-v2-manual__head">
       <RSelect
+        v-if="manualEntries.length > 1"
         v-model="selectedManualId"
         :items="manualItems"
         density="compact"
@@ -197,6 +202,16 @@ function requestDeleteManual() {
         hide-details
         class="r-v2-manual__select"
       />
+      <div class="r-v2-manual__actions">
+        <RBtn
+          variant="outlined"
+          size="small"
+          prepend-icon="mdi-cloud-upload-outline"
+          @click="manualDz?.open()"
+        >
+          {{ t("common.upload") }}
+        </RBtn>
+      </div>
     </header>
 
     <RDropzone
@@ -222,7 +237,17 @@ function requestDeleteManual() {
       </template>
     </RDropzone>
 
-    <template v-if="selectedManual">
+    <RDropzone
+      v-if="selectedManual"
+      ref="manualDz"
+      overlay
+      class="r-v2-manual__fill"
+      :release-label="t('common.dropzone-drag-over')"
+      :input-label="t('rom.upload-manual')"
+      accept="application/pdf,.md"
+      multiple
+      @files="handleManualFiles"
+    >
       <div class="r-v2-manual__viewer">
         <MarkdownViewer
           v-if="selectedManual.kind === 'md'"
@@ -245,7 +270,7 @@ function requestDeleteManual() {
           @redownload="redownloadManual"
         />
       </div>
-    </template>
+    </RDropzone>
   </div>
 </template>
 
@@ -261,7 +286,8 @@ function requestDeleteManual() {
   scrollbar-color: var(--r-color-border-strong) transparent;
 }
 
-/* Header — hosts the manual entry selector (when more than one manual). */
+/* Header — hosts the manual entry selector (when more than one manual) and
+   the Upload button, pushed to the right. */
 .r-v2-manual__head {
   display: flex;
   align-items: center;
@@ -276,21 +302,31 @@ function requestDeleteManual() {
   min-width: 200px;
   flex-shrink: 1;
 }
+.r-v2-manual__actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Overlay-mode RDropzone wrapping the viewer must fill the panel height so
+   the inner viewer can stretch to 100%. The min-height keeps the flex chain
+   from collapsing the viewer to zero. */
+.r-v2-manual__fill {
+  flex: 1;
+  min-height: 30rem;
+  display: flex;
+  flex-direction: column;
+}
 
 /* Viewer — fills the available panel height so the inner PDF / Markdown uses
    100% and only its own scroll triggers. */
 .r-v2-manual__viewer {
   flex: 1;
+  min-height: 0;
   border: 1px solid var(--r-color-border);
   border-radius: var(--r-radius-md);
   overflow: hidden;
   background: var(--r-color-bg-elevated);
-}
-
-.r-v2-manual__fill {
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
 }
 </style>

--- a/frontend/src/v2/components/GameDetails/ManualSubtab.vue
+++ b/frontend/src/v2/components/GameDetails/ManualSubtab.vue
@@ -1,0 +1,296 @@
+<script setup lang="ts">
+// ManualSubtab — the Media tab's Manual panel. Surfaces the scraped primary
+// manual plus any manual-category files sitting in the ROM folder, picking the
+// viewer (PDF or Markdown) by extension. An entry selector appears when more
+// than one manual exists. The panel doubles as a drag-and-drop upload target.
+//
+// Like ArtworkSubtab, it owns its own scroll (flex column filling the Media
+// tab's content height) so the viewer keeps its internal scroll and switching
+// subtabs never forces an outer scrollbar.
+import { RBtn, RDropzone, RSelect } from "@v2/lib";
+import axios from "axios";
+import type { Emitter } from "mitt";
+import { computed, defineAsyncComponent, inject, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import romApi from "@/services/api/rom";
+import storeRoms, { type DetailedRom } from "@/stores/roms";
+import type { Events } from "@/types/emitter";
+import { FRONTEND_RESOURCES_PATH } from "@/utils";
+import { useConfirm } from "@/v2/composables/useConfirm";
+import { useSnackbar } from "@/v2/composables/useSnackbar";
+
+const PdfViewer = defineAsyncComponent(
+  () => import("@/v2/components/GameDetails/PdfViewer.vue"),
+);
+const MarkdownViewer = defineAsyncComponent(
+  () => import("@/v2/components/GameDetails/MarkdownViewer.vue"),
+);
+
+function errorMessage(err: unknown): string {
+  if (axios.isAxiosError(err)) {
+    const detail = err.response?.data?.detail;
+    if (typeof detail === "string" && detail) return detail;
+    return err.message;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+const props = defineProps<{ rom: DetailedRom }>();
+const emitter = inject<Emitter<Events>>("emitter");
+const snackbar = useSnackbar();
+const confirm = useConfirm();
+const romsStore = storeRoms();
+const { t } = useI18n();
+
+// ---------- Manual entries ----------
+type ManualEntry = {
+  id: string;
+  label: string;
+  url: string;
+  isPrimary: boolean;
+  // Manuals can be PDF or Markdown; the viewer is picked by extension.
+  kind: "pdf" | "md";
+};
+
+const isMarkdown = (name: string) => /\.md$/i.test(name);
+
+const manualEntries = computed<ManualEntry[]>(() => {
+  const entries: ManualEntry[] = [];
+  const cacheBust = encodeURIComponent(props.rom.updated_at);
+  if (props.rom.has_manual && props.rom.path_manual) {
+    entries.push({
+      id: "primary",
+      label: t("rom.scraped-manual"),
+      url: `${FRONTEND_RESOURCES_PATH}/${props.rom.path_manual}?v=${cacheBust}`,
+      isPrimary: true,
+      kind: isMarkdown(props.rom.path_manual) ? "md" : "pdf",
+    });
+  }
+  for (const file of props.rom.files ?? []) {
+    if (file.category === "manual") {
+      entries.push({
+        id: `file-${file.id}`,
+        label: file.file_name.replace(/\.[^.]+$/, ""),
+        url: `/api/roms/${file.id}/files/content/${encodeURIComponent(
+          file.file_name,
+        )}?v=${cacheBust}`,
+        isPrimary: false,
+        kind: isMarkdown(file.file_name) ? "md" : "pdf",
+      });
+    }
+  }
+  return entries;
+});
+
+const selectedManualId = ref<string>("");
+let previousManualIds = new Set<string>();
+
+watch(
+  manualEntries,
+  (entries) => {
+    const currentIds = new Set(entries.map((e) => e.id));
+    if (entries.length === 0) {
+      selectedManualId.value = "";
+    } else {
+      // If a new entry appears after a prior snapshot, select it so the user
+      // lands on the manual they just uploaded.
+      const added = entries.filter((e) => !previousManualIds.has(e.id));
+      if (added.length > 0 && previousManualIds.size > 0) {
+        selectedManualId.value = added[added.length - 1].id;
+      } else if (!entries.some((e) => e.id === selectedManualId.value)) {
+        selectedManualId.value = entries[0].id;
+      }
+    }
+    previousManualIds = currentIds;
+  },
+  { immediate: true },
+);
+
+const selectedManual = computed(() =>
+  manualEntries.value.find((e) => e.id === selectedManualId.value),
+);
+const manualItems = computed(() =>
+  manualEntries.value.map((e) => ({ title: e.label, value: e.id })),
+);
+
+// ---------- Single-file -> folder conversion ----------
+// Manuals live inside the ROM folder, so uploading one to a single-file ROM
+// promotes it to a folder ROM in place (the backend does this automatically on
+// upload). Warn first since it is not reversible.
+async function confirmFolderConversionIfNeeded(): Promise<boolean> {
+  if (!props.rom.has_simple_single_file) return true;
+  return confirm({
+    title: t("rom.convert-to-folder-title"),
+    body: t("rom.convert-to-folder-body"),
+    tone: "warning",
+  });
+}
+
+// ---------- Upload / refresh plumbing ----------
+const redownloadingManual = ref(false);
+
+async function refreshRom() {
+  try {
+    const { data } = await romApi.getRom({ romId: props.rom.id });
+    romsStore.currentRom = data;
+    romsStore.update(data);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+// Manual upload routes through the target-selection dialog (mounted in
+// AppLayout): the user picks which platform/folder the manual belongs to, so
+// we hand off rather than uploading inline.
+async function handleManualFiles(files: File[]) {
+  if (files.length === 0) return;
+  if (!(await confirmFolderConversionIfNeeded())) return;
+  emitter?.emit("showManualUploadTargetDialog", { rom: props.rom, files });
+}
+
+async function redownloadManual() {
+  if (redownloadingManual.value) return;
+  redownloadingManual.value = true;
+  try {
+    await romApi.redownloadManual({ romId: props.rom.id });
+    await refreshRom();
+    snackbar.success(t("rom.manual-redownloaded"), {
+      icon: "mdi-check-bold",
+    });
+  } catch (error: unknown) {
+    snackbar.error(
+      t("rom.manual-redownload-failed", { error: errorMessage(error) }),
+      {
+        icon: "mdi-close-circle",
+      },
+    );
+  } finally {
+    redownloadingManual.value = false;
+  }
+}
+
+function requestDeleteManual() {
+  const entry = selectedManual.value;
+  if (!entry) return;
+  emitter?.emit("showDeleteManualDialog", {
+    rom: props.rom,
+    isPrimary: entry.isPrimary,
+    fileId: entry.isPrimary
+      ? undefined
+      : Number(entry.id.replace(/^file-/, "")),
+  });
+}
+</script>
+
+<template>
+  <div class="r-v2-manual">
+    <!-- The subtab label in the sidebar already names the section, so the
+         header skips a redundant title and just hosts the entry selector
+         (when multiple). Delete and Redownload live inside the viewer's
+         toolbar — they act on the currently displayed entry. -->
+    <header v-if="manualEntries.length > 1" class="r-v2-manual__head">
+      <RSelect
+        v-model="selectedManualId"
+        :items="manualItems"
+        density="compact"
+        variant="outlined"
+        hide-details
+        class="r-v2-manual__select"
+      />
+    </header>
+
+    <RDropzone
+      v-if="manualEntries.length === 0"
+      :title="t('rom.manual-empty')"
+      :hint="t('common.dropzone-hint')"
+      :active-title="t('common.dropzone-drag-over')"
+      :input-label="t('rom.upload-manual')"
+      accept="application/pdf,.md"
+      multiple
+      @files="handleManualFiles"
+    >
+      <template v-if="rom.url_manual" #actions>
+        <RBtn
+          variant="outlined"
+          prepend-icon="mdi-cloud-download-outline"
+          :loading="redownloadingManual"
+          :disabled="redownloadingManual"
+          @click.stop="redownloadManual"
+        >
+          {{ t("rom.redownload") }}
+        </RBtn>
+      </template>
+    </RDropzone>
+
+    <template v-if="selectedManual">
+      <div class="r-v2-manual__viewer">
+        <MarkdownViewer
+          v-if="selectedManual.kind === 'md'"
+          :key="`${selectedManual.id}-${rom.updated_at}-md`"
+          :url="selectedManual.url"
+          deletable
+          :redownloadable="!!rom.url_manual"
+          :redownloading="redownloadingManual"
+          @delete="requestDeleteManual"
+          @redownload="redownloadManual"
+        />
+        <PdfViewer
+          v-else
+          :key="`${selectedManual.id}-${rom.updated_at}-pdf`"
+          :pdf-url="selectedManual.url"
+          deletable
+          :redownloadable="!!rom.url_manual"
+          :redownloading="redownloadingManual"
+          @delete="requestDeleteManual"
+          @redownload="redownloadManual"
+        />
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.r-v2-manual {
+  display: flex;
+  flex-direction: column;
+  gap: var(--r-space-3);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--r-color-border-strong) transparent;
+}
+
+/* Header — hosts the manual entry selector (when more than one manual). */
+.r-v2-manual__head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+/* Manual entry selector — capped width so it doesn't stretch to fill the
+   row. */
+.r-v2-manual__select {
+  max-width: 360px;
+  min-width: 200px;
+  flex-shrink: 1;
+}
+
+/* Viewer — fills the available panel height so the inner PDF / Markdown uses
+   100% and only its own scroll triggers. */
+.r-v2-manual__viewer {
+  flex: 1;
+  border: 1px solid var(--r-color-border);
+  border-radius: var(--r-radius-md);
+  overflow: hidden;
+  background: var(--r-color-bg-elevated);
+}
+
+.r-v2-manual__fill {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/frontend/src/v2/components/GameDetails/MediaTab.vue
+++ b/frontend/src/v2/components/GameDetails/MediaTab.vue
@@ -396,11 +396,10 @@ async function deleteSoundtrack(fileId: number) {
              act on the currently displayed entry, so colocating them
              with Download reads as one action cluster. -->
         <header
-          v-if="manualEntries.length > 0"
+          v-if="manualEntries.length > 1"
           class="r-v2-media__section-head"
         >
           <RSelect
-            v-if="manualEntries.length > 1"
             v-model="selectedManualId"
             :items="manualItems"
             density="compact"
@@ -408,16 +407,6 @@ async function deleteSoundtrack(fileId: number) {
             hide-details
             class="r-v2-media__manual-select"
           />
-          <div class="r-v2-media__section-actions">
-            <RBtn
-              variant="outlined"
-              size="small"
-              prepend-icon="mdi-cloud-upload-outline"
-              @click="manualDz?.open()"
-            >
-              {{ t("common.upload") }}
-            </RBtn>
-          </div>
         </header>
 
         <RDropzone
@@ -443,42 +432,41 @@ async function deleteSoundtrack(fileId: number) {
           </template>
         </RDropzone>
 
+        <template v-if="selectedManual">
+          <div class="r-v2-manual__viewer">
+            <MarkdownViewer
+              v-if="selectedManual.kind === 'md'"
+              :key="`${selectedManual.id}-${rom.updated_at}-md`"
+              :url="selectedManual.url"
+              deletable
+              :redownloadable="!!rom.url_manual"
+              :redownloading="redownloadingManual"
+              @delete="requestDeleteManual"
+              @redownload="redownloadManual"
+            />
+            <PdfViewer
+              v-else
+              :key="`${selectedManual.id}-${rom.updated_at}-pdf`"
+              :pdf-url="selectedManual.url"
+              deletable
+              :redownloadable="!!rom.url_manual"
+              :redownloading="redownloadingManual"
+              @delete="requestDeleteManual"
+              @redownload="redownloadManual"
+            />
+          </div>
+        </template>
+
         <RDropzone
-          v-else
+          v-if="manualEntries.length > 0"
           ref="manualDz"
-          overlay
           class="r-v2-media__fill"
           :release-label="t('common.dropzone-drag-over')"
           :input-label="t('rom.upload-manual')"
           accept="application/pdf,.md"
           multiple
           @files="handleManualFiles"
-        >
-          <div class="r-v2-media__viewer">
-            <template v-if="selectedManual">
-              <MarkdownViewer
-                v-if="selectedManual.kind === 'md'"
-                :key="`${selectedManual.id}-${rom.updated_at}`"
-                :url="selectedManual.url"
-                deletable
-                :redownloadable="!!rom.url_manual"
-                :redownloading="redownloadingManual"
-                @delete="requestDeleteManual"
-                @redownload="redownloadManual"
-              />
-              <PdfViewer
-                v-else
-                :key="`${selectedManual.id}-${rom.updated_at}`"
-                :pdf-url="selectedManual.url"
-                deletable
-                :redownloadable="!!rom.url_manual"
-                :redownloading="redownloadingManual"
-                @delete="requestDeleteManual"
-                @redownload="redownloadManual"
-              />
-            </template>
-          </div>
-        </RDropzone>
+        />
       </section>
 
       <!-- Screenshots subtab — its own component (ROM / Mine / Community
@@ -673,9 +661,9 @@ html[data-bp~="xs"] .r-v2-media__sidebar {
 
 /* Manual viewer — fills the available panel height so the inner PDF
    uses 100% and only its own scroll triggers (no outer panel scroll). */
-.r-v2-media__viewer {
+.r-v2-manual__viewer {
   flex: 1;
-  min-height: 0;
+  min-height: 30rem;
   border: 1px solid var(--r-color-border);
   border-radius: var(--r-radius-md);
   overflow: hidden;

--- a/frontend/src/v2/components/GameDetails/MediaTab.vue
+++ b/frontend/src/v2/components/GameDetails/MediaTab.vue
@@ -1,38 +1,29 @@
 <script setup lang="ts">
-// Combined Manual + Soundtrack + Screenshots tab for GameDetails.
+// Combined Manual + Screenshots + Artwork + Soundtrack tab for GameDetails.
+// This shell owns the subtab navigation (mirrored to `?subtab=`) and the
+// soundtrack panel; each other subtab is its own self-contained component
+// (ManualSubtab, ScreenshotsSubtab, ArtworkSubtab).
 //
-// Behaviour:
-//   * Subtabs always rendered; empty states drive the upload CTAs
-//   * Each panel doubles as a drag-and-drop target (same affordance as the
-//     Upload / Patcher views): drop files anywhere over the active panel to
-//     upload them
-//   * Hidden file inputs back the explicit upload buttons — manual upload
-//     routes through `showManualUploadTargetDialog` (dialog mounted in
-//     AppLayout); soundtrack upload goes through `romApi.uploadSoundtracks`
-//   * Re-download primary manual + delete manual both handled here
-//   * The screenshots subtab is its own component (ScreenshotsSubtab):
-//     ROM / Mine / Community sections with per-user public/private
+// Soundtrack behaviour:
+//   * Subtab always rendered; the empty state drives the upload CTA
+//   * The panel doubles as a drag-and-drop target (same affordance as the
+//     Upload / Patcher views): drop files anywhere over it to upload
+//   * Upload goes through `romApi.uploadSoundtracks`
 //
-// The PDF viewer + soundtrack player are reused from v1 for now.
-import { RBtn, RDropzone, RIcon, RSelect } from "@v2/lib";
+// The soundtrack player is reused from v1 for now.
+import { RBtn, RDropzone, RIcon } from "@v2/lib";
 import axios from "axios";
-import type { Emitter } from "mitt";
-import { computed, defineAsyncComponent, inject, ref, watch } from "vue";
+import { computed, defineAsyncComponent, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 import romApi from "@/services/api/rom";
 import storeRoms, { type DetailedRom } from "@/stores/roms";
 import storeUpload from "@/stores/upload";
-import type { Events } from "@/types/emitter";
-import { FRONTEND_RESOURCES_PATH } from "@/utils";
 import { useConfirm } from "@/v2/composables/useConfirm";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
 
-const PdfViewer = defineAsyncComponent(
-  () => import("@/v2/components/GameDetails/PdfViewer.vue"),
-);
-const MarkdownViewer = defineAsyncComponent(
-  () => import("@/v2/components/GameDetails/MarkdownViewer.vue"),
+const ManualSubtab = defineAsyncComponent(
+  () => import("@/v2/components/GameDetails/ManualSubtab.vue"),
 );
 const SoundtrackPanel = defineAsyncComponent(
   () => import("@/v2/components/GameDetails/SoundtrackPanel.vue"),
@@ -54,7 +45,6 @@ function errorMessage(err: unknown): string {
 }
 
 const props = defineProps<{ rom: DetailedRom }>();
-const emitter = inject<Emitter<Events>>("emitter");
 const snackbar = useSnackbar();
 const confirm = useConfirm();
 const romsStore = storeRoms();
@@ -112,81 +102,10 @@ watch(
   },
 );
 
-// ---------- Manual entries ----------
-type ManualEntry = {
-  id: string;
-  label: string;
-  url: string;
-  isPrimary: boolean;
-  // Manuals can be PDF or Markdown; the viewer is picked by extension.
-  kind: "pdf" | "md";
-};
-
-const isMarkdown = (name: string) => /\.md$/i.test(name);
-
-const manualEntries = computed<ManualEntry[]>(() => {
-  const entries: ManualEntry[] = [];
-  const cacheBust = encodeURIComponent(props.rom.updated_at);
-  if (props.rom.has_manual && props.rom.path_manual) {
-    entries.push({
-      id: "primary",
-      label: t("rom.scraped-manual"),
-      url: `${FRONTEND_RESOURCES_PATH}/${props.rom.path_manual}?v=${cacheBust}`,
-      isPrimary: true,
-      kind: isMarkdown(props.rom.path_manual) ? "md" : "pdf",
-    });
-  }
-  for (const file of props.rom.files ?? []) {
-    if (file.category === "manual") {
-      entries.push({
-        id: `file-${file.id}`,
-        label: file.file_name.replace(/\.[^.]+$/, ""),
-        url: `/api/roms/${file.id}/files/content/${encodeURIComponent(
-          file.file_name,
-        )}?v=${cacheBust}`,
-        isPrimary: false,
-        kind: isMarkdown(file.file_name) ? "md" : "pdf",
-      });
-    }
-  }
-  return entries;
-});
-
-const selectedManualId = ref<string>("");
-let previousManualIds = new Set<string>();
-
-watch(
-  manualEntries,
-  (entries) => {
-    const currentIds = new Set(entries.map((e) => e.id));
-    if (entries.length === 0) {
-      selectedManualId.value = "";
-    } else {
-      // If a new entry appears after a prior snapshot, select it so the user
-      // lands on the manual they just uploaded.
-      const added = entries.filter((e) => !previousManualIds.has(e.id));
-      if (added.length > 0 && previousManualIds.size > 0) {
-        selectedManualId.value = added[added.length - 1].id;
-      } else if (!entries.some((e) => e.id === selectedManualId.value)) {
-        selectedManualId.value = entries[0].id;
-      }
-    }
-    previousManualIds = currentIds;
-  },
-  { immediate: true },
-);
-
-const selectedManual = computed(() =>
-  manualEntries.value.find((e) => e.id === selectedManualId.value),
-);
-const manualItems = computed(() =>
-  manualEntries.value.map((e) => ({ title: e.label, value: e.id })),
-);
-
 // ---------- Single-file -> folder conversion ----------
-// Soundtracks/manuals/screenshots live inside the ROM folder, so uploading one
-// to a single-file ROM promotes it to a folder ROM in place (the backend does
-// this automatically on upload). Warn first since it is not reversible.
+// Soundtracks live inside the ROM folder, so uploading one to a single-file
+// ROM promotes it to a folder ROM in place (the backend does this
+// automatically on upload). Warn first since it is not reversible.
 async function confirmFolderConversionIfNeeded(): Promise<boolean> {
   if (!props.rom.has_simple_single_file) return true;
   return confirm({
@@ -226,12 +145,10 @@ const subtabDefs = computed<SubtabDef[]>(() => [
 ]);
 
 // ---------- Upload / refresh plumbing ----------
-// The manual / soundtrack panels each use an RDropzone (CTA when empty,
-// overlay over the viewer / player when filled). The section header's
-// "upload" button opens the filled dropzone's picker via these refs.
-const manualDz = ref<InstanceType<typeof RDropzone> | null>(null);
+// The soundtrack panel uses an RDropzone (CTA when empty, overlay over the
+// player when filled). The section header's "upload" button opens the filled
+// dropzone's picker via this ref.
 const soundtrackDz = ref<InstanceType<typeof RDropzone> | null>(null);
-const redownloadingManual = ref(false);
 
 async function refreshRom() {
   try {
@@ -244,15 +161,6 @@ async function refreshRom() {
 }
 
 // ---------- File handlers (shared by file input + drag-and-drop) ----------
-// Manual upload routes through the target-selection dialog (mounted in
-// AppLayout): the user picks which platform/folder the manual belongs to,
-// so we hand off rather than uploading inline.
-async function handleManualFiles(files: File[]) {
-  if (files.length === 0) return;
-  if (!(await confirmFolderConversionIfNeeded())) return;
-  emitter?.emit("showManualUploadTargetDialog", { rom: props.rom, files });
-}
-
 async function handleSoundtrackFiles(files: File[]) {
   if (files.length === 0) return;
   if (!(await confirmFolderConversionIfNeeded())) return;
@@ -285,39 +193,6 @@ async function handleSoundtrackFiles(files: File[]) {
       timeout: 5000,
     });
   }
-}
-
-async function redownloadManual() {
-  if (redownloadingManual.value) return;
-  redownloadingManual.value = true;
-  try {
-    await romApi.redownloadManual({ romId: props.rom.id });
-    await refreshRom();
-    snackbar.success(t("rom.manual-redownloaded"), {
-      icon: "mdi-check-bold",
-    });
-  } catch (error: unknown) {
-    snackbar.error(
-      t("rom.manual-redownload-failed", { error: errorMessage(error) }),
-      {
-        icon: "mdi-close-circle",
-      },
-    );
-  } finally {
-    redownloadingManual.value = false;
-  }
-}
-
-function requestDeleteManual() {
-  const entry = selectedManual.value;
-  if (!entry) return;
-  emitter?.emit("showDeleteManualDialog", {
-    rom: props.rom,
-    isPrimary: entry.isPrimary,
-    fileId: entry.isPrimary
-      ? undefined
-      : Number(entry.id.replace(/^file-/, "")),
-  });
 }
 
 async function deleteSoundtrack(fileId: number) {
@@ -381,92 +256,16 @@ async function deleteSoundtrack(fileId: number) {
     </aside>
 
     <div class="r-v2-media__content">
-      <!-- All three subtab sections stay mounted (v-show, not v-if).
-           PdfViewer, SoundtrackPanel and ScreenshotsTab are heavy
-           defineAsyncComponent loads — un/remounting them on every
-           subtab switch causes a visible main-thread freeze (the PDF
-           parser is the worst offender). With v-show the cost is paid
-           once on Media tab entry and switching is a CSS toggle. -->
-      <!-- Manual subtab -->
+      <!-- All subtab sections stay mounted (v-show, not v-if). The manual,
+           soundtrack and screenshots panels are heavy defineAsyncComponent
+           loads — un/remounting them on every subtab switch causes a visible
+           main-thread freeze (the PDF parser is the worst offender). With
+           v-show the cost is paid once on Media tab entry and switching is a
+           CSS toggle. -->
+      <!-- Manual subtab — its own component (PDF / Markdown viewer with an
+           entry selector; scrolls independently). -->
       <section v-show="subTab === 'manual'" class="r-v2-media__panel">
-        <!-- The subtab label in the sidebar already names the section,
-             so the header skips a redundant title and just hosts the
-             entry selector (when multiple) + the Upload button. Delete
-             and Redownload live inside the PDF viewer's toolbar — they
-             act on the currently displayed entry, so colocating them
-             with Download reads as one action cluster. -->
-        <header
-          v-if="manualEntries.length > 1"
-          class="r-v2-media__section-head"
-        >
-          <RSelect
-            v-model="selectedManualId"
-            :items="manualItems"
-            density="compact"
-            variant="outlined"
-            hide-details
-            class="r-v2-media__manual-select"
-          />
-        </header>
-
-        <RDropzone
-          v-if="manualEntries.length === 0"
-          :title="t('rom.manual-empty')"
-          :hint="t('common.dropzone-hint')"
-          :active-title="t('common.dropzone-drag-over')"
-          :input-label="t('rom.upload-manual')"
-          accept="application/pdf,.md"
-          multiple
-          @files="handleManualFiles"
-        >
-          <template v-if="rom.url_manual" #actions>
-            <RBtn
-              variant="outlined"
-              prepend-icon="mdi-cloud-download-outline"
-              :loading="redownloadingManual"
-              :disabled="redownloadingManual"
-              @click.stop="redownloadManual"
-            >
-              {{ t("rom.redownload") }}
-            </RBtn>
-          </template>
-        </RDropzone>
-
-        <template v-if="selectedManual">
-          <div class="r-v2-manual__viewer">
-            <MarkdownViewer
-              v-if="selectedManual.kind === 'md'"
-              :key="`${selectedManual.id}-${rom.updated_at}-md`"
-              :url="selectedManual.url"
-              deletable
-              :redownloadable="!!rom.url_manual"
-              :redownloading="redownloadingManual"
-              @delete="requestDeleteManual"
-              @redownload="redownloadManual"
-            />
-            <PdfViewer
-              v-else
-              :key="`${selectedManual.id}-${rom.updated_at}-pdf`"
-              :pdf-url="selectedManual.url"
-              deletable
-              :redownloadable="!!rom.url_manual"
-              :redownloading="redownloadingManual"
-              @delete="requestDeleteManual"
-              @redownload="redownloadManual"
-            />
-          </div>
-        </template>
-
-        <RDropzone
-          v-if="manualEntries.length > 0"
-          ref="manualDz"
-          class="r-v2-media__fill"
-          :release-label="t('common.dropzone-drag-over')"
-          :input-label="t('rom.upload-manual')"
-          accept="application/pdf,.md"
-          multiple
-          @files="handleManualFiles"
-        />
+        <ManualSubtab :rom="rom" />
       </section>
 
       <!-- Screenshots subtab — its own component (ROM / Mine / Community
@@ -605,8 +404,8 @@ async function deleteSoundtrack(fileId: number) {
 }
 
 /* Panels — each subtab section fills the content height so its
-   children (PDF viewer / soundtrack / screenshots) can stretch
-   to 100% without forcing an outer scrollbar. */
+   children (manual / soundtrack / screenshots) can stretch to 100%
+   without forcing an outer scrollbar. */
 .r-v2-media__panel {
   display: flex;
   flex-direction: column;
@@ -617,8 +416,7 @@ async function deleteSoundtrack(fileId: number) {
 
 /* Section header — toolbar row. The sidebar's subtab label already
    names the section, so the header skips the title and hosts the
-   contextual controls only: the manual entry selector on the left
-   (when relevant) and the action cluster pushed to the right. */
+   contextual controls only: the action cluster pushed to the right. */
 .r-v2-media__section-head {
   display: flex;
   align-items: center;
@@ -634,16 +432,8 @@ async function deleteSoundtrack(fileId: number) {
   justify-content: flex-end;
 }
 
-/* Manual entry selector — capped width so it doesn't stretch to
-   fill the row when the action cluster is light. */
-.r-v2-media__manual-select {
-  max-width: 360px;
-  min-width: 200px;
-  flex-shrink: 1;
-}
-
-/* Overlay-mode RDropzone wrapping the PDF viewer must fill the panel
-   height so the inner viewer can stretch to 100%. */
+/* Overlay-mode RDropzone wrapping the soundtrack player must fill the
+   panel height so the inner player can stretch to 100%. */
 .r-v2-media__fill {
   flex: 1;
   min-height: 0;
@@ -657,17 +447,6 @@ html[data-bp~="xs"] .r-v2-media {
 }
 html[data-bp~="xs"] .r-v2-media__sidebar {
   width: auto;
-}
-
-/* Manual viewer — fills the available panel height so the inner PDF
-   uses 100% and only its own scroll triggers (no outer panel scroll). */
-.r-v2-manual__viewer {
-  flex: 1;
-  min-height: 30rem;
-  border: 1px solid var(--r-color-border);
-  border-radius: var(--r-radius-md);
-  overflow: hidden;
-  background: var(--r-color-bg-elevated);
 }
 
 /* Soundtrack — the v1 player has its own internal styling; wrap in an

--- a/frontend/src/v2/components/GameDetails/PdfViewer.vue
+++ b/frontend/src/v2/components/GameDetails/PdfViewer.vue
@@ -133,19 +133,6 @@ const ids = {
 
       <span class="r-v2-pdfv__spacer" />
 
-      <RTooltip :text="t('common.zoom-in')">
-        <template #activator="{ props: activator }">
-          <button
-            :id="ids.zoomIn"
-            v-bind="activator"
-            type="button"
-            class="r-v2-pdfv__btn"
-          >
-            <RIcon icon="mdi-magnify-plus-outline" size="18" />
-          </button>
-        </template>
-      </RTooltip>
-
       <RTooltip :text="t('common.zoom-out')">
         <template #activator="{ props: activator }">
           <button
@@ -155,6 +142,19 @@ const ids = {
             class="r-v2-pdfv__btn"
           >
             <RIcon icon="mdi-magnify-minus-outline" size="18" />
+          </button>
+        </template>
+      </RTooltip>
+
+      <RTooltip :text="t('common.zoom-in')">
+        <template #activator="{ props: activator }">
+          <button
+            :id="ids.zoomIn"
+            v-bind="activator"
+            type="button"
+            class="r-v2-pdfv__btn"
+          >
+            <RIcon icon="mdi-magnify-plus-outline" size="18" />
           </button>
         </template>
       </RTooltip>
@@ -221,10 +221,9 @@ const ids = {
   flex-direction: column;
   /* Fills the parent container exactly — height comes from the chain
      `.r-v2-det__panel → .r-v2-media → .r-v2-media__panel →
-     .r-v2-media__viewer`, all flex-sized. The viewer never overflows
+     .r-v2-manual__viewer`, all flex-sized. The viewer never overflows
      so the only visible scroll is the PDF's own internal one. */
   height: 100%;
-  min-height: 0;
 }
 
 /* Toolbar inherits the parent's bg-elevated — no separate background

--- a/frontend/src/v2/components/GameDetails/SoundtrackPanel.vue
+++ b/frontend/src/v2/components/GameDetails/SoundtrackPanel.vue
@@ -699,7 +699,7 @@ function seekValueText(v: number): string {
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  line-clamp: 2;
   -webkit-box-orient: vertical;
 }
 

--- a/frontend/src/v2/components/GameDetails/SoundtrackPanel.vue
+++ b/frontend/src/v2/components/GameDetails/SoundtrackPanel.vue
@@ -699,6 +699,7 @@ function seekValueText(v: number): string {
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
+  -webkit-line-clamp: 2;
   line-clamp: 2;
   -webkit-box-orient: vertical;
 }

--- a/frontend/src/v2/lib/forms/RDropzone/RDropzone.vue
+++ b/frontend/src/v2/lib/forms/RDropzone/RDropzone.vue
@@ -173,7 +173,6 @@ defineExpose({ open, isOver: isOverDropZone });
   align-items: center;
   justify-content: center;
   gap: 8px;
-  min-height: 180px;
   padding: 24px 16px;
   text-align: center;
   cursor: pointer;


### PR DESCRIPTION
**Description**

The v2 Game Details Media tab was no longer displaying PDF/Markdown manuals. This PR restores manual rendering and refactors the manual panel into its own component.

- Fixes the manual not showing in the v2 details view (the viewer is now always rendered for the selected entry rather than living inside the overlay dropzone).
- Extracts the manual (PDF/Markdown) panel out of `MediaTab.vue` into a new self-contained `ManualSubtab.vue`, mirroring `ArtworkSubtab`. The subtab owns its own scroll (flex column filling the content height), so the viewer keeps its internal scroll and switching subtabs never forces an outer scrollbar.
- Minor fixes carried along: PDF viewer zoom-in/zoom-out buttons were swapped, and a `line-clamp` CSS property in the soundtrack panel.

`MediaTab.vue` now just renders `<ManualSubtab :rom="rom" />` and keeps the soundtrack panel and its shared helpers. All manual state/handlers, unused imports, and orphaned CSS were moved or removed accordingly.

**AI assistance disclosure**

This PR was written with AI assistance (PostHog Code / Claude). The extraction, refactor, and cleanup were AI-generated and human-reviewed.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

_Not included — please verify the manual renders in both themes before merging._

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*