### PR TITLE
fix(v2): link IGDB provider to game page by slug

### DIFF
--- a/frontend/src/v2/components/GameDetails/OverviewTab.vue
+++ b/frontend/src/v2/components/GameDetails/OverviewTab.vue
@@ -133,7 +133,7 @@ const dataProviders = computed(() =>
   PROVIDERS.map((p) => {
     const id = providerId(props.rom, p);
     if (id === null) return null;
-    return { name: p.name, href: p.url ? p.url(id) : null };
+    return { name: p.name, href: p.url ? p.url(id, props.rom) : null };
   }).filter((e): e is { name: string; href: string | null } => e !== null),
 );
 

--- a/frontend/src/v2/components/GameDetails/ProviderGrid.vue
+++ b/frontend/src/v2/components/GameDetails/ProviderGrid.vue
@@ -27,7 +27,7 @@ const entries = computed<Entry[]>(() => {
       accent: p.color,
       logo: p.logo,
       id,
-      href: id !== null && p.url ? p.url(id) : null,
+      href: id !== null && p.url ? p.url(id, props.rom) : null,
     };
   });
   // Linked first; the cards know how to dim themselves when unlinked.

--- a/frontend/src/v2/components/GameDetails/providers.ts
+++ b/frontend/src/v2/components/GameDetails/providers.ts
@@ -13,8 +13,10 @@ export type Provider = {
   color: string;
   /** Optional favicon for the provider's identity. */
   logo: string | null;
-  /** Optional URL builder; when null the card renders unlinked. */
-  url: ((id: string | number) => string) | null;
+  /** Optional URL builder; when null the card renders unlinked. The ROM is
+   *  passed so builders can reach fields beyond the provider ID (e.g. IGDB
+   *  links by slug, not by numeric ID). */
+  url: ((id: string | number, rom: DetailedRom) => string) | null;
 };
 
 export const PROVIDERS: Provider[] = [
@@ -23,7 +25,13 @@ export const PROVIDERS: Provider[] = [
     name: "IGDB",
     color: "var(--r-color-provider-igdb)",
     logo: "/assets/scrappers/igdb.png",
-    url: (id) => `https://www.igdb.com/search?type=1&q=${id}`,
+    // IGDB game pages live at /games/<slug>; the numeric ID only feeds a text
+    // search that returns nothing. Fall back to the ID search when the slug
+    // (populated from the IGDB match) is missing.
+    url: (id, rom) =>
+      rom.slug
+        ? `https://www.igdb.com/games/${rom.slug}`
+        : `https://www.igdb.com/search?type=1&q=${id}`,
   },
   {
     key: "moby_id",


### PR DESCRIPTION
**Description**

The IGDB provider link in the v2 GameDetails provider grid built a text-search URL from the numeric provider ID (`/search?type=1&q=<id>`), which returns no results. This points the link at the canonical `/games/<slug>` page when the ROM's slug is present, and only falls back to the ID search when the slug is missing.

To support this, the `Provider.url` builder now receives the `DetailedRom` in addition to the ID, so builders can reach fields beyond the provider ID (both `OverviewTab.vue` and `ProviderGrid.vue` call sites updated).

> [!NOTE]
> This change was written with AI assistance (PostHog Code). The author reviewed and verified the change.

**Checklist**

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*