### PR TITLE
fix(metadata): search the whole filename for Sony serial codes

### DIFF
--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -738,7 +738,7 @@ class IGDBHandler(MetadataHandler):
             fallback_rom = IGDBRom(igdb_id=None, name=search_term)
 
         # Support for sony serial filename format (PS, PS2, PSP)
-        match = SONY_SERIAL_REGEX.search(fs_name, re.IGNORECASE)
+        match = SONY_SERIAL_REGEX.search(fs_name)
         if platform_igdb_id == PS1_IGDB_ID and match:
             search_term = await self._ps1_serial_format(match, search_term)
             fallback_rom = IGDBRom(igdb_id=None, name=search_term)

--- a/backend/handler/metadata/moby_handler.py
+++ b/backend/handler/metadata/moby_handler.py
@@ -184,7 +184,7 @@ class MobyGamesHandler(MetadataHandler):
             fallback_rom = MobyGamesRom(moby_id=None, name=search_term)
 
         # Support for sony serial filename format (PS, PS3, PS3)
-        match = SONY_SERIAL_REGEX.search(fs_name, re.IGNORECASE)
+        match = SONY_SERIAL_REGEX.search(fs_name)
         if platform_moby_id == PS1_MOBY_ID and match:
             search_term = await self._ps1_serial_format(match, search_term)
             fallback_rom = MobyGamesRom(moby_id=None, name=search_term)

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -800,7 +800,7 @@ class SSHandler(MetadataHandler):
             fallback_rom = SSRom(ss_id=None, name=search_term)
 
         # Support for sony serial filename format (PS, PS3, PS3)
-        match = SONY_SERIAL_REGEX.search(file_name, re.IGNORECASE)
+        match = SONY_SERIAL_REGEX.search(file_name)
         if platform_ss_id == PS1_SS_ID and match:
             search_term = await self._ps1_serial_format(match, search_term)
             fallback_rom = SSRom(ss_id=None, name=search_term)

--- a/backend/tests/handler/metadata/test_igdb_handler.py
+++ b/backend/tests/handler/metadata/test_igdb_handler.py
@@ -1,13 +1,16 @@
 """Tests for the IGDB metadata handler."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from adapters.services.igdb_types import GameType
+from handler.metadata.base_handler import PS1_SERIAL_INDEX_KEY
 from handler.metadata.igdb_handler import (
     FAMICOM_IGDB_ID,
     NES_IGDB_ID,
+    PS1_IGDB_ID,
     SNES_IGDB_ID,
     SUPER_FAMICOM_IGDB_ID,
     IGDBHandler,
@@ -15,6 +18,7 @@ from handler.metadata.igdb_handler import (
     _platform_igdb_ids_with_twin,
     get_igdb_preferred_locale,
 )
+from handler.redis_handler import async_cache
 
 GENESIS_IGDB_ID = 29
 
@@ -671,3 +675,33 @@ class TestSearchRomRegionalTwinPlatforms:
         assert any(
             f"platforms=[{GENESIS_IGDB_ID}]" in w for w in captured_wheres
         ), captured_wheres
+
+
+class TestSonySerialFilenames:
+    """Tests for Sony serial resolution in get_rom."""
+
+    @pytest.mark.asyncio
+    async def test_serial_at_filename_start_resolves_title(self):
+        """A serial in the first two characters of the filename must still hit
+        the serial index. Regression: re.IGNORECASE was passed as the ``pos``
+        argument of ``Pattern.search()``, skipping the first two characters,
+        so files named by their serial (e.g. ``SCUS-94163.bin``) were never
+        resolved."""
+        handler = IGDBHandler()
+
+        with (
+            patch(
+                "handler.metadata.igdb_handler.IGDBHandler.is_enabled",
+                return_value=True,
+            ),
+            patch.object(async_cache, "hget", new_callable=AsyncMock) as mock_hget,
+            patch.object(
+                IGDBHandler, "_search_rom", new_callable=AsyncMock, return_value=None
+            ),
+        ):
+            mock_hget.return_value = json.dumps({"title": "Gran Turismo"})
+            result = await handler.get_rom(MagicMock(), "SCUS-94163.bin", PS1_IGDB_ID)
+
+        mock_hget.assert_awaited_once_with(PS1_SERIAL_INDEX_KEY, "SCUS-94163")
+        assert result.get("name") == "Gran Turismo"
+        assert result["igdb_id"] is None

--- a/backend/tests/handler/metadata/test_moby_handler.py
+++ b/backend/tests/handler/metadata/test_moby_handler.py
@@ -1,0 +1,43 @@
+"""Tests for the MobyGames metadata handler."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from handler.metadata.base_handler import PS1_SERIAL_INDEX_KEY
+from handler.metadata.moby_handler import PS1_MOBY_ID, MobyGamesHandler
+from handler.redis_handler import async_cache
+
+
+class TestSonySerialFilenames:
+    """Tests for Sony serial resolution in get_rom."""
+
+    @pytest.mark.asyncio
+    async def test_serial_at_filename_start_resolves_title(self):
+        """A serial in the first two characters of the filename must still hit
+        the serial index. Regression: re.IGNORECASE was passed as the ``pos``
+        argument of ``Pattern.search()``, skipping the first two characters,
+        so files named by their serial (e.g. ``SCUS-94163.bin``) were never
+        resolved."""
+        handler = MobyGamesHandler()
+
+        with (
+            patch(
+                "handler.metadata.moby_handler.MobyGamesHandler.is_enabled",
+                return_value=True,
+            ),
+            patch.object(async_cache, "hget", new_callable=AsyncMock) as mock_hget,
+            patch.object(
+                MobyGamesHandler,
+                "_search_rom",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            mock_hget.return_value = json.dumps({"title": "Gran Turismo"})
+            result = await handler.get_rom("SCUS-94163.bin", PS1_MOBY_ID)
+
+        mock_hget.assert_awaited_once_with(PS1_SERIAL_INDEX_KEY, "SCUS-94163")
+        assert result.get("name") == "Gran Turismo"
+        assert result["moby_id"] is None

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -1,5 +1,6 @@
 """Tests for the ScreenScraper metadata handler."""
 
+import json
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, urlparse
@@ -9,7 +10,9 @@ from fastapi import HTTPException, status
 
 from adapters.services.screenscraper_types import SSGame
 from config.config_manager import Config, MetadataMediaType
+from handler.metadata.base_handler import PS1_SERIAL_INDEX_KEY
 from handler.metadata.ss_handler import (
+    PS1_SS_ID,
     SSHandler,
     _get_rom_type,
     _is_notgame,
@@ -18,6 +21,7 @@ from handler.metadata.ss_handler import (
     extract_metadata_from_ss_rom,
     get_preferred_regions,
 )
+from handler.redis_handler import async_cache
 
 
 def _make_config(
@@ -1207,3 +1211,33 @@ class TestSearchTermEncoding:
         url = captured["url"]
         assert "%2B" in url
         assert "%252B" not in url
+
+
+class TestSonySerialFilenames:
+    """Tests for Sony serial resolution in get_rom."""
+
+    @pytest.mark.asyncio
+    async def test_serial_at_filename_start_resolves_title(self):
+        """A serial in the first two characters of the filename must still hit
+        the serial index. Regression: re.IGNORECASE was passed as the ``pos``
+        argument of ``Pattern.search()``, skipping the first two characters,
+        so files named by their serial (e.g. ``SCUS-94163.bin``) were never
+        resolved."""
+        handler = SSHandler()
+
+        with (
+            patch(
+                "handler.metadata.ss_handler.SSHandler.is_enabled",
+                return_value=True,
+            ),
+            patch.object(async_cache, "hget", new_callable=AsyncMock) as mock_hget,
+            patch.object(
+                SSHandler, "_search_rom", new_callable=AsyncMock, return_value=None
+            ),
+        ):
+            mock_hget.return_value = json.dumps({"title": "Gran Turismo"})
+            result = await handler.get_rom(MagicMock(), "SCUS-94163.bin", PS1_SS_ID)
+
+        mock_hget.assert_awaited_once_with(PS1_SERIAL_INDEX_KEY, "SCUS-94163")
+        assert result.get("name") == "Gran Turismo"
+        assert result["ss_id"] is None


### PR DESCRIPTION
**Description**

`Pattern.search()` takes `pos` as its second argument, not `flags`. The Sony serial detection in the IGDB, MobyGames, and ScreenScraper handlers passed `re.IGNORECASE` (value 2) there, so the serial scan started at index 2 of the filename. Any PS1/PS2/PSP file whose serial sits in the first two characters - most commonly files named by their serial like `SCUS-94163.bin` - never matched `SONY_SERIAL_REGEX`, silently skipped the serial index resolution, and went unidentified by all three providers.

The flag added nothing: the regex already matches both cases via `[a-zA-Z]`, and #3621's fix uppercases the serial before the Redis lookup. This PR drops the stray argument at the three call sites so serials are found anywhere in the filename, and adds one regression test per handler (`get_rom` with a serial-at-position-0 filename must hit the serial index and surface the resolved title).

Note: `tests/handler/metadata/test_base_handler.py` already asserts `SONY_SERIAL_REGEX` matches `"SLUS-12345"` at position 0, and `endpoints/feeds.py` calls the same regex without the extra argument; the three handler call sites were the outliers.

> AI assistance disclosure: this contribution was researched, written, and tested with AI assistance (Claude), with the fix verified fail-before/pass-after locally and reviewed by me.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
