### PR TITLE
fix(scan): resolve "Reg-" prefixed region shortcodes to full names

### DIFF
--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -214,8 +214,8 @@ class FSRomsHandler(FSHandler):
             # Region prefix
             region_match = REGION_TAG_REGEX.match(raw_tag)
             if region_match:
-                key = region_match[1].lower()
-                regions.append(REGIONS_BY_SHORTCODE.get(key, region_match[1]))
+                region = region_match[1]
+                regions.append(REGIONS_BY_SHORTCODE.get(region, region))
                 continue
 
             # Revision prefix

--- a/backend/tests/handler/filesystem/test_roms_handler.py
+++ b/backend/tests/handler/filesystem/test_roms_handler.py
@@ -272,6 +272,15 @@ class TestFSRomsHandler:
         assert parsed_tags.version == ""
         assert "versionB" in parsed_tags.other_tags
 
+    def test_parse_tags_reg_prefix_resolves_shortcode(self, handler: FSRomsHandler):
+        """A "Reg-" prefixed shortcode resolves to its full region name."""
+        assert "Japan" in handler.parse_tags("Game [Reg-J].rom").regions
+        assert "USA" in handler.parse_tags("Game [Reg-U].rom").regions
+        assert "Netherlands" in handler.parse_tags("Game [Reg-NL].rom").regions
+
+        # A value that is not a shortcode is kept verbatim.
+        assert "PAL" in handler.parse_tags("Game [Reg-PAL].rom").regions
+
     def test_exclude_multi_roms_filters_excluded(self, handler: FSRomsHandler, config):
         """Test exclude_multi_roms filters out excluded multi-file ROMs"""
         roms = ["Game1", "excluded_multi", "Game2", "Game3"]


### PR DESCRIPTION
**Description**

`parse_tags` failed to resolve region shortcodes that use the `Reg-` prefix.

PR #3035 (Fixes #3026) made region/language shortcode lookups case-sensitive by keying `REGIONS_BY_SHORTCODE` on the uppercase codes and matching the plain tag lookups against the raw (un-lowered) tag. The `Reg-` prefix branch was missed: it still lowercased the captured shortcode before the lookup, so it could never hit the now uppercase-keyed dict. A tag like `[Reg-J]` was therefore stored as the raw `"J"` instead of resolving to `"Japan"` (`[Reg-U]` -> `"U"` instead of `"USA"`, etc.).

This matches the shortcode with its original case, consistent with the plain lookup a few lines above, so `[Reg-J]` resolves to `Japan` and `[Reg-U]` to `USA`. Non-shortcode values such as `[Reg-PAL]` are still kept verbatim via the `.get(..., fallback)`.

> AI assistance disclosure: this PR was written primarily by Claude Code (bug analysis, one-line fix, and the added unit test), reviewed and verified by me before submitting.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
