### PR TITLE
fix(retroachievements): resolve m3u playlists to natively hashed discs

### DIFF
--- a/backend/adapters/services/rahasher.py
+++ b/backend/adapters/services/rahasher.py
@@ -59,6 +59,32 @@ def _pick_ra_file(folder: Path) -> Path | None:
     return picked if _size(picked) >= 0 else None
 
 
+def _first_m3u_entry(m3u_path: Path) -> Path | None:
+    """Resolve an ``.m3u`` playlist to the first disc file it points at.
+
+    Mirrors RAHasher's own playlist handling (rcheevos hashes the first
+    entry): the first non-empty, non-comment line is the disc path, taken
+    relative to the playlist's folder unless absolute. Returns ``None`` when
+    the playlist can't be read or that entry doesn't exist on disk.
+    """
+    try:
+        lines = m3u_path.read_text(encoding="utf-8-sig", errors="replace").splitlines()
+    except OSError:
+        return None
+    for line in lines:
+        entry = line.strip()
+        if not entry or entry.startswith("#"):
+            continue
+        entry_path = Path(entry)
+        if not entry_path.is_absolute():
+            entry_path = m3u_path.parent / entry
+        try:
+            return entry_path if entry_path.is_file() else None
+        except OSError:
+            return None
+    return None
+
+
 # Platforms whose hash algorithm requires an on-disk disc image
 # (ISO9660/bin+cue/CHD). When the source file is an archive, RAHasher falls
 # back to "buffer hash" mode which these consoles don't support, failing
@@ -217,6 +243,25 @@ class RAHasherService:
                 resolved = await asyncio.to_thread(_pick_ra_file, folder)
                 if resolved is not None:
                     file_path = str(resolved)
+
+        # Multi-disc .m3u playlists are followed by RAHasher itself, but only
+        # to formats it can read. When the first playlist entry is a container
+        # we hash natively (RVZ/WIA on GameCube/Wii, compressed ISO on PSP),
+        # resolve the playlist to that disc so the native-hash dispatch below
+        # sees it (issue #3797).
+        if file_path.lower().endswith(".m3u"):
+            entry = await asyncio.to_thread(_first_m3u_entry, Path(file_path))
+            if entry is not None:
+                entry_str = str(entry)
+                is_native_entry = (
+                    platform["ra_id"] == PSP_RA_ID
+                    and is_psp_native_hash_file(entry_str)
+                ) or (
+                    platform["ra_id"] in (NGC_RA_ID, WII_RA_ID)
+                    and is_rvz_native_hash_file(entry_str)
+                )
+                if is_native_entry:
+                    file_path = entry_str
 
         # PSP compressed-ISO containers (.cso/.ciso/.zso/.dax) can't be read by
         # RAHasher ("Could not open track"). Compute the PSP RA hash natively

--- a/backend/tests/adapters/services/test_rahasher.py
+++ b/backend/tests/adapters/services/test_rahasher.py
@@ -9,6 +9,7 @@ from adapters.services.rahasher import (
     RAHASHER_VALID_HASH_REGEX,
     RAHasherError,
     RAHasherService,
+    _first_m3u_entry,
     _pick_ra_file,
 )
 from handler.metadata.base_handler import UniversalPlatformSlug as UPS
@@ -483,6 +484,63 @@ class TestPickRAFile:
         assert _pick_ra_file(tmp_path) == cue
 
 
+class TestFirstM3uEntry:
+    """Unit tests for resolving an .m3u playlist to its first disc file,
+    mirroring RAHasher's own playlist handling (it hashes the first entry)."""
+
+    def test_returns_first_entry_relative_to_playlist_folder(self, tmp_path):
+        disc1 = tmp_path / "game (Disc 1).rvz"
+        disc1.write_bytes(b"x" * 100)
+        (tmp_path / "game (Disc 2).rvz").write_bytes(b"x" * 100)
+        m3u = tmp_path / "game.m3u"
+        m3u.write_text("game (Disc 1).rvz\ngame (Disc 2).rvz\n")
+
+        assert _first_m3u_entry(m3u) == disc1
+
+    def test_skips_comments_and_blank_lines(self, tmp_path):
+        disc = tmp_path / "disc.cue"
+        disc.write_bytes(b"x" * 10)
+        m3u = tmp_path / "game.m3u"
+        m3u.write_text("#EXTM3U\n\n# a comment\ndisc.cue\n")
+
+        assert _first_m3u_entry(m3u) == disc
+
+    def test_handles_utf8_bom_and_crlf(self, tmp_path):
+        disc = tmp_path / "disc.rvz"
+        disc.write_bytes(b"x" * 10)
+        m3u = tmp_path / "game.m3u"
+        m3u.write_bytes(b"\xef\xbb\xbfdisc.rvz\r\n")
+
+        assert _first_m3u_entry(m3u) == disc
+
+    def test_resolves_absolute_entry_as_is(self, tmp_path):
+        disc = tmp_path / "elsewhere" / "disc.rvz"
+        disc.parent.mkdir()
+        disc.write_bytes(b"x" * 10)
+        m3u = tmp_path / "game.m3u"
+        m3u.write_text(f"{disc}\n")
+
+        assert _first_m3u_entry(m3u) == disc
+
+    def test_returns_none_when_first_entry_missing(self, tmp_path):
+        """Only the first entry counts (RAHasher hashes the first disc);
+        a dangling first entry means the playlist can't be resolved."""
+        (tmp_path / "game (Disc 2).rvz").write_bytes(b"x" * 10)
+        m3u = tmp_path / "game.m3u"
+        m3u.write_text("game (Disc 1).rvz\ngame (Disc 2).rvz\n")
+
+        assert _first_m3u_entry(m3u) is None
+
+    def test_returns_none_for_unreadable_playlist(self, tmp_path):
+        assert _first_m3u_entry(tmp_path / "missing.m3u") is None
+
+    def test_returns_none_for_empty_playlist(self, tmp_path):
+        m3u = tmp_path / "game.m3u"
+        m3u.write_text("#EXTM3U\n\n")
+
+        assert _first_m3u_entry(m3u) is None
+
+
 class TestRAHasherWildcardFolderResolution:
     """Folder-based disc ROMs (.cue + .bin) must resolve the "/*" glob to a real
     descriptor file before spawning RAHasher — it is launched without a shell,
@@ -807,6 +865,259 @@ class TestRAHasherRvzNativeHashing:
         mock_gc_native.assert_not_called()
         mock_wii_native.assert_not_called()
         mock_subprocess.assert_called_once()
+
+
+class TestRAHasherM3uNativeResolution:
+    """Folder-based multi-disc ROMs resolve to their .m3u playlist, but RAHasher
+    can only follow a playlist to formats it can read. Playlists pointing at
+    natively-hashed containers (RVZ/WIA, PSP compressed ISOs) must resolve to
+    the first disc so the native hashers see it (issue #3797)."""
+
+    @pytest.fixture
+    def service(self):
+        return RAHasherService()
+
+    def _make_ngc_folder(self, tmp_path):
+        """The exact layout from issue #3797: two .rvz discs plus an .m3u."""
+        disc1 = tmp_path / "Tales of Symphonia (Usa) (Disc 1).rvz"
+        disc1.write_bytes(b"x" * 200)
+        (tmp_path / "Tales of Symphonia (Usa) (Disc 2).rvz").write_bytes(b"x" * 300)
+        m3u = tmp_path / "Tales of Symphonia (Usa).m3u"
+        m3u.write_text(
+            "Tales of Symphonia (Usa) (Disc 1).rvz\n"
+            "Tales of Symphonia (Usa) (Disc 2).rvz\n"
+        )
+        return disc1
+
+    @pytest.mark.asyncio
+    async def test_ngc_folder_with_m3u_hashes_first_disc_natively(
+        self, service: RAHasherService, tmp_path
+    ):
+        """The folder glob resolves to the .m3u, which must then resolve to
+        disc 1 and short-circuit into the native GameCube hasher."""
+        ngc_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.NGC]
+        disc1 = self._make_ngc_folder(tmp_path)
+
+        with (
+            patch(
+                "adapters.services.rahasher.calculate_gamecube_ra_hash",
+                return_value="a1b2c3d4e5f6789012345678901234ab",
+            ) as mock_native,
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+        ):
+            result = await service.calculate_hash(
+                {"ra_id": ngc_id, "slug": "ngc"}, f"{tmp_path}/*"
+            )
+
+        assert result == "a1b2c3d4e5f6789012345678901234ab"
+        mock_native.assert_called_once_with(str(disc1))
+        mock_subprocess.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_wii_folder_with_m3u_hashes_first_disc_natively(
+        self, service: RAHasherService, tmp_path
+    ):
+        wii_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.WII]
+        disc1 = tmp_path / "game (Disc 1).wia"
+        disc1.write_bytes(b"x" * 200)
+        (tmp_path / "game (Disc 2).wia").write_bytes(b"x" * 300)
+        (tmp_path / "game.m3u").write_text("game (Disc 1).wia\ngame (Disc 2).wia\n")
+
+        with (
+            patch(
+                "adapters.services.rahasher.calculate_wii_ra_hash",
+                return_value="a1b2c3d4e5f6789012345678901234ab",
+            ) as mock_native,
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+        ):
+            result = await service.calculate_hash(
+                {"ra_id": wii_id, "slug": "wii"}, f"{tmp_path}/*"
+            )
+
+        assert result == "a1b2c3d4e5f6789012345678901234ab"
+        mock_native.assert_called_once_with(str(disc1))
+        mock_subprocess.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_direct_m3u_file_resolves_to_native_disc(
+        self, service: RAHasherService, tmp_path
+    ):
+        """A standalone .m3u scanned as a single-file ROM must resolve the
+        same way as the folder-glob path."""
+        ngc_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.NGC]
+        disc1 = self._make_ngc_folder(tmp_path)
+
+        with (
+            patch(
+                "adapters.services.rahasher.calculate_gamecube_ra_hash",
+                return_value="a1b2c3d4e5f6789012345678901234ab",
+            ) as mock_native,
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+        ):
+            result = await service.calculate_hash(
+                {"ra_id": ngc_id, "slug": "ngc"},
+                str(tmp_path / "Tales of Symphonia (Usa).m3u"),
+            )
+
+        assert result == "a1b2c3d4e5f6789012345678901234ab"
+        mock_native.assert_called_once_with(str(disc1))
+        mock_subprocess.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_psp_m3u_resolves_to_native_container(
+        self, service: RAHasherService, tmp_path
+    ):
+        psp_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSP]
+        disc1 = tmp_path / "game (Disc 1).cso"
+        disc1.write_bytes(b"x" * 200)
+        (tmp_path / "game (Disc 2).cso").write_bytes(b"x" * 300)
+        (tmp_path / "game.m3u").write_text("game (Disc 1).cso\ngame (Disc 2).cso\n")
+
+        with (
+            patch(
+                "adapters.services.rahasher.calculate_psp_ra_hash",
+                return_value="a1b2c3d4e5f6789012345678901234ab",
+            ) as mock_native,
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+        ):
+            result = await service.calculate_hash(
+                {"ra_id": psp_id, "slug": "psp"}, f"{tmp_path}/*"
+            )
+
+        assert result == "a1b2c3d4e5f6789012345678901234ab"
+        mock_native.assert_called_once_with(str(disc1))
+        mock_subprocess.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_m3u_of_cue_discs_still_goes_to_rahasher(
+        self, service: RAHasherService, tmp_path
+    ):
+        """Playlists of formats RAHasher reads (bin/cue) keep their current
+        behavior: the .m3u itself is handed to RAHasher."""
+        psx_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSX]
+        (tmp_path / "game (Disc 1).bin").write_bytes(b"x" * 5000)
+        (tmp_path / "game (Disc 1).cue").write_bytes(b"x" * 50)
+        (tmp_path / "game (Disc 2).bin").write_bytes(b"x" * 5000)
+        (tmp_path / "game (Disc 2).cue").write_bytes(b"x" * 50)
+        m3u = tmp_path / "game.m3u"
+        m3u.write_text("game (Disc 1).cue\ngame (Disc 2).cue\n")
+
+        mock_proc = AsyncMock()
+        mock_proc.wait.return_value = 0
+        mock_proc.stdout.read.return_value = b"a1b2c3d4e5f6789012345678901234ab\n"
+        mock_proc.stderr = None
+
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=mock_proc
+        ) as mock_subprocess:
+            result = await service.calculate_hash(
+                {"ra_id": psx_id, "slug": "psx"}, str(m3u)
+            )
+
+        assert result == "a1b2c3d4e5f6789012345678901234ab"
+        call_args = mock_subprocess.call_args[0]
+        assert str(m3u) in call_args
+
+    @pytest.mark.asyncio
+    async def test_rvz_m3u_on_other_platform_keeps_playlist(
+        self, service: RAHasherService, tmp_path
+    ):
+        """An .rvz playlist on a non-GameCube/Wii platform must not trigger
+        native resolution; behavior is unchanged."""
+        psx_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.PSX]
+        (tmp_path / "game.rvz").write_bytes(b"x" * 200)
+        m3u = tmp_path / "game.m3u"
+        m3u.write_text("game.rvz\n")
+
+        mock_proc = AsyncMock()
+        mock_proc.wait.return_value = 1
+        mock_proc.stdout.read.return_value = b""
+        mock_proc.stderr.read.return_value = b"Could not open track"
+
+        with (
+            patch(
+                "adapters.services.rahasher.calculate_gamecube_ra_hash"
+            ) as mock_gc_native,
+            patch(
+                "adapters.services.rahasher.calculate_wii_ra_hash"
+            ) as mock_wii_native,
+            patch(
+                "asyncio.create_subprocess_exec", return_value=mock_proc
+            ) as mock_subprocess,
+        ):
+            result = await service.calculate_hash(
+                {"ra_id": psx_id, "slug": "psx"}, str(m3u)
+            )
+
+        assert result == ""
+        mock_gc_native.assert_not_called()
+        mock_wii_native.assert_not_called()
+        call_args = mock_subprocess.call_args[0]
+        assert str(m3u) in call_args
+
+    @pytest.mark.asyncio
+    async def test_dangling_m3u_falls_through_to_rahasher(
+        self, service: RAHasherService, tmp_path
+    ):
+        """A playlist whose first entry is missing on disk keeps the .m3u
+        path and falls through to RAHasher without crashing."""
+        ngc_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.NGC]
+        m3u = tmp_path / "game.m3u"
+        m3u.write_text("game (Disc 1).rvz\n")
+
+        mock_proc = AsyncMock()
+        mock_proc.wait.return_value = 1
+        mock_proc.stdout.read.return_value = b""
+        mock_proc.stderr.read.return_value = b"Could not open file"
+
+        with (
+            patch(
+                "adapters.services.rahasher.calculate_gamecube_ra_hash"
+            ) as mock_native,
+            patch(
+                "asyncio.create_subprocess_exec", return_value=mock_proc
+            ) as mock_subprocess,
+        ):
+            result = await service.calculate_hash(
+                {"ra_id": ngc_id, "slug": "ngc"}, f"{tmp_path}/*"
+            )
+
+        assert result == ""
+        mock_native.assert_not_called()
+        call_args = mock_subprocess.call_args[0]
+        assert str(m3u) in call_args
+
+    @pytest.mark.asyncio
+    async def test_native_failure_falls_back_to_rahasher_with_disc(
+        self, service: RAHasherService, tmp_path
+    ):
+        """If the native hasher can't parse the resolved disc, RAHasher is
+        still attempted with the disc file (no worse than before)."""
+        ngc_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[UPS.NGC]
+        disc1 = self._make_ngc_folder(tmp_path)
+
+        mock_proc = AsyncMock()
+        mock_proc.wait.return_value = 1
+        mock_proc.stdout.read.return_value = b""
+        mock_proc.stderr.read.return_value = b"Not a Gamecube disc"
+
+        with (
+            patch(
+                "adapters.services.rahasher.calculate_gamecube_ra_hash",
+                return_value="",
+            ) as mock_native,
+            patch(
+                "asyncio.create_subprocess_exec", return_value=mock_proc
+            ) as mock_subprocess,
+        ):
+            result = await service.calculate_hash(
+                {"ra_id": ngc_id, "slug": "ngc"}, f"{tmp_path}/*"
+            )
+
+        assert result == ""
+        mock_native.assert_called_once_with(str(disc1))
+        call_args = mock_subprocess.call_args[0]
+        assert str(disc1) in call_args
 
 
 class TestRAHasherError:

--- a/backend/tests/adapters/services/test_rahasher.py
+++ b/backend/tests/adapters/services/test_rahasher.py
@@ -778,6 +778,39 @@ class TestRAHasherRvzNativeHashing:
         mock_subprocess.assert_not_called()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "ups,slug,native_fn",
+        [
+            (UPS.NGC, "ngc", "calculate_gamecube_ra_hash"),
+            (UPS.WII, "wii", "calculate_wii_ra_hash"),
+        ],
+    )
+    async def test_folder_glob_without_descriptor_hashes_largest_rvz_natively(
+        self, service: RAHasherService, tmp_path, ups, slug, native_fn
+    ):
+        """A disc folder with no .cue/.gdi/.m3u falls back to the largest
+        file; when that is an .rvz it must reach the native hasher."""
+        platform_id = PLATFORM_SLUG_TO_RETROACHIEVEMENTS_ID[ups]
+        (tmp_path / "game (Disc 1).rvz").write_bytes(b"x" * 200)
+        disc2 = tmp_path / "game (Disc 2).rvz"
+        disc2.write_bytes(b"x" * 300)
+
+        with (
+            patch(
+                f"adapters.services.rahasher.{native_fn}",
+                return_value="a1b2c3d4e5f6789012345678901234ab",
+            ) as mock_native,
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+        ):
+            result = await service.calculate_hash(
+                {"ra_id": platform_id, "slug": slug}, f"{tmp_path}/*"
+            )
+
+        assert result == "a1b2c3d4e5f6789012345678901234ab"
+        mock_native.assert_called_once_with(str(disc2))
+        mock_subprocess.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_falls_back_to_rahasher_when_native_fails(
         self, service: RAHasherService
     ):


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3797

**What changed and why**

Folder-based multi-disc ROMs (e.g. `ngc/Tales of Symphonia (USA)/` holding two
`.rvz` discs plus an `.m3u`) got no RetroAchievements hash. The `/*` glob
resolution added in #3497 correctly prefers the `.m3u` descriptor, but the
native RVZ/WIA hashing added in #3657 only triggers on `.rvz`/`.wia` paths, so
the playlist fell through to RAHasher, which cannot read RVZ containers
("Not a Gamecube disc") and returned an empty hash. Single-file RVZs at the
platform root worked, which is exactly the asymmetry reported in the issue.

The fix resolves an `.m3u` to its first disc entry, but only when that entry
is a container we hash natively (RVZ/WIA on GameCube/Wii, compressed ISO on
PSP). This mirrors RAHasher's own playlist handling (rcheevos hashes the first
entry), so playlists of formats RAHasher can read (`.cue`/`.gdi` sets) keep
their current behavior unchanged.

**Files modified**

- `backend/adapters/services/rahasher.py`: new `_first_m3u_entry()` helper
  (first non-empty, non-comment playlist line, resolved relative to the
  playlist's folder; handles BOM/CRLF; returns `None` for unreadable or
  dangling playlists) and a platform-gated resolution step in
  `calculate_hash()` between the `/*` glob resolution and the native-hash
  dispatch.
- `backend/tests/adapters/services/test_rahasher.py`: 15 new tests, unit
  tests for the playlist parser plus integration tests covering the exact
  issue layout (NGC folder with two `.rvz` + `.m3u`), Wii/WIA, PSP/CSO, a
  standalone `.m3u` ROM, and regression guards (cue playlists still handed to
  RAHasher, `.rvz` playlists on other platforms untouched, dangling playlists
  fall through without crashing).

**Testing notes**

- Full backend suite: 2085 passed, 0 failures.
- Verified end-to-end with the real `Tales of Symphonia (USA) (Disc 1).rvz`
  in the issue's exact folder layout: on master, RAHasher receives the `.m3u`
  and fails with `Not a Gamecube disc` (empty hash); with this fix the native
  GameCube hasher returns `25156adf6843add13144a8fae239689a`, which matches a
  registered hash for Tales of Symphonia (RA game 6981) per
  `API_GetGameList` (`i=16&h=1`).

**Reviewer attention**

- The resolution is deliberately conservative: it only swaps the playlist for
  its first entry when the platform + extension pair would be hashed
  natively. All other playlist handling is byte-for-byte previous behavior.
- Playlist entries may be absolute paths; this matches RAHasher's own
  playlist following, and the native hashers still validate container magic
  before parsing.
- `_first_m3u_entry` reads the playlist with `read_text()` (no size cap).
  Real playlists are tiny; happy to bound the read if preferred.

**AI assistance disclosure:** This PR was implemented with AI assistance
(Claude Code): root-cause analysis, implementation, tests, and the
verification runs described above were done by the agent under human
direction and review.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes