### PR TITLE
fix(frontend): base v2 verified badge on real DB hash matches

### DIFF
--- a/frontend/src/locales/bg_BG/rom.json
+++ b/frontend/src/locales/bg_BG/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "Потвърждение",
   "verified-rom": "Потвърден ROM",
+  "verified-rom-hint": "Hash verified against ROM database",
   "versions-count": "{n} версии",
   "volume-mute": "Заглуши",
   "volume-unmute": "Включи звука",

--- a/frontend/src/locales/cs_CZ/rom.json
+++ b/frontend/src/locales/cs_CZ/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "Ověření",
   "verified-rom": "Ověřená ROM",
+  "verified-rom-hint": "Hash verified against ROM database",
   "versions-count": "{n} verzí",
   "volume-mute": "Ztlumit",
   "volume-unmute": "Zrušit ztlumení",

--- a/frontend/src/locales/de_DE/rom.json
+++ b/frontend/src/locales/de_DE/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "Verifizierung",
   "verified-rom": "Verifizierte ROM",
+  "verified-rom-hint": "Hash mit ROM-Datenbank abgeglichen",
   "versions-count": "{n} Versionen",
   "volume-mute": "Stummschalten",
   "volume-unmute": "Stummschaltung aufheben",

--- a/frontend/src/locales/en_GB/rom.json
+++ b/frontend/src/locales/en_GB/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "Verification",
   "verified-rom": "Verified ROM",
+  "verified-rom-hint": "Hash verified against ROM database",
   "versions-count": "{n} versions",
   "volume-mute": "Mute",
   "volume-unmute": "Unmute",

--- a/frontend/src/locales/en_US/rom.json
+++ b/frontend/src/locales/en_US/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Upload tracks",
   "verification": "Verification",
   "verified-rom": "Verified ROM",
+  "verified-rom-hint": "Hash verified against ROM database",
   "versions-count": "{n} versions",
   "volume-mute": "Mute",
   "volume-unmute": "Unmute",

--- a/frontend/src/locales/es_ES/rom.json
+++ b/frontend/src/locales/es_ES/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "Verificación",
   "verified-rom": "ROM verificada",
+  "verified-rom-hint": "Hash verificado contra una base de datos de ROM",
   "versions-count": "{n} versiones",
   "volume-mute": "Silenciar",
   "volume-unmute": "Quitar silencio",

--- a/frontend/src/locales/fr_FR/rom.json
+++ b/frontend/src/locales/fr_FR/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "Vérification",
   "verified-rom": "ROM vérifiée",
+  "verified-rom-hint": "Empreinte vérifiée dans une base de données de ROM",
   "versions-count": "{n} versions",
   "volume-mute": "Couper le son",
   "volume-unmute": "Activer le son",

--- a/frontend/src/locales/hu_HU/rom.json
+++ b/frontend/src/locales/hu_HU/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "Ellenőrzés",
   "verified-rom": "Ellenőrzött ROM",
+  "verified-rom-hint": "Hash verified against ROM database",
   "versions-count": "{n} verzió",
   "volume-mute": "Némítás",
   "volume-unmute": "Némítás feloldása",

--- a/frontend/src/locales/it_IT/rom.json
+++ b/frontend/src/locales/it_IT/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "Verifica",
   "verified-rom": "ROM verificata",
+  "verified-rom-hint": "Hash verificato su un database di ROM",
   "versions-count": "{n} versioni",
   "volume-mute": "Disattiva audio",
   "volume-unmute": "Riattiva audio",

--- a/frontend/src/locales/ja_JP/rom.json
+++ b/frontend/src/locales/ja_JP/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "検証",
   "verified-rom": "確認済みROM",
+  "verified-rom-hint": "Hash verified against ROM database",
   "versions-count": "{n}件のバージョン",
   "volume-mute": "ミュート",
   "volume-unmute": "ミュート解除",

--- a/frontend/src/locales/ko_KR/rom.json
+++ b/frontend/src/locales/ko_KR/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "검증",
   "verified-rom": "검증된 ROM",
+  "verified-rom-hint": "Hash verified against ROM database",
   "versions-count": "{n}개 버전",
   "volume-mute": "음소거",
   "volume-unmute": "음소거 해제",

--- a/frontend/src/locales/pl_PL/rom.json
+++ b/frontend/src/locales/pl_PL/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "Weryfikacja",
   "verified-rom": "Zweryfikowany ROM",
+  "verified-rom-hint": "Hash verified against ROM database",
   "versions-count": "{n} wersji",
   "volume-mute": "Wycisz",
   "volume-unmute": "Wyłącz wyciszenie",

--- a/frontend/src/locales/pt_BR/rom.json
+++ b/frontend/src/locales/pt_BR/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "Verificação",
   "verified-rom": "ROM verificada",
+  "verified-rom-hint": "Hash verificado em banco de dados de ROM",
   "versions-count": "{n} versões",
   "volume-mute": "Silenciar",
   "volume-unmute": "Reativar som",

--- a/frontend/src/locales/ro_RO/rom.json
+++ b/frontend/src/locales/ro_RO/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "Verificare",
   "verified-rom": "ROM verificat",
+  "verified-rom-hint": "Hash verified against ROM database",
   "versions-count": "{n} versiuni",
   "volume-mute": "Mut",
   "volume-unmute": "Activează sunetul",

--- a/frontend/src/locales/ru_RU/rom.json
+++ b/frontend/src/locales/ru_RU/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "Проверка",
   "verified-rom": "Проверенный ROM",
+  "verified-rom-hint": "Hash verified against ROM database",
   "versions-count": "{n} версий",
   "volume-mute": "Отключить звук",
   "volume-unmute": "Включить звук",

--- a/frontend/src/locales/tr_TR/rom.json
+++ b/frontend/src/locales/tr_TR/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Parça yükle",
   "verification": "Doğrulama",
   "verified-rom": "Doğrulanmış ROM",
+  "verified-rom-hint": "Hash verified against ROM database",
   "versions-count": "{n} sürüm",
   "volume-mute": "Sesi kapat",
   "volume-unmute": "Sesi aç",

--- a/frontend/src/locales/zh_CN/rom.json
+++ b/frontend/src/locales/zh_CN/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "验证",
   "verified-rom": "已验证 ROM",
+  "verified-rom-hint": "Hash verified against ROM database",
   "versions-count": "{n} 个版本",
   "volume-mute": "静音",
   "volume-unmute": "取消静音",

--- a/frontend/src/locales/zh_TW/rom.json
+++ b/frontend/src/locales/zh_TW/rom.json
@@ -431,6 +431,7 @@
   "upload-tracks": "Add tracks",
   "verification": "驗證",
   "verified-rom": "已驗證 ROM",
+  "verified-rom-hint": "Hash verified against ROM database",
   "versions-count": "{n} 個版本",
   "volume-mute": "靜音",
   "volume-unmute": "取消靜音",

--- a/frontend/src/v2/components/GameDetails/GameHeader.vue
+++ b/frontend/src/v2/components/GameDetails/GameHeader.vue
@@ -60,12 +60,17 @@ const actions = useGameActions(() => props.rom);
       <span v-if="verified" class="r-v2-det-header__sep"> · </span>
       <!-- Icon-only verified indicator. The check decagram is a strong
            enough signal on its own; the "Verified" word was just noise
-           in a row that's already mostly text. RTooltip preserves the
-           label for keyboard / hover discovery. -->
-      <span v-if="verified" class="r-v2-det-header__verified">
+           in a row that's already mostly text. The tooltip spells out
+           what "verified" means (a database hash match) so the badge
+           isn't cryptic; the short label is the accessible name. -->
+      <span
+        v-if="verified"
+        class="r-v2-det-header__verified"
+        :aria-label="t('rom.verified-rom')"
+      >
         <RIcon icon="mdi-check-decagram" :size="18" color="success" />
         <RTooltip
-          :text="t('rom.verified-rom')"
+          :text="t('rom.verified-rom-hint')"
           location="top"
           activator="parent"
         />

--- a/frontend/src/v2/components/GameDetails/GameHeader.vue
+++ b/frontend/src/v2/components/GameDetails/GameHeader.vue
@@ -67,6 +67,7 @@ const actions = useGameActions(() => props.rom);
         v-if="verified"
         class="r-v2-det-header__verified"
         :aria-label="t('rom.verified-rom')"
+        tabindex="0"
       >
         <RIcon icon="mdi-check-decagram" :size="18" color="success" />
         <RTooltip

--- a/frontend/src/v2/components/GameDetails/MetadataTab.vue
+++ b/frontend/src/v2/components/GameDetails/MetadataTab.vue
@@ -3,9 +3,8 @@
 //   1. File info — name + size only.
 //   2. Hashes — CRC, MD5, SHA1, all mono. RTag with eyebrow label.
 //   3. Verification — RTag per database; tone="success" for match,
-//      neutral for miss. Independent from the "Verified" pill in the
-//      title header which only checks `crc_hash`. RA match comes from
-//      `rom.ra_id`.
+//      neutral for miss. Same source of truth (Hasheous match flags) as
+//      the "Verified" badge in the header, via `VERIFICATION_DATABASES`.
 //   4. Metadata sources — ProviderGrid (linked + unlinked).
 import { RTag } from "@v2/lib";
 import { computed } from "vue";
@@ -14,6 +13,10 @@ import type { DetailedRom } from "@/stores/roms";
 import { formatBytes } from "@/utils";
 import ProviderGrid from "@/v2/components/GameDetails/ProviderGrid.vue";
 import HashChip from "@/v2/components/shared/HashChip.vue";
+import {
+  matchesDatabase,
+  VERIFICATION_DATABASES,
+} from "@/v2/utils/romVerification";
 
 defineOptions({ inheritAttrs: false });
 
@@ -55,24 +58,16 @@ const hashRows = computed<{ label: string; value: string | null }[]>(() => {
 
 type Verification = { label: string; match: boolean };
 
-// Per-database match badges. Hasheous covers TOSEC / No-Intro / Redump
-// / FBNeo / MAME (either Arcade or MESS counts). RA is independent —
-// the rom is "verified as RA" when it has an `ra_id` linked.
-const verifications = computed<Verification[]>(() => {
-  const r = props.rom;
-  const h = r.hasheous_metadata ?? null;
-  return [
-    { label: "TOSEC", match: Boolean(h?.tosec_match) },
-    { label: "No-Intro", match: Boolean(h?.nointro_match) },
-    { label: "Redump", match: Boolean(h?.redump_match) },
-    { label: "FBNeo", match: Boolean(h?.fbneo_match) },
-    {
-      label: "MAME",
-      match: Boolean(h?.mame_arcade_match || h?.mame_mess_match),
-    },
-    { label: "RA", match: Boolean(r.ra_id) },
-  ];
-});
+// Per-database match badges, driven by the shared VERIFICATION_DATABASES
+// so this list stays in lockstep with the header badge and the backend
+// filter. A match means the ROM's hash was found in that database (via
+// Hasheous), which is what "verified" communicates.
+const verifications = computed<Verification[]>(() =>
+  VERIFICATION_DATABASES.map((db) => ({
+    label: db.label,
+    match: matchesDatabase(props.rom, db.keys),
+  })),
+);
 </script>
 
 <template>

--- a/frontend/src/v2/utils/romVerification.test.ts
+++ b/frontend/src/v2/utils/romVerification.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  isRomVerified,
+  matchesDatabase,
+  VERIFICATION_DATABASES,
+  VERIFICATION_KEYS,
+} from "./romVerification";
+
+describe("isRomVerified", () => {
+  it("is false when there is no hasheous metadata", () => {
+    expect(isRomVerified({})).toBe(false);
+    expect(isRomVerified({ hasheous_metadata: null })).toBe(false);
+  });
+
+  it("is false when no signature matched (e.g. a hashed-but-unmatched archive)", () => {
+    expect(
+      isRomVerified({
+        hasheous_metadata: {
+          tosec_match: false,
+          nointro_match: false,
+          ra_match: false,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when any single database matched", () => {
+    for (const key of VERIFICATION_KEYS) {
+      expect(isRomVerified({ hasheous_metadata: { [key]: true } })).toBe(true);
+    }
+  });
+});
+
+describe("matchesDatabase", () => {
+  it("matches MAME on either the arcade or the mess flag", () => {
+    const mame = VERIFICATION_DATABASES.find((db) => db.label === "MAME")!;
+    expect(matchesDatabase({}, mame.keys)).toBe(false);
+    expect(
+      matchesDatabase(
+        { hasheous_metadata: { mame_arcade_match: true } },
+        mame.keys,
+      ),
+    ).toBe(true);
+    expect(
+      matchesDatabase(
+        { hasheous_metadata: { mame_mess_match: true } },
+        mame.keys,
+      ),
+    ).toBe(true);
+  });
+
+  it("treats RetroAchievements as a database match (ra_match, not ra_id)", () => {
+    const ra = VERIFICATION_DATABASES.find(
+      (db) => db.label === "RetroAchievements",
+    )!;
+    expect(ra.keys).toEqual(["ra_match"]);
+    expect(
+      matchesDatabase({ hasheous_metadata: { ra_match: true } }, ra.keys),
+    ).toBe(true);
+  });
+});
+
+describe("VERIFICATION_KEYS", () => {
+  it("is the flattened set of every database's match flags", () => {
+    expect(VERIFICATION_KEYS).toEqual(
+      VERIFICATION_DATABASES.flatMap((db) => db.keys),
+    );
+  });
+});

--- a/frontend/src/v2/utils/romVerification.test.ts
+++ b/frontend/src/v2/utils/romVerification.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import type { RomHasheousMetadata } from "@/__generated__";
+import type { SimpleRom } from "@/stores/roms";
 import {
   isRomVerified,
   matchesDatabase,
@@ -6,27 +8,27 @@ import {
   VERIFICATION_KEYS,
 } from "./romVerification";
 
+// Only `hasheous_metadata` is read; cast a minimal stub to SimpleRom.
+const rom = (hasheous_metadata?: RomHasheousMetadata | null): SimpleRom =>
+  ({ hasheous_metadata }) as SimpleRom;
+
 describe("isRomVerified", () => {
   it("is false when there is no hasheous metadata", () => {
-    expect(isRomVerified({})).toBe(false);
-    expect(isRomVerified({ hasheous_metadata: null })).toBe(false);
+    expect(isRomVerified(rom())).toBe(false);
+    expect(isRomVerified(rom(null))).toBe(false);
   });
 
   it("is false when no signature matched (e.g. a hashed-but-unmatched archive)", () => {
     expect(
-      isRomVerified({
-        hasheous_metadata: {
-          tosec_match: false,
-          nointro_match: false,
-          ra_match: false,
-        },
-      }),
+      isRomVerified(
+        rom({ tosec_match: false, nointro_match: false, ra_match: false }),
+      ),
     ).toBe(false);
   });
 
   it("is true when any single database matched", () => {
     for (const key of VERIFICATION_KEYS) {
-      expect(isRomVerified({ hasheous_metadata: { [key]: true } })).toBe(true);
+      expect(isRomVerified(rom({ [key]: true }))).toBe(true);
     }
   });
 });
@@ -34,19 +36,13 @@ describe("isRomVerified", () => {
 describe("matchesDatabase", () => {
   it("matches MAME on either the arcade or the mess flag", () => {
     const mame = VERIFICATION_DATABASES.find((db) => db.label === "MAME")!;
-    expect(matchesDatabase({}, mame.keys)).toBe(false);
-    expect(
-      matchesDatabase(
-        { hasheous_metadata: { mame_arcade_match: true } },
-        mame.keys,
-      ),
-    ).toBe(true);
-    expect(
-      matchesDatabase(
-        { hasheous_metadata: { mame_mess_match: true } },
-        mame.keys,
-      ),
-    ).toBe(true);
+    expect(matchesDatabase(rom(), mame.keys)).toBe(false);
+    expect(matchesDatabase(rom({ mame_arcade_match: true }), mame.keys)).toBe(
+      true,
+    );
+    expect(matchesDatabase(rom({ mame_mess_match: true }), mame.keys)).toBe(
+      true,
+    );
   });
 
   it("treats RetroAchievements as a database match (ra_match, not ra_id)", () => {
@@ -54,9 +50,7 @@ describe("matchesDatabase", () => {
       (db) => db.label === "RetroAchievements",
     )!;
     expect(ra.keys).toEqual(["ra_match"]);
-    expect(
-      matchesDatabase({ hasheous_metadata: { ra_match: true } }, ra.keys),
-    ).toBe(true);
+    expect(matchesDatabase(rom({ ra_match: true }), ra.keys)).toBe(true);
   });
 });
 

--- a/frontend/src/v2/utils/romVerification.ts
+++ b/frontend/src/v2/utils/romVerification.ts
@@ -1,0 +1,46 @@
+// romVerification — single source of truth for what "verified" means: a
+// ROM whose file hash matched a known ROM database (via Hasheous). Mirrors
+// the backend's `_filter_by_verified` (roms_handler.py) so the header
+// badge, the per-database chips in the Metadata tab, and the library
+// "verified" filter all agree. Merely having a computed hash
+// (crc/md5/sha1) does NOT make a ROM verified.
+import type { RomHasheousMetadata } from "@/__generated__";
+
+// Each database this ROM's hash can be checked against, with the Hasheous
+// match flag(s) that count as a hit. MAME reports Arcade and MESS
+// separately; either one means the ROM matched MAME. Order is the display
+// order for the Metadata tab chips.
+export const VERIFICATION_DATABASES: {
+  label: string;
+  keys: (keyof RomHasheousMetadata)[];
+}[] = [
+  { label: "TOSEC", keys: ["tosec_match"] },
+  { label: "No-Intro", keys: ["nointro_match"] },
+  { label: "Redump", keys: ["redump_match"] },
+  { label: "MAME", keys: ["mame_arcade_match", "mame_mess_match"] },
+  { label: "FBNeo", keys: ["fbneo_match"] },
+  { label: "WHDLoad", keys: ["whdload_match"] },
+  { label: "PureDOS", keys: ["puredos_match"] },
+  { label: "RetroAchievements", keys: ["ra_match"] },
+];
+
+// Flattened match flags, i.e. the exact set the backend filters on.
+export const VERIFICATION_KEYS: (keyof RomHasheousMetadata)[] =
+  VERIFICATION_DATABASES.flatMap((db) => db.keys);
+
+type WithHasheous = { hasheous_metadata?: RomHasheousMetadata | null };
+
+// Whether a single database matched for this ROM.
+export function matchesDatabase(
+  rom: WithHasheous,
+  keys: (keyof RomHasheousMetadata)[],
+): boolean {
+  const h = rom.hasheous_metadata;
+  if (!h) return false;
+  return keys.some((key) => Boolean(h[key]));
+}
+
+// Whether the ROM is verified against any known database.
+export function isRomVerified(rom: WithHasheous): boolean {
+  return matchesDatabase(rom, VERIFICATION_KEYS);
+}

--- a/frontend/src/v2/utils/romVerification.ts
+++ b/frontend/src/v2/utils/romVerification.ts
@@ -5,6 +5,7 @@
 // "verified" filter all agree. Merely having a computed hash
 // (crc/md5/sha1) does NOT make a ROM verified.
 import type { RomHasheousMetadata } from "@/__generated__";
+import type { SimpleRom } from "@/stores/roms";
 
 // Each database this ROM's hash can be checked against, with the Hasheous
 // match flag(s) that count as a hit. MAME reports Arcade and MESS
@@ -28,11 +29,9 @@ export const VERIFICATION_DATABASES: {
 export const VERIFICATION_KEYS: (keyof RomHasheousMetadata)[] =
   VERIFICATION_DATABASES.flatMap((db) => db.keys);
 
-type WithHasheous = { hasheous_metadata?: RomHasheousMetadata | null };
-
 // Whether a single database matched for this ROM.
 export function matchesDatabase(
-  rom: WithHasheous,
+  rom: SimpleRom,
   keys: (keyof RomHasheousMetadata)[],
 ): boolean {
   const h = rom.hasheous_metadata;
@@ -41,6 +40,6 @@ export function matchesDatabase(
 }
 
 // Whether the ROM is verified against any known database.
-export function isRomVerified(rom: WithHasheous): boolean {
+export function isRomVerified(rom: SimpleRom): boolean {
   return matchesDatabase(rom, VERIFICATION_KEYS);
 }

--- a/frontend/src/v2/views/GameDetails.vue
+++ b/frontend/src/v2/views/GameDetails.vue
@@ -29,6 +29,7 @@ import SaveDataTab from "@/v2/components/GameDetails/SaveDataTab.vue";
 import { useBackgroundArt } from "@/v2/composables/useBackgroundArt";
 import { useRightStickScroll } from "@/v2/composables/useRightStickScroll";
 import { useWebpSupport } from "@/v2/composables/useWebpSupport";
+import { isRomVerified } from "@/v2/utils/romVerification";
 
 const route = useRoute();
 const router = useRouter();
@@ -129,7 +130,9 @@ const regions = computed(() => currentRom.value?.regions ?? []);
 const languages = computed(() => currentRom.value?.languages ?? []);
 const tags = computed(() => currentRom.value?.tags ?? []);
 
-const verified = computed(() => Boolean(currentRom.value?.crc_hash));
+const verified = computed(() =>
+  currentRom.value ? isRomVerified(currentRom.value) : false,
+);
 
 const coverPath = computed(() => {
   const r = currentRom.value;


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3806
Fixes #3807

The v2 game-details "Verified ROM" badge was gated on `crc_hash` being present:

```ts
const verified = computed(() => Boolean(currentRom.value?.crc_hash));
```

A `crc_hash` (and md5/sha1) is computed for essentially every ROM, so the badge appeared on ROMs that never matched any hash database, e.g. the 7z-compressed Astro Boy GBA ROM in #3806 (which fails to match because of the separate archive-hashing bug #3808, but was still shown as verified).

**What changed**

- **New `frontend/src/v2/utils/romVerification.ts`** — single source of truth for what "verified" means, mirroring the backend's `_filter_by_verified` (`roms_handler.py`). A ROM is verified only when a Hasheous signature match flag is set. Exports `VERIFICATION_DATABASES`, `VERIFICATION_KEYS`, `matchesDatabase()`, and `isRomVerified()`.
- **`GameDetails.vue`** — the header badge now derives from `isRomVerified(currentRom)` instead of `crc_hash`.
- **`MetadataTab.vue`** — the per-database chips are now driven by the shared `VERIFICATION_DATABASES`, so the badge, the chip list, and the backend filter can't drift apart. Fixes the RetroAchievements chip to use `ra_match` (an actual hash match) instead of `ra_id` (mere metadata linkage), and adds the previously-missing WHDLoad / PureDOS databases.
- **Clarify the badge (#3807)** — the header tooltip now explains what "verified" means (a database hash match via Hasheous / RetroAchievements) via a new `rom.verified-rom-hint` key added to all 18 locales (translated for en/fr/es/it/pt/de, English placeholder elsewhere). The short "Verified ROM" label is kept as the icon's `aria-label`.

Note: this is the display/clarity fix. The underlying "7z hashing hashes the archive instead of the ROM" problem is tracked separately in #3808 (backend `rahasher.py`).

**AI assistance disclosure**
<sup>Per CONTRIBUTING.md.</sup>

This PR was written with AI assistance (Claude Code). All changes were reviewed by the author.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A

**Verification**

- `romVerification.test.ts`: 6 unit tests (no-metadata, hashed-but-unmatched, per-key match, MAME arcade/mess, RA via `ra_match`, keys-are-flattened) — pass.
- `npm run typecheck`: clean.
- `check_i18n_locales.py` + `check_i18n_sorted.py`: pass.
- `trunk fmt` + `trunk check` on all touched files: no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)