### PR TITLE
feat: inject ScreenScraper dev credentials at build time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,9 @@ jobs:
           tags: ${{ steps.meta-slim.outputs.tags }}
           labels: ${{ steps.meta-slim.outputs.labels }}
           target: slim-image
+          build-args: |
+            SCREENSCRAPER_DEV_ID=${{ secrets.SCREENSCRAPER_DEV_ID }}
+            SCREENSCRAPER_DEV_PASSWORD=${{ secrets.SCREENSCRAPER_DEV_PASSWORD }}
 
       - name: Build full image
         id: build-full
@@ -127,6 +130,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           target: full-image
+          build-args: |
+            SCREENSCRAPER_DEV_ID=${{ secrets.SCREENSCRAPER_DEV_ID }}
+            SCREENSCRAPER_DEV_PASSWORD=${{ secrets.SCREENSCRAPER_DEV_PASSWORD }}
 
   trigger-docs-and-web:
     permissions:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -107,6 +107,9 @@ jobs:
           platforms: linux/arm64,linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           target: full-image
+          build-args: |
+            SCREENSCRAPER_DEV_ID=${{ secrets.SCREENSCRAPER_DEV_ID }}
+            SCREENSCRAPER_DEV_PASSWORD=${{ secrets.SCREENSCRAPER_DEV_PASSWORD }}
 
       # PR builds always push to GHCR only, so the image link is hardcoded to GHCR.
       - name: Comment PR with GHCR image link

--- a/backend/adapters/services/screenscraper.py
+++ b/backend/adapters/services/screenscraper.py
@@ -1,5 +1,4 @@
 import asyncio
-import base64
 import http
 import json
 from typing import Final, cast
@@ -10,14 +9,17 @@ from aiohttp.client import ClientTimeout
 from fastapi import HTTPException, status
 
 from adapters.services.screenscraper_types import SSGame
-from config import SCREENSCRAPER_PASSWORD, SCREENSCRAPER_USER
+from config import (
+    SCREENSCRAPER_DEV_ID,
+    SCREENSCRAPER_DEV_PASSWORD,
+    SCREENSCRAPER_PASSWORD,
+    SCREENSCRAPER_USER,
+)
 from logger.logger import log
 from utils import get_version
 from utils.context import ctx_aiohttp_session
 from utils.rate_limiter import ConcurrencyLimiter
 
-SS_DEV_ID: Final = base64.b64decode("enVyZGkxNQ==").decode()
-SS_DEV_PASSWORD: Final = base64.b64decode("eFRKd29PRmpPUUc=").decode()
 LOGIN_ERROR_CHECK: Final = "Erreur de login"
 
 # ScreenScraper enforces a per-account *thread* (concurrency) cap rather than a
@@ -82,8 +84,8 @@ async def auth_middleware(
     """ScreenScraper API authentication mechanism."""
     req.url = req.url.update_query(
         {
-            "devid": SS_DEV_ID,
-            "devpassword": SS_DEV_PASSWORD,
+            "devid": SCREENSCRAPER_DEV_ID or "",
+            "devpassword": SCREENSCRAPER_DEV_PASSWORD or "",
             "output": "json",
             "softname": "romm",
             "ssid": SCREENSCRAPER_USER or "",

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -89,6 +89,9 @@ MOBYGAMES_API_KEY: Final[str | None] = _get_env("MOBYGAMES_API_KEY")
 # SCREENSCRAPER
 SCREENSCRAPER_USER: Final[str | None] = _get_env("SCREENSCRAPER_USER")
 SCREENSCRAPER_PASSWORD: Final[str | None] = _get_env("SCREENSCRAPER_PASSWORD")
+# Developer credentials, injected at build time.
+SCREENSCRAPER_DEV_ID: Final[str | None] = _get_env("SCREENSCRAPER_DEV_ID")
+SCREENSCRAPER_DEV_PASSWORD: Final[str | None] = _get_env("SCREENSCRAPER_DEV_PASSWORD")
 
 # STEAMGRIDDB
 STEAMGRIDDB_API_KEY: Final[str | None] = _get_env("STEAMGRIDDB_API_KEY")

--- a/backend/tests/adapters/services/test_screenscraper.py
+++ b/backend/tests/adapters/services/test_screenscraper.py
@@ -1,5 +1,4 @@
 import asyncio
-import base64
 import http
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -11,8 +10,6 @@ from fastapi import HTTPException, status
 
 from adapters.services.screenscraper import (
     LOGIN_ERROR_CHECK,
-    SS_DEV_ID,
-    SS_DEV_PASSWORD,
     ScreenScraperService,
     auth_middleware,
     is_daily_quota_exhausted,
@@ -26,22 +23,14 @@ INVALID_SYSTEM_ID = 999999
 class TestScreenScraperConstants:
     """Test ScreenScraper constants and configuration."""
 
-    def test_ss_dev_id_decoded(self):
-        """Test that SS_DEV_ID is properly decoded."""
-        expected = base64.b64decode("enVyZGkxNQ==").decode()
-        assert SS_DEV_ID == expected
-
-    def test_ss_dev_password_decoded(self):
-        """Test that SS_DEV_PASSWORD is properly decoded."""
-        expected = base64.b64decode("eFRKd29PRmpPUUc=").decode()
-        assert SS_DEV_PASSWORD == expected
-
     def test_login_error_check_constant(self):
         """Test that LOGIN_ERROR_CHECK constant is defined."""
         assert LOGIN_ERROR_CHECK == "Erreur de login"
 
 
 class TestAuthMiddleware:
+    @patch("adapters.services.screenscraper.SCREENSCRAPER_DEV_ID", "dev_id")
+    @patch("adapters.services.screenscraper.SCREENSCRAPER_DEV_PASSWORD", "dev_pass")
     @patch("adapters.services.screenscraper.SCREENSCRAPER_USER", "test_user")
     @patch("adapters.services.screenscraper.SCREENSCRAPER_PASSWORD", "test_pass")
     @pytest.mark.asyncio
@@ -59,8 +48,8 @@ class TestAuthMiddleware:
 
         # Check that the URL now contains all auth parameters
         expected_params = {
-            "devid": SS_DEV_ID,
-            "devpassword": SS_DEV_PASSWORD,
+            "devid": "dev_id",
+            "devpassword": "dev_pass",
             "output": "json",
             "softname": "romm",
             "ssid": "test_user",
@@ -73,6 +62,8 @@ class TestAuthMiddleware:
         mock_handler.assert_called_once_with(mock_request)
         assert result == mock_response
 
+    @patch("adapters.services.screenscraper.SCREENSCRAPER_DEV_ID", None)
+    @patch("adapters.services.screenscraper.SCREENSCRAPER_DEV_PASSWORD", None)
     @patch("adapters.services.screenscraper.SCREENSCRAPER_USER", "")
     @patch("adapters.services.screenscraper.SCREENSCRAPER_PASSWORD", "")
     @pytest.mark.asyncio
@@ -88,8 +79,8 @@ class TestAuthMiddleware:
         result = await auth_middleware(mock_request, mock_handler)
 
         expected_params = {
-            "devid": SS_DEV_ID,
-            "devpassword": SS_DEV_PASSWORD,
+            "devid": "",
+            "devpassword": "",
             "output": "json",
             "softname": "romm",
             "ssid": "",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -224,6 +224,13 @@ COPY --from=backend-build /src/.venv /src/.venv
 
 ENV PATH="/src/.venv/bin:${PATH}"
 
+# ScreenScraper developer (application) credentials, injected at build time from
+# CI secrets. Kept out of the source tree; empty when not supplied at build.
+ARG SCREENSCRAPER_DEV_ID
+ARG SCREENSCRAPER_DEV_PASSWORD
+ENV SCREENSCRAPER_DEV_ID=${SCREENSCRAPER_DEV_ID}
+ENV SCREENSCRAPER_DEV_PASSWORD=${SCREENSCRAPER_DEV_PASSWORD}
+
 # Security: Set security-focused environment variables
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/docker/build_local_image.sh
+++ b/docker/build_local_image.sh
@@ -3,4 +3,6 @@
 branch_name="$(git symbolic-ref HEAD 2>/dev/null)"
 branch_name=${branch_name##refs/heads/}
 branch_name=${branch_name//\//-} # Replace slashes with dashes
-docker build -t "rommapp/romm-testing:local-${branch_name}" . --file ./docker/Dockerfile
+docker build -t "rommapp/romm-testing:local-${branch_name}" . --file ./docker/Dockerfile \
+	--build-arg "SCREENSCRAPER_DEV_ID=${SCREENSCRAPER_DEV_ID}" \
+	--build-arg "SCREENSCRAPER_DEV_PASSWORD=${SCREENSCRAPER_DEV_PASSWORD}"

--- a/env.template
+++ b/env.template
@@ -69,6 +69,9 @@ HASHEOUS_API_ENABLED=false  # Enable Hasheous API integration
 FLASHPOINT_API_ENABLED=false  # Enable Flashpoint API integration
 HLTB_API_ENABLED=false  # Enable HowLongToBeat API integration
 TGDB_API_ENABLED=false  # Enable TheGamesDB API integration
+# Only use when building your own image or running from source
+# SCREENSCRAPER_DEV_ID=
+# SCREENSCRAPER_DEV_PASSWORD=
 
 # Scans & Tasks
 SCAN_TIMEOUT=14400  # Timeout for background scan/rescan tasks in seconds


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Removes the hardcoded (base64-obfuscated) ScreenScraper *developer* (application) credentials from the source tree and injects them at build time instead.

- `SS_DEV_ID` / `SS_DEV_PASSWORD` constants deleted from `backend/adapters/services/screenscraper.py`. The auth middleware now reads `SCREENSCRAPER_DEV_ID` / `SCREENSCRAPER_DEV_PASSWORD` from config (falling back to `""` when unset), mirroring how the per-user `SCREENSCRAPER_USER` / `SCREENSCRAPER_PASSWORD` already work.
- `docker/Dockerfile`: the `slim-image` stage declares matching `ARG`s and bakes them into `ENV`; this propagates to `full-image`, `dev-slim`, and `dev-full`.
- CI (`build.yml`, `test-build.yml`): both `docker/build-push-action` steps pass `build-args` sourced from `secrets.SCREENSCRAPER_DEV_ID` / `secrets.SCREENSCRAPER_DEV_PASSWORD` (secrets already configured on the repo).
- `docker/build_local_image.sh`: forwards the two local env vars as `--build-arg`s for local image builds.
- `env.template`: documents the two vars, left **commented out** on purpose. An empty value in a `.env` consumed via `env_file` would otherwise override the image's baked-in ENV and break out-of-the-box ScreenScraper for self-hosters.

Note: because the values are baked into image `ENV`, they remain visible via `docker inspect` / `docker history`, which is no weaker than the previous base64-in-source situation while keeping the secrets out of the git tree going forward. Rotating the credentials with ScreenScraper is recommended since they were previously committed.

**AI assistance disclosure**: This PR was written with AI assistance (PostHog Code / Claude). The change was fully authored by the agent and reviewed by the author.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*