### PR TITLE
fix(scan): strip leading dot from dot-separated version tags

### DIFF
--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -141,7 +141,7 @@ def _make_file_hash(
 
 
 GENERIC_TAG_REGEX = re.compile(r"\(([^)]+)\)|\[([^]]+)\]")
-VERSION_TAG_REGEX = re.compile(r"^(?:version|ver|v)(?:[\s_-](.*)|([.\d].*))", re.I)
+VERSION_TAG_REGEX = re.compile(r"^(?:version|ver|v)(?:[\s._-](.*)|([.\d].*))", re.I)
 REGION_TAG_REGEX = re.compile(r"^reg[\s|-](.*)$", re.I)
 REVISION_TAG_REGEX = re.compile(r"^rev[\s|-](.*)$", re.I)
 

--- a/backend/tests/handler/filesystem/test_roms_handler.py
+++ b/backend/tests/handler/filesystem/test_roms_handler.py
@@ -241,6 +241,24 @@ class TestFSRomsHandler:
         parsed_tags = handler.parse_tags(fs_name)
         assert parsed_tags.version == "1.2.3"
 
+        # A dot separator (e.g. "v.1.0", "Ver. 1.00") must not leak into the
+        # version as a leading dot.
+        fs_name = "My Game (v.1.2.3).rom"
+        parsed_tags = handler.parse_tags(fs_name)
+        assert parsed_tags.version == "1.2.3"
+
+        fs_name = "My Game (Ver.1.2.3).rom"
+        parsed_tags = handler.parse_tags(fs_name)
+        assert parsed_tags.version == "1.2.3"
+
+        fs_name = "My Game (Ver. 1.00).rom"
+        parsed_tags = handler.parse_tags(fs_name)
+        assert parsed_tags.version == "1.00"
+
+        fs_name = "My Game (Version.2).rom"
+        parsed_tags = handler.parse_tags(fs_name)
+        assert parsed_tags.version == "2"
+
     def test_parse_tags_non_version_tags_starting_with_v(self, handler: FSRomsHandler):
         """Test parse_tags keeps non-version tags starting with v as generic tags"""
         fs_name = "Rom [2026] [Variation].rom"


### PR DESCRIPTION
**Description**

`VERSION_TAG_REGEX` only treated whitespace, underscore, and hyphen as separators after the version prefix (`version`/`ver`/`v`). A dot-separated tag such as `(v.1.0)` or `(Ver. 1.00)` therefore fell through to the no-separator branch and captured the dot into the version, producing `.1.0` / `.1.00` instead of `1.0` / `1.00`. That wrong value is then persisted to `Rom.version` during scanning and on rename.

This adds `.` to the separator character class so the dot is consumed like the other separators. Digit-prefixed tags like `(v1.0)` are unaffected (they still match the no-separator branch), and non-version `v*` tags (e.g. `[versionB]`) are still ignored. Added unit tests covering `(v.1.2.3)`, `(Ver.1.2.3)`, `(Ver. 1.00)`, and `(Version.2)`.

**Checklist**
- [x] I've tested the changes locally (`pytest tests/handler/filesystem/test_roms_handler.py`, 73 passed)
- [x] I've updated relevant comments
- [x] I've added unit tests that cover the changes

---
This PR was prepared with AI assistance (Claude): the bug was identified via code audit, the one-line regex fix and tests authored with AI help, and verified with fail-before/pass-after unit tests run against the project's test database.
