### PR TITLE
ci: fail PRs that modify the frozen frontend v1 UI

### DIFF
--- a/.github/workflows/frontend-v1-frozen.yml
+++ b/.github/workflows/frontend-v1-frozen.yml
@@ -9,6 +9,7 @@ name: Frontend v1 Frozen Check
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - "frontend/src/views/**"
       - "frontend/src/components/**"

--- a/.github/workflows/frontend-v1-frozen.yml
+++ b/.github/workflows/frontend-v1-frozen.yml
@@ -1,0 +1,59 @@
+name: Frontend v1 Frozen Check
+
+# The v1 UI is frozen and slated for deletion. New frontend work goes in
+# frontend/src/v2/. This check fails if a PR modifies any v1 UI code so the
+# freeze is enforced automatically.
+#
+# Sanctioned exception: for a critical v1 bug fix, add the "allow-v1-changes"
+# label to the PR to bypass this check.
+
+on:
+  pull_request:
+    paths:
+      - "frontend/src/views/**"
+      - "frontend/src/components/**"
+      - "frontend/src/console/**"
+      - "frontend/src/layouts/**"
+
+permissions: read-all
+
+jobs:
+  check-v1-frozen:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.3.0
+        with:
+          fetch-depth: 0
+
+      - name: Fail if v1 UI files changed
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HAS_BYPASS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'allow-v1-changes') }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+
+          v1_files=$(git diff --name-only "origin/$BASE_REF...HEAD" -- \
+            "frontend/src/views/" \
+            "frontend/src/components/" \
+            "frontend/src/console/" \
+            "frontend/src/layouts/")
+
+          if [ -z "$v1_files" ]; then
+            echo "No v1 UI files changed."
+            exit 0
+          fi
+
+          echo "This PR modifies frozen v1 UI files:"
+          echo "$v1_files" | sed 's/^/  - /'
+          echo ""
+
+          if [ "$HAS_BYPASS_LABEL" = "true" ]; then
+            echo "The 'allow-v1-changes' label is present; allowing v1 changes."
+            exit 0
+          fi
+
+          echo "::error::The v1 UI (frontend/src/{views,components,console,layouts}) is frozen."
+          echo "New frontend work must go in frontend/src/v2/."
+          echo "For a sanctioned critical bug fix, add the 'allow-v1-changes' label to this PR."
+          exit 1


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Adds a CI workflow (`.github/workflows/frontend-v1-frozen.yml`) that fails any PR touching the frozen v1 UI, keeping new frontend work in `frontend/src/v2/`.

- Triggers only on PRs that modify `frontend/src/{views,components,console,layouts}/**` (the exact set marked frozen in `CLAUDE.md`; v2 under `frontend/src/v2/` is unaffected).
- Diffs the PR against its base branch and fails, listing the offending files and pointing contributors to v2.
- **Escape hatch:** since v1 may be touched only for a critical bug fix, adding the `allow-v1-changes` label to a PR bypasses the check.

Follow-ups (not in this PR):
- Create the `allow-v1-changes` label in the repo.
- Add this check to branch protection to make it blocking.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

---

> [!NOTE]
> **AI assistance disclosure:** This change was authored with AI assistance (PostHog Code). The workflow logic and PR description were AI-generated and human-reviewed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*