### PR TITLE
fix(ss): tolerate ScreenScraper's invalid JSON escapes

### DIFF
--- a/backend/adapters/services/screenscraper.py
+++ b/backend/adapters/services/screenscraper.py
@@ -27,7 +27,7 @@ LOGIN_ERROR_CHECK: Final = "Erreur de login"
 # text fields (e.g. game synopses), which the strict parser rejects with
 # "Invalid \escape" and discards the whole response. Match any backslash that is
 # not part of a valid JSON escape so we can repair those before parsing.
-_INVALID_ESCAPE_RE: Final = re.compile(r'\\(?!["\\/bfnrtu])')
+_INVALID_ESCAPE_RE: Final = re.compile(r'\\(?!["\\/bfnrt]|u[0-9a-fA-F]{4})')
 
 
 def _loads_lenient(text: str) -> dict:

--- a/backend/adapters/services/screenscraper.py
+++ b/backend/adapters/services/screenscraper.py
@@ -1,6 +1,7 @@
 import asyncio
 import http
 import json
+import re
 from typing import Final, cast
 
 import aiohttp
@@ -21,6 +22,26 @@ from utils.context import ctx_aiohttp_session
 from utils.rate_limiter import ConcurrencyLimiter
 
 LOGIN_ERROR_CHECK: Final = "Erreur de login"
+
+# ScreenScraper occasionally returns malformed JSON with unescaped backslashes in
+# text fields (e.g. game synopses), which the strict parser rejects with
+# "Invalid \escape" and discards the whole response. Match any backslash that is
+# not part of a valid JSON escape so we can repair those before parsing.
+_INVALID_ESCAPE_RE: Final = re.compile(r'\\(?!["\\/bfnrtu])')
+
+
+def _loads_lenient(text: str) -> dict:
+    """Parse a ScreenScraper JSON payload, repairing invalid escapes on failure.
+
+    A single unescaped backslash would otherwise sink an entire response (and thus
+    the match), so on a decode error we double any backslash that isn't a valid
+    JSON escape and try once more.
+    """
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return json.loads(_INVALID_ESCAPE_RE.sub(r"\\\\", text))
+
 
 # ScreenScraper enforces a per-account *thread* (concurrency) cap rather than a
 # request rate. Because a request can take several seconds, spacing out request
@@ -140,7 +161,7 @@ class ScreenScraperService:
                         status_code=status.HTTP_401_UNAUTHORIZED,
                         detail="Invalid ScreenScraper credentials",
                     )
-                data = await res.json()
+                data = await res.json(loads=_loads_lenient)
             _update_thread_allowance(data)
             return data
         except aiohttp.ServerTimeoutError:
@@ -213,7 +234,7 @@ class ScreenScraperService:
                         status_code=status.HTTP_401_UNAUTHORIZED,
                         detail="Invalid ScreenScraper credentials",
                     )
-                data = await res.json()
+                data = await res.json(loads=_loads_lenient)
             _update_thread_allowance(data)
             return data
         except (aiohttp.ClientResponseError, aiohttp.ServerTimeoutError) as err:

--- a/backend/tests/adapters/services/test_screenscraper.py
+++ b/backend/tests/adapters/services/test_screenscraper.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException, status
 from adapters.services.screenscraper import (
     LOGIN_ERROR_CHECK,
     ScreenScraperService,
+    _loads_lenient,
     auth_middleware,
     is_daily_quota_exhausted,
     reset_daily_quota,
@@ -1124,3 +1125,23 @@ class TestScreenScraperServiceEdgeCases:
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
         assert "Invalid ScreenScraper credentials" in exc_info.value.detail
         assert mock_session.get.call_count == 2
+
+
+class TestLoadsLenient:
+    """Test tolerant parsing of ScreenScraper's occasionally malformed JSON."""
+
+    def test_parses_valid_json(self):
+        assert _loads_lenient('{"a": 1, "b": "x"}') == {"a": 1, "b": "x"}
+
+    def test_repairs_invalid_backslash_escape(self):
+        # ScreenScraper sometimes emits raw backslashes in text fields, which the
+        # strict parser rejects with "Invalid \escape".
+        raw = '{"synopsis": "path C:\\emu\\games"}'
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(raw)
+        assert _loads_lenient(raw) == {"synopsis": "path C:\\emu\\games"}
+
+    def test_preserves_valid_escapes(self):
+        assert _loads_lenient('{"s": "line\\nbreak \\"quoted\\" \\u00e9"}') == {
+            "s": 'line\nbreak "quoted" é'
+        }


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

ScreenScraper's API occasionally returns malformed JSON: some text fields (e.g. game synopses) contain raw, unescaped backslashes, producing sequences like `\e` that aren't valid JSON escapes. Python's strict parser (via aiohttp's `res.json()`) rejects the **entire** response with:

```
[screenscraper] Error decoding JSON response from ScreenScraper: Invalid \escape: line 26 column 11
```

`_request()` caught the `JSONDecodeError` and returned `{}`, which reads as "no match". So ScreenScraper silently found nothing, even for trivially-matchable titles like Banjo-Kazooie, while IGDB/SGDB/Libretro (clean JSON) matched fine.

**Fix:** parse leniently. On a decode error, double any backslash that isn't a valid JSON escape and retry, instead of discarding the whole response. Valid escapes (`\n`, `\"`, `\uXXXX`, etc.) are preserved; if the retry still fails, the existing `{}` fallback applies.

Applied at both request sites via aiohttp's `res.json(loads=...)` hook to keep the change minimal.

Fixes #3764

> Note: the PlayMatch error in the same issue is tracked separately and already fixed for the next release. The issue also mentions LaunchBox, but there was no LaunchBox error in the reporter's logs to diagnose.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

**AI assistance disclosure:** This PR was written with AI assistance (PostHog Code / Claude). The root-cause analysis, code change, and tests were AI-generated and reviewed by a human before submission.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*