### PR TITLE
perf(backend): index roms (platform_id, fs_size_bytes)

### DIFF
--- a/backend/alembic/versions/0097_roms_platform_fs_size_index.py
+++ b/backend/alembic/versions/0097_roms_platform_fs_size_index.py
@@ -1,12 +1,5 @@
 """Add composite index on roms (platform_id, fs_size_bytes)
 
-GET /api/platforms and GET /api/stats both sum roms.fs_size_bytes (per platform
-and across the whole library). fs_size_bytes was not part of any index, so the
-database had to read actual rows from the very wide, JSON-heavy roms table,
-taking 5-11s on large libraries. This composite index lets both sums resolve as
-index-only scans that never touch the wide rows; the optimizer picks it for both
-query shapes on its own.
-
 Revision ID: 0097_roms_platform_fs_size_index
 Revises: 0096_fix_virtual_collections
 Create Date: 2026-07-16 00:00:00.000000

--- a/backend/alembic/versions/0097_roms_platform_fs_size_index.py
+++ b/backend/alembic/versions/0097_roms_platform_fs_size_index.py
@@ -1,0 +1,40 @@
+"""Add composite index on roms (platform_id, fs_size_bytes)
+
+GET /api/platforms and GET /api/stats both sum roms.fs_size_bytes (per platform
+and across the whole library). fs_size_bytes was not part of any index, so the
+database had to read actual rows from the very wide, JSON-heavy roms table,
+taking 5-11s on large libraries. This composite index lets both sums resolve as
+index-only scans that never touch the wide rows; the optimizer picks it for both
+query shapes on its own.
+
+Revision ID: 0097_roms_platform_fs_size_index
+Revises: 0096_fix_virtual_collections
+Create Date: 2026-07-16 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0097_roms_platform_fs_size_index"
+down_revision = "0096_fix_virtual_collections"
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = "idx_roms_platform_fs_size"
+INDEX_COLUMNS = ["platform_id", "fs_size_bytes"]
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("roms", schema=None) as batch_op:
+        batch_op.create_index(
+            INDEX_NAME,
+            INDEX_COLUMNS,
+            unique=False,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("roms", schema=None) as batch_op:
+        batch_op.drop_index(INDEX_NAME, if_exists=True)

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -268,8 +268,6 @@ class Rom(BaseModel):
             "tgdb_id",
             "id",
         ),
-        # Covering index so per-platform and whole-library SUM(fs_size_bytes)
-        # are index-only scans that never touch the wide roms rows
         Index("idx_roms_platform_fs_size", "platform_id", "fs_size_bytes"),
         Index("idx_roms_name", "name"),
         Index("idx_roms_name_sort_key", "name_sort_key"),

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -268,6 +268,9 @@ class Rom(BaseModel):
             "tgdb_id",
             "id",
         ),
+        # Covering index so per-platform and whole-library SUM(fs_size_bytes)
+        # are index-only scans that never touch the wide roms rows
+        Index("idx_roms_platform_fs_size", "platform_id", "fs_size_bytes"),
         Index("idx_roms_name", "name"),
         Index("idx_roms_name_sort_key", "name_sort_key"),
         Index("idx_roms_igdb_id", "igdb_id"),


### PR DESCRIPTION
**Description**

`GET /api/platforms` (11.5s) and `GET /api/stats` (~5s) slow down badly as the library grows because both sum `roms.fs_size_bytes` (per-platform via the `Platform.fs_size_bytes` column property, and whole-library for stats). `fs_size_bytes` was not part of any index, so the database had to read actual rows from the very wide, JSON-heavy `roms` table (964 MB / 92,800 roms in the reporter's case). `rom_count` on the same model is instant because `COUNT` is satisfied by the existing `platform_id` index.

This PR adds a composite index on `roms (platform_id, fs_size_bytes)`, turning both sums into index-only scans that never touch the wide rows. The optimizer picks the covering index for both query shapes on its own, so no query changes are needed.

Changes:
- `backend/models/rom.py`: add `Index("idx_roms_platform_fs_size", "platform_id", "fs_size_bytes")` to `Rom.__table_args__`.
- `backend/alembic/versions/0097_roms_platform_fs_size_index.py`: migration creating the index, using `batch_alter_table` + `if_not_exists`/`if_exists` for MariaDB/MySQL/PostgreSQL compatibility (mirrors the existing `0093` index migration).

Reported measurements (from the issue and a member's replica of a 92,800-rom production DB):

| Query | Before | After |
| --- | --- | --- |
| Per-platform `SUM(fs_size_bytes)` + `COUNT` (`/api/platforms` shape) | 5.15s | 0.07s |
| Whole-library `SUM(fs_size_bytes)` (`/api/stats` shape) | 4.06s | 0.03s |

Index build took ~4.7s on the 964 MB table, so the migration is cheap even for large libraries.

Fixes #3769

**AI-assistance disclosure**: This change was written with AI assistance (PostHog Code / Claude). The diagnosis, index design, and migration were AI-generated; the timings in the issue and above were verified by a maintainer with read-only queries against a production-scale database.

**Checklist**

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A (index-only change; see timing table above)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*