### PR TITLE
fix(docker): proxy nginx to gunicorn over TCP instead of unix socket

### DIFF
--- a/docker/init_scripts/docker-entrypoint.sh
+++ b/docker/init_scripts/docker-entrypoint.sh
@@ -38,6 +38,8 @@ done
 # support the default value syntax `${VAR:-default}`.
 export ROMM_BASE_PATH=${ROMM_BASE_PATH:-/romm}
 export ROMM_PORT=${ROMM_PORT:-8080}
+# Keep the nginx upstream port in sync with the port gunicorn binds to.
+export DEV_PORT=${DEV_PORT:-5000}
 
 # Disable nginx access logs when log level is WARNING, ERROR, or CRITICAL
 loglevel="${LOGLEVEL:-INFO}"

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -86,28 +86,31 @@ run_startup() {
 	fi
 }
 
-wait_for_gunicorn_socket() {
-	debug_log "Waiting for gunicorn socket file..."
+wait_for_gunicorn() {
+	local host="127.0.0.1"
+	local port="${DEV_PORT:-5000}"
+	debug_log "Waiting for gunicorn on ${host}:${port}..."
 	local wait_seconds=${WEB_SERVER_GUNICORN_WAIT_SECONDS:=30}
 	local retries=$((wait_seconds * 2))
 
-	while [[ ! -S /tmp/gunicorn.sock && retries -gt 0 ]]; do
+	# Temporarily disable errexit while polling the TCP port.
+	set +o errexit
+	while ((retries > 0)); do
+		if (echo >/dev/tcp/"${host}"/"${port}") 2>/dev/null; then
+			set -o errexit
+			debug_log "Gunicorn is ready and accepting connections"
+			return 0
+		fi
 		sleep 0.5
 		((retries--))
 	done
+	set -o errexit
 
-	if [[ -S /tmp/gunicorn.sock ]]; then
-		debug_log "Gunicorn socket file found"
-	else
-		warn_log "Gunicorn socket file not found after waiting ${wait_seconds}s!"
-	fi
+	warn_log "Gunicorn did not become ready after waiting ${wait_seconds}s!"
 }
 
 # Runs our main process and creates a corresponding PID file
 start_bin_gunicorn() {
-	# cleanup potentially leftover socket
-	rm /tmp/gunicorn.sock -f
-
 	# Wire LOGLEVEL into Gunicorn's logging config so it respects the env var.
 	local gunicorn_level="${LOGLEVEL^^}"
 	local gunicorn_log_config="/tmp/gunicorn/logging.conf"
@@ -126,7 +129,6 @@ start_bin_gunicorn() {
 	otel_prefix wrap api
 	"${wrap[@]}" gunicorn \
 		--bind=0.0.0.0:"${DEV_PORT:-5000}" \
-		--bind=unix:/tmp/gunicorn.sock \
 		--pid=/tmp/gunicorn.pid \
 		--forwarded-allow-ips="*" \
 		--worker-class uvicorn_worker.UvicornWorker \
@@ -143,7 +145,7 @@ start_bin_gunicorn() {
 
 # Commands to start nginx (handling PID creation internally)
 start_bin_nginx() {
-	wait_for_gunicorn_socket
+	wait_for_gunicorn
 
 	info_log "Starting nginx"
 	if [[ ${EUID} -ne 0 ]]; then

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -81,7 +81,7 @@ http {
         gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
         upstream wsgi_server {
-            server unix:/tmp/gunicorn.sock;
+            server 127.0.0.1:5000;
         }
 
         include /etc/nginx/conf.d/*.conf;

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -80,9 +80,7 @@ http {
         gzip_http_version 1.1;
         gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
-        upstream wsgi_server {
-            server 127.0.0.1:5000;
-        }
-
+        # The `wsgi_server` upstream is defined in a templated conf.d file so its
+        # port can track ${DEV_PORT} via envsubst (nginx.conf is not templated).
         include /etc/nginx/conf.d/*.conf;
 }

--- a/docker/nginx/templates/default.conf.template
+++ b/docker/nginx/templates/default.conf.template
@@ -2,6 +2,12 @@
 # by using `envsubst` to replace the environment variables in the template with
 # their actual values.
 
+# Gunicorn upstream. Defined here (not in nginx.conf) so the port stays in sync
+# with the ${DEV_PORT} gunicorn binds to.
+upstream wsgi_server {
+    server 127.0.0.1:${DEV_PORT};
+}
+
 # Helper to get scheme regardless if we are behind a proxy or not
 map $http_x_forwarded_proto $forwardscheme {
     default $scheme;


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3809

nginx sits in front of gunicorn and, in the default (root) container, its worker processes are dropped to the `romm` user (`nginx -g 'user romm;'`) while gunicorn creates `/tmp/gunicorn.sock` as **root**. That cross-user setup only works because gunicorn's default `umask` (`0`) leaves the socket world-writable, so `romm` can still `connect()`.

On some hosts (reported on OpenMediaVault) that assumption breaks and the worker cannot reach the socket, so every `/api/*` request 502s and the UI shows "server connection lost" / version `0.0.0`:

```
[crit] connect() to unix:/tmp/gunicorn.sock failed (13: Permission denied) while connecting to upstream ... GET /api/heartbeat
INFO: [RomM][nginx] ... GET /api/heartbeat 502
```

**Fix:** proxy over loopback TCP (`127.0.0.1:5000`), which gunicorn already binds via `--bind=0.0.0.0:${DEV_PORT:-5000}`. A TCP connection has no socket-file owner/mode (and no MAC label), so the root-vs-`romm` split is irrelevant and the whole class of socket-permission failures goes away. No behavior change for deployments that already work.

Changes:
- `docker/nginx/default.conf`: upstream `wsgi_server` now points at `127.0.0.1:5000` instead of `unix:/tmp/gunicorn.sock`.
- `docker/init_scripts/init`: drop the `--bind=unix:/tmp/gunicorn.sock` bind and the leftover-socket cleanup; readiness gate (`wait_for_gunicorn`) now polls the TCP port instead of waiting for the socket file. The `WEB_SERVER_GUNICORN_WAIT_SECONDS` knob is unchanged.

**AI-assistance disclosure:** This change was investigated and implemented with AI assistance (PostHog Code / Claude). The root-cause analysis, the code changes, and this description were AI-generated and human-reviewed.

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

Fixes #3809

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*