### PR TITLE
fix(migrations): make DDL idempotent on partial-failure reruns

### DIFF
--- a/backend/alembic/versions/0014_asset_files.py
+++ b/backend/alembic/versions/0014_asset_files.py
@@ -168,18 +168,13 @@ def upgrade() -> None:
         batch_op.drop_constraint(constraint_name=pk_constraint_name, type_="primary")
         batch_op.drop_column("n_roms", if_exists=True)
 
-    # Switch to new id column as platform primary key. Raw DDL has no portable
-    # "IF NOT EXISTS", so guard it to stay idempotent on a partial-failure rerun.
-    platform_columns = {
-        column["name"] for column in sa.inspect(connection).get_columns("platforms")
-    }
-    if "id" not in platform_columns:
-        if is_postgresql(connection):
-            op.execute("ALTER TABLE platforms ADD COLUMN id SERIAL PRIMARY KEY")
-        else:
-            op.execute(
-                "ALTER TABLE platforms ADD COLUMN id INTEGER(11) NOT NULL AUTO_INCREMENT PRIMARY KEY"
-            )
+    # Switch to new id column as platform primary key
+    if is_postgresql(connection):
+        op.execute("ALTER TABLE platforms ADD COLUMN id SERIAL PRIMARY KEY")
+    else:
+        op.execute(
+            "ALTER TABLE platforms ADD COLUMN id INTEGER(11) NOT NULL AUTO_INCREMENT PRIMARY KEY"
+        )
 
     # Add new columns to roms table
     with op.batch_alter_table("roms", schema=None) as batch_op:

--- a/backend/alembic/versions/0014_asset_files.py
+++ b/backend/alembic/versions/0014_asset_files.py
@@ -168,13 +168,18 @@ def upgrade() -> None:
         batch_op.drop_constraint(constraint_name=pk_constraint_name, type_="primary")
         batch_op.drop_column("n_roms", if_exists=True)
 
-    # Switch to new id column as platform primary key
-    if is_postgresql(connection):
-        op.execute("ALTER TABLE platforms ADD COLUMN id SERIAL PRIMARY KEY")
-    else:
-        op.execute(
-            "ALTER TABLE platforms ADD COLUMN id INTEGER(11) NOT NULL AUTO_INCREMENT PRIMARY KEY"
-        )
+    # Switch to new id column as platform primary key. Raw DDL has no portable
+    # "IF NOT EXISTS", so guard it to stay idempotent on a partial-failure rerun.
+    platform_columns = {
+        column["name"] for column in sa.inspect(connection).get_columns("platforms")
+    }
+    if "id" not in platform_columns:
+        if is_postgresql(connection):
+            op.execute("ALTER TABLE platforms ADD COLUMN id SERIAL PRIMARY KEY")
+        else:
+            op.execute(
+                "ALTER TABLE platforms ADD COLUMN id INTEGER(11) NOT NULL AUTO_INCREMENT PRIMARY KEY"
+            )
 
     # Add new columns to roms table
     with op.batch_alter_table("roms", schema=None) as batch_op:

--- a/backend/alembic/versions/0033_rom_file_and_hashes.py
+++ b/backend/alembic/versions/0033_rom_file_and_hashes.py
@@ -37,7 +37,7 @@ def upgrade() -> None:
             name="romfilecategory",
             create_type=False,
         )
-        rom_file_category_enum.create(connection, checkfirst=False)
+        rom_file_category_enum.create(connection, checkfirst=True)
     else:
         rom_file_category_enum = sa.Enum(
             "GAME",
@@ -263,4 +263,4 @@ def downgrade() -> None:
     op.drop_table("rom_files", if_exists=True)
 
     if is_postgresql(connection):
-        ENUM(name="romfilecategory").drop(connection, checkfirst=False)
+        ENUM(name="romfilecategory").drop(connection, checkfirst=True)

--- a/backend/alembic/versions/0084_add_roms_search_index.py
+++ b/backend/alembic/versions/0084_add_roms_search_index.py
@@ -47,12 +47,18 @@ def upgrade() -> None:
 
     # 1. DB-specific search indexes on roms.name and roms.fs_name.
     if is_mysql(bind) or is_mariadb(bind):
-        op.execute(
-            sa.text(
-                f"CREATE FULLTEXT INDEX {FULLTEXT_INDEX_NAME} "
-                "ON roms (name, fs_name)"
+        # MySQL/MariaDB have no portable "IF NOT EXISTS" for FULLTEXT indexes, so
+        # guard the create to stay idempotent if a prior run partially applied.
+        existing_indexes = {
+            index["name"] for index in sa.inspect(bind).get_indexes("roms")
+        }
+        if FULLTEXT_INDEX_NAME not in existing_indexes:
+            op.execute(
+                sa.text(
+                    f"CREATE FULLTEXT INDEX {FULLTEXT_INDEX_NAME} "
+                    "ON roms (name, fs_name)"
+                )
             )
-        )
     elif is_postgresql(bind):
         # pg_trgm is a trusted extension since PostgreSQL 13, so a non-superuser
         # with CREATE on the database can install it.
@@ -130,7 +136,12 @@ def downgrade() -> None:
 
     # 1. DB-specific search indexes.
     if is_mysql(bind) or is_mariadb(bind):
-        op.execute(sa.text(f"DROP INDEX {FULLTEXT_INDEX_NAME} ON roms"))
+        # MySQL has no portable "IF EXISTS" for DROP INDEX, so guard the drop.
+        existing_indexes = {
+            index["name"] for index in sa.inspect(bind).get_indexes("roms")
+        }
+        if FULLTEXT_INDEX_NAME in existing_indexes:
+            op.execute(sa.text(f"DROP INDEX {FULLTEXT_INDEX_NAME} ON roms"))
     elif is_postgresql(bind):
         # Leave the pg_trgm extension in place; other objects may depend on it.
         op.execute(sa.text(f"DROP INDEX IF EXISTS {PG_FS_NAME_INDEX}"))


### PR DESCRIPTION
**Description**

Migration `0084_add_roms_search_index` could crash on startup with:

```
mariadb.OperationalError: Duplicate key name 'idx_roms_name_fs_name_fulltext'
[SQL: CREATE FULLTEXT INDEX idx_roms_name_fs_name_fulltext ON roms (name, fs_name)]
```

This happens when a prior run of the migration created the FULLTEXT index but then failed at a later step (e.g. the `name_sort_key` backfill, which touches every row) before Alembic recorded the revision as applied. On every subsequent boot, Alembic re-runs `0084` from the top and dies immediately re-creating an index that already exists. Unlike the PostgreSQL branch and the later steps in the same migration, the MySQL/MariaDB `CREATE FULLTEXT INDEX` had no idempotency guard, and there is no portable `IF NOT EXISTS` form for it.

This PR guards the raw DDL in the affected migrations so that re-running a partially-applied migration is safe:

- **`0084_add_roms_search_index.py`** — check existing indexes via `sa.inspect(bind).get_indexes("roms")` before creating/dropping the FULLTEXT index (the reported crash).
- **`0014_asset_files.py`** — check existing columns via `sa.inspect(connection).get_columns("platforms")` before the raw `ALTER TABLE platforms ADD COLUMN id ...` (same class of bug; older migration, lower practical risk).
- **`0033_rom_file_and_hashes.py`** — switch the Postgres enum `create()`/`drop()` from `checkfirst=False` to `checkfirst=True`, matching the safe pattern already used in `0062`/`0092`.

Fixes the migration failure reported in the attached startup log.

**AI assistance disclosure**

This change was written with AI assistance (PostHog Code). The failure was diagnosed from a user-provided startup log, the fix and the audit of other migrations for the same defect were AI-generated, and all changes were human-reviewed.

**Checklist**

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*