### PR TITLE
fix(v2): batch gallery hydration into windows and cap concurrency

### DIFF
--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -183,9 +183,10 @@ export interface GetRomsParams {
   playerCountsLogic?: string | null;
   metadataProvidersLogic?: string | null;
   tagsLogic?: string | null;
-  // Skip the char index / filter-value aggregations server-side
+  // Skip the char index / filter-value / id-index aggregations server-side
   withCharIndex?: boolean;
   withFilterValues?: boolean;
+  withRomIdIndex?: boolean;
   // Cancel an in-flight request
   signal?: AbortSignal;
 }
@@ -236,6 +237,7 @@ async function getRoms({
   tagsLogic = null,
   withCharIndex = undefined,
   withFilterValues = undefined,
+  withRomIdIndex = undefined,
   signal = undefined,
 }: GetRomsParams) {
   const params = {
@@ -345,6 +347,9 @@ async function getRoms({
     ...(withCharIndex !== undefined ? { with_char_index: withCharIndex } : {}),
     ...(withFilterValues !== undefined
       ? { with_filter_values: withFilterValues }
+      : {}),
+    ...(withRomIdIndex !== undefined
+      ? { with_rom_id_index: withRomIdIndex }
       : {}),
   };
 

--- a/frontend/src/v2/components/Gallery/GalleryShell.vue
+++ b/frontend/src/v2/components/Gallery/GalleryShell.vue
@@ -554,23 +554,20 @@ const currentLetter = computed<string>(() => {
   return "";
 });
 
-// Per-card viewport-driven fetch. The shell tracks which positions are
-// currently visible (from the rows in `viewportRange`) and keeps
-// `byPosition` in sync via per-card `GET /roms/{id}/simple` calls — pure
-// by-id lookups on the backend, much faster than the paginated
-// `getRoms(limit/offset)` pipeline. Each fetch is independent, so covers
-// stream in as their individual responses land.
+// Viewport-driven windowed fetch. The shell collects which positions are
+// currently visible (from the rows in `viewportRange`, for both grid and
+// list layouts) and hands them to the store's `syncVisibleWindows`, which
+// aligns each to its shared 72-item window, dedupes, starts the windows
+// covering the viewport, and cancels any that scrolled out of view.
+// Batching visible cards into a handful of paginated `getRoms` requests
+// (instead of one request per card) is what keeps a fast scroll — or two
+// users scrolling at once — from flooding the single-worker backend.
 //
-// No idle-time prefetch: when the user stops scrolling, no new requests
-// are fired. Cards already in the viewport that are still missing keep
-// loading; everything off-screen waits until the user scrolls there.
-//
-// Cancellation: positions that leave the viewport while their fetch is in
-// flight are aborted via `cancelFetchAt`. A small debounce on viewport
-// changes prevents fire-and-cancel storms during smooth scrolling — only
-// when the viewport settles for `FETCH_DEBOUNCE_MS` do we sync.
+// A small debounce on viewport changes prevents fire-and-cancel storms
+// during smooth scrolling — only when the viewport settles for
+// `FETCH_DEBOUNCE_MS` do we sync. Both layouts share this one path, so the
+// list is debounced too (list rows no longer self-fetch on mount).
 const FETCH_DEBOUNCE_MS = 80;
-const visiblePositions = new Set<number>();
 let fetchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingRange: { first: number; last: number } | null = null;
 
@@ -583,34 +580,20 @@ function collectVisiblePositions(range: {
   const items = virtualItems.value;
   for (let i = range.first; i <= range.last; i++) {
     const it = items[i];
-    if (!it || it.kind !== "row") continue;
-    for (let p = it.startPosition; p < it.endPosition; p++) out.add(p);
+    if (!it) continue;
+    // Grid rows fan out into a contiguous run of card positions; list rows
+    // carry a single position each.
+    if (it.kind === "row") {
+      for (let p = it.startPosition; p < it.endPosition; p++) out.add(p);
+    } else if (it.kind === "list-row") {
+      out.add(it.position);
+    }
   }
   return out;
 }
 
 function syncFetches(range: { first: number; last: number }) {
-  const next = collectVisiblePositions(range);
-
-  // Cancel positions that left the viewport before their fetch resolved.
-  // The store's per-position controller handles the network abort;
-  // idempotent if nothing was in flight.
-  for (const p of visiblePositions) {
-    if (!next.has(p) && !galleryRoms.byPosition.has(p)) {
-      galleryRoms.cancelFetchAt(p);
-    }
-  }
-
-  // Fire per-card fetches for positions that just entered. The store
-  // dedupes against in-flight + already-loaded internally.
-  for (const p of next) {
-    if (!galleryRoms.byPosition.has(p)) {
-      void galleryRoms.fetchRomAt(p);
-    }
-  }
-
-  visiblePositions.clear();
-  for (const p of next) visiblePositions.add(p);
+  galleryRoms.syncVisibleWindows(collectVisiblePositions(range));
 }
 
 function scheduleFetchSync(range: { first: number; last: number }) {
@@ -663,9 +646,9 @@ function scrollToLetter(letter: string) {
     toolbarHeight.value + (layout.value === "list" ? LIST_HEADER_HEIGHT : 0);
   scrollerRef.value?.scrollToIndex(idx, { smooth: true, stickyOffset });
   // The viewport-driven fetch sync handles the destination — once the
-  // smooth scroll settles, `update:viewportRange` fires and the cards
-  // at the landing zone start loading via `syncFetches` (grid) or via
-  // each `GameListRow`'s onMounted (list). No manual prefetch needed.
+  // smooth scroll settles, `update:viewportRange` fires and the windows at
+  // the landing zone start loading via `syncFetches` (both layouts). No
+  // manual prefetch needed.
 }
 
 // ── Search filter (debounced) ───────────────────────────────────────
@@ -792,12 +775,10 @@ onBeforeUnmount(() => {
   gallerySelection.clear();
   if (searchDebounce) clearTimeout(searchDebounce);
   if (fetchDebounceTimer) clearTimeout(fetchDebounceTimer);
-  // When leaving the gallery entirely, stop any per-card fetches still in
-  // flight so navigating away mid-scroll doesn't keep the network /
-  // backend busy. Keeps the hydrated cache so returning to the same
-  // gallery is instant.
+  // When leaving the gallery entirely, stop any in-flight window fetches so
+  // navigating away mid-scroll doesn't keep the network / backend busy.
+  // Keeps the hydrated cache so returning to the same gallery is instant.
   galleryRoms.abortInFlight();
-  visiblePositions.clear();
   inflowResizeObserver?.disconnect();
   inflowResizeObserver = null;
   // Drop the debug stats so the overlay doesn't show stale gallery numbers

--- a/frontend/src/v2/components/Gallery/GameListRow.vue
+++ b/frontend/src/v2/components/Gallery/GameListRow.vue
@@ -2,16 +2,6 @@
 // GameListRow — single row of the list-mode gallery.
 //
 // Owns:
-//   * Per-row lazy fetch: a watch fires `fetchRomAt(position)` whenever
-//     the row is missing its rom but the store knows the id — covering
-//     both mount ("entered the overscan window") and a context refresh
-//     that clears `byPosition` under a still-mounted row. onUnmount aborts
-//     the fetch via `cancelFetchAt(position)` so a fast scroll past
-//     mid-flight doesn't keep server work queued for invisible rows.
-//     Mirror of the per-card grid flow, with the same "row mount =
-//     entered viewport" contract via the shell's RVirtualScroller
-//     overscan window.
-//
 //   * Skeleton ↔ real swap — when `getRomAt(position)` returns null the
 //     row paints skeleton placeholders in every column; once the fetch
 //     resolves it flips to the real cells. Same row height in both
@@ -29,7 +19,7 @@ import {
   RSkeletonBlock,
   RTooltip,
 } from "@v2/lib";
-import { computed, onBeforeUnmount, watch } from "vue";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import storePlatforms from "@/stores/platforms";
@@ -59,13 +49,13 @@ defineOptions({ inheritAttrs: false });
 const PILLS_VISIBLE = 4;
 
 interface Props {
-  /** Absolute position in the active gallery (0-indexed). Drives the
-   * row's per-row fetch + serves as the lookup key into the store's
-   * `byPosition` map. Pass either this or `rom`, not both. */
+  /** Absolute position in the active gallery (0-indexed). Serves as the
+   * lookup key into the store's `byPosition` map; the shell drives the
+   * windowed fetch that fills it. Pass either this or `rom`, not both. */
   position?: number;
   /** Static ROM data — used by non-gallery surfaces (Settings → Missing
    * games) that already own the rom list. When provided, the row skips
-   * the galleryRoms position lookup and the per-row lazy fetch. */
+   * the galleryRoms position lookup. */
   rom?: SimpleRom | null;
   /** Cover variant — when the browser supports webp the thumb URL is
    * rewritten to .webp before the request. Wired from the shell so the
@@ -263,39 +253,6 @@ function onRowPointerEnd() {
   if (isStatic.value) return;
   selectionInput.handlePointerEnd();
 }
-
-// Kick the per-row fetch whenever this position is missing its rom but
-// the store knows its id. This covers both mount ("entered the overscan
-// window") and a context refresh: a filter / search / sort / scan clears
-// `byPosition` and repopulates `romIdIndex`, but the row can stay mounted
-// at the same position — without this watch it would sit on skeletons
-// until it scrolled out and remounted. The store dedupes against
-// in-flight + already-loaded, so re-runs are cheap. Guarding on the id
-// (not just null rom) also re-fetches when a resort lands a different rom
-// at the same position.
-watch(
-  () => {
-    if (isStatic.value || props.position === undefined) return null;
-    if (galleryRoms.byPosition.has(props.position)) return null;
-    return galleryRoms.romIdIndex[props.position] ?? null;
-  },
-  (romId) => {
-    if (romId != null && props.position !== undefined) {
-      void galleryRoms.fetchRomAt(props.position);
-    }
-  },
-  { immediate: true },
-);
-
-onBeforeUnmount(() => {
-  if (isStatic.value || props.position === undefined) return;
-  // Left the overscan window before the fetch resolved — abort so the
-  // server doesn't keep building a row the user already scrolled past.
-  // Idempotent if nothing was in flight.
-  if (!galleryRoms.byPosition.has(props.position)) {
-    galleryRoms.cancelFetchAt(props.position);
-  }
-});
 </script>
 
 <template>

--- a/frontend/src/v2/stores/galleryRoms.test.ts
+++ b/frontend/src/v2/stores/galleryRoms.test.ts
@@ -1,0 +1,128 @@
+import { flushPromises } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// Import after the mock so the store binds to the mocked rom API.
+import storeGalleryRoms from "@/v2/stores/galleryRoms";
+
+const { getRoms } = vi.hoisted(() => ({ getRoms: vi.fn() }));
+
+vi.mock("@/services/api/rom", () => ({
+  default: { getRoms },
+}));
+
+interface Deferred {
+  promise: Promise<unknown>;
+  resolve: (value: unknown) => void;
+}
+
+function deferred(): Deferred {
+  let resolve!: (value: unknown) => void;
+  const promise = new Promise<unknown>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function windowResponse(offset: number, total = 1000) {
+  return { data: { total, items: [], char_index: {}, rom_id_index: [] } };
+}
+
+describe("galleryRoms windowed fetch", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    getRoms.mockReset();
+    // Resolve the batched-apply frame yield synchronously so a window's
+    // `finally` (which drains the queue) runs without waiting a real frame.
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("collapses many visible positions into one request per 72-item window", async () => {
+    getRoms.mockImplementation((params: { offset: number }) =>
+      Promise.resolve(windowResponse(params.offset)),
+    );
+    const store = storeGalleryRoms();
+
+    // Every position falls inside the first 72-item window.
+    store.syncVisibleWindows([0, 5, 40, 71]);
+
+    expect(getRoms).toHaveBeenCalledTimes(1);
+    expect(getRoms.mock.calls[0][0].offset).toBe(0);
+
+    // Positions straddling the window boundary hit exactly two windows.
+    await flushPromises();
+    getRoms.mockClear();
+    store.byPosition = new Map();
+    store.loadedWindows = new Set();
+    store.syncVisibleWindows([70, 72, 100]);
+    const offsets = getRoms.mock.calls
+      .map((c) => c[0].offset)
+      .sort((a, b) => a - b);
+    expect(offsets).toEqual([0, 72]);
+
+    await flushPromises();
+  });
+
+  it("caps concurrent window fetches and drains the queue as slots free up", async () => {
+    const pending = new Map<number, Deferred>();
+    getRoms.mockImplementation((params: { offset: number }) => {
+      const d = deferred();
+      pending.set(params.offset, d);
+      return d.promise;
+    });
+    const store = storeGalleryRoms();
+
+    // Six distinct windows want to load at once (0, 72, ..., 360).
+    store.syncVisibleWindows([0, 72, 144, 216, 288, 360]);
+
+    // Only MAX_CONCURRENT_WINDOWS (4) may be in flight; the rest are parked.
+    expect(getRoms).toHaveBeenCalledTimes(4);
+
+    // Resolve the four in-flight windows; each freed slot pulls one from the
+    // queue until all six have run.
+    for (const offset of [0, 72, 144, 216]) {
+      pending.get(offset)?.resolve(windowResponse(offset));
+    }
+    await flushPromises();
+
+    expect(getRoms).toHaveBeenCalledTimes(6);
+    const offsets = getRoms.mock.calls
+      .map((c) => c[0].offset)
+      .sort((a, b) => a - b);
+    expect(offsets).toEqual([0, 72, 144, 216, 288, 360]);
+  });
+
+  it("does not exceed the cap even as queued windows drain", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const pending: Deferred[] = [];
+    getRoms.mockImplementation(() => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      const d = deferred();
+      pending.push(d);
+      return d.promise.finally(() => {
+        inFlight--;
+      });
+    });
+    const store = storeGalleryRoms();
+
+    store.syncVisibleWindows([0, 72, 144, 216, 288, 360, 432, 504]);
+
+    // Drain by resolving windows one at a time; the peak in-flight count must
+    // never pass the cap of 4.
+    while (pending.length > 0) {
+      pending.shift()?.resolve(windowResponse(0));
+      await flushPromises();
+    }
+
+    expect(peak).toBe(4);
+    expect(getRoms).toHaveBeenCalledTimes(8);
+  });
+});

--- a/frontend/src/v2/stores/galleryRoms.test.ts
+++ b/frontend/src/v2/stores/galleryRoms.test.ts
@@ -126,6 +126,43 @@ describe("galleryRoms windowed fetch", () => {
     expect(getRoms).toHaveBeenCalledTimes(8);
   });
 
+  it("keeps the bootstrap char_index when the first window skips aggregations", async () => {
+    getRoms.mockImplementation((params: { limit?: number }) => {
+      // The bootstrap (limit 1) carries the char index; the follow-up
+      // window skips it and the backend returns an empty (but truthy) {}.
+      if (params.limit === 1) {
+        return Promise.resolve({
+          data: {
+            total: 500,
+            items: [],
+            char_index: { A: 0, B: 10 },
+            rom_id_index: [1, 2, 3],
+          },
+        });
+      }
+      return Promise.resolve(windowResponse(0, 500));
+    });
+    const store = storeGalleryRoms();
+
+    await store.fetchInitialMetadata();
+    expect(store.charIndex).toEqual({ A: 0, B: 10 });
+    expect(store.metadataLoaded).toBe(true);
+
+    // Window 0 loads with the aggregations skipped; its empty char_index
+    // must not wipe what the bootstrap populated (the AlphaStrip bug).
+    store.syncVisibleWindows([0]);
+    await flushPromises();
+
+    const windowCall = getRoms.mock.calls.find(
+      (c) => c[0].withCharIndex === false,
+    );
+    expect(windowCall).toBeTruthy();
+    // The follow-up window also opts out of the full-library id-index scan
+    // the bootstrap already paid for.
+    expect(windowCall?.[0].withRomIdIndex).toBe(false);
+    expect(store.charIndex).toEqual({ A: 0, B: 10 });
+  });
+
   it("does not mark a window loaded when the context is invalidated mid-apply", async () => {
     // Controllable frame yield so we can interleave a context switch between
     // the batched-apply's frames.

--- a/frontend/src/v2/stores/galleryRoms.test.ts
+++ b/frontend/src/v2/stores/galleryRoms.test.ts
@@ -125,4 +125,49 @@ describe("galleryRoms windowed fetch", () => {
     expect(peak).toBe(4);
     expect(getRoms).toHaveBeenCalledTimes(8);
   });
+
+  it("does not mark a window loaded when the context is invalidated mid-apply", async () => {
+    // Controllable frame yield so we can interleave a context switch between
+    // the batched-apply's frames.
+    const frames: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      frames.push(cb);
+      return frames.length;
+    });
+
+    const first = deferred();
+    getRoms.mockImplementation(() => first.promise);
+    const store = storeGalleryRoms();
+
+    store.syncVisibleWindows([0]);
+    expect(getRoms).toHaveBeenCalledTimes(1);
+
+    // More than one apply batch (APPLY_BATCH_SIZE = 8) so the apply parks on
+    // a frame partway through.
+    const items = Array.from({ length: 16 }, (_, i) => ({ id: i }));
+    first.resolve({
+      data: { total: 1000, items, char_index: {}, rom_id_index: [] },
+    });
+    await flushPromises();
+    expect(frames.length).toBeGreaterThan(0);
+
+    // Context switch (filter / sort / scan refresh) while the response is
+    // still being applied.
+    store.invalidateWindows();
+
+    // Resume the parked frame(s): the apply sees it is no longer current and
+    // bails without marking the window loaded.
+    while (frames.length > 0) {
+      frames.shift()?.(0);
+      await flushPromises();
+    }
+    expect(store.loadedWindows.has(0)).toBe(false);
+
+    // The fresh context must be able to refetch offset 0 — not skip it as
+    // "already loaded" and strand its cards as permanent skeletons.
+    getRoms.mockClear();
+    getRoms.mockImplementation(() => deferred().promise);
+    store.syncVisibleWindows([0]);
+    expect(getRoms).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/v2/stores/galleryRoms.ts
+++ b/frontend/src/v2/stores/galleryRoms.ts
@@ -487,13 +487,26 @@ export default defineStore("v2GalleryRoms", {
       const controller = new AbortController();
       inFlightControllers.set(ctrlKey, controller);
 
+      // Skip the char-index / filter-value / id-index aggregations when the
+      // bootstrap already loaded them. Capture the decision now: it also gates
+      // whether this response is allowed to re-apply that metadata below. The
+      // backend returns an EMPTY (but truthy) `char_index: {}` / `filter_values`
+      // object when these are skipped, so re-applying it would wipe the
+      // populated values and blank the AlphaStrip / filter drawer. The id
+      // index is a full-library scan we already paid for in the bootstrap, so
+      // window fetches opt out of recomputing it.
+      const withAggregations = !this.metadataLoaded;
+
       try {
         const response = await romApi.getRoms({
           ...params,
-          // Skip char index / filter-value aggregations when initial data is loaded
-          ...(this.metadataLoaded
-            ? { withCharIndex: false, withFilterValues: false }
-            : {}),
+          ...(withAggregations
+            ? {}
+            : {
+                withCharIndex: false,
+                withFilterValues: false,
+                withRomIdIndex: false,
+              }),
           signal: controller.signal,
         });
         // Re-check identity: invalidateWindows / resetGallery / a context
@@ -504,7 +517,11 @@ export default defineStore("v2GalleryRoms", {
         if (inFlightControllers.get(ctrlKey) !== controller) return;
 
         const data = response.data;
-        if (offset === 0) {
+        // Only apply the full metadata when this window actually fetched the
+        // aggregations (the very first window before the bootstrap resolved).
+        // Otherwise char_index / filter_values come back empty and would
+        // clobber what the bootstrap populated, so just refresh `total`.
+        if (offset === 0 && withAggregations) {
           this._applyMetadata(data, galleryFilter, platformsStore);
         } else if (data.total !== null && data.total !== undefined) {
           this.total = data.total;

--- a/frontend/src/v2/stores/galleryRoms.ts
+++ b/frontend/src/v2/stores/galleryRoms.ts
@@ -496,9 +496,12 @@ export default defineStore("v2GalleryRoms", {
             : {}),
           signal: controller.signal,
         });
-        // Re-check that this window is still relevant — invalidateWindows
-        // / resetGallery may have run while we were waiting.
-        if (!this.pendingWindows.has(offset)) return;
+        // Re-check identity: invalidateWindows / resetGallery / a context
+        // switch may have run while we were waiting, and a fresh fetch may
+        // already own this offset. Compare the controller rather than
+        // `pendingWindows` membership (which a replacement fetch re-adds)
+        // so we never apply stale data over the new context.
+        if (inFlightControllers.get(ctrlKey) !== controller) return;
 
         const data = response.data;
         if (offset === 0) {
@@ -522,9 +525,18 @@ export default defineStore("v2GalleryRoms", {
         // main thread long enough that AlphaStrip clicks queued during
         // the flush miss their frame. `applyItemsBatched` pauses every
         // row (8 items) so input dispatches between paints.
-        await applyItemsBatched(this.byPosition, data.items, offset, () =>
-          this.pendingWindows.has(offset),
+        await applyItemsBatched(
+          this.byPosition,
+          data.items,
+          offset,
+          () => inFlightControllers.get(ctrlKey) === controller,
         );
+
+        // A context switch during the frame-yielded apply may have
+        // superseded us partway through. Marking the window loaded now would
+        // leave it partially applied yet skipped by later syncs — permanent
+        // skeletons for the fresh context. Bail unless we're still current.
+        if (inFlightControllers.get(ctrlKey) !== controller) return;
 
         this.loadedWindows.add(offset);
         // Recovered — drop any retry bookkeeping for this window.
@@ -534,6 +546,9 @@ export default defineStore("v2GalleryRoms", {
         // clean so the window is eligible to refetch under the new
         // gallery context without the UI flagging it as broken.
         if (axios.isCancel(err)) return;
+        // A late error for a window a newer fetch already owns isn't ours to
+        // record or retry against the current context.
+        if (inFlightControllers.get(ctrlKey) !== controller) return;
         this.failedWindows.add(offset);
         // Surface in console; UI keeps the skeletons in place until the
         // retry below (or a viewport / gallery-state change) refetches.
@@ -554,9 +569,14 @@ export default defineStore("v2GalleryRoms", {
           retryTimers.set(offset, timer);
         }
       } finally {
-        inFlightControllers.delete(ctrlKey);
-        this.pendingWindows.delete(offset);
-        if (offset === 0) this.initialFetching = false;
+        // Only clear our own bookkeeping — a replacement fetch may already
+        // own the key (see the identity checks above), and deleting it would
+        // strand that request's window as a skeleton.
+        if (inFlightControllers.get(ctrlKey) === controller) {
+          inFlightControllers.delete(ctrlKey);
+          this.pendingWindows.delete(offset);
+          if (offset === 0) this.initialFetching = false;
+        }
         // A slot freed up — start the next queued window, if any.
         this._drainWindowQueue();
       }

--- a/frontend/src/v2/stores/galleryRoms.ts
+++ b/frontend/src/v2/stores/galleryRoms.ts
@@ -569,16 +569,13 @@ export default defineStore("v2GalleryRoms", {
           retryTimers.set(offset, timer);
         }
       } finally {
-        // Only clear our own bookkeeping — a replacement fetch may already
-        // own the key (see the identity checks above), and deleting it would
-        // strand that request's window as a skeleton.
         if (inFlightControllers.get(ctrlKey) === controller) {
           inFlightControllers.delete(ctrlKey);
           this.pendingWindows.delete(offset);
           if (offset === 0) this.initialFetching = false;
+          // A slot freed up — start the next queued window, if any.
+          this._drainWindowQueue();
         }
-        // A slot freed up — start the next queued window, if any.
-        this._drainWindowQueue();
       }
     },
 

--- a/frontend/src/v2/stores/galleryRoms.ts
+++ b/frontend/src/v2/stores/galleryRoms.ts
@@ -1,17 +1,16 @@
-// galleryRoms (v2) — sparse store for the active gallery list.
+// galleryRoms (v2) — windowed/sparse store for the active gallery list.
 //
 // Replaces v1's `stores/roms.ts` for the gallery-list responsibility.
 // What lives here:
 //   - the gallery context (currentPlatform / Collection / Virtual / Smart),
-//   - the total ROM count + per-letter offset table + id index from the
-//     backend,
-//   - a sparse `byPosition` map that holds whatever positions have been
-//     hydrated so far (per-card, driven by row visibility),
-//   - book-keeping for in-flight per-card fetches.
+//   - the total ROM count + per-letter offset table from the backend,
+//   - a sparse `byPosition` map that holds whatever windows have been
+//     fetched so far,
+//   - book-keeping for in-flight / loaded / failed windows.
 //
 // Why a NEW store rather than extending v1:
 //   v1 collapses pagination into `fetchRoms()` advancing a single
-//   `fetchOffset`. v2 needs random-access per-card loads (driven by which
+//   `fetchOffset`. v2 needs random-access window loads (driven by which
 //   rows enter the virtualiser's viewport, including skeleton rows for
 //   positions we've never touched). Forking lets v2 model that cleanly
 //   while v1 stays frozen. Per the constitution, the v1 gallery-list
@@ -57,22 +56,109 @@ export type GalleryOrderKey =
 
 type GalleryFilterStore = ExtractPiniaStoreType<typeof storeGalleryFilter>;
 
-// Default page size — the backend's pagination limit, used by the
-// metadata bootstrap's request params.
+// Default window size — the backend's pagination limit. Smaller windows
+// mean more round-trips but finer-grained fills; larger windows mean
+// fewer requests but each one downloads more.
 const WINDOW_SIZE = 72;
 
-// In-flight `AbortController`s keyed by request: `rom:${position}` for a
-// per-card hydration fetch, `bootstrap` for the lightweight metadata
-// bootstrap. Lives outside store state so Pinia doesn't try to proxy
-// native abort objects (which break under reactivity).
+// In-flight `AbortController`s keyed by request: `window:${offset}`
+// for a windowed fetch, `bootstrap` for the lightweight metadata
+// bootstrap. Lives outside store state so Pinia doesn't
+// try to proxy native abort objects (which break under reactivity).
 // `invalidateWindows()` / `resetGallery()` abort every pending request,
 // so a fast-typed search box or a platform-switch mid-load doesn't
 // leave server work going for results we'll throw away.
 const inFlightControllers = new Map<string, AbortController>();
 
+// A failed window is only refetched when `fetchWindowAt` is called for it
+// again, which for a static viewport (no scroll) never happens on its own.
+// So a transient failure would strand up to `WINDOW_SIZE` visible cards as
+// skeletons. To self-heal, a failed window schedules a bounded, backing-off
+// retry; `retryTimers` holds the pending timeouts (keyed by offset) and
+// `retryCounts` the attempts so far. Both are cleared by `abortAllInFlight`
+// on any gallery-context switch so we never retry against a stale context.
+const RETRY_BACKOFF_MS = 2000;
+const MAX_WINDOW_RETRIES = 3;
+const retryTimers = new Map<number, ReturnType<typeof setTimeout>>();
+const retryCounts = new Map<number, number>();
+
+function clearRetry(offset: number) {
+  const timer = retryTimers.get(offset);
+  if (timer !== undefined) clearTimeout(timer);
+  retryTimers.delete(offset);
+  retryCounts.delete(offset);
+}
+
+// Ceiling on concurrently in-flight window fetches. Windowing already
+// collapses the old per-card request storm ~72x, but two or more users
+// fast-scrolling a large library can still line up several windows at once
+// against a backend that defaults to a single worker. This bounds how many
+// hit the server simultaneously per client; windows over the ceiling wait in
+// `queuedWindows` (FIFO) and drain as slots free up. Cleared by
+// `abortAllInFlight` on any gallery-context switch.
+const MAX_CONCURRENT_WINDOWS = 4;
+const queuedWindows: number[] = [];
+
+function clearQueue() {
+  queuedWindows.length = 0;
+}
+
 function abortAllInFlight() {
   for (const ctrl of inFlightControllers.values()) ctrl.abort();
   inFlightControllers.clear();
+  for (const timer of retryTimers.values()) clearTimeout(timer);
+  retryTimers.clear();
+  retryCounts.clear();
+  clearQueue();
+}
+
+// Abort a single in-flight window fetch. The rejected request is caught
+// as a cancel in `fetchWindowAt` (no `failedWindows` entry, no retry) and
+// its `finally` clears the pending/controller bookkeeping.
+function cancelWindow(offset: number) {
+  const ctrl = inFlightControllers.get(`window:${offset}`);
+  if (ctrl) ctrl.abort();
+}
+
+// Apply items to `byPosition` in row-sized batches with a rAF yield
+// between batches. Each Map.set() invalidates Vue's per-key dep, and
+// when many cards are in the viewport / overscan zone they all
+// re-render in the same microtask flush — synchronously, on the main
+// thread. With dozens of items landing back-to-back (initial window,
+// or rapid-fire background fill), the flush can run >30ms and queued
+// input events (AlphaStrip clicks especially) miss their frame.
+//
+// Yielding every `BATCH_SIZE` items lets the browser paint the new
+// cards AND dispatch any pending input between batches. We pick 8 as
+// the default — one row's worth — so a per-row dwell fetch (8 items)
+// stays a single batch (no extra frames), while a 72-item window
+// becomes 9 small batches that each fit comfortably in a frame.
+const APPLY_BATCH_SIZE = 8;
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame !== "undefined") {
+      requestAnimationFrame(() => resolve());
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+}
+
+async function applyItemsBatched(
+  byPosition: Map<number, SimpleRom>,
+  items: SimpleRom[],
+  baseOffset: number,
+  isStillRelevant: () => boolean,
+): Promise<void> {
+  for (let i = 0; i < items.length; i += APPLY_BATCH_SIZE) {
+    if (!isStillRelevant()) return;
+    const end = Math.min(i + APPLY_BATCH_SIZE, items.length);
+    for (let j = i; j < end; j++) {
+      byPosition.set(baseOffset + j, items[j]);
+    }
+    if (end < items.length) await nextFrame();
+  }
 }
 
 interface State {
@@ -91,13 +177,18 @@ interface State {
   charIndex: Record<string, number>;
   romIdIndex: number[];
   byPosition: Map<number, SimpleRom>;
-  // True until the very first metadata bootstrap resolves — view shows a
-  // skeleton hero/skeleton rows during this phase.
+  loadedWindows: Set<number>;
+  pendingWindows: Set<number>;
+  failedWindows: Set<number>;
+  // True until the very first metadata bootstrap (or fetchWindow(0))
+  // resolves — view shows a skeleton hero/skeleton rows during this
+  // phase.
   initialFetching: boolean;
   // True once total / charIndex / romIdIndex / filter_values have been
-  // populated by the lightweight `fetchInitialMetadata()` bootstrap.
-  // Gates the bootstrap dedup and the per-card hydration (which needs
-  // `romIdIndex` before it can resolve a position to a rom id).
+  // populated, either by the lightweight `fetchInitialMetadata()`
+  // bootstrap or by `fetchWindowAt(0)`. Used to gate the initial
+  // bootstrap dedup independently of `loadedWindows` (metadata
+  // bootstrap doesn't load any window).
   metadataLoaded: boolean;
   // Order params — gallery-list scoped (separate from v1's localStorage
   // keys so v1/v2 don't fight over the same value).
@@ -115,11 +206,18 @@ const defaults = (): State => ({
   charIndex: {},
   romIdIndex: [],
   byPosition: new Map(),
+  loadedWindows: new Set(),
+  pendingWindows: new Set(),
+  failedWindows: new Set(),
   initialFetching: false,
   metadataLoaded: false,
   orderBy: "name",
   orderDir: "asc",
 });
+
+function alignToWindow(offset: number): number {
+  return Math.floor(offset / WINDOW_SIZE) * WINDOW_SIZE;
+}
 
 export default defineStore("v2GalleryRoms", {
   state: () => defaults(),
@@ -133,6 +231,8 @@ export default defineStore("v2GalleryRoms", {
         state.currentSmartCollection ||
         state.currentSearch
       ),
+    /** True when at least the first window has loaded. */
+    hasInitial: (state) => state.loadedWindows.size > 0,
   },
 
   actions: {
@@ -187,6 +287,9 @@ export default defineStore("v2GalleryRoms", {
       this.charIndex = {};
       this.romIdIndex = [];
       this.byPosition = new Map();
+      this.loadedWindows = new Set();
+      this.pendingWindows = new Set();
+      this.failedWindows = new Set();
       this.initialFetching = false;
       this.metadataLoaded = false;
     },
@@ -200,6 +303,9 @@ export default defineStore("v2GalleryRoms", {
       this.charIndex = {};
       this.romIdIndex = [];
       this.byPosition = new Map();
+      this.loadedWindows = new Set();
+      this.pendingWindows = new Set();
+      this.failedWindows = new Set();
       this.initialFetching = false;
       this.metadataLoaded = false;
     },
@@ -267,8 +373,9 @@ export default defineStore("v2GalleryRoms", {
     },
 
     /** Apply the metadata side effects from a `getRoms` response —
-     * total, char_index, rom_id_index, plus filter side panels. Used by
-     * the lightweight `fetchInitialMetadata()` bootstrap. */
+     * total, char_index, rom_id_index, plus filter side panels (only on
+     * first fetch). Shared by `fetchWindowAt(0)` and the lightweight
+     * `fetchInitialMetadata()` bootstrap. */
     _applyMetadata(
       data: GetRomsResponse,
       galleryFilter: GalleryFilterStore,
@@ -302,9 +409,10 @@ export default defineStore("v2GalleryRoms", {
 
     /** Lightweight bootstrap: fetch only the gallery's metadata (total,
      * char_index, rom_id_index, filter_values) without loading any
-     * items. Sizes the virtualiser (via `total`) so both layouts can
-     * render skeleton rows immediately, then hydrate each visible
-     * position through the viewport-driven per-card `fetchRomAt(p)` sync.
+     * items. Sizes the virtualiser (via `total`) before any window
+     * lands, so both layouts can render skeleton rows immediately and
+     * then hydrate them through the viewport-driven `fetchWindowAt`
+     * sync.
      *
      * The backend's `limit` minimum is 1, so we still pay for one
      * `SimpleRomSchema` build server-side, but the item is discarded
@@ -345,77 +453,172 @@ export default defineStore("v2GalleryRoms", {
       }
     },
 
-    /** Fetch the single ROM at `position` via `GET /roms/{id}/simple` —
-     * the lightweight schema endpoint that skips the eager `user_saves`
-     * / `user_states` / `user_screenshots` / `user_collections` /
-     * `all_user_notes` arrays. The gallery card only needs the `has_*`
-     * indicator flags + cover paths + platform info — all on
-     * `SimpleRomSchema`. Detailed arrays are pulled on demand by the
-     * game-details page or by quick-action dialogs (note editor,
-     * achievements panel) when the user actually opens them.
-     *
-     * Requires `romIdIndex[position]` — populated by the
-     * `fetchInitialMetadata()` bootstrap for the active gallery. Returns
-     * silently if the index isn't loaded yet.
-     *
-     * Per-position `AbortController` allows the shell to cancel fetches
-     * for cards that left the viewport before resolving.
-     * `cancelFetchAt(position)` is the cancel side. */
-    async fetchRomAt(position: number): Promise<void> {
+    /** Fetch the window that contains `position` (rounding down to the
+     * window grid). Dedupes against pending / loaded windows. The very
+     * first window also seeds `total` and `charIndex`. */
+    async fetchWindowAt(position: number): Promise<void> {
       if (position < 0) return;
-      if (this.total > 0 && position >= this.total) return;
-      if (this.byPosition.has(position)) return;
-      const romId = this.romIdIndex[position];
-      if (!romId) return;
+      const offset = alignToWindow(position);
+      // Total is unknown for offset 0; for any non-initial offset, refuse
+      // to fetch past total.
+      if (this.total > 0 && offset >= this.total) return;
+      if (this.loadedWindows.has(offset)) return;
+      if (this.pendingWindows.has(offset)) return;
 
-      const ctrlKey = `rom:${position}`;
-      if (inFlightControllers.has(ctrlKey)) return;
+      // Concurrency cap: if every slot is busy, park this window and let a
+      // settling fetch drain it (see `MAX_CONCURRENT_WINDOWS`). Offset 0 is
+      // the initial window and is never queued (nothing is in flight yet).
+      if (offset !== 0 && this.pendingWindows.size >= MAX_CONCURRENT_WINDOWS) {
+        if (!queuedWindows.includes(offset)) queuedWindows.push(offset);
+        return;
+      }
+      // Starting now — drop any queue entry so the drain loop won't re-run it.
+      const queuedAt = queuedWindows.indexOf(offset);
+      if (queuedAt !== -1) queuedWindows.splice(queuedAt, 1);
 
+      this.pendingWindows.add(offset);
+      this.failedWindows.delete(offset);
+      if (offset === 0 && !this.metadataLoaded) this.initialFetching = true;
+
+      const galleryFilter = storeGalleryFilter();
+      const platformsStore = storePlatforms();
+      const params = this._buildRequestParams(galleryFilter, offset);
+      const ctrlKey = `window:${offset}`;
       const controller = new AbortController();
       inFlightControllers.set(ctrlKey, controller);
 
       try {
-        const response = await romApi.getRomSimple({
-          romId,
+        const response = await romApi.getRoms({
+          ...params,
+          // Skip char index / filter-value aggregations when initial data is loaded
+          ...(this.metadataLoaded
+            ? { withCharIndex: false, withFilterValues: false }
+            : {}),
           signal: controller.signal,
         });
-        // Re-check that we're still the relevant request for this key — a
-        // fast scroll-past + cancel + re-enter can replace our controller
-        // with a newer one under the same key before we land. Identity
-        // comparison keeps us from applying our stale response over it.
-        if (inFlightControllers.get(ctrlKey) !== controller) return;
-        this.byPosition.set(position, response.data);
-      } catch (err) {
-        if (axios.isCancel(err)) return;
-        console.error("[v2GalleryRoms] rom fetch failed", position, romId, err);
-      } finally {
-        // Only clear our own entry — a replacement request may already own
-        // the key (see the identity check above), and deleting it would
-        // strand that request's response and leave the card a skeleton.
-        if (inFlightControllers.get(ctrlKey) === controller) {
-          inFlightControllers.delete(ctrlKey);
+        // Re-check that this window is still relevant — invalidateWindows
+        // / resetGallery may have run while we were waiting.
+        if (!this.pendingWindows.has(offset)) return;
+
+        const data = response.data;
+        if (offset === 0) {
+          this._applyMetadata(data, galleryFilter, platformsStore);
+        } else if (data.total !== null && data.total !== undefined) {
+          this.total = data.total;
         }
-      }
-    },
 
-    /** Cancel an in-flight per-position fetch — typically called by the
-     * shell when a card leaves the viewport before its request resolves.
-     * No-op if nothing is in flight for that position. */
-    cancelFetchAt(position: number) {
-      const ctrlKey = `rom:${position}`;
-      const ctrl = inFlightControllers.get(ctrlKey);
-      if (ctrl) {
-        ctrl.abort();
+        // Place items at their absolute positions (offset .. offset + N).
+        // We rely on Vue 3's reactive Map: `set(k, v)` triggers per-key
+        // dependents. Earlier passes reassigned `this.byPosition` to a
+        // new Map after each window which DEFEATED that — every
+        // `getRomAt(p)` reader was invalidated, and the gallery
+        // virtualItems computed (which iterates positions) had to
+        // rebuild end-to-end on every window response. That blocked the
+        // event loop hard enough to freeze the scroller. Mutating in
+        // place keeps the dependents narrow: only positions that just
+        // resolved trigger a re-render.
+        //
+        // Batched + frame-yielded: 72 sets in one microtask block the
+        // main thread long enough that AlphaStrip clicks queued during
+        // the flush miss their frame. `applyItemsBatched` pauses every
+        // row (8 items) so input dispatches between paints.
+        await applyItemsBatched(this.byPosition, data.items, offset, () =>
+          this.pendingWindows.has(offset),
+        );
+
+        this.loadedWindows.add(offset);
+        // Recovered — drop any retry bookkeeping for this window.
+        clearRetry(offset);
+      } catch (err) {
+        // An explicit abort isn't a failure — keep `failedWindows`
+        // clean so the window is eligible to refetch under the new
+        // gallery context without the UI flagging it as broken.
+        if (axios.isCancel(err)) return;
+        this.failedWindows.add(offset);
+        // Surface in console; UI keeps the skeletons in place until the
+        // retry below (or a viewport / gallery-state change) refetches.
+        console.error("[v2GalleryRoms] window fetch failed", offset, err);
+        // Self-heal a stranded viewport: schedule a bounded, backing-off
+        // refetch so a transient blip doesn't leave the window's cards as
+        // skeletons until the user happens to scroll.
+        const attempts = retryCounts.get(offset) ?? 0;
+        if (attempts < MAX_WINDOW_RETRIES && !retryTimers.has(offset)) {
+          retryCounts.set(offset, attempts + 1);
+          const timer = setTimeout(
+            () => {
+              retryTimers.delete(offset);
+              void this.fetchWindowAt(offset);
+            },
+            RETRY_BACKOFF_MS * (attempts + 1),
+          );
+          retryTimers.set(offset, timer);
+        }
+      } finally {
         inFlightControllers.delete(ctrlKey);
+        this.pendingWindows.delete(offset);
+        if (offset === 0) this.initialFetching = false;
+        // A slot freed up — start the next queued window, if any.
+        this._drainWindowQueue();
       }
     },
 
-    /** Abort every in-flight per-card fetch without wiping the hydrated
-     * cache. The shell calls this when the gallery unmounts so navigating
-     * away mid-scroll doesn't leave requests running; a return to the
-     * same gallery still reuses whatever `byPosition` already holds. */
+    /** Start queued windows as in-flight slots free up. Called from a
+     * window fetch's `finally`; the cap in `fetchWindowAt` guards the
+     * ceiling, so this just feeds it the next parked offset. */
+    _drainWindowQueue() {
+      while (
+        queuedWindows.length > 0 &&
+        this.pendingWindows.size < MAX_CONCURRENT_WINDOWS
+      ) {
+        const next = queuedWindows.shift();
+        if (next === undefined) break;
+        if (this.loadedWindows.has(next) || this.pendingWindows.has(next)) {
+          continue;
+        }
+        void this.fetchWindowAt(next);
+      }
+    },
+
+    /** Reconcile in-flight window fetches with the currently visible
+     * positions. Starts any window covering a visible position (deduped
+     * inside `fetchWindowAt`) and aborts any in-flight or retry-pending
+     * window that no longer covers one. Without the abort, scrolling
+     * through a large library would leave every window it passed
+     * downloading and applying in the background — the exact wasted
+     * network / backend / render work this store exists to avoid on
+     * low-power devices. Driven by the shell's debounced viewport sync. */
+    syncVisibleWindows(positions: Iterable<number>) {
+      const wanted = new Set<number>();
+      for (const p of positions) {
+        if (p < 0) continue;
+        if (this.total > 0 && p >= this.total) continue;
+        wanted.add(alignToWindow(p));
+      }
+      // Cancel windows that drifted out of view. Snapshot first: aborting
+      // settles a fetch's `finally` (which mutates these sets) on a later
+      // microtask, but iterate a copy to stay safe regardless.
+      for (const offset of [...this.pendingWindows]) {
+        if (!wanted.has(offset)) cancelWindow(offset);
+      }
+      for (const offset of [...retryTimers.keys()]) {
+        if (!wanted.has(offset)) clearRetry(offset);
+      }
+      // Drop parked windows that scrolled out of view before getting a slot.
+      for (let i = queuedWindows.length - 1; i >= 0; i--) {
+        if (!wanted.has(queuedWindows[i])) queuedWindows.splice(i, 1);
+      }
+      for (const offset of wanted) {
+        void this.fetchWindowAt(offset);
+      }
+    },
+
+    /** Abort every in-flight window fetch + pending retry without wiping
+     * the loaded cache. The shell calls this when the gallery unmounts so
+     * navigating away mid-scroll doesn't leave downloads running; a
+     * return to the same gallery still reuses `loadedWindows`. */
     abortInFlight() {
       abortAllInFlight();
+      this.pendingWindows = new Set();
       this.initialFetching = false;
     },
 


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3800 — frequent crashes/restarts when multiple users fast-scroll large ROM lists (900+) on the v2 UI.

**Root cause.** The v2 gallery hydrated each visible card with its own `GET /roms/{id}/simple` request. Fast-scrolling a large library fires dozens of concurrent requests, and two users doing it at once funnel them all through a backend that defaults to a single gunicorn/uvicorn worker (`WEB_SERVER_CONCURRENCY=1`). The worker gets recycled (`--max-requests 1000`) / timed out / OOM-killed under the burst, and the container's watchdog restarts it — the "red restart warning" the reporter saw. Cover image files themselves are static (served by nginx), so the amplifier is the per-card API traffic, not the images.

Note this reverses the direction of `560a75f9` ("hydrate gallery cards per-card"). That revert optimized `/simple` latency but reintroduced the request-volume storm this issue reports.

**Fix — re-batch hydration into windows:**
- Store: replace per-card `fetchRomAt`/`cancelFetchAt` with `fetchWindowAt` + `syncVisibleWindows`. Each visible position aligns to its shared 72-item window and loads via one paginated `getRoms`; positions in the same window collapse to a single request, deduped against loaded/pending windows, with out-of-view windows cancelled and failed ones retried on bounded backoff.
- `GalleryShell.collectVisiblePositions` now covers both grid (`row`) and list (`list-row`) items, so both layouts route through the debounced `syncFetches` → `syncVisibleWindows`.
- `GameListRow` no longer self-fetches on mount; the shell drives it.

**Fix — debounce + cap the client:**
- The list path now goes through the shell's existing 80ms fetch debounce (previously grid-only; list rows fired undebounced on every mount).
- New `MAX_CONCURRENT_WINDOWS = 4` ceiling in the store: windows over the cap queue and drain as in-flight slots free up, so no scroll speed can flood the backend.

A full viewport now resolves in a handful of paginated requests instead of ~one per card.

Out of scope (defense-in-depth, can follow up separately): the single-worker default, the aggressive `--max-requests`, and the untuned DB pool that let the storm escalate into a restart.

**AI assistance disclosure:** This change was authored with AI assistance (Claude Code / Opus 4.8). The investigation, diagnosis, code changes, comments, and tests were AI-generated and human-reviewed.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A (loading behavior only, no visual change).

---
Verification: `npm run typecheck` clean; full vitest suite passes (493 tests, incl. 3 new store tests asserting per-window batching and the concurrency cap); `trunk fmt && trunk check` clean on changed files. Not driven in a live browser — reproducing the symptom needs a 900+ ROM library under concurrent multi-user load; the new unit tests assert the batching and cap invariants directly instead.