### PR TITLE
Fixed the translation of "player-count"

### DIFF
--- a/frontend/src/locales/zh_CN/rom.json
+++ b/frontend/src/locales/zh_CN/rom.json
@@ -254,7 +254,7 @@
   "pick-track-prompt": "选择一首曲目开始播放",
   "play": "开始游玩",
   "play-track": "播放 {title}",
-  "player-count": "球员",
+  "player-count": "人数",
   "players-n": "{n} 位玩家",
   "private": "私人",
   "provider-flashpoint-id": "Flashpoint ID",


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>
The zh_CN translation of "player-count" isn't correct so I fixed it.

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)
