### PR TITLE
fix(platforms): include TGDB handler in tgdb_id fallback for supported platforms

### DIFF
--- a/backend/tests/utils/test_platforms.py
+++ b/backend/tests/utils/test_platforms.py
@@ -23,3 +23,18 @@ def test_supported_platform_not_shadowed_by_variant():
 
     assert arcade.name == "Arcade"
     assert arcade.fs_slug == "arcade"
+
+
+def test_supported_platform_keeps_tgdb_id_from_tgdb():
+    """The TGDB platform ID must survive the metadata merge.
+
+    Regression for the tgdb_id fallback chain missing the TGDB handler
+    itself: MobyGames platforms never carry a tgdb_id and the Hasheous
+    platform list has no TGDB mappings, so every unmatched platform was
+    reported with tgdb_id=None even when TGDB knows the platform.
+    """
+    supported = get_supported_platforms()
+    threedo = next(p for p in supported if p.slug == "3do")
+
+    # TGDB maps the 3DO platform to ID 25.
+    assert threedo.tgdb_id == 25

--- a/backend/utils/platforms.py
+++ b/backend/utils/platforms.py
@@ -90,6 +90,7 @@ def get_supported_platforms() -> list[PlatformSchema]:
                 or None,
                 "tgdb_id": moby_platform.get("tgdb_id")
                 or hasheous_platform.get("tgdb_id")
+                or tgdb_platform.get("tgdb_id")
                 or None,
                 "name": igdb_platform.get("name")
                 or ss_platform.get("name")


### PR DESCRIPTION
**Description**

`get_supported_platforms()` (backing `GET /api/platforms/supported` and the heartbeat payload) always reported `tgdb_id=None` for platforms not yet in the database.

PR #3254 added `or tgdb_platform.get("tgdb_id")` to the tgdb_id fallback chain in `scan_handler.py`, but the identical chain in the supported-platforms path was missed. There the explicit `"tgdb_id"` key overrides the value spread from `**tgdb_platform`, and neither remaining source can supply one: MobyGames platform entries never carry a `tgdb_id`, and every entry in `HASHEOUS_PLATFORM_LIST` has `tgdb_id=None`. So even platforms TGDB maps (e.g. `3do` -> 25) were reported without TGDB support.

This mirrors the scan-time chain by falling back to the TGDB platform entry itself, and adds a regression test (fails before, passes after).

> AI assistance disclosure: this PR was written primarily by Claude Code (bug analysis, one-line fix, and the added unit test), reviewed and verified by me before submitting.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
