### PR TITLE
fix(v2): batch gallery cover fetches into windows

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,14 +7,14 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.5
+      ref: v1.10.2
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
     - go@1.21.0
     - node@22.16.0
-    - python@3.13.3
+    - python@3.14.4
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   disabled:
@@ -22,27 +22,29 @@ lint:
     - oxipng
     - pyright
   enabled:
+    - grype@0.110.0
+    - pinact@4.0.0
     - dotenv-linter@4.0.0
     - hadolint@2.14.0
-    - markdownlint@0.48.0
-    - eslint@10.0.3
+    - markdownlint@0.49.1
+    - eslint@10.7.0
     - actionlint@1.7.11
     - bandit@1.9.4
-    - black@26.3.0
-    - checkov@3.2.508
+    - black@26.5.1
+    - checkov@3.3.8
     - git-diff-check
     - isort@8.0.1
-    - mypy@1.19.1
+    - mypy@2.3.0
     - osv-scanner@2.3.3
-    - prettier@3.8.1:
+    - prettier@3.9.5:
         packages:
           - "@trivago/prettier-plugin-sort-imports@6.0.2"
-          - "@vue/compiler-sfc@3.5.29"
-    - ruff@0.15.5
+          - "@vue/compiler-sfc@3.5.40"
+    - ruff@0.15.22
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - taplo@0.10.0
-    - trivy@0.69.3
+    - trivy@0.70.0
     - trufflehog@3.93.7
     - yamllint@1.38.0
   ignore:

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -182,14 +182,10 @@ export interface GetRomsParams {
   playerCountsLogic?: string | null;
   metadataProvidersLogic?: string | null;
   tagsLogic?: string | null;
-  // Skip the char index / filter-value aggregations server-side. Left
-  // undefined (the server default is `true`) unless a caller has already
-  // hydrated that metadata and only wants the paged items.
+  // Skip the char index / filter-value aggregations server-side
   withCharIndex?: boolean;
   withFilterValues?: boolean;
-  // Cancellation: pass an AbortSignal to let the caller abort an
-  // in-flight request (e.g. search-typing → previous query aborted,
-  // gallery-context switch → previous platform's windows aborted).
+  // Cancel an in-flight request
   signal?: AbortSignal;
 }
 

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -182,6 +182,11 @@ export interface GetRomsParams {
   playerCountsLogic?: string | null;
   metadataProvidersLogic?: string | null;
   tagsLogic?: string | null;
+  // Skip the char index / filter-value aggregations server-side. Left
+  // undefined (the server default is `true`) unless a caller has already
+  // hydrated that metadata and only wants the paged items.
+  withCharIndex?: boolean;
+  withFilterValues?: boolean;
   // Cancellation: pass an AbortSignal to let the caller abort an
   // in-flight request (e.g. search-typing → previous query aborted,
   // gallery-context switch → previous platform's windows aborted).
@@ -231,6 +236,8 @@ async function getRoms({
   playerCountsLogic = null,
   metadataProvidersLogic = null,
   tagsLogic = null,
+  withCharIndex = undefined,
+  withFilterValues = undefined,
   signal = undefined,
 }: GetRomsParams) {
   const params = {
@@ -336,6 +343,10 @@ async function getRoms({
     ...(filterSaves !== null ? { has_saves: filterSaves } : {}),
     ...(filterStates !== null ? { has_states: filterStates } : {}),
     ...(filterVerified !== null ? { verified: filterVerified } : {}),
+    ...(withCharIndex !== undefined ? { with_char_index: withCharIndex } : {}),
+    ...(withFilterValues !== undefined
+      ? { with_filter_values: withFilterValues }
+      : {}),
   };
 
   return api.get<GetRomsResponse>(`/roms`, {

--- a/frontend/src/v2/components/Gallery/GalleryShell.vue
+++ b/frontend/src/v2/components/Gallery/GalleryShell.vue
@@ -772,10 +772,9 @@ onBeforeUnmount(() => {
   gallerySelection.clear();
   if (searchDebounce) clearTimeout(searchDebounce);
   if (fetchDebounceTimer) clearTimeout(fetchDebounceTimer);
-  // Leaving the gallery entirely (onBeforeRouteLeave doesn't reset the
-  // store): stop any window fetches still downloading so navigating away
-  // mid-scroll doesn't keep the network / backend busy. Keeps the loaded
-  // cache so returning to the same gallery is instant.
+  // When leaving the gallery entirely, stop any window fetches still
+  // downloading so navigating away mid-scroll doesn't keep the network /
+  // backend busy. Keeps the loaded cache so returning to the same gallery is instant.
   galleryRoms.abortInFlight();
   inflowResizeObserver?.disconnect();
   inflowResizeObserver = null;

--- a/frontend/src/v2/components/Gallery/GalleryShell.vue
+++ b/frontend/src/v2/components/Gallery/GalleryShell.vue
@@ -551,22 +551,26 @@ const currentLetter = computed<string>(() => {
   return "";
 });
 
-// Viewport-driven fetch. The shell tracks which positions are
-// currently visible (from the rows in `viewportRange`) and keeps
+// Viewport-driven fetch. The shell collects the positions currently in
+// view (rows in `viewportRange`) and hands them to the store, which keeps
 // `byPosition` in sync by fetching the 72-item windows those positions
-// fall into via `fetchWindowAt`. Windows are shared across cards and
-// cached in the store, so a full viewport resolves in a handful of
-// paginated requests rather than one per card.
+// fall into. Windows are shared across cards and cached, so a full
+// viewport resolves in a handful of paginated requests rather than one
+// per card. (Fetching per-card instead issued one request plus one DB
+// lookup per visible card, so ~100 simultaneous round-trips on a full
+// grid, which the browser's per-host connection cap then serialized into
+// slow waves on low-power devices.)
 //
-// No idle-time prefetch: when the user stops scrolling, no new
-// requests are fired. Windows already covering the viewport keep
-// loading; everything off-screen waits until the user scrolls there.
+// The store also aborts windows that scrolled out of view, so paging
+// through a large library doesn't leave departed windows downloading.
+//
+// No idle-time prefetch: when the user stops scrolling, no new requests
+// are fired for off-screen positions.
 //
 // A small debounce on viewport changes prevents request storms during
 // smooth scrolling: only when the viewport settles for
 // `FETCH_DEBOUNCE_MS` do we sync.
 const FETCH_DEBOUNCE_MS = 80;
-const visiblePositions = new Set<number>();
 let fetchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingRange: { first: number; last: number } | null = null;
 
@@ -586,24 +590,7 @@ function collectVisiblePositions(range: {
 }
 
 function syncFetches(range: { first: number; last: number }) {
-  const next = collectVisiblePositions(range);
-
-  // Fetch the windows covering the positions that just entered. The
-  // store aligns each position to its 72-item window and dedupes
-  // against pending + loaded windows, so this collapses to one
-  // paginated request per window regardless of how many cards are on
-  // screen. (Fetching per-card instead issued one request plus one DB
-  // lookup per visible card, so ~100 simultaneous round-trips on a full
-  // grid, which the browser's per-host connection cap then serialized
-  // into slow waves on low-power devices.)
-  for (const p of next) {
-    if (!galleryRoms.byPosition.has(p)) {
-      void galleryRoms.fetchWindowAt(p);
-    }
-  }
-
-  visiblePositions.clear();
-  for (const p of next) visiblePositions.add(p);
+  galleryRoms.syncVisibleWindows(collectVisiblePositions(range));
 }
 
 function scheduleFetchSync(range: { first: number; last: number }) {
@@ -619,11 +606,10 @@ function scheduleFetchSync(range: { first: number; last: number }) {
 }
 
 // When the virtualItems list itself changes (gallery context switch,
-// search invalidate), drop the visible-position bookkeeping. The
-// store's `invalidateWindows` / `resetGallery` already aborts every
-// in-flight request, so we just clear local state.
+// search invalidate), drop the pending debounced sync. The store's
+// `invalidateWindows` / `resetGallery` already aborts every in-flight
+// request, so we just clear local state.
 watch(virtualItems, () => {
-  visiblePositions.clear();
   if (fetchDebounceTimer) {
     clearTimeout(fetchDebounceTimer);
     fetchDebounceTimer = null;
@@ -786,7 +772,11 @@ onBeforeUnmount(() => {
   gallerySelection.clear();
   if (searchDebounce) clearTimeout(searchDebounce);
   if (fetchDebounceTimer) clearTimeout(fetchDebounceTimer);
-  visiblePositions.clear();
+  // Leaving the gallery entirely (onBeforeRouteLeave doesn't reset the
+  // store): stop any window fetches still downloading so navigating away
+  // mid-scroll doesn't keep the network / backend busy. Keeps the loaded
+  // cache so returning to the same gallery is instant.
+  galleryRoms.abortInFlight();
   inflowResizeObserver?.disconnect();
   inflowResizeObserver = null;
   // Drop the debug stats so the overlay doesn't show stale gallery numbers

--- a/frontend/src/v2/components/Gallery/GalleryShell.vue
+++ b/frontend/src/v2/components/Gallery/GalleryShell.vue
@@ -551,23 +551,20 @@ const currentLetter = computed<string>(() => {
   return "";
 });
 
-// Per-card viewport-driven fetch. The shell tracks which positions
-// are currently visible (from the rows in `viewportRange`) and keeps
-// `byPosition` in sync via per-card `getRom(id)` calls — pure by-id
-// DB lookups on the backend, much faster than the paginated
-// `getRoms(limit/offset)` pipeline. Each fetch is independent, so
-// covers stream in as their individual responses land.
+// Viewport-driven fetch. The shell tracks which positions are
+// currently visible (from the rows in `viewportRange`) and keeps
+// `byPosition` in sync by fetching the 72-item windows those positions
+// fall into via `fetchWindowAt`. Windows are shared across cards and
+// cached in the store, so a full viewport resolves in a handful of
+// paginated requests rather than one per card.
 //
 // No idle-time prefetch: when the user stops scrolling, no new
-// requests are fired. Cards already in the viewport that are still
-// missing keep loading; everything off-screen waits until the user
-// scrolls there.
+// requests are fired. Windows already covering the viewport keep
+// loading; everything off-screen waits until the user scrolls there.
 //
-// Cancellation: positions that leave the viewport while their fetch
-// is in flight are aborted via `cancelFetchAt`. A small debounce on
-// viewport changes prevents fire-and-cancel storms during smooth
-// scrolling — only when the viewport settles for `FETCH_DEBOUNCE_MS`
-// do we sync.
+// A small debounce on viewport changes prevents request storms during
+// smooth scrolling: only when the viewport settles for
+// `FETCH_DEBOUNCE_MS` do we sync.
 const FETCH_DEBOUNCE_MS = 80;
 const visiblePositions = new Set<number>();
 let fetchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -591,20 +588,17 @@ function collectVisiblePositions(range: {
 function syncFetches(range: { first: number; last: number }) {
   const next = collectVisiblePositions(range);
 
-  // Cancel positions that left the viewport before their fetch
-  // resolved. The store's per-position controller handles the network
-  // abort; idempotent if nothing was in flight.
-  for (const p of visiblePositions) {
-    if (!next.has(p) && !galleryRoms.byPosition.has(p)) {
-      galleryRoms.cancelFetchAt(p);
-    }
-  }
-
-  // Fire per-card fetches for positions that just entered. The store
-  // dedupes against in-flight + already-loaded internally.
+  // Fetch the windows covering the positions that just entered. The
+  // store aligns each position to its 72-item window and dedupes
+  // against pending + loaded windows, so this collapses to one
+  // paginated request per window regardless of how many cards are on
+  // screen. (Fetching per-card instead issued one request plus one DB
+  // lookup per visible card, so ~100 simultaneous round-trips on a full
+  // grid, which the browser's per-host connection cap then serialized
+  // into slow waves on low-power devices.)
   for (const p of next) {
     if (!galleryRoms.byPosition.has(p)) {
-      void galleryRoms.fetchRomAt(p);
+      void galleryRoms.fetchWindowAt(p);
     }
   }
 
@@ -792,12 +786,6 @@ onBeforeUnmount(() => {
   gallerySelection.clear();
   if (searchDebounce) clearTimeout(searchDebounce);
   if (fetchDebounceTimer) clearTimeout(fetchDebounceTimer);
-  // Cancel any per-position fetches still in flight for our last
-  // visible set — `invalidateWindows` / `resetGallery` already aborts
-  // window-level fetches; this covers per-card cleanup on unmount.
-  for (const p of visiblePositions) {
-    if (!galleryRoms.byPosition.has(p)) galleryRoms.cancelFetchAt(p);
-  }
   visiblePositions.clear();
   inflowResizeObserver?.disconnect();
   inflowResizeObserver = null;

--- a/frontend/src/v2/components/Gallery/GameListRow.vue
+++ b/frontend/src/v2/components/Gallery/GameListRow.vue
@@ -2,11 +2,10 @@
 // GameListRow — single row of the list-mode gallery.
 //
 // Owns:
-//   * Per-row lazy fetch — onMount fires `fetchRomAt(position)`; the
-//     store dedupes against in-flight + already-loaded. onUnmount aborts
-//     the fetch via `cancelFetchAt(position)` so a fast scroll past
-//     mid-flight doesn't keep server work queued for invisible rows.
-//     Mirror of the per-card flow in grid mode — same "row mount =
+//   * Per-row lazy fetch: onMount fires `fetchWindowAt(position)` and
+//     the store aligns the position to its 72-item window, deduping
+//     against pending + loaded windows, so rows sharing a window share
+//     one request. Mirror of the grid flow, with the same "row mount =
 //     entered viewport" contract via the shell's RVirtualScroller
 //     overscan window.
 //
@@ -27,7 +26,7 @@ import {
   RSkeletonBlock,
   RTooltip,
 } from "@v2/lib";
-import { computed, onBeforeUnmount, onMounted } from "vue";
+import { computed, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import storePlatforms from "@/stores/platforms";
@@ -266,19 +265,9 @@ onMounted(() => {
   // Static mode (rom passed as prop) skips the gallery's per-row fetch
   // entirely — the consumer already owns the rom data.
   if (isStatic.value || props.position === undefined) return;
-  // Entered the overscan window — kick the per-row fetch. Store dedupes
-  // against in-flight + already-loaded.
-  void galleryRoms.fetchRomAt(props.position);
-});
-
-onBeforeUnmount(() => {
-  if (isStatic.value || props.position === undefined) return;
-  // Left the overscan window before the fetch resolved — abort so the
-  // server doesn't keep building a row the user already scrolled past.
-  // Idempotent if nothing was in flight.
-  if (!galleryRoms.byPosition.has(props.position)) {
-    galleryRoms.cancelFetchAt(props.position);
-  }
+  // Entered the overscan window, so kick the window fetch. Store aligns
+  // to the window grid and dedupes against pending + loaded windows.
+  void galleryRoms.fetchWindowAt(props.position);
 });
 </script>
 

--- a/frontend/src/v2/stores/galleryRoms.ts
+++ b/frontend/src/v2/stores/galleryRoms.ts
@@ -97,6 +97,14 @@ function abortAllInFlight() {
   retryCounts.clear();
 }
 
+// Abort a single in-flight window fetch. The rejected request is caught
+// as a cancel in `fetchWindowAt` (no `failedWindows` entry, no retry) and
+// its `finally` clears the pending/controller bookkeeping.
+function cancelWindow(offset: number) {
+  const ctrl = inFlightControllers.get(`window:${offset}`);
+  if (ctrl) ctrl.abort();
+}
+
 // Apply items to `byPosition` in row-sized batches with a rAF yield
 // between batches. Each Map.set() invalidates Vue's per-key dep, and
 // when many cards are in the viewport / overscan zone they all
@@ -519,6 +527,45 @@ export default defineStore("v2GalleryRoms", {
         this.pendingWindows.delete(offset);
         if (offset === 0) this.initialFetching = false;
       }
+    },
+
+    /** Reconcile in-flight window fetches with the currently visible
+     * positions. Starts any window covering a visible position (deduped
+     * inside `fetchWindowAt`) and aborts any in-flight or retry-pending
+     * window that no longer covers one. Without the abort, scrolling
+     * through a large library would leave every window it passed
+     * downloading and applying in the background — the exact wasted
+     * network / backend / render work this store exists to avoid on
+     * low-power devices. Driven by the shell's debounced viewport sync. */
+    syncVisibleWindows(positions: Iterable<number>) {
+      const wanted = new Set<number>();
+      for (const p of positions) {
+        if (p < 0) continue;
+        if (this.total > 0 && p >= this.total) continue;
+        wanted.add(alignToWindow(p));
+      }
+      // Cancel windows that drifted out of view. Snapshot first: aborting
+      // settles a fetch's `finally` (which mutates these sets) on a later
+      // microtask, but iterate a copy to stay safe regardless.
+      for (const offset of [...this.pendingWindows]) {
+        if (!wanted.has(offset)) cancelWindow(offset);
+      }
+      for (const offset of [...retryTimers.keys()]) {
+        if (!wanted.has(offset)) clearRetry(offset);
+      }
+      for (const offset of wanted) {
+        void this.fetchWindowAt(offset);
+      }
+    },
+
+    /** Abort every in-flight window fetch + pending retry without wiping
+     * the loaded cache. The shell calls this when the gallery unmounts so
+     * navigating away mid-scroll doesn't leave downloads running; a
+     * return to the same gallery still reuses `loadedWindows`. */
+    abortInFlight() {
+      abortAllInFlight();
+      this.pendingWindows = new Set();
+      this.initialFetching = false;
     },
 
     /** Apply (in place) an updated ROM to whatever position currently

--- a/frontend/src/v2/stores/galleryRoms.ts
+++ b/frontend/src/v2/stores/galleryRoms.ts
@@ -460,16 +460,11 @@ export default defineStore("v2GalleryRoms", {
       const controller = new AbortController();
       inFlightControllers.set(ctrlKey, controller);
 
-      // Once the bootstrap (or window 0) has populated the filter panel,
-      // alpha strip, and id index, later windows only need their paged
-      // items — skip the char index / filter-value aggregations so the
-      // backend doesn't recompute them for every window.
-      const skipMetadata = this.metadataLoaded;
-
       try {
         const response = await romApi.getRoms({
           ...params,
-          ...(skipMetadata
+          // Skip char index / filter-value aggregations when initial data is loaded
+          ...(this.metadataLoaded
             ? { withCharIndex: false, withFilterValues: false }
             : {}),
           signal: controller.signal,

--- a/frontend/src/v2/stores/galleryRoms.ts
+++ b/frontend/src/v2/stores/galleryRoms.ts
@@ -460,9 +460,18 @@ export default defineStore("v2GalleryRoms", {
       const controller = new AbortController();
       inFlightControllers.set(ctrlKey, controller);
 
+      // Once the bootstrap (or window 0) has populated the filter panel,
+      // alpha strip, and id index, later windows only need their paged
+      // items — skip the char index / filter-value aggregations so the
+      // backend doesn't recompute them for every window.
+      const skipMetadata = this.metadataLoaded;
+
       try {
         const response = await romApi.getRoms({
           ...params,
+          ...(skipMetadata
+            ? { withCharIndex: false, withFilterValues: false }
+            : {}),
           signal: controller.signal,
         });
         // Re-check that this window is still relevant — invalidateWindows

--- a/frontend/src/v2/stores/galleryRoms.ts
+++ b/frontend/src/v2/stores/galleryRoms.ts
@@ -61,9 +61,9 @@ type GalleryFilterStore = ExtractPiniaStoreType<typeof storeGalleryFilter>;
 // fewer requests but each one downloads more.
 const WINDOW_SIZE = 72;
 
-// In-flight `AbortController`s keyed by request — `window:${offset}`
-// for the windowed initial fetch, `range:${offset}:${limit}` for the
-// per-row dwell prefetch. Lives outside store state so Pinia doesn't
+// In-flight `AbortController`s keyed by request: `window:${offset}`
+// for a windowed fetch, `bootstrap` for the lightweight metadata
+// bootstrap. Lives outside store state so Pinia doesn't
 // try to proxy native abort objects (which break under reactivity).
 // `invalidateWindows()` / `resetGallery()` abort every pending request,
 // so a fast-typed search box or a platform-switch mid-load doesn't
@@ -140,10 +140,10 @@ interface State {
   // phase.
   initialFetching: boolean;
   // True once total / charIndex / romIdIndex / filter_values have been
-  // populated — either by the lightweight `fetchInitialMetadata()`
-  // bootstrap or by `fetchWindowAt(0)`. Used to gate the initial fetch
-  // dedup independently of `loadedWindows` (metadata bootstrap doesn't
-  // load any window).
+  // populated, either by the lightweight `fetchInitialMetadata()`
+  // bootstrap or by `fetchWindowAt(0)`. Used to gate the initial
+  // bootstrap dedup independently of `loadedWindows` (metadata
+  // bootstrap doesn't load any window).
   metadataLoaded: boolean;
   // Order params — gallery-list scoped (separate from v1's localStorage
   // keys so v1/v2 don't fight over the same value).
@@ -363,15 +363,14 @@ export default defineStore("v2GalleryRoms", {
 
     /** Lightweight bootstrap: fetch only the gallery's metadata (total,
      * char_index, rom_id_index, filter_values) without loading any
-     * items. Use this when items will be hydrated lazily through the
-     * per-card `fetchRomAt(p)` viewport sync — e.g. grid-mode galleries.
+     * items. Sizes the virtualiser (via `total`) before any window
+     * lands, so both layouts can render skeleton rows immediately and
+     * then hydrate them through the viewport-driven `fetchWindowAt`
+     * sync.
      *
      * The backend's `limit` minimum is 1, so we still pay for one
-     * `SimpleRomSchema` build server-side, but we discard the item
-     * client-side: every position (including 0) loads through the
-     * unified per-card path so the staggered fade-in applies to the
-     * first rows the same as the rest. List mode still wants
-     * `fetchWindowAt(0)` because the table reads `byPosition` directly. */
+     * `SimpleRomSchema` build server-side, but the item is discarded
+     * client-side. */
     async fetchInitialMetadata(): Promise<void> {
       if (this.metadataLoaded) return;
       if (this.initialFetching) return;
@@ -480,76 +479,6 @@ export default defineStore("v2GalleryRoms", {
         inFlightControllers.delete(ctrlKey);
         this.pendingWindows.delete(offset);
         if (offset === 0) this.initialFetching = false;
-      }
-    },
-
-    /** Fetch an arbitrary `[offset, offset + limit)` range. Used by the
-     * per-row dwell prefetch in the gallery views — instead of always
-     * pulling the full 72-item window, a row asks for exactly its 8
-     * positions, so visible rows can resolve in parallel and the user
-     * sees covers stream in row-by-row.
-     *
-     * Skips the request when every position in the range is already
-     * loaded; dedupes concurrent identical requests by (offset, limit)
-     * key. The initial window — total / charIndex bootstrapping — still
-     * goes through `fetchWindowAt(0)`. */
-    /** Fetch the single ROM at `position` via `GET /roms/{id}/simple` —
-     * the lightweight schema endpoint that skips the eager `user_saves`
-     * / `user_states` / `user_screenshots` / `user_collections` /
-     * `all_user_notes` arrays (those are 5 separate DB queries each;
-     * dropping them takes the call from ~500ms to a typical by-id
-     * lookup). The gallery card only needs the `has_*` indicator
-     * flags + cover paths + platform info — all on `SimpleRomSchema`.
-     * Detailed arrays are pulled on demand by the game-details page
-     * or by quick-action dialogs (note editor, achievements panel)
-     * when the user actually opens them.
-     *
-     * Requires `romIdIndex[position]` — populated by the first
-     * `fetchWindowAt(0)` for the active gallery. Returns silently
-     * if the index isn't loaded yet.
-     *
-     * Per-position `AbortController` allows the shell to cancel
-     * fetches for cards that left the viewport before resolving.
-     * `cancelFetchAt(position)` is the cancel side. */
-    async fetchRomAt(position: number): Promise<void> {
-      if (position < 0) return;
-      if (this.total > 0 && position >= this.total) return;
-      if (this.byPosition.has(position)) return;
-      const romId = this.romIdIndex[position];
-      if (!romId) return;
-
-      const ctrlKey = `rom:${position}`;
-      if (inFlightControllers.has(ctrlKey)) return;
-
-      const controller = new AbortController();
-      inFlightControllers.set(ctrlKey, controller);
-
-      try {
-        const response = await romApi.getRomSimple({
-          romId,
-          signal: controller.signal,
-        });
-        // Re-check that the shell still wants this position — a fast
-        // scroll past + cancel races against the response landing.
-        if (!inFlightControllers.has(ctrlKey)) return;
-        this.byPosition.set(position, response.data);
-      } catch (err) {
-        if (axios.isCancel(err)) return;
-        console.error("[v2GalleryRoms] rom fetch failed", position, romId, err);
-      } finally {
-        inFlightControllers.delete(ctrlKey);
-      }
-    },
-
-    /** Cancel an in-flight per-position fetch — typically called by
-     * the shell when a card leaves the viewport before its request
-     * resolves. No-op if nothing is in flight for that position. */
-    cancelFetchAt(position: number) {
-      const ctrlKey = `rom:${position}`;
-      const ctrl = inFlightControllers.get(ctrlKey);
-      if (ctrl) {
-        ctrl.abort();
-        inFlightControllers.delete(ctrlKey);
       }
     },
 

--- a/frontend/src/v2/stores/galleryRoms.ts
+++ b/frontend/src/v2/stores/galleryRoms.ts
@@ -70,9 +70,31 @@ const WINDOW_SIZE = 72;
 // leave server work going for results we'll throw away.
 const inFlightControllers = new Map<string, AbortController>();
 
+// A failed window is only refetched when `fetchWindowAt` is called for it
+// again, which for a static viewport (no scroll) never happens on its own.
+// So a transient failure would strand up to `WINDOW_SIZE` visible cards as
+// skeletons. To self-heal, a failed window schedules a bounded, backing-off
+// retry; `retryTimers` holds the pending timeouts (keyed by offset) and
+// `retryCounts` the attempts so far. Both are cleared by `abortAllInFlight`
+// on any gallery-context switch so we never retry against a stale context.
+const RETRY_BACKOFF_MS = 2000;
+const MAX_WINDOW_RETRIES = 3;
+const retryTimers = new Map<number, ReturnType<typeof setTimeout>>();
+const retryCounts = new Map<number, number>();
+
+function clearRetry(offset: number) {
+  const timer = retryTimers.get(offset);
+  if (timer !== undefined) clearTimeout(timer);
+  retryTimers.delete(offset);
+  retryCounts.delete(offset);
+}
+
 function abortAllInFlight() {
   for (const ctrl of inFlightControllers.values()) ctrl.abort();
   inFlightControllers.clear();
+  for (const timer of retryTimers.values()) clearTimeout(timer);
+  retryTimers.clear();
+  retryCounts.clear();
 }
 
 // Apply items to `byPosition` in row-sized batches with a rAF yield
@@ -466,15 +488,32 @@ export default defineStore("v2GalleryRoms", {
         );
 
         this.loadedWindows.add(offset);
+        // Recovered — drop any retry bookkeeping for this window.
+        clearRetry(offset);
       } catch (err) {
         // An explicit abort isn't a failure — keep `failedWindows`
         // clean so the window is eligible to refetch under the new
         // gallery context without the UI flagging it as broken.
         if (axios.isCancel(err)) return;
         this.failedWindows.add(offset);
-        // Surface in console; UI keeps the skeletons in place — the
-        // window can be retried by re-entering the row.
+        // Surface in console; UI keeps the skeletons in place until the
+        // retry below (or a viewport / gallery-state change) refetches.
         console.error("[v2GalleryRoms] window fetch failed", offset, err);
+        // Self-heal a stranded viewport: schedule a bounded, backing-off
+        // refetch so a transient blip doesn't leave the window's cards as
+        // skeletons until the user happens to scroll.
+        const attempts = retryCounts.get(offset) ?? 0;
+        if (attempts < MAX_WINDOW_RETRIES && !retryTimers.has(offset)) {
+          retryCounts.set(offset, attempts + 1);
+          const timer = setTimeout(
+            () => {
+              retryTimers.delete(offset);
+              void this.fetchWindowAt(offset);
+            },
+            RETRY_BACKOFF_MS * (attempts + 1),
+          );
+          retryTimers.set(offset, timer);
+        }
       } finally {
         inFlightControllers.delete(ctrlKey);
         this.pendingWindows.delete(offset);


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The v2 gallery is dramatically slower than v1 to load cover thumbnails on low-power devices. On an Amlogic S905W2 TV box, a grid of ~108 covers takes 1-2 minutes to fill; the v1 UI loaded the same library in 1-2 seconds.

**Root cause:** v2 hydrated each visible card with its own `GET /roms/{id}/simple` request, i.e. one HTTP round trip and one DB lookup per card. On a full grid that fires ~100 requests almost simultaneously. The browser's per-host connection limit (~6) serializes them into ~17 slow waves, and each wave pays full HTTP + JSON + a discrete backend query. v1 instead fetched a whole page (`GET /roms?limit=72&offset=...`) in 1-2 batched requests.

**Fix:** route both layouts' hydration through the store's existing `fetchWindowAt`, which aligns each visible position to its shared 72-item window and dedupes against pending/loaded windows:

- Grid: `GalleryShell.syncFetches` now calls `fetchWindowAt(p)` per visible position instead of per-card `fetchRomAt(p)`. Positions in the same window collapse to a single request (the store adds the offset to `pendingWindows` synchronously before its first `await`, so concurrent calls dedupe).
- List: `GameListRow` mount now calls `fetchWindowAt(position)`.
- Removes the now-unused `fetchRomAt` / `cancelFetchAt` store actions and their per-position `AbortController` bookkeeping. Per-window fetches are still aborted en masse by `invalidateWindows` / `resetGallery` on context switch.

A full viewport now resolves in a handful of paginated requests rather than one per card, matching v1's batched loading.

Note: two secondary GPU costs also compound this on weak GPUs but are out of scope here: the always-on full-viewport `filter: blur(28px)` background layer, and the per-card `filter: blur(16px)` cover reveal animation. Happy to follow up on those separately.

**AI assistance disclosure:** This change was authored with AI assistance (PostHog Code / Claude). The diagnosis, code changes, and comment updates were AI-generated and human-reviewed.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A (no visual change; loading behavior only).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*