### PR TITLE
fix(docker): name the /romm volume to avoid anonymous volume

### DIFF
--- a/examples/docker-compose.example.yml
+++ b/examples/docker-compose.example.yml
@@ -1,5 +1,6 @@
 volumes:
   mysql_data:
+  romm_data:
   romm_resources:
   romm_redis_data:
 
@@ -20,6 +21,7 @@ services:
       - STEAMGRIDDB_API_KEY= # https://docs.romm.app/latest/Getting-Started/Metadata-Providers/#steamgriddb
       - HASHEOUS_API_ENABLED=true # https://docs.romm.app/latest/Getting-Started/Metadata-Providers/#hasheous
     volumes:
+      - romm_data:/romm # Base data dir; named so Docker doesn't create an anonymous volume for the image's /romm VOLUME
       - romm_resources:/romm/resources # Resources fetched from IGDB (covers, screenshots, etc.)
       - romm_redis_data:/redis-data # Cached data for background tasks
       - /path/to/library:/romm/library # Your game library. Check https://docs.romm.app/latest/Getting-Started/Folder-Structure/ for more details.


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The `rommapp/romm` image declares `/romm` as a `VOLUME` (`docker/Dockerfile`), but the example compose only mounted subpaths of it (`/romm/resources`, `/romm/library`, `/romm/assets`, `/romm/config`), never `/romm` itself. Because `/romm` was declared as a volume with no explicit mount, Docker fell back to creating an **anonymous volume** (random ID, `com.docker.volume.anonymous`) for the `/romm` base directory.

This PR adds a named `romm_data` volume mounted at `/romm` in `examples/docker-compose.example.yml`:
- Added `romm_data:` to the top-level `volumes:` section
- Added `- romm_data:/romm` to the `romm` service mounts

**Why this layer, and not declaring subdirs as `VOLUME`s in the Dockerfile:** declaring `/romm/library`, `/romm/resources`, etc. as image-level volumes would put each subdir on its own anonymous filesystem for any default deployment, breaking the cross-directory hardlinks RomM uses (`link_or_copy_file` in `backend/utils/filesystem.py`) and silently degrading them to full copies. The Dockerfile intentionally declares only the parent `/romm` for this reason. Naming the base volume in the compose file is topologically identical to the existing recommended setup (the other mounts were already separate); it just replaces the one anonymous volume with a named, identifiable one.

Fixes #3734

**AI assistance disclosure:** This change was authored with AI assistance (PostHog Code). The investigation, fix, and PR description were AI-generated and human-reviewed.

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
