### PR TITLE
perf(roms): make full rom id index opt-out on GET /api/roms

### DIFF
--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -311,9 +311,7 @@ def get_roms(
         bool,
         Query(
             description=(
-                "Whether to return the full ordered rom id index that backs"
-                " virtual scroll. Disable it for small rails that only need a"
-                " page, to skip the full-library scan."
+                "Whether to return the full ordered rom id index that backs virtual scroll."
             )
         ),
     ] = True,

--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -307,6 +307,16 @@ def get_roms(
     with_filter_values: Annotated[
         bool, Query(description="Whether to return filter values.")
     ] = True,
+    with_rom_id_index: Annotated[
+        bool,
+        Query(
+            description=(
+                "Whether to return the full ordered rom id index that backs"
+                " virtual scroll. Disable it for small rails that only need a"
+                " page, to skip the full-library scan."
+            )
+        ),
+    ] = True,
     search_term: Annotated[
         str | None,
         Query(description="Search term to filter roms."),
@@ -729,14 +739,18 @@ def get_roms(
         filter_values = RomFiltersDict(**query_filters)
 
     # The full ordered id list backs virtual scroll, so it's computed over the
-    # whole result set on every request. Memoise the unscoped library scan (same
-    # key scheme as the other sidecars); scoped/searched sets stay live.
-    rom_id_index_cache_key = build_unscoped_sidecar_cache_key(
-        request.user.id, order_by, order_dir, group_by_meta_id, is_unscoped
-    )
-    rom_id_index = db_rom_handler.get_rom_id_index(
-        query=query, cache_key=rom_id_index_cache_key
-    )
+    # whole result set. Callers that only need a page (e.g. the home rails) opt
+    # out with with_rom_id_index=false and avoid the full-library scan.
+    rom_id_index: list[int] = []
+    if with_rom_id_index:
+        # Memoise the unscoped library scan (same key scheme as the other
+        # sidecars); scoped/searched sets stay live.
+        rom_id_index_cache_key = build_unscoped_sidecar_cache_key(
+            request.user.id, order_by, order_dir, group_by_meta_id, is_unscoped
+        )
+        rom_id_index = db_rom_handler.get_rom_id_index(
+            query=query, cache_key=rom_id_index_cache_key
+        )
 
     # Hydrate the requested page and its additional data
     with sync_session.begin() as session:
@@ -779,14 +793,22 @@ def get_roms(
             ]
 
         params = resolve_params()
-        total = len(rom_id_index)
-        page_ids = list(rom_id_index[params.offset : params.offset + params.limit])
-        if page_ids:
-            page_rows = session.scalars(query.where(Rom.id.in_(page_ids))).all()
-            rows_by_id = {rom.id: rom for rom in page_rows}
-            page_items = [rows_by_id[i] for i in page_ids if i in rows_by_id]
+        if with_rom_id_index:
+            total = len(rom_id_index)
+            page_ids = list(rom_id_index[params.offset : params.offset + params.limit])
+            if page_ids:
+                page_rows = session.scalars(query.where(Rom.id.in_(page_ids))).all()
+                rows_by_id = {rom.id: rom for rom in page_rows}
+                page_items = [rows_by_id[i] for i in page_ids if i in rows_by_id]
+            else:
+                page_items = []
         else:
-            page_items = []
+            # Let the database serve the page from the sort index instead of
+            # walking the whole primary key to build a full id list.
+            page_items = list(
+                session.scalars(query.offset(params.offset).limit(params.limit)).all()
+            )
+            total = db_rom_handler.get_rom_count(query=query, session=session)
 
         return CustomLimitOffsetPage.create(
             _transform(page_items),

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -1412,8 +1412,8 @@ class DBRomsHandler(DBBaseHandler):
     ) -> int:
         """Count matching roms without materialising their ids.
 
-        For callers that need a page and its total but not the full ordered id
-        list (e.g. the home rails), so the database can serve the page from the
+        For callers that need a page and its total but not the full
+        ordered id list, so the database can serve the page from the
         sort index instead of scanning the whole library.
         """
         return (

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -1348,6 +1348,26 @@ class DBRomsHandler(DBBaseHandler):
         return ids
 
     @begin_session
+    def get_rom_count(
+        self,
+        query: Query,
+        *,
+        session: Session = None,  # type: ignore
+    ) -> int:
+        """Count matching roms without materialising their ids.
+
+        For callers that need a page and its total but not the full ordered id
+        list (e.g. the home rails), so the database can serve the page from the
+        sort index instead of scanning the whole library.
+        """
+        return (
+            session.scalar(
+                select(func.count()).select_from(query.order_by(None).subquery())
+            )
+            or 0
+        )
+
+    @begin_session
     def get_roms_by_fs_name(
         self,
         platform_id: int,

--- a/backend/tests/endpoints/roms/test_rom.py
+++ b/backend/tests/endpoints/roms/test_rom.py
@@ -148,6 +148,31 @@ def test_get_all_roms(
     assert items[0]["sibling_roms"] == []
 
 
+def test_get_roms_without_rom_id_index(
+    client: TestClient, access_token: str, rom: Rom, platform: Platform
+):
+    response = client.get(
+        "/api/roms",
+        headers={"Authorization": f"Bearer {access_token}"},
+        params={
+            "platform_id": platform.id,
+            "limit": 15,
+            "with_rom_id_index": False,
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    body = response.json()
+
+    # The page and total stay correct, but the full id index is not built.
+    assert body["total"] == 1
+    assert body["rom_id_index"] == []
+
+    items = body["items"]
+    assert len(items) == 1
+    assert items[0]["id"] == rom.id
+
+
 def test_get_roms_filter_by_metadata_providers(
     client: TestClient, access_token: str, rom: Rom, platform: Platform
 ):

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -355,6 +355,7 @@ async function getRecentRoms() {
       limit: RECENT_ROMS_LIMIT,
       with_char_index: false,
       with_filter_values: false,
+      with_rom_id_index: false,
     },
   });
 }
@@ -367,6 +368,7 @@ async function getRecentPlayedRoms() {
       limit: RECENT_PLAYED_ROMS_LIMIT,
       with_char_index: false,
       with_filter_values: false,
+      with_rom_id_index: false,
       last_played: true,
     },
   });

--- a/frontend/src/services/cache/api.ts
+++ b/frontend/src/services/cache/api.ts
@@ -170,6 +170,7 @@ class CachedApiService {
       limit: 15,
       with_char_index: false,
       with_filter_values: false,
+      with_rom_id_index: false,
     });
 
     return cacheService.request<GetRomsResponse>(config, onBackgroundUpdate);
@@ -184,6 +185,7 @@ class CachedApiService {
       limit: 15,
       with_char_index: false,
       with_filter_values: false,
+      with_rom_id_index: false,
       last_played: true,
     });
 
@@ -202,6 +204,7 @@ class CachedApiService {
       limit: 15,
       with_char_index: false,
       with_filter_values: false,
+      with_rom_id_index: false,
     });
   }
 
@@ -212,6 +215,7 @@ class CachedApiService {
       limit: 15,
       with_char_index: false,
       with_filter_values: false,
+      with_rom_id_index: false,
       last_played: true,
     });
   }


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3770

The home page rails ("recently added" and "continue playing") call `GET /api/roms?limit=15&order_by=id&order_dir=desc`. That endpoint always computes `rom_id_index`, the complete ordered list of every matching rom id, which exists to back the gallery's virtual scroll. On a large library (the reporter has ~92,800 roms) this means:

- a full-table scan (`SELECT id FROM roms ORDER BY id DESC`) that took ~5.3s uncached, and
- ~600 KB of JSON (one integer per rom) shipped just to render 15 cards.

There were already opt-outs for the other sidecars (`with_char_index`, `with_filter_values`) but none for `rom_id_index`.

**Changes**

- **Backend** — add a `with_rom_id_index` query param to `GET /api/roms`, defaulting to `true` for backwards compatibility (mirroring the existing sidecar flags). When `false`, the full index is skipped and the requested page is served directly with `offset`/`limit` off the sort index, with a lightweight `COUNT(*)` for `total`. Added a `get_rom_count()` handler helper for the count. Default behavior (virtual-scroll gallery) is unchanged.
- **Frontend** — the home rail fetches (`getRecentRoms` / `getRecentPlayedRoms`, plus their cache-clear mirrors) now pass `with_rom_id_index: false`.

A 15-card rail now costs a small page query plus a count, and a few KB of payload.

The response schema is unchanged (`rom_id_index` is still present, just empty when opted out), so no OpenAPI/type regeneration is needed.

**AI assistance disclosure**

This change was written with AI assistance (PostHog Code / Claude). The implementation, tests, and verification were AI-generated and human-reviewed.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A (backend/data-fetching change, no visual difference).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
