### PR TITLE
revert(v2): hydrate gallery cards per-card via /roms/{id}/simple

### DIFF
--- a/frontend/src/v2/components/Gallery/GalleryShell.vue
+++ b/frontend/src/v2/components/Gallery/GalleryShell.vue
@@ -551,26 +551,23 @@ const currentLetter = computed<string>(() => {
   return "";
 });
 
-// Viewport-driven fetch. The shell collects the positions currently in
-// view (rows in `viewportRange`) and hands them to the store, which keeps
-// `byPosition` in sync by fetching the 72-item windows those positions
-// fall into. Windows are shared across cards and cached, so a full
-// viewport resolves in a handful of paginated requests rather than one
-// per card. (Fetching per-card instead issued one request plus one DB
-// lookup per visible card, so ~100 simultaneous round-trips on a full
-// grid, which the browser's per-host connection cap then serialized into
-// slow waves on low-power devices.)
-//
-// The store also aborts windows that scrolled out of view, so paging
-// through a large library doesn't leave departed windows downloading.
+// Per-card viewport-driven fetch. The shell tracks which positions are
+// currently visible (from the rows in `viewportRange`) and keeps
+// `byPosition` in sync via per-card `GET /roms/{id}/simple` calls — pure
+// by-id lookups on the backend, much faster than the paginated
+// `getRoms(limit/offset)` pipeline. Each fetch is independent, so covers
+// stream in as their individual responses land.
 //
 // No idle-time prefetch: when the user stops scrolling, no new requests
-// are fired for off-screen positions.
+// are fired. Cards already in the viewport that are still missing keep
+// loading; everything off-screen waits until the user scrolls there.
 //
-// A small debounce on viewport changes prevents request storms during
-// smooth scrolling: only when the viewport settles for
-// `FETCH_DEBOUNCE_MS` do we sync.
+// Cancellation: positions that leave the viewport while their fetch is in
+// flight are aborted via `cancelFetchAt`. A small debounce on viewport
+// changes prevents fire-and-cancel storms during smooth scrolling — only
+// when the viewport settles for `FETCH_DEBOUNCE_MS` do we sync.
 const FETCH_DEBOUNCE_MS = 80;
+const visiblePositions = new Set<number>();
 let fetchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingRange: { first: number; last: number } | null = null;
 
@@ -590,7 +587,27 @@ function collectVisiblePositions(range: {
 }
 
 function syncFetches(range: { first: number; last: number }) {
-  galleryRoms.syncVisibleWindows(collectVisiblePositions(range));
+  const next = collectVisiblePositions(range);
+
+  // Cancel positions that left the viewport before their fetch resolved.
+  // The store's per-position controller handles the network abort;
+  // idempotent if nothing was in flight.
+  for (const p of visiblePositions) {
+    if (!next.has(p) && !galleryRoms.byPosition.has(p)) {
+      galleryRoms.cancelFetchAt(p);
+    }
+  }
+
+  // Fire per-card fetches for positions that just entered. The store
+  // dedupes against in-flight + already-loaded internally.
+  for (const p of next) {
+    if (!galleryRoms.byPosition.has(p)) {
+      void galleryRoms.fetchRomAt(p);
+    }
+  }
+
+  visiblePositions.clear();
+  for (const p of next) visiblePositions.add(p);
 }
 
 function scheduleFetchSync(range: { first: number; last: number }) {
@@ -772,10 +789,12 @@ onBeforeUnmount(() => {
   gallerySelection.clear();
   if (searchDebounce) clearTimeout(searchDebounce);
   if (fetchDebounceTimer) clearTimeout(fetchDebounceTimer);
-  // When leaving the gallery entirely, stop any window fetches still
-  // downloading so navigating away mid-scroll doesn't keep the network /
-  // backend busy. Keeps the loaded cache so returning to the same gallery is instant.
+  // When leaving the gallery entirely, stop any per-card fetches still in
+  // flight so navigating away mid-scroll doesn't keep the network /
+  // backend busy. Keeps the hydrated cache so returning to the same
+  // gallery is instant.
   galleryRoms.abortInFlight();
+  visiblePositions.clear();
   inflowResizeObserver?.disconnect();
   inflowResizeObserver = null;
   // Drop the debug stats so the overlay doesn't show stale gallery numbers

--- a/frontend/src/v2/components/Gallery/GameListRow.vue
+++ b/frontend/src/v2/components/Gallery/GameListRow.vue
@@ -2,12 +2,15 @@
 // GameListRow — single row of the list-mode gallery.
 //
 // Owns:
-//   * Per-row lazy fetch: onMount fires `fetchRomAt(position)`; the store
-//     dedupes against in-flight + already-loaded. onUnmount aborts the
-//     fetch via `cancelFetchAt(position)` so a fast scroll past mid-flight
-//     doesn't keep server work queued for invisible rows. Mirror of the
-//     per-card grid flow, with the same "row mount = entered viewport"
-//     contract via the shell's RVirtualScroller overscan window.
+//   * Per-row lazy fetch: a watch fires `fetchRomAt(position)` whenever
+//     the row is missing its rom but the store knows the id — covering
+//     both mount ("entered the overscan window") and a context refresh
+//     that clears `byPosition` under a still-mounted row. onUnmount aborts
+//     the fetch via `cancelFetchAt(position)` so a fast scroll past
+//     mid-flight doesn't keep server work queued for invisible rows.
+//     Mirror of the per-card grid flow, with the same "row mount =
+//     entered viewport" contract via the shell's RVirtualScroller
+//     overscan window.
 //
 //   * Skeleton ↔ real swap — when `getRomAt(position)` returns null the
 //     row paints skeleton placeholders in every column; once the fetch
@@ -26,7 +29,7 @@ import {
   RSkeletonBlock,
   RTooltip,
 } from "@v2/lib";
-import { computed, onBeforeUnmount, onMounted } from "vue";
+import { computed, onBeforeUnmount, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import storePlatforms from "@/stores/platforms";
@@ -261,14 +264,28 @@ function onRowPointerEnd() {
   selectionInput.handlePointerEnd();
 }
 
-onMounted(() => {
-  // Static mode (rom passed as prop) skips the gallery's per-row fetch
-  // entirely — the consumer already owns the rom data.
-  if (isStatic.value || props.position === undefined) return;
-  // Entered the overscan window — kick the per-row fetch. Store dedupes
-  // against in-flight + already-loaded.
-  void galleryRoms.fetchRomAt(props.position);
-});
+// Kick the per-row fetch whenever this position is missing its rom but
+// the store knows its id. This covers both mount ("entered the overscan
+// window") and a context refresh: a filter / search / sort / scan clears
+// `byPosition` and repopulates `romIdIndex`, but the row can stay mounted
+// at the same position — without this watch it would sit on skeletons
+// until it scrolled out and remounted. The store dedupes against
+// in-flight + already-loaded, so re-runs are cheap. Guarding on the id
+// (not just null rom) also re-fetches when a resort lands a different rom
+// at the same position.
+watch(
+  () => {
+    if (isStatic.value || props.position === undefined) return null;
+    if (galleryRoms.byPosition.has(props.position)) return null;
+    return galleryRoms.romIdIndex[props.position] ?? null;
+  },
+  (romId) => {
+    if (romId != null && props.position !== undefined) {
+      void galleryRoms.fetchRomAt(props.position);
+    }
+  },
+  { immediate: true },
+);
 
 onBeforeUnmount(() => {
   if (isStatic.value || props.position === undefined) return;

--- a/frontend/src/v2/components/Gallery/GameListRow.vue
+++ b/frontend/src/v2/components/Gallery/GameListRow.vue
@@ -2,12 +2,12 @@
 // GameListRow — single row of the list-mode gallery.
 //
 // Owns:
-//   * Per-row lazy fetch: onMount fires `fetchWindowAt(position)` and
-//     the store aligns the position to its 72-item window, deduping
-//     against pending + loaded windows, so rows sharing a window share
-//     one request. Mirror of the grid flow, with the same "row mount =
-//     entered viewport" contract via the shell's RVirtualScroller
-//     overscan window.
+//   * Per-row lazy fetch: onMount fires `fetchRomAt(position)`; the store
+//     dedupes against in-flight + already-loaded. onUnmount aborts the
+//     fetch via `cancelFetchAt(position)` so a fast scroll past mid-flight
+//     doesn't keep server work queued for invisible rows. Mirror of the
+//     per-card grid flow, with the same "row mount = entered viewport"
+//     contract via the shell's RVirtualScroller overscan window.
 //
 //   * Skeleton ↔ real swap — when `getRomAt(position)` returns null the
 //     row paints skeleton placeholders in every column; once the fetch
@@ -26,7 +26,7 @@ import {
   RSkeletonBlock,
   RTooltip,
 } from "@v2/lib";
-import { computed, onMounted } from "vue";
+import { computed, onBeforeUnmount, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import storePlatforms from "@/stores/platforms";
@@ -265,9 +265,19 @@ onMounted(() => {
   // Static mode (rom passed as prop) skips the gallery's per-row fetch
   // entirely — the consumer already owns the rom data.
   if (isStatic.value || props.position === undefined) return;
-  // Entered the overscan window, so kick the window fetch. Store aligns
-  // to the window grid and dedupes against pending + loaded windows.
-  void galleryRoms.fetchWindowAt(props.position);
+  // Entered the overscan window — kick the per-row fetch. Store dedupes
+  // against in-flight + already-loaded.
+  void galleryRoms.fetchRomAt(props.position);
+});
+
+onBeforeUnmount(() => {
+  if (isStatic.value || props.position === undefined) return;
+  // Left the overscan window before the fetch resolved — abort so the
+  // server doesn't keep building a row the user already scrolled past.
+  // Idempotent if nothing was in flight.
+  if (!galleryRoms.byPosition.has(props.position)) {
+    galleryRoms.cancelFetchAt(props.position);
+  }
 });
 </script>
 

--- a/frontend/src/v2/stores/galleryRoms.ts
+++ b/frontend/src/v2/stores/galleryRoms.ts
@@ -378,15 +378,22 @@ export default defineStore("v2GalleryRoms", {
           romId,
           signal: controller.signal,
         });
-        // Re-check that the shell still wants this position — a fast
-        // scroll past + cancel races against the response landing.
-        if (!inFlightControllers.has(ctrlKey)) return;
+        // Re-check that we're still the relevant request for this key — a
+        // fast scroll-past + cancel + re-enter can replace our controller
+        // with a newer one under the same key before we land. Identity
+        // comparison keeps us from applying our stale response over it.
+        if (inFlightControllers.get(ctrlKey) !== controller) return;
         this.byPosition.set(position, response.data);
       } catch (err) {
         if (axios.isCancel(err)) return;
         console.error("[v2GalleryRoms] rom fetch failed", position, romId, err);
       } finally {
-        inFlightControllers.delete(ctrlKey);
+        // Only clear our own entry — a replacement request may already own
+        // the key (see the identity check above), and deleting it would
+        // strand that request's response and leave the card a skeleton.
+        if (inFlightControllers.get(ctrlKey) === controller) {
+          inFlightControllers.delete(ctrlKey);
+        }
       }
     },
 

--- a/frontend/src/v2/stores/galleryRoms.ts
+++ b/frontend/src/v2/stores/galleryRoms.ts
@@ -1,16 +1,17 @@
-// galleryRoms (v2) — windowed/sparse store for the active gallery list.
+// galleryRoms (v2) — sparse store for the active gallery list.
 //
 // Replaces v1's `stores/roms.ts` for the gallery-list responsibility.
 // What lives here:
 //   - the gallery context (currentPlatform / Collection / Virtual / Smart),
-//   - the total ROM count + per-letter offset table from the backend,
-//   - a sparse `byPosition` map that holds whatever windows have been
-//     fetched so far,
-//   - book-keeping for in-flight / loaded / failed windows.
+//   - the total ROM count + per-letter offset table + id index from the
+//     backend,
+//   - a sparse `byPosition` map that holds whatever positions have been
+//     hydrated so far (per-card, driven by row visibility),
+//   - book-keeping for in-flight per-card fetches.
 //
 // Why a NEW store rather than extending v1:
 //   v1 collapses pagination into `fetchRoms()` advancing a single
-//   `fetchOffset`. v2 needs random-access window loads (driven by which
+//   `fetchOffset`. v2 needs random-access per-card loads (driven by which
 //   rows enter the virtualiser's viewport, including skeleton rows for
 //   positions we've never touched). Forking lets v2 model that cleanly
 //   while v1 stays frozen. Per the constitution, the v1 gallery-list
@@ -56,94 +57,22 @@ export type GalleryOrderKey =
 
 type GalleryFilterStore = ExtractPiniaStoreType<typeof storeGalleryFilter>;
 
-// Default window size — the backend's pagination limit. Smaller windows
-// mean more round-trips but finer-grained fills; larger windows mean
-// fewer requests but each one downloads more.
+// Default page size — the backend's pagination limit, used by the
+// metadata bootstrap's request params.
 const WINDOW_SIZE = 72;
 
-// In-flight `AbortController`s keyed by request: `window:${offset}`
-// for a windowed fetch, `bootstrap` for the lightweight metadata
-// bootstrap. Lives outside store state so Pinia doesn't
-// try to proxy native abort objects (which break under reactivity).
+// In-flight `AbortController`s keyed by request: `rom:${position}` for a
+// per-card hydration fetch, `bootstrap` for the lightweight metadata
+// bootstrap. Lives outside store state so Pinia doesn't try to proxy
+// native abort objects (which break under reactivity).
 // `invalidateWindows()` / `resetGallery()` abort every pending request,
 // so a fast-typed search box or a platform-switch mid-load doesn't
 // leave server work going for results we'll throw away.
 const inFlightControllers = new Map<string, AbortController>();
 
-// A failed window is only refetched when `fetchWindowAt` is called for it
-// again, which for a static viewport (no scroll) never happens on its own.
-// So a transient failure would strand up to `WINDOW_SIZE` visible cards as
-// skeletons. To self-heal, a failed window schedules a bounded, backing-off
-// retry; `retryTimers` holds the pending timeouts (keyed by offset) and
-// `retryCounts` the attempts so far. Both are cleared by `abortAllInFlight`
-// on any gallery-context switch so we never retry against a stale context.
-const RETRY_BACKOFF_MS = 2000;
-const MAX_WINDOW_RETRIES = 3;
-const retryTimers = new Map<number, ReturnType<typeof setTimeout>>();
-const retryCounts = new Map<number, number>();
-
-function clearRetry(offset: number) {
-  const timer = retryTimers.get(offset);
-  if (timer !== undefined) clearTimeout(timer);
-  retryTimers.delete(offset);
-  retryCounts.delete(offset);
-}
-
 function abortAllInFlight() {
   for (const ctrl of inFlightControllers.values()) ctrl.abort();
   inFlightControllers.clear();
-  for (const timer of retryTimers.values()) clearTimeout(timer);
-  retryTimers.clear();
-  retryCounts.clear();
-}
-
-// Abort a single in-flight window fetch. The rejected request is caught
-// as a cancel in `fetchWindowAt` (no `failedWindows` entry, no retry) and
-// its `finally` clears the pending/controller bookkeeping.
-function cancelWindow(offset: number) {
-  const ctrl = inFlightControllers.get(`window:${offset}`);
-  if (ctrl) ctrl.abort();
-}
-
-// Apply items to `byPosition` in row-sized batches with a rAF yield
-// between batches. Each Map.set() invalidates Vue's per-key dep, and
-// when many cards are in the viewport / overscan zone they all
-// re-render in the same microtask flush — synchronously, on the main
-// thread. With dozens of items landing back-to-back (initial window,
-// or rapid-fire background fill), the flush can run >30ms and queued
-// input events (AlphaStrip clicks especially) miss their frame.
-//
-// Yielding every `BATCH_SIZE` items lets the browser paint the new
-// cards AND dispatch any pending input between batches. We pick 8 as
-// the default — one row's worth — so a per-row dwell fetch (8 items)
-// stays a single batch (no extra frames), while a 72-item window
-// becomes 9 small batches that each fit comfortably in a frame.
-const APPLY_BATCH_SIZE = 8;
-
-function nextFrame(): Promise<void> {
-  return new Promise((resolve) => {
-    if (typeof requestAnimationFrame !== "undefined") {
-      requestAnimationFrame(() => resolve());
-    } else {
-      setTimeout(resolve, 0);
-    }
-  });
-}
-
-async function applyItemsBatched(
-  byPosition: Map<number, SimpleRom>,
-  items: SimpleRom[],
-  baseOffset: number,
-  isStillRelevant: () => boolean,
-): Promise<void> {
-  for (let i = 0; i < items.length; i += APPLY_BATCH_SIZE) {
-    if (!isStillRelevant()) return;
-    const end = Math.min(i + APPLY_BATCH_SIZE, items.length);
-    for (let j = i; j < end; j++) {
-      byPosition.set(baseOffset + j, items[j]);
-    }
-    if (end < items.length) await nextFrame();
-  }
 }
 
 interface State {
@@ -162,18 +91,13 @@ interface State {
   charIndex: Record<string, number>;
   romIdIndex: number[];
   byPosition: Map<number, SimpleRom>;
-  loadedWindows: Set<number>;
-  pendingWindows: Set<number>;
-  failedWindows: Set<number>;
-  // True until the very first metadata bootstrap (or fetchWindow(0))
-  // resolves — view shows a skeleton hero/skeleton rows during this
-  // phase.
+  // True until the very first metadata bootstrap resolves — view shows a
+  // skeleton hero/skeleton rows during this phase.
   initialFetching: boolean;
   // True once total / charIndex / romIdIndex / filter_values have been
-  // populated, either by the lightweight `fetchInitialMetadata()`
-  // bootstrap or by `fetchWindowAt(0)`. Used to gate the initial
-  // bootstrap dedup independently of `loadedWindows` (metadata
-  // bootstrap doesn't load any window).
+  // populated by the lightweight `fetchInitialMetadata()` bootstrap.
+  // Gates the bootstrap dedup and the per-card hydration (which needs
+  // `romIdIndex` before it can resolve a position to a rom id).
   metadataLoaded: boolean;
   // Order params — gallery-list scoped (separate from v1's localStorage
   // keys so v1/v2 don't fight over the same value).
@@ -191,18 +115,11 @@ const defaults = (): State => ({
   charIndex: {},
   romIdIndex: [],
   byPosition: new Map(),
-  loadedWindows: new Set(),
-  pendingWindows: new Set(),
-  failedWindows: new Set(),
   initialFetching: false,
   metadataLoaded: false,
   orderBy: "name",
   orderDir: "asc",
 });
-
-function alignToWindow(offset: number): number {
-  return Math.floor(offset / WINDOW_SIZE) * WINDOW_SIZE;
-}
 
 export default defineStore("v2GalleryRoms", {
   state: () => defaults(),
@@ -216,8 +133,6 @@ export default defineStore("v2GalleryRoms", {
         state.currentSmartCollection ||
         state.currentSearch
       ),
-    /** True when at least the first window has loaded. */
-    hasInitial: (state) => state.loadedWindows.size > 0,
   },
 
   actions: {
@@ -272,9 +187,6 @@ export default defineStore("v2GalleryRoms", {
       this.charIndex = {};
       this.romIdIndex = [];
       this.byPosition = new Map();
-      this.loadedWindows = new Set();
-      this.pendingWindows = new Set();
-      this.failedWindows = new Set();
       this.initialFetching = false;
       this.metadataLoaded = false;
     },
@@ -288,9 +200,6 @@ export default defineStore("v2GalleryRoms", {
       this.charIndex = {};
       this.romIdIndex = [];
       this.byPosition = new Map();
-      this.loadedWindows = new Set();
-      this.pendingWindows = new Set();
-      this.failedWindows = new Set();
       this.initialFetching = false;
       this.metadataLoaded = false;
     },
@@ -357,9 +266,8 @@ export default defineStore("v2GalleryRoms", {
     },
 
     /** Apply the metadata side effects from a `getRoms` response —
-     * total, char_index, rom_id_index, plus filter side panels (only on
-     * first fetch). Shared by `fetchWindowAt(0)` and the lightweight
-     * `fetchInitialMetadata()` bootstrap. */
+     * total, char_index, rom_id_index, plus filter side panels. Used by
+     * the lightweight `fetchInitialMetadata()` bootstrap. */
     _applyMetadata(
       data: GetRomsResponse,
       galleryFilter: GalleryFilterStore,
@@ -393,10 +301,9 @@ export default defineStore("v2GalleryRoms", {
 
     /** Lightweight bootstrap: fetch only the gallery's metadata (total,
      * char_index, rom_id_index, filter_values) without loading any
-     * items. Sizes the virtualiser (via `total`) before any window
-     * lands, so both layouts can render skeleton rows immediately and
-     * then hydrate them through the viewport-driven `fetchWindowAt`
-     * sync.
+     * items. Sizes the virtualiser (via `total`) so both layouts can
+     * render skeleton rows immediately, then hydrate each visible
+     * position through the viewport-driven per-card `fetchRomAt(p)` sync.
      *
      * The backend's `limit` minimum is 1, so we still pay for one
      * `SimpleRomSchema` build server-side, but the item is discarded
@@ -437,138 +344,70 @@ export default defineStore("v2GalleryRoms", {
       }
     },
 
-    /** Fetch the window that contains `position` (rounding down to the
-     * window grid). Dedupes against pending / loaded windows. The very
-     * first window also seeds `total` and `charIndex`. */
-    async fetchWindowAt(position: number): Promise<void> {
+    /** Fetch the single ROM at `position` via `GET /roms/{id}/simple` —
+     * the lightweight schema endpoint that skips the eager `user_saves`
+     * / `user_states` / `user_screenshots` / `user_collections` /
+     * `all_user_notes` arrays. The gallery card only needs the `has_*`
+     * indicator flags + cover paths + platform info — all on
+     * `SimpleRomSchema`. Detailed arrays are pulled on demand by the
+     * game-details page or by quick-action dialogs (note editor,
+     * achievements panel) when the user actually opens them.
+     *
+     * Requires `romIdIndex[position]` — populated by the
+     * `fetchInitialMetadata()` bootstrap for the active gallery. Returns
+     * silently if the index isn't loaded yet.
+     *
+     * Per-position `AbortController` allows the shell to cancel fetches
+     * for cards that left the viewport before resolving.
+     * `cancelFetchAt(position)` is the cancel side. */
+    async fetchRomAt(position: number): Promise<void> {
       if (position < 0) return;
-      const offset = alignToWindow(position);
-      // Total is unknown for offset 0; for any non-initial offset, refuse
-      // to fetch past total.
-      if (this.total > 0 && offset >= this.total) return;
-      if (this.loadedWindows.has(offset)) return;
-      if (this.pendingWindows.has(offset)) return;
+      if (this.total > 0 && position >= this.total) return;
+      if (this.byPosition.has(position)) return;
+      const romId = this.romIdIndex[position];
+      if (!romId) return;
 
-      this.pendingWindows.add(offset);
-      this.failedWindows.delete(offset);
-      if (offset === 0 && !this.metadataLoaded) this.initialFetching = true;
+      const ctrlKey = `rom:${position}`;
+      if (inFlightControllers.has(ctrlKey)) return;
 
-      const galleryFilter = storeGalleryFilter();
-      const platformsStore = storePlatforms();
-      const params = this._buildRequestParams(galleryFilter, offset);
-      const ctrlKey = `window:${offset}`;
       const controller = new AbortController();
       inFlightControllers.set(ctrlKey, controller);
 
       try {
-        const response = await romApi.getRoms({
-          ...params,
-          // Skip char index / filter-value aggregations when initial data is loaded
-          ...(this.metadataLoaded
-            ? { withCharIndex: false, withFilterValues: false }
-            : {}),
+        const response = await romApi.getRomSimple({
+          romId,
           signal: controller.signal,
         });
-        // Re-check that this window is still relevant — invalidateWindows
-        // / resetGallery may have run while we were waiting.
-        if (!this.pendingWindows.has(offset)) return;
-
-        const data = response.data;
-        if (offset === 0) {
-          this._applyMetadata(data, galleryFilter, platformsStore);
-        } else if (data.total !== null && data.total !== undefined) {
-          this.total = data.total;
-        }
-
-        // Place items at their absolute positions (offset .. offset + N).
-        // We rely on Vue 3's reactive Map: `set(k, v)` triggers per-key
-        // dependents. Earlier passes reassigned `this.byPosition` to a
-        // new Map after each window which DEFEATED that — every
-        // `getRomAt(p)` reader was invalidated, and the gallery
-        // virtualItems computed (which iterates positions) had to
-        // rebuild end-to-end on every window response. That blocked the
-        // event loop hard enough to freeze the scroller. Mutating in
-        // place keeps the dependents narrow: only positions that just
-        // resolved trigger a re-render.
-        //
-        // Batched + frame-yielded: 72 sets in one microtask block the
-        // main thread long enough that AlphaStrip clicks queued during
-        // the flush miss their frame. `applyItemsBatched` pauses every
-        // row (8 items) so input dispatches between paints.
-        await applyItemsBatched(this.byPosition, data.items, offset, () =>
-          this.pendingWindows.has(offset),
-        );
-
-        this.loadedWindows.add(offset);
-        // Recovered — drop any retry bookkeeping for this window.
-        clearRetry(offset);
+        // Re-check that the shell still wants this position — a fast
+        // scroll past + cancel races against the response landing.
+        if (!inFlightControllers.has(ctrlKey)) return;
+        this.byPosition.set(position, response.data);
       } catch (err) {
-        // An explicit abort isn't a failure — keep `failedWindows`
-        // clean so the window is eligible to refetch under the new
-        // gallery context without the UI flagging it as broken.
         if (axios.isCancel(err)) return;
-        this.failedWindows.add(offset);
-        // Surface in console; UI keeps the skeletons in place until the
-        // retry below (or a viewport / gallery-state change) refetches.
-        console.error("[v2GalleryRoms] window fetch failed", offset, err);
-        // Self-heal a stranded viewport: schedule a bounded, backing-off
-        // refetch so a transient blip doesn't leave the window's cards as
-        // skeletons until the user happens to scroll.
-        const attempts = retryCounts.get(offset) ?? 0;
-        if (attempts < MAX_WINDOW_RETRIES && !retryTimers.has(offset)) {
-          retryCounts.set(offset, attempts + 1);
-          const timer = setTimeout(
-            () => {
-              retryTimers.delete(offset);
-              void this.fetchWindowAt(offset);
-            },
-            RETRY_BACKOFF_MS * (attempts + 1),
-          );
-          retryTimers.set(offset, timer);
-        }
+        console.error("[v2GalleryRoms] rom fetch failed", position, romId, err);
       } finally {
         inFlightControllers.delete(ctrlKey);
-        this.pendingWindows.delete(offset);
-        if (offset === 0) this.initialFetching = false;
       }
     },
 
-    /** Reconcile in-flight window fetches with the currently visible
-     * positions. Starts any window covering a visible position (deduped
-     * inside `fetchWindowAt`) and aborts any in-flight or retry-pending
-     * window that no longer covers one. Without the abort, scrolling
-     * through a large library would leave every window it passed
-     * downloading and applying in the background — the exact wasted
-     * network / backend / render work this store exists to avoid on
-     * low-power devices. Driven by the shell's debounced viewport sync. */
-    syncVisibleWindows(positions: Iterable<number>) {
-      const wanted = new Set<number>();
-      for (const p of positions) {
-        if (p < 0) continue;
-        if (this.total > 0 && p >= this.total) continue;
-        wanted.add(alignToWindow(p));
-      }
-      // Cancel windows that drifted out of view. Snapshot first: aborting
-      // settles a fetch's `finally` (which mutates these sets) on a later
-      // microtask, but iterate a copy to stay safe regardless.
-      for (const offset of [...this.pendingWindows]) {
-        if (!wanted.has(offset)) cancelWindow(offset);
-      }
-      for (const offset of [...retryTimers.keys()]) {
-        if (!wanted.has(offset)) clearRetry(offset);
-      }
-      for (const offset of wanted) {
-        void this.fetchWindowAt(offset);
+    /** Cancel an in-flight per-position fetch — typically called by the
+     * shell when a card leaves the viewport before its request resolves.
+     * No-op if nothing is in flight for that position. */
+    cancelFetchAt(position: number) {
+      const ctrlKey = `rom:${position}`;
+      const ctrl = inFlightControllers.get(ctrlKey);
+      if (ctrl) {
+        ctrl.abort();
+        inFlightControllers.delete(ctrlKey);
       }
     },
 
-    /** Abort every in-flight window fetch + pending retry without wiping
-     * the loaded cache. The shell calls this when the gallery unmounts so
-     * navigating away mid-scroll doesn't leave downloads running; a
-     * return to the same gallery still reuses `loadedWindows`. */
+    /** Abort every in-flight per-card fetch without wiping the hydrated
+     * cache. The shell calls this when the gallery unmounts so navigating
+     * away mid-scroll doesn't leave requests running; a return to the
+     * same gallery still reuses whatever `byPosition` already holds. */
     abortInFlight() {
       abortAllInFlight();
-      this.pendingWindows = new Set();
       this.initialFetching = false;
     },
 


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The v2 gallery previously hydrated each visible card with its own `GET /roms/{id}/simple` request. Because that endpoint was slow at the time, a prior change ([#3765](https://github.com/rommapp/romm/pull/3765)) switched hydration to batched 72-item window fetches through the paginated `/roms` list endpoint.

Now that `/roms/{id}/simple` is fast (lightweight eager-load), this reverts the gallery back to per-card hydration:

- **`galleryRoms` store** — reintroduces `fetchRomAt(position)` (per-card `GET /roms/{id}/simple`) and `cancelFetchAt(position)`. Removes the now-unreachable window-fetch machinery: `fetchWindowAt`, `syncVisibleWindows`, `cancelWindow`, the window auto-retry (`retryTimers`/`retryCounts`/backoff), the batched-apply helpers (`applyItemsBatched`/`nextFrame`), `alignToWindow`, the `loadedWindows`/`pendingWindows`/`failedWindows` state, and the unused `hasInitial` getter.
- **`GalleryShell`** — grid-mode viewport sync fires `fetchRomAt` for entered positions and `cancelFetchAt` for departed ones, restoring the `visiblePositions` tracking set.
- **`GameListRow`** — row mount fires `fetchRomAt`, unmount aborts via `cancelFetchAt`.

Kept from the intervening work, as intended:
- the `withCharIndex` / `withFilterValues` skip params on the roms API (`services/api/rom.ts` untouched),
- the `abortInFlight` store action, still wired into the shell's unmount.

The lightweight `fetchInitialMetadata` bootstrap (seeds `total` / `charIndex` / `romIdIndex` / `filter_values`) is unchanged.

**AI assistance disclosure**: This PR was written with AI assistance (PostHog Code / Claude). The change was reviewed by the author.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

_No UI/visual change; behavior-only revert of the hydration path._

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*