### PR TITLE
feat(v2): link Hasheous provider to game detail page

### DIFF
--- a/frontend/src/v2/components/GameDetails/providers.ts
+++ b/frontend/src/v2/components/GameDetails/providers.ts
@@ -65,7 +65,8 @@ export const PROVIDERS: Provider[] = [
     name: "Hasheous",
     color: "var(--r-color-provider-hasheous)",
     logo: "/assets/scrappers/hasheous.png",
-    url: null,
+    url: (id) =>
+      `https://hasheous.org/index.html?page=dataobjectdetail&type=game&id=${id}`,
   },
   {
     key: "flashpoint_id",


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Adds a URL builder for the **Hasheous** provider in the v2 `GameDetails` provider registry. Previously its card rendered unlinked (`url: null`); it now links out to the corresponding game page on hasheous.org, matching the behavior of the other metadata providers in the grid.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

---

**AI assistance disclosure:** This change was written with AI assistance (PostHog Code). The provider URL pattern was authored and reviewed by AI.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*