### PR TITLE
fix: respect configured IGDB region priority

### DIFF
--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -353,22 +353,32 @@ REGION_TO_IGDB_LOCALE: dict[str, str | None] = {
 
 
 def get_igdb_preferred_locale(rom: Rom | None = None) -> str | None:
-    """Get IGDB locale, preferring the rom's own region tag when available.
+    """Get IGDB locale from the ROM's prioritized regions when available.
 
     Maps region priority codes to IGDB's game_localizations region identifiers.
-    Checks the rom's tagged regions first, then falls back to scan.priority.region.
+    Prioritizes the ROM's tagged regions by scan.priority.region, then falls
+    back to scan.priority.region.
 
     Returns:
         IGDB region identifier (e.g., "ja-JP", "EU") or None for default
     """
+    config = cm.get_config()
+    priority = config.SCAN_REGION_PRIORITY
+
     if rom is not None and isinstance(rom.regions, list):
+        rom_codes: list[str] = []
         for region_name in rom.regions:
             code = region_name_to_provider_shortcode(region_name)
             if code and code in REGION_TO_IGDB_LOCALE:
-                return REGION_TO_IGDB_LOCALE[code]
+                rom_codes.append(code)
 
-    config = cm.get_config()
-    for region in config.SCAN_REGION_PRIORITY:
+        rom_codes.sort(
+            key=lambda code: priority.index(code) if code in priority else len(priority)
+        )
+        if rom_codes:
+            return REGION_TO_IGDB_LOCALE[rom_codes[0]]
+
+    for region in priority:
         if region.lower() in REGION_TO_IGDB_LOCALE:
             return REGION_TO_IGDB_LOCALE[region.lower()]
 

--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -364,6 +364,7 @@ def get_igdb_preferred_locale(rom: Rom | None = None) -> str | None:
     """
     config = cm.get_config()
     priority = config.SCAN_REGION_PRIORITY
+    normalized_priority = [region.lower() for region in priority]
 
     if rom is not None and isinstance(rom.regions, list):
         rom_codes: list[str] = []
@@ -373,7 +374,11 @@ def get_igdb_preferred_locale(rom: Rom | None = None) -> str | None:
                 rom_codes.append(code)
 
         rom_codes.sort(
-            key=lambda code: priority.index(code) if code in priority else len(priority)
+            key=lambda code: (
+                normalized_priority.index(code)
+                if code in normalized_priority
+                else len(normalized_priority)
+            )
         )
         if rom_codes:
             return REGION_TO_IGDB_LOCALE[rom_codes[0]]

--- a/backend/tests/handler/metadata/test_igdb_handler.py
+++ b/backend/tests/handler/metadata/test_igdb_handler.py
@@ -1,6 +1,6 @@
 """Tests for the IGDB metadata handler."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -13,6 +13,7 @@ from handler.metadata.igdb_handler import (
     IGDBHandler,
     _build_platforms_where,
     _platform_igdb_ids_with_twin,
+    get_igdb_preferred_locale,
 )
 
 GENESIS_IGDB_ID = 29
@@ -60,6 +61,19 @@ def _make_game(
         "multiplayer_modes": [],
         "game_localizations": [{"name": n} for n in (game_localizations or [])],
     }
+
+
+class TestGetIGDBPreferredLocale:
+    def test_multi_region_rom_respects_user_priority(self):
+        """The configured priority wins over filename tag order."""
+        rom = MagicMock()
+        rom.regions = ["Japan", "USA"]
+        config = MagicMock(SCAN_REGION_PRIORITY=["us", "jp"])
+
+        with patch("handler.metadata.igdb_handler.cm.get_config", return_value=config):
+            locale = get_igdb_preferred_locale(rom)
+
+        assert locale is None
 
 
 class TestSearchRomGameTypeFilter:

--- a/backend/tests/handler/metadata/test_igdb_handler.py
+++ b/backend/tests/handler/metadata/test_igdb_handler.py
@@ -68,7 +68,7 @@ class TestGetIGDBPreferredLocale:
         """The configured priority wins over filename tag order."""
         rom = MagicMock()
         rom.regions = ["Japan", "USA"]
-        config = MagicMock(SCAN_REGION_PRIORITY=["us", "jp"])
+        config = MagicMock(SCAN_REGION_PRIORITY=["JP", "us"])
 
         with patch("handler.metadata.igdb_handler.cm.get_config", return_value=config):
             locale = get_igdb_preferred_locale(rom)

--- a/backend/tests/handler/metadata/test_igdb_handler.py
+++ b/backend/tests/handler/metadata/test_igdb_handler.py
@@ -73,7 +73,7 @@ class TestGetIGDBPreferredLocale:
         with patch("handler.metadata.igdb_handler.cm.get_config", return_value=config):
             locale = get_igdb_preferred_locale(rom)
 
-        assert locale is None
+        assert locale == "ja-JP"
 
 
 class TestSearchRomGameTypeFilter:


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Prioritize a ROM's tagged regions according to `SCAN_REGION_PRIORITY` before selecting its IGDB localization. This keeps locale selection consistent with the user's regional preference when ROM filenames contain multiple region tags.

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

Not applicable.

**AI Assistance**

This PR was written with PostHog Code. AI assisted with the code change, regression test, validation, commit, and PR description.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*