### PR TITLE
fix(playmatch): handle empty heartbeat query

### DIFF
--- a/backend/handler/metadata/playmatch_handler.py
+++ b/backend/handler/metadata/playmatch_handler.py
@@ -141,7 +141,7 @@ class PlaymatchHandler(MetadataHandler):
             if value is not None and value != ""  # drop None and ""
         }
 
-        url_with_query = yarl.URL(url).update_query(**filtered_query)
+        url_with_query = yarl.URL(url).update_query(filtered_query)
 
         log.debug(
             "API request: URL=%s, Timeout=%s",

--- a/backend/tests/handler/metadata/test_playmatch_handler.py
+++ b/backend/tests/handler/metadata/test_playmatch_handler.py
@@ -1,0 +1,30 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from handler.metadata.playmatch_handler import PlaymatchHandler
+from utils import get_version
+
+
+@patch("handler.metadata.playmatch_handler.ctx_httpx_client")
+async def test_heartbeat_requests_health_without_query(mock_ctx_httpx_client):
+    handler = PlaymatchHandler()
+    mock_client = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"status": "ok"}
+    mock_client.get.return_value = mock_response
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    with (
+        patch.object(handler, "is_enabled", return_value=True),
+        patch(
+            "handler.metadata.playmatch_handler._rate_limiter.acquire",
+            new_callable=AsyncMock,
+        ),
+    ):
+        assert await handler.heartbeat() is True
+
+    mock_client.get.assert_awaited_once_with(
+        handler.healthcheck_url,
+        headers={"user-agent": f"RomM/{get_version()}"},
+        timeout=60,
+    )
+    mock_response.raise_for_status.assert_called_once()


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
The 5.0 metadata page checks the Playmatch health endpoint as soon as Playmatch is enabled. That check currently fails before sending a request because RomM expands an empty query into `yarl.URL.update_query()`, which yarl rejects.

This passes the query dictionary directly instead. Empty heartbeat queries now keep the original health URL, while normal identify queries still add their parameters.

Also adds a regression test for the Playmatch heartbeat request.

**Disclosure**
I am not a Python developer and am not very familiar with the RomM codebase. I used Codex using GPT 5.6 Sol to help with the Playmatch heartbeat bugfix and to validate the regression test. I reviewed the result before submitting.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

Backend change only, no screenshots needed
