### PR TITLE
fix(ui): remove cover-art attribution link on details pages

### DIFF
--- a/frontend/src/components/Details/Info/GameInfo.vue
+++ b/frontend/src/components/Details/Info/GameInfo.vue
@@ -364,16 +364,8 @@ function getFilterValues(path: string): string[] {
               </span> </template
             >.
           </div>
-          <div v-if="rom.url_cover && coverImageSource" class="mt-1">
-            Cover art provided by
-            <a
-              :href="rom.url_cover"
-              target="_blank"
-              rel="noopener noreferrer"
-              style="color: inherit"
-            >
-              {{ coverImageSource }}</a
-            >.
+          <div v-if="coverImageSource" class="mt-1">
+            Cover art provided by {{ coverImageSource }}.
           </div>
         </v-col>
       </v-row>

--- a/frontend/src/v2/components/GameDetails/OverviewTab.vue
+++ b/frontend/src/v2/components/GameDetails/OverviewTab.vue
@@ -338,19 +338,9 @@ const coverSource = computed(() => {
           >
         </template>
       </i18n-t>
-      <i18n-t
-        v-if="coverSource && rom.url_cover"
-        keypath="rom.cover-art-provided-by"
-        tag="div"
-      >
+      <i18n-t v-if="coverSource" keypath="rom.cover-art-provided-by" tag="div">
         <template #source>
-          <a
-            class="overview-tab__attribution-link"
-            :href="rom.url_cover"
-            target="_blank"
-            rel="noopener"
-            >{{ coverSource }}</a
-          >
+          <span>{{ coverSource }}</span>
         </template>
       </i18n-t>
     </div>


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The "Cover art provided by X" line at the bottom of the game details pages linked the source name to `rom.url_cover`. For ScreenScraper, that field is a media download URL with embedded credentials, so the link exposed those credentials in the UI (and to anyone the URL was shared with).

This change renders the cover-art source as plain text instead of a link, on both the legacy (v1) and v2 details pages. The metadata provider attribution links (IGDB, MobyGames, etc.) are unchanged since those point to public pages.

We keep storing `url_cover` in the database as-is; this only removes it from the UI.

Fixes #3612

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

---

**AI assistance disclosure:** This PR was written with AI assistance (PostHog Code). The change (identifying the credential-leaking link, editing both v1 and v2 templates, and verifying with typecheck) was AI-generated and human-reviewed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*