### PR TITLE
fix(v2): render match-rom covers at full width in Safari

### DIFF
--- a/frontend/src/v2/components/MatchRom/MatchRomBodyGrid.vue
+++ b/frontend/src/v2/components/MatchRom/MatchRomBodyGrid.vue
@@ -301,6 +301,12 @@ watch(
   /* Shrink-wrap the card's natural width and never shrink below it (a fixed
      -height card shrunk on the cross axis would crop its cover). */
   flex: 0 0 auto;
+  /* Lay the card out as a flex item (not a block child). GameCard derives its
+     width from a fixed height via the cover's `aspect-ratio`; as a block child
+     of a shrink-to-fit cell that width resolution is circular, and WebKit
+     (Safari) collapses it to a thin sliver. Flex intrinsic sizing resolves it
+     correctly, the same path the gallery row already relies on. */
+  display: flex;
   /* …but never wider than the grid: a wide cover (landscape provider art, or
      a card wider than a narrow phone) draws its width from the cover aspect
      and is otherwise unbounded, so it would spill past the right edge. Cap it


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes the manual "Match ROM" dialog rendering result covers as thin vertical slivers in Safari (fine in Chromium).

**Root cause**

The v2 `GameCard` derives a non-hero card's width from a fixed height via CSS `aspect-ratio` (`.r-gc { width: auto }` → `.r-gc__art { height: fixed; width: auto }` → `.game-cover { aspect-ratio }`).

- In the gallery, `GameCard` is a *direct flex child* of its row, so WebKit resolves the width through flex intrinsic sizing (correct).
- In `MatchRomBodyGrid.vue`, each card was wrapped in an extra *block-level* `.match-grid__card-cell` (`flex: 0 0 auto`). There the card's `width: auto` resolved against a shrink-to-fit containing block whose width depended on the card. WebKit collapses that circular case to a near-zero width, producing the slivers. Chromium resolves it via intrinsic sizing.

**Fix**

Give `.match-grid__card-cell` `display: flex` so its `GameCard` becomes a flex item and sizes via the same intrinsic-sizing path the gallery already uses. The existing `max-width: 100%` caps on the card and art box are untouched, so wide-cover scaling is unchanged.

**AI assistance disclosure**

This change was authored with AI assistance (PostHog Code): diagnosis and the CSS fix. Reviewed by the PR author.

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

<sub>Note: `npm run typecheck` and `trunk fmt`/`trunk check` pass. Visual confirmation in Safari (both themes) still recommended before merge; a CSS-only sliver-repro isn't covered by unit tests.</sub>

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*