### PR TITLE
fix(search): rank PostgreSQL search by trigram similarity + fail soft on pg_trgm

### DIFF
--- a/backend/alembic/versions/0084_add_roms_search_index.py
+++ b/backend/alembic/versions/0084_add_roms_search_index.py
@@ -26,6 +26,7 @@ Create Date: 2026-06-16 00:00:00.000000
 import sqlalchemy as sa
 from alembic import op
 
+from logger.logger import log
 from models.rom import NAME_SORT_KEY_MAX_LENGTH, compute_name_sort_key
 from utils.database import is_mariadb, is_mysql, is_postgresql
 
@@ -61,20 +62,36 @@ def upgrade() -> None:
             )
     elif is_postgresql(bind):
         # pg_trgm is a trusted extension since PostgreSQL 13, so a non-superuser
-        # with CREATE on the database can install it.
-        op.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
-        op.execute(
-            sa.text(
-                f"CREATE INDEX IF NOT EXISTS {PG_NAME_INDEX} "
-                "ON roms USING gin (name gin_trgm_ops)"
+        # with CREATE on the database can install it. Some managed providers
+        # still gate it behind an allowlist, so fail soft: skip the trigram
+        # indexes and let search fall back to the (unindexed) ILIKE path rather
+        # than aborting the whole upgrade. A SAVEPOINT keeps the surrounding
+        # migration transaction usable after a failed CREATE EXTENSION.
+        trgm_available = True
+        try:
+            with bind.begin_nested():
+                op.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+        except Exception:
+            trgm_available = False
+            log.warning(
+                "[0084] Could not create the pg_trgm extension; skipping the "
+                "trigram search indexes. ROM search will use a slower "
+                "sequential scan. Enable pg_trgm on your PostgreSQL instance "
+                "and re-run migrations to restore index-backed search."
             )
-        )
-        op.execute(
-            sa.text(
-                f"CREATE INDEX IF NOT EXISTS {PG_FS_NAME_INDEX} "
-                "ON roms USING gin (fs_name gin_trgm_ops)"
+        if trgm_available:
+            op.execute(
+                sa.text(
+                    f"CREATE INDEX IF NOT EXISTS {PG_NAME_INDEX} "
+                    "ON roms USING gin (name gin_trgm_ops)"
+                )
             )
-        )
+            op.execute(
+                sa.text(
+                    f"CREATE INDEX IF NOT EXISTS {PG_FS_NAME_INDEX} "
+                    "ON roms USING gin (fs_name gin_trgm_ops)"
+                )
+            )
 
     # 2. Plain index on roms.name.
     with op.batch_alter_table("roms", schema=None) as batch_op:

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -40,6 +40,7 @@ from config import ROMM_DB_DRIVER
 from decorators.database import begin_session
 from handler.metadata.base_handler import UniversalPlatformSlug as UPS
 from handler.redis_handler import sync_cache
+from logger.logger import log
 from models.assets import Save, Screenshot, State
 from models.base import compute_file_name_parts
 from models.platform import Platform
@@ -64,7 +65,7 @@ from utils.database import (
     json_array_contains_value,
 )
 
-from .base_handler import DBBaseHandler
+from .base_handler import DBBaseHandler, sync_engine
 
 EJS_SUPPORTED_PLATFORMS = [
     UPS._3DO,
@@ -125,6 +126,33 @@ FULLTEXT_BOOLEAN_OPERATORS_REGEX = re.compile(r'[+\-~<>()"@*]')
 
 # 3 is the default minimum size in InnoDB
 FULLTEXT_MIN_TOKEN_SIZE = 3
+
+# Whether the pg_trgm extension is installed, resolved once and cached. Search
+# on PostgreSQL only ranks by trigram similarity when it is available, so it can
+# degrade to the plain ILIKE fallback on providers where migration 0084 could
+# not create the extension.
+_pg_trgm_available: bool | None = None
+
+
+def _postgresql_trgm_available() -> bool:
+    global _pg_trgm_available
+    if _pg_trgm_available is None:
+        if ROMM_DB_DRIVER != "postgresql":
+            _pg_trgm_available = False
+        else:
+            try:
+                with sync_engine.connect() as conn:
+                    _pg_trgm_available = (
+                        conn.execute(
+                            text("SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm'")
+                        ).scalar()
+                        is not None
+                    )
+            except Exception:
+                log.warning("Could not determine pg_trgm availability", exc_info=True)
+                _pg_trgm_available = False
+    return _pg_trgm_available
+
 
 # Cached ROM filter values (genres/franchises/etc.) so it doesn't get
 # recomputed on every call to /api/roms
@@ -430,6 +458,14 @@ class DBRomsHandler(DBBaseHandler):
             if len(words) > 1:
                 parts.append('"' + " ".join(words) + '"')
         return " ".join(parts) if parts else None
+
+    def _build_pg_relevance_term(self, search_term: str) -> str | None:
+        # pg_trgm similarity() compares plain trigram sets, so flatten the OR
+        # groups and operators into a single string to rank candidates against.
+        words = FULLTEXT_BOOLEAN_OPERATORS_REGEX.sub(
+            " ", search_term.replace("|", " ")
+        ).split()
+        return " ".join(words) if words else None
 
     def _filter_by_search_term(self, query: Query, search_term: str):
         terms = [term.strip() for term in search_term.split("|")]
@@ -1163,6 +1199,22 @@ class DBRomsHandler(DBBaseHandler):
                 relevance_clause = text(
                     "MATCH(roms.name, roms.fs_name) "
                     "AGAINST(:relevance IN BOOLEAN MODE) DESC"
+                ).bindparams(relevance=relevance)
+        elif (
+            search_term
+            and ROMM_DB_DRIVER == "postgresql"
+            and _postgresql_trgm_available()
+        ):
+            # Rank by the best trigram similarity across name and fs_name. The
+            # ILIKE filter (index-backed by pg_trgm) already narrows the set, so
+            # similarity() only runs over the matches.
+            relevance = self._build_pg_relevance_term(search_term)
+            if relevance:
+                relevance_clause = text(
+                    "GREATEST("
+                    "similarity(roms.name, :relevance), "
+                    "similarity(roms.fs_name, :relevance)"
+                    ") DESC"
                 ).bindparams(relevance=relevance)
 
         if order_by:  # explicit sort wins, relevance breaks ties

--- a/backend/tests/handler/test_db_handler.py
+++ b/backend/tests/handler/test_db_handler.py
@@ -13,6 +13,7 @@ from handler.database import (
     db_state_handler,
     db_user_handler,
 )
+from handler.database.roms_handler import _postgresql_trgm_available
 from models.assets import Save, Screenshot, State
 from models.platform import Platform
 from models.rom import Rom, compute_name_sort_key
@@ -249,13 +250,19 @@ def test_filter_by_search_term_multi_word_and_ranking(platform: Platform):
     # Only titles containing BOTH words appear (AND semantics).
     assert set(result_ids) == {ff.id, ff7.id, fantasy_final.id}
 
-    # Relevance ordering uses MATCH ... AGAINST, which only runs on
-    # MySQL/MariaDB; PostgreSQL falls back to name ordering, so the
-    # phrase-ranking assertions only hold on those drivers.
+    # Relevance ordering is engine-specific: MySQL/MariaDB rank with
+    # MATCH ... AGAINST, PostgreSQL ranks with pg_trgm similarity() (when the
+    # extension is installed), and each has its own tie-breaking behavior.
     if ROMM_DB_DRIVER in ("mariadb", "mysql"):
         # Exact-order phrase matches rank above the reversed-order match.
         assert result_ids.index(ff.id) < result_ids.index(fantasy_final.id)
         assert result_ids.index(ff7.id) < result_ids.index(fantasy_final.id)
+    elif ROMM_DB_DRIVER == "postgresql" and _postgresql_trgm_available():
+        # "Final Fantasy" and "Fantasy Final" share the same trigram set as the
+        # query, so both are maximally similar; "Final Fantasy VII" carries the
+        # extra "VII" trigrams, lowering its similarity, so it ranks last.
+        assert result_ids.index(ff7.id) > result_ids.index(ff.id)
+        assert result_ids.index(ff7.id) > result_ids.index(fantasy_final.id)
 
     # The relevance ORDER BY must also survive the group_by_meta_id subquery
     # wrapping used by the gallery (each ROM here is its own group).


### PR DESCRIPTION
**Description**

Fixes #3774.

On PostgreSQL, ROM search was index-backed (the pg_trgm GIN indexes from migration `0084` accelerate the existing `ILIKE '%word%'` filter) but was **never relevance-ranked**. The `ORDER BY` relevance clause in `get_roms_query` was only built for MySQL/MariaDB (`MATCH ... AGAINST`), so PG users got results sorted alphabetically by name rather than by match quality, unlike MariaDB users.

This PR closes that gap and hardens the migration:

- **PG relevance ranking.** `get_roms_query` now adds a `similarity()`-based `ORDER BY` for PostgreSQL (`GREATEST(similarity(name, term), similarity(fs_name, term)) DESC`). The `ILIKE` filter (index-backed by pg_trgm) narrows the candidate set first, so `similarity()` only runs over the matches. It's gated on the `pg_trgm` extension actually being installed (checked once and cached), so it degrades cleanly to the plain `ILIKE` fallback when the extension is absent.
- **Fail-soft migration.** Migration `0084` now wraps `CREATE EXTENSION pg_trgm` in a `SAVEPOINT` and, on failure, logs a warning and skips the trigram indexes instead of aborting the whole upgrade. This keeps upgrades working on locked-down managed PG providers that gate `pg_trgm` behind an allowlist (search falls back to the sequential-scan `ILIKE` path there).

The trigram index itself (part 1 of the issue's suggested fix) was already shipped in `0084`; this PR implements the remaining relevance-ranking piece (part 2) plus the fail-soft caveat.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Verified by running `tests/handler/test_db_handler.py` against **PostgreSQL 16** (pg_trgm installed, relevance-ranking assertions exercised) and **MariaDB** (30 passed on each). The SAVEPOINT fail-soft path was verified to keep the surrounding transaction usable after a failed `CREATE EXTENSION`.

#### AI assistance disclosure

This change was implemented with AI assistance (PostHog Code / Claude): investigation of the issue, the code and migration changes, and the tests were all AI-generated and reviewed by a human before submission.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*