### PR TITLE
(fix) Missing last platform-stats progressbar

### DIFF
--- a/frontend/src/v2/components/Settings/PlatformsStatsSection.vue
+++ b/frontend/src/v2/components/Settings/PlatformsStatsSection.vue
@@ -318,9 +318,6 @@ function coveragePercent(matched: number, total: number): string {
 .r-v2-plat-stats__row:first-child {
   padding-top: 0;
 }
-.r-v2-plat-stats__row:last-child .r-v2-plat-stats__bar {
-  display: none;
-}
 
 .r-v2-plat-stats__icon {
   flex-shrink: 0;


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
Currently, the progressbar for the % disk usage of the last platform does not show up in `SYSTEM > Server stats`.\
Therefore this PR removes the `display: none;` for the last progressbar in the `PlatformStatsSection.vue` component.

**Checklist**
- [X] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

**Screenshots**

Previous:
<img width="1878" height="997" alt="image" src="https://github.com/user-attachments/assets/4dc96552-9427-4119-8268-0c56beb4bb6c" />

Now:
<img width="1878" height="997" alt="image" src="https://github.com/user-attachments/assets/0fcd9282-0952-4eac-a38d-d390cc2dacc1" />

