### PR TITLE
fix(backend): lightweight eager-load for /roms/{id}/simple

### DIFF
--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -1083,7 +1083,7 @@ def get_rom_simple(
     fetched on user-driven detail interactions (game details page, quick-
     note dialog open, achievements panel)."""
 
-    rom = db_rom_handler.get_rom(id)
+    rom = db_rom_handler.get_rom_simple(id)
 
     if not rom:
         raise RomNotFoundInDatabaseException(id)

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -243,6 +243,50 @@ def with_details(func):
     return wrapper
 
 
+def with_simple_details(func):
+    """Lightweight eager-load for the `SimpleRomSchema` (v2 gallery card).
+
+    Loads only the relationships `SimpleRomSchema` serializes (rom_users,
+    files, sibling_roms + their rom_users, notes) and the deferred file-count
+    columns, skipping the `saves` / `states` / `screenshots` / `collections`
+    arrays that `with_details` pulls for the detail view. Keeps per-card
+    hydration cheap on low-power hosts.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        kwargs["query"] = select(Rom).options(
+            selectinload(Rom.platform),
+            selectinload(Rom.rom_users).options(noload(RomUser.rom)),
+            selectinload(Rom.metadatum).options(noload(RomMetadata.rom)),
+            selectinload(Rom.files).options(
+                joinedload(RomFile.rom).load_only(Rom.fs_path, Rom.fs_name),
+                selectinload(RomFile.track_meta),
+            ),
+            selectinload(Rom.sibling_roms).options(
+                noload(Rom.platform),
+                noload(Rom.metadatum),
+                # Per-sibling is_main_sibling resolution needs each sibling's
+                # RomUser (relationship is `lazy="raise"`).
+                selectinload(Rom.rom_users).options(noload(RomUser.rom)),
+                load_only(
+                    Rom.id,
+                    Rom.name,
+                    Rom.platform_id,
+                    Rom.fs_name_no_tags,
+                    Rom.fs_name_no_ext,
+                ),
+            ),
+            selectinload(Rom.notes),
+            undefer(Rom.multi_file),
+            undefer(Rom.top_level_file_count),
+            undefer(Rom.has_soundtrack),
+        )
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
 class DBRomsHandler(DBBaseHandler):
     @begin_session
     @with_details
@@ -266,6 +310,18 @@ class DBRomsHandler(DBBaseHandler):
         query: Query = None,  # type: ignore
         session: Session = None,  # type: ignore
     ) -> Rom | None:
+        return session.scalar(query.filter_by(id=id).limit(1))
+
+    @begin_session
+    @with_simple_details
+    def get_rom_simple(
+        self,
+        id: int,
+        *,
+        query: Query = None,  # type: ignore
+        session: Session = None,  # type: ignore
+    ) -> Rom | None:
+        """Get a rom by ID with only the loads `SimpleRomSchema` needs."""
         return session.scalar(query.filter_by(id=id).limit(1))
 
     @begin_session

--- a/backend/tests/endpoints/roms/test_rom.py
+++ b/backend/tests/endpoints/roms/test_rom.py
@@ -44,6 +44,32 @@ def test_get_rom(client: TestClient, access_token: str, rom: Rom):
     assert body["id"] == rom.id
 
 
+def test_get_rom_simple(client: TestClient, access_token: str, rom: Rom):
+    response = client.get(
+        f"/api/roms/{rom.id}/simple",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    body = response.json()
+    assert body["id"] == rom.id
+    # SimpleRomSchema stays lightweight: none of the detail-only arrays are
+    # present, so the endpoint must not eager-load them.
+    assert "user_saves" not in body
+    assert "user_states" not in body
+    assert "user_screenshots" not in body
+    assert "user_collections" not in body
+    assert "all_user_notes" not in body
+
+
+def test_get_rom_simple_missing_returns_404(client: TestClient, access_token: str):
+    response = client.get(
+        "/api/roms/999999/simple",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
 def test_download_multi_file_rom_content(
     client: TestClient, access_token: str, multi_file_rom: Rom
 ):


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The v2 gallery per-card endpoint `GET /api/roms/{id}/simple` was calling `db_rom_handler.get_rom(id)`, the same DB method the full detail endpoint uses. That method is wrapped by `with_details`, which eager-loads `saves`, `states`, `screenshots`, and `collections` (each an extra `selectinload` query). `SimpleRomSchema` never serializes any of those arrays, so every gallery card paid for four detail-only relationship loads it discarded, making cards slow to hydrate (noticeable on low-power hosts).

This PR:

- Adds a `with_simple_details` decorator in `backend/handler/database/roms_handler.py` that eager-loads only what `SimpleRomSchema` actually reads: `platform`, `metadatum`, `rom_users`, `files` (+ `track_meta`), `sibling_roms` with their `rom_users` (needed for per-sibling `is_main_sibling`), `notes`, and the deferred `multi_file` / `top_level_file_count` / `has_soundtrack` columns.
- Adds a `get_rom_simple` handler method backed by that decorator.
- Points the `/roms/{id}/simple` endpoint at `get_rom_simple` instead of `get_rom`.

The response wire shape is unchanged; only the wasted queries are removed.

**AI assistance disclosure**

This change was written with AI assistance (PostHog Code / Claude). The full implementation, tests, and this description were AI-generated and reviewed before submission.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A (backend-only change, no visual difference).

Fixes #3771

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
