### PR TITLE
fix(v2): render visible labels on device-auth and token expiry selects

### DIFF
--- a/frontend/src/v2/components/Settings/CreateClientTokenDialog.vue
+++ b/frontend/src/v2/components/Settings/CreateClientTokenDialog.vue
@@ -416,6 +416,7 @@ onBeforeUnmount(() => {
           v-model="selectedExpiry"
           :items="expiryOptions"
           :label="t('settings.client-token-select-expiry')"
+          prefix-label="stacked"
           variant="outlined"
           density="comfortable"
           hide-details

--- a/frontend/src/v2/views/DevicePair.vue
+++ b/frontend/src/v2/views/DevicePair.vue
@@ -20,12 +20,7 @@ import deviceAuthApi, {
 type ApiError = AxiosError<{ detail?: string }>;
 
 type Status =
-  | "loading"
-  | "ready"
-  | "submitting"
-  | "approved"
-  | "denied"
-  | "error";
+  "loading" | "ready" | "submitting" | "approved" | "denied" | "error";
 
 const route = useRoute();
 const { t } = useI18n();
@@ -227,6 +222,7 @@ async function deny() {
       <RTextField
         v-model="editedDeviceName"
         :label="t('settings.device-auth-device-name')"
+        prefix-label="stacked"
         variant="outlined"
         density="comfortable"
       />
@@ -279,6 +275,7 @@ async function deny() {
       <RSelect
         v-model="expiresIn"
         :label="t('settings.device-auth-expires-in')"
+        prefix-label="stacked"
         :items="EXPIRY_OPTIONS"
         item-title="label"
         item-value="value"


### PR DESCRIPTION
**Description**

The v2 `RSelect` / `RTextField` primitives only render a **visible** label when `prefix-label` is set (`"stacked"` or `"inline"`). With just `:label`, the text degrades to a placeholder + `aria-label`. Because these fields always hold a value, the placeholder never shows, so no label was ever visible.

This adds `prefix-label="stacked"` to:

- The **"Token expires in"** select on the device authorization screen (`DevicePair.vue`) — the field reported in #3814, which always shows "Never" so its placeholder-label never appeared.
- The **"Device name"** field beside it, which had the same latent issue, so the authorize form is consistently labeled.
- The **"Expiration"** select in the create-client-token dialog (`CreateClientTokenDialog.vue`), which had the identical latent issue.

(Trunk also collapsed a pre-existing multi-line union type in `DevicePair.vue` when formatting the touched file.)

Fixes #3814

**AI assistance disclosure**

This change was written with AI assistance (Claude Code / Opus 4.8). The root-cause analysis, the fix, and live verification were AI-driven and human-reviewed.

**Checklist**

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

Device authorization screen with the now-visible **"Device name"** and **"Token expires in"** labels, verified against the live backend (real pending device-auth flow) in the v2 UI. The card is intentionally always-dark regardless of theme, so light and dark render identically.

Before: the expiry dropdown showed only "Never" with no label indicating its purpose.
After: "Token expires in" renders above the dropdown, and "Device name" above its field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)