### PR TITLE
fix(netplay): correct room-list and socket URLs behind a reverse proxy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,22 +42,22 @@ jobs:
         run: echo "Triggered by ${{ github.event_name }}"
 
       - name: Checkout code
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.6.0
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.11.1
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3.5.0
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3.5.0
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Generate Docker metadata (slim)
         id: meta-slim
-        uses: docker/metadata-action@v5.8.0
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: |
             name=rommapp/romm
@@ -85,7 +85,7 @@ jobs:
 
       - name: Generate Docker metadata (full)
         id: meta
-        uses: docker/metadata-action@v5.8.0
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: |
             name=rommapp/romm
@@ -106,7 +106,7 @@ jobs:
 
       - name: Build slim image
         id: build-slim
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           file: docker/Dockerfile
           context: .
@@ -121,7 +121,7 @@ jobs:
 
       - name: Build full image
         id: build-full
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           file: docker/Dockerfile
           context: .

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,10 +24,10 @@ jobs:
         options: --health-cmd="redis-cli ping" --health-interval=5s --health-timeout=2s --health-retries=3
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.7.0
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
 
       - name: Install Python
         run: uv python install 3.13
@@ -39,7 +39,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5.0.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: frontend/.nvmrc
 

--- a/.github/workflows/frontend-v1-frozen.yml
+++ b/.github/workflows/frontend-v1-frozen.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5.0.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: frontend/.nvmrc
           cache: "npm"
@@ -38,10 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5.0.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: frontend/.nvmrc
           cache: "npm"

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v6.0.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -29,7 +29,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install mariadb connectors
         run: |
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get install -y libmariadb3 libmariadb-dev
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.7.0
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
 
       - name: Install python
         run: uv python install 3.13
@@ -80,7 +80,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Install mariadb connectors
         run: |
@@ -88,7 +88,7 @@ jobs:
           sudo apt-get install -y libmariadb3 libmariadb-dev
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.7.0
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
 
       - name: Install python
         run: uv python install 3.13

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -50,7 +50,7 @@ jobs:
           --health-cmd="redis-cli ping" --health-interval=5s --health-timeout=2s --health-retries=3
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Install mariadb connectors
         run: |
@@ -58,7 +58,7 @@ jobs:
           sudo apt-get install -y libmariadb3 libmariadb-dev
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.7.0
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
 
       - name: Install python
         run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -47,7 +47,7 @@ jobs:
         run: echo "Triggered by ${{ github.event_name }}"
 
       - name: Checkout code
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
           fetch-depth: 0
@@ -55,7 +55,7 @@ jobs:
       - name: PR comment build starting
         if: github.event_name == 'pull_request'
         id: build-comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const comment = await github.rest.issues.createComment({
@@ -67,14 +67,14 @@ jobs:
             core.setOutput('comment-id', comment.data.id);
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.6.0
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.11.1
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Login to GHCR
         if: env.USE_GHCR == 'true'
-        uses: docker/login-action@v3.5.0
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -82,14 +82,14 @@ jobs:
 
       - name: Login to Docker Hub
         if: env.USE_DOCKERHUB == 'true'
-        uses: docker/login-action@v3.5.0
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Generate Docker metadata
         id: meta
-        uses: docker/metadata-action@v5.8.0
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: |
             ${{ env.USE_GHCR == 'true' && format('name=ghcr.io/{0}/romm-testing', github.repository_owner) || '' }}
@@ -99,7 +99,7 @@ jobs:
 
       - name: Build full image
         id: build-full
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           file: docker/Dockerfile
           context: .
@@ -114,7 +114,7 @@ jobs:
       # PR builds always push to GHCR only, so the image link is hardcoded to GHCR.
       - name: Comment PR with GHCR image link
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           HEAD_REF: ${{ github.head_ref }}
         with:

--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -17,6 +17,6 @@ jobs:
       contents: read # For repo checkout
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v1.2.4
+        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -20,10 +20,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5.0.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: frontend/.nvmrc
           cache: "npm"

--- a/.github/workflows/update-hltb-api-url.yml
+++ b/.github/workflows/update-hltb-api-url.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.7.0
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
 
       - name: Install python
         run: |
@@ -31,7 +31,7 @@ jobs:
           uv run python -m utils.update_hltb_api_url
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           add-paths: |
             backend/handler/metadata/fixtures/hltb_api_url

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ RomM (ROM Manager) allows you to scan, enrich, browse and play your game collect
 
 ## Preview
 
-|                                       🖥 Desktop                                       |                                                           📱 Mobile                                                            |
+|                                       🖥 Desktop                                        |                                                           📱 Mobile                                                            |
 | :------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------: |
 | <img src=".github/resources/screenshots/preview-desktop.webp" alt="desktop preview" /> | <img style="width: 325px; aspect-ratio: auto;" src=".github/resources/screenshots/preview-mobile.webp" alt="mobile preview" /> |
 

--- a/backend/tests/utils/test_rvz_hasher.py
+++ b/backend/tests/utils/test_rvz_hasher.py
@@ -652,7 +652,9 @@ class TestCalculateGamecubeRaHash:
             RvzBuilder(bytes(disc), disc_type=1, compression=compression).build()
         )
 
-        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(disc)
+        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(
+            bytes(disc)
+        )
 
     def test_wia_container_matches_reference_hash(self, tmp_path):
         """WIA (chunk >= 2 MiB, 8-byte group entries) hashes like its RVZ twin."""
@@ -668,7 +670,9 @@ class TestCalculateGamecubeRaHash:
             ).build()
         )
 
-        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(disc)
+        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(
+            bytes(disc)
+        )
 
     def test_groups_stored_raw_despite_compressed_codec(self, tmp_path):
         """RVZ groups without the MSB flag are stored raw even in a zstd file."""
@@ -683,7 +687,9 @@ class TestCalculateGamecubeRaHash:
             ).build()
         )
 
-        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(disc)
+        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(
+            bytes(disc)
+        )
 
     def test_zero_groups_decode_as_zeroes(self, tmp_path):
         """An all-zero chunk is stored with data_size 0 and must read as zeroes."""
@@ -693,7 +699,9 @@ class TestCalculateGamecubeRaHash:
         path = tmp_path / "game.rvz"
         path.write_bytes(RvzBuilder(bytes(disc), disc_type=1).build())
 
-        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(disc)
+        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(
+            bytes(disc)
+        )
 
     def test_rvz_packed_junk_regenerates_original_bytes(self, tmp_path):
         """A junk-packed run must regenerate the PRNG bytes the disc held."""
@@ -717,7 +725,9 @@ class TestCalculateGamecubeRaHash:
             ).build()
         )
 
-        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(disc)
+        assert calculate_gamecube_ra_hash(str(path)) == reference_gamecube_hash(
+            bytes(disc)
+        )
 
     def test_returns_empty_for_non_gamecube_disc(self, tmp_path):
         """A Wii disc in the GameCube hasher fails the magic check."""

--- a/frontend/src/components/Home/Collections.vue
+++ b/frontend/src/components/Home/Collections.vue
@@ -10,9 +10,7 @@ const props = defineProps<{
   collections: CollectionType[];
   title: string;
   setting:
-    | "gridCollections"
-    | "gridVirtualCollections"
-    | "gridSmartCollections";
+    "gridCollections" | "gridVirtualCollections" | "gridSmartCollections";
 }>();
 
 const gridCollections = useLocalStorage(`settings.${props.setting}`, false);

--- a/frontend/src/components/Settings/UserInterface/Interface.vue
+++ b/frontend/src/components/Settings/UserInterface/Interface.vue
@@ -36,10 +36,7 @@ const {
 
 // Boxart
 export type BoxartStyleOption =
-  | "cover_path"
-  | "box3d_path"
-  | "physical_path"
-  | "miximage_path";
+  "cover_path" | "box3d_path" | "physical_path" | "miximage_path";
 
 const homeOptions = computed(() => [
   {

--- a/frontend/src/console/utils/sfx.ts
+++ b/frontend/src/console/utils/sfx.ts
@@ -22,12 +22,7 @@ function ensureCtx() {
 }
 
 export type SfxType =
-  | "move"
-  | "confirm"
-  | "back"
-  | "error"
-  | "delete"
-  | "favorite";
+  "move" | "confirm" | "back" | "error" | "delete" | "favorite";
 
 interface ClickOpts {
   toneHz?: number; // fundamental pitch component

--- a/frontend/src/console/views/Game.vue
+++ b/frontend/src/console/views/Game.vue
@@ -32,12 +32,7 @@ import {
 } from "@/utils/covers";
 
 type FocusZone =
-  | "play"
-  | "description"
-  | "details"
-  | "shots"
-  | "lightbox"
-  | "states";
+  "play" | "description" | "details" | "shots" | "lightbox" | "states";
 
 type PlayerState = "loading" | "unsupported" | "error" | "ready";
 

--- a/frontend/src/stores/soundtrackPlayer.ts
+++ b/frontend/src/stores/soundtrackPlayer.ts
@@ -17,13 +17,7 @@ export interface PlayerTrack {
 // Audio-tag fields are sourced from the generated schema; the rest (duration in
 // seconds + resolved cover URLs) are UI-specific to the player.
 type AudioTagKey =
-  | "title"
-  | "artist"
-  | "album"
-  | "year"
-  | "genre"
-  | "track"
-  | "disc";
+  "title" | "artist" | "album" | "year" | "genre" | "track" | "disc";
 
 export type PlayerMeta = {
   [K in AudioTagKey]?: NonNullable<TrackMetaSchema[K]>;

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -675,10 +675,7 @@ export function isRuffleEmulationSupported(
 }
 
 export type PlayingStatus =
-  | RomUserStatus
-  | "backlogged"
-  | "now_playing"
-  | "hidden";
+  RomUserStatus | "backlogged" | "now_playing" | "hidden";
 
 /**
  * Map of ROM statuses to their corresponding emoji, text, and i18n key.

--- a/frontend/src/v2/components/AppShell/UserMenu.vue
+++ b/frontend/src/v2/components/AppShell/UserMenu.vue
@@ -101,8 +101,7 @@ async function onLogout() {
     snackbar.success("Logged out", { icon: "mdi-check-bold" });
     await router.push({ name: ROUTES.LOGIN });
     const pinia = getActivePinia() as
-      | { _s?: Map<string, { reset?: () => void } & StateTree> }
-      | undefined;
+      { _s?: Map<string, { reset?: () => void } & StateTree> } | undefined;
     pinia?._s?.forEach((store) => {
       store.reset?.();
     });

--- a/frontend/src/v2/components/Collections/collectionListColumns.ts
+++ b/frontend/src/v2/components/Collections/collectionListColumns.ts
@@ -8,10 +8,7 @@
 // (96px, right-aligned).
 
 export type CollectionListSortKey =
-  | "name"
-  | "kind"
-  | "visibility"
-  | "rom_count";
+  "name" | "kind" | "visibility" | "rom_count";
 
 export interface CollectionListColumn {
   /** Unique column id. */

--- a/frontend/src/v2/components/GameDetails/FilesTab/FilesTab.vue
+++ b/frontend/src/v2/components/GameDetails/FilesTab/FilesTab.vue
@@ -520,8 +520,7 @@ async function deleteSelectedFiles() {
   }
   if (failed > 0) {
     const firstError = results.find((r) => r.status === "rejected") as
-      | PromiseRejectedResult
-      | undefined;
+      PromiseRejectedResult | undefined;
     snackbar.error(
       t("rom.file-delete-failed", {
         error: firstError ? errorMessage(firstError.reason) : "",

--- a/frontend/src/v2/components/Platforms/platformListColumns.ts
+++ b/frontend/src/v2/components/Platforms/platformListColumns.ts
@@ -9,12 +9,7 @@
 // column to keep the row legible without horizontal scroll.
 
 export type PlatformSortKey =
-  | "name"
-  | "family"
-  | "category"
-  | "generation"
-  | "playable"
-  | "rom_count";
+  "name" | "family" | "category" | "generation" | "playable" | "rom_count";
 
 export interface PlatformColumn {
   key: PlatformSortKey;

--- a/frontend/src/v2/components/Settings/MissingGamesSection.vue
+++ b/frontend/src/v2/components/Settings/MissingGamesSection.vue
@@ -120,8 +120,7 @@ const listSortKey = computed<ListSortKey | null>(() => {
 // table never collapses to "empty" between the fetch firing and total
 // resolving.
 type VItem =
-  | { kind: "list-row"; position: number }
-  | { kind: "skeleton"; key: number };
+  { kind: "list-row"; position: number } | { kind: "skeleton"; key: number };
 
 const virtualItems = computed<VItem[]>(() => {
   if (!metadataLoaded.value) {

--- a/frontend/src/v2/composables/useCoverArt/index.ts
+++ b/frontend/src/v2/composables/useCoverArt/index.ts
@@ -40,10 +40,7 @@ import {
 import { useWebpSupport } from "@/v2/composables/useWebpSupport";
 
 export type BoxartStyle =
-  | "cover_path"
-  | "box3d_path"
-  | "physical_path"
-  | "miximage_path";
+  "cover_path" | "box3d_path" | "physical_path" | "miximage_path";
 
 /** Styles that resolve to an alternative artwork on the rom's metadata
  *  (everything except the default box art). These literals are exactly

--- a/frontend/src/v2/composables/useGalleryMode/index.ts
+++ b/frontend/src/v2/composables/useGalleryMode/index.ts
@@ -20,12 +20,7 @@
 import { useLocalStorage, type RemovableRef } from "@vueuse/core";
 
 export type GroupByMode =
-  | "letter"
-  | "family"
-  | "category"
-  | "generation"
-  | "playable"
-  | "none";
+  "letter" | "family" | "category" | "generation" | "playable" | "none";
 export type LayoutMode = "grid" | "list";
 export type ToolbarPosition = "header" | "floating";
 

--- a/frontend/src/v2/lib/forms/RRating/RRating.vue
+++ b/frontend/src/v2/lib/forms/RRating/RRating.vue
@@ -28,13 +28,7 @@ interface Props {
   halfIcon?: string;
   clearable?: boolean;
   size?:
-    | "x-small"
-    | "small"
-    | "default"
-    | "large"
-    | "x-large"
-    | string
-    | number;
+    "x-small" | "small" | "default" | "large" | "x-large" | string | number;
   readonly?: boolean;
   halfIncrements?: boolean;
   density?: "default" | "comfortable" | "compact";

--- a/frontend/src/v2/lib/forms/RSelect/RSelect.vue
+++ b/frontend/src/v2/lib/forms/RSelect/RSelect.vue
@@ -102,12 +102,7 @@ interface Props {
   searchPlaceholder?: string;
   /** Where to place the menu relative to the activator. */
   menuLocation?:
-    | "bottom"
-    | "top"
-    | "bottom start"
-    | "bottom end"
-    | "top start"
-    | "top end";
+    "bottom" | "top" | "bottom start" | "bottom end" | "top start" | "top end";
   /** Px gap between activator and menu. */
   menuOffset?: number;
   /** Hard cap on visible chips (defaults to ∞). Overflow is otherwise

--- a/frontend/src/v2/lib/structural/RTooltip/RTooltip.vue
+++ b/frontend/src/v2/lib/structural/RTooltip/RTooltip.vue
@@ -228,10 +228,7 @@ const arrowStyle = computed<Record<string, string>>(() => {
   const data = middlewareData.value.arrow;
   if (!data) return {};
   const side = activePlacement.value.split("-")[0] as
-    | "top"
-    | "right"
-    | "bottom"
-    | "left";
+    "top" | "right" | "bottom" | "left";
   const staticSide = {
     top: "bottom",
     right: "left",

--- a/frontend/src/v2/views/Scan.vue
+++ b/frontend/src/v2/views/Scan.vue
@@ -311,12 +311,7 @@ function onScroll(e: Event) {
 }
 
 type ScanType =
-  | "new_platforms"
-  | "quick"
-  | "unmatched"
-  | "update"
-  | "hashes"
-  | "complete";
+  "new_platforms" | "quick" | "unmatched" | "update" | "hashes" | "complete";
 
 const scanOptions: { title: string; subtitle: string; value: ScanType }[] = [
   {

--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -389,6 +389,45 @@ window.EJS_onSaveState = async function ({
 window.EJS_onGameStart = async () => {
   sessionStartTime.value = new Date();
 
+  // Install netplay overrides synchronously, before any await below, so they
+  // are in place before room polling or a Create/Join action can start.
+  // EmulatorJS' nightly netplay builds its URLs from `netplay.url` (the page
+  // host by default), which does not match how RomM serves netplay: the room
+  // list lives at /api/netplay/list and the socket at /netplay/socket.io. Point
+  // both at the right place so netplay works behind any reverse proxy / domain.
+  const netplay = window.EJS_emulator?.netplay;
+  if (netplay) {
+    // Room-list polling: use RomM's REST endpoint with a root-relative path,
+    // instead of `netplay.url + "/list"` (which resolves relative to the SPA
+    // route and duplicates the domain inside the request path).
+    netplay.getOpenRooms = async () => {
+      try {
+        const response = await fetch(
+          `/api/netplay/list?game_id=${window.EJS_gameID}`,
+        );
+        if (!response.ok) return {};
+        return await response.json();
+      } catch (error) {
+        console.error("Error fetching netplay rooms:", error);
+        return {};
+      }
+    };
+  }
+
+  // EmulatorJS connects with `io(netplay.url)` using Socket.IO's default path.
+  // Wrap the bundled global `io` so netplay uses RomM's mounted socket path.
+  // Only EmulatorJS uses this global; RomM's own app socket imports the client.
+  if (window.io && !window.io.__rommNetplayPatched) {
+    const originalIo = window.io;
+    const patchedIo = ((url: string, opts?: Record<string, unknown>) =>
+      originalIo(url, {
+        ...opts,
+        path: "/netplay/socket.io",
+      })) as NonNullable<Window["io"]>;
+    patchedIo.__rommNetplayPatched = true;
+    window.io = patchedIo;
+  }
+
   void (async () => {
     const ready = await waitForGameManager();
     if (!ready) {
@@ -470,43 +509,6 @@ window.EJS_onGameStart = async () => {
     romsStore.update(romRef.value);
     immediateExit();
   });
-
-  // EmulatorJS' nightly netplay builds its URLs from `netplay.url` (the page
-  // host by default), which does not match how RomM serves netplay: the room
-  // list lives at /api/netplay/list and the socket at /netplay/socket.io. Point
-  // both at the right place so netplay works behind any reverse proxy / domain.
-  const netplay = window.EJS_emulator?.netplay;
-  if (netplay) {
-    // Room-list polling: use RomM's REST endpoint with a root-relative path,
-    // instead of `netplay.url + "/list"` (which resolves relative to the SPA
-    // route and duplicates the domain inside the request path).
-    netplay.getOpenRooms = async () => {
-      try {
-        const response = await fetch(
-          `/api/netplay/list?game_id=${window.EJS_gameID}`,
-        );
-        if (!response.ok) return {};
-        return await response.json();
-      } catch (error) {
-        console.error("Error fetching netplay rooms:", error);
-        return {};
-      }
-    };
-  }
-
-  // EmulatorJS connects with `io(netplay.url)` using Socket.IO's default path.
-  // Wrap the bundled global `io` so netplay uses RomM's mounted socket path.
-  // Only EmulatorJS uses this global; RomM's own app socket imports the client.
-  if (window.io && !window.io.__rommNetplayPatched) {
-    const originalIo = window.io;
-    const patchedIo = ((url: string, opts?: Record<string, unknown>) =>
-      originalIo(url, {
-        ...opts,
-        path: "/netplay/socket.io",
-      })) as NonNullable<Window["io"]>;
-    patchedIo.__rommNetplayPatched = true;
-    window.io = patchedIo;
-  }
 };
 
 function immediateExit() {

--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -182,9 +182,7 @@ const {
   EJS_NETPLAY_ICE_SERVERS,
   EJS_NETPLAY_ENABLED,
 } = configStore.config;
-// Full origin (with scheme), so EmulatorJS' `io(netplay.url)` connects to the
-// right server behind any reverse proxy / custom domain. The socket path and
-// room-list endpoint are corrected in the netplay overrides below.
+// Full origin (with scheme)
 window.EJS_netplayServer = EJS_NETPLAY_ENABLED ? window.location.origin : "";
 window.EJS_netplayICEServers = EJS_NETPLAY_ENABLED
   ? EJS_NETPLAY_ICE_SERVERS
@@ -391,15 +389,8 @@ window.EJS_onGameStart = async () => {
 
   // Install netplay overrides synchronously, before any await below, so they
   // are in place before room polling or a Create/Join action can start.
-  // EmulatorJS' nightly netplay builds its URLs from `netplay.url` (the page
-  // host by default), which does not match how RomM serves netplay: the room
-  // list lives at /api/netplay/list and the socket at /netplay/socket.io. Point
-  // both at the right place so netplay works behind any reverse proxy / domain.
   const netplay = window.EJS_emulator?.netplay;
   if (netplay) {
-    // Room-list polling: use RomM's REST endpoint with a root-relative path,
-    // instead of `netplay.url + "/list"` (which resolves relative to the SPA
-    // route and duplicates the domain inside the request path).
     netplay.getOpenRooms = async () => {
       try {
         const response = await fetch(
@@ -414,9 +405,7 @@ window.EJS_onGameStart = async () => {
     };
   }
 
-  // EmulatorJS connects with `io(netplay.url)` using Socket.IO's default path.
-  // Wrap the bundled global `io` so netplay uses RomM's mounted socket path.
-  // Only EmulatorJS uses this global; RomM's own app socket imports the client.
+  // Wrap the bundled global `io` so netplay uses mounted socket path.
   if (window.io && !window.io.__rommNetplayPatched) {
     const originalIo = window.io;
     const patchedIo = ((url: string, opts?: Record<string, unknown>) =>

--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -122,6 +122,10 @@ declare global {
       save: ArrayBuffer;
     }) => void;
     EJS_onLoadSave: () => void;
+    // Socket.IO global, bundled by EmulatorJS and used by its netplay code.
+    io?: ((url: string, opts?: Record<string, unknown>) => unknown) & {
+      __rommNetplayPatched?: boolean;
+    };
   }
 }
 
@@ -178,7 +182,10 @@ const {
   EJS_NETPLAY_ICE_SERVERS,
   EJS_NETPLAY_ENABLED,
 } = configStore.config;
-window.EJS_netplayServer = EJS_NETPLAY_ENABLED ? window.location.host : "";
+// Full origin (with scheme), so EmulatorJS' `io(netplay.url)` connects to the
+// right server behind any reverse proxy / custom domain. The socket path and
+// room-list endpoint are corrected in the netplay overrides below.
+window.EJS_netplayServer = EJS_NETPLAY_ENABLED ? window.location.origin : "";
 window.EJS_netplayICEServers = EJS_NETPLAY_ENABLED
   ? EJS_NETPLAY_ICE_SERVERS
   : [];
@@ -464,27 +471,42 @@ window.EJS_onGameStart = async () => {
     immediateExit();
   });
 
-  // The netplay implementation is finnicky, these overrides make it work
-  const { defineNetplayFunctions } = window.EJS_emulator;
-  window.EJS_emulator.defineNetplayFunctions = () => {
-    defineNetplayFunctions.bind(window.EJS_emulator)();
-
-    window.EJS_emulator.netplay.url = {
-      path: "/netplay/socket.io",
-    };
-
-    window.EJS_emulator.netplayGetOpenRooms = async () => {
+  // EmulatorJS' nightly netplay builds its URLs from `netplay.url` (the page
+  // host by default), which does not match how RomM serves netplay: the room
+  // list lives at /api/netplay/list and the socket at /netplay/socket.io. Point
+  // both at the right place so netplay works behind any reverse proxy / domain.
+  const netplay = window.EJS_emulator?.netplay;
+  if (netplay) {
+    // Room-list polling: use RomM's REST endpoint with a root-relative path,
+    // instead of `netplay.url + "/list"` (which resolves relative to the SPA
+    // route and duplicates the domain inside the request path).
+    netplay.getOpenRooms = async () => {
       try {
         const response = await fetch(
           `/api/netplay/list?game_id=${window.EJS_gameID}`,
         );
+        if (!response.ok) return {};
         return await response.json();
       } catch (error) {
-        console.error("Error fetching open rooms:", error);
+        console.error("Error fetching netplay rooms:", error);
         return {};
       }
     };
-  };
+  }
+
+  // EmulatorJS connects with `io(netplay.url)` using Socket.IO's default path.
+  // Wrap the bundled global `io` so netplay uses RomM's mounted socket path.
+  // Only EmulatorJS uses this global; RomM's own app socket imports the client.
+  if (window.io && !window.io.__rommNetplayPatched) {
+    const originalIo = window.io;
+    const patchedIo = ((url: string, opts?: Record<string, unknown>) =>
+      originalIo(url, {
+        ...opts,
+        path: "/netplay/socket.io",
+      })) as NonNullable<Window["io"]>;
+    patchedIo.__rommNetplayPatched = true;
+    window.io = patchedIo;
+  }
 };
 
 function immediateExit() {


### PR DESCRIPTION
**Description**

Fixes #3799 — behind a reverse proxy / custom domain, the netplay room list is always empty and Create/Join Room do nothing.

**Root cause**

RomM's netplay overrides in `Player.vue` targeted an outdated EmulatorJS API (the netplay functions moved from the emulator object onto the `netplay` instance in the nightly build). On the current `nightly` build those overrides are dead code, so the emulator's own URL logic runs instead:

- `getOpenRooms()` builds the request from `netplay.url`, which RomM set to `window.location.host` (a bare host, no scheme). The browser resolves that **relative to the current SPA route**, producing `https://<domain>/<route>/<domain>/list?...` — the domain duplicated inside the path, exactly as in the report. nginx's SPA fallback (`try_files ... /index.html`) then answers with `index.html` (200, `text/html`), `JSON.parse` fails, the error is swallowed, and the room list is always empty.
- The socket connects with `io(netplay.url)` using Socket.IO's **default** path instead of RomM's mounted `/netplay/socket.io`, so creating/joining a room silently does nothing.

**Changes** (`frontend/src/views/Player/EmulatorJS/Player.vue`)

1. `EJS_netplayServer`: `window.location.host` → `window.location.origin` (scheme included, so `io()` has an unambiguous absolute server).
2. Override `netplay.getOpenRooms` on the actual netplay instance to hit `/api/netplay/list?game_id=...` with a **root-relative** path (correct on any domain / proxy). The `/api/netplay/list` endpoint already exists in the backend.
3. Wrap the EmulatorJS-bundled global `io` (socket.io is bundled UMD onto `window.io`, and netplay's `io(this.url)` uses that global) to inject `path: "/netplay/socket.io"`. The wrap is idempotent and only affects EmulatorJS — RomM's own app socket imports the client module rather than using the global.

No backend changes required.

**AI assistance disclosure**

This change was investigated and implemented with AI assistance (Claude Code): root-cause analysis of the EmulatorJS nightly netplay source, the fix, and this description. All changes were reviewed by a human.

**Checklist**

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

**Note on testing:** typecheck and `trunk fmt`/`trunk check` pass clean. End-to-end netplay could not be exercised here (it requires the live `nightly` CDN build, STUN/TURN, and a custom domain). Please smoke-test behind a reverse proxy: confirm the polling request in DevTools hits `/api/netplay/list?...` and returns JSON, and that Create/Join rooms connect over `/netplay/socket.io`.

**Known fragility:** netplay pins EmulatorJS to `nightly`, so this class of breakage can recur whenever upstream refactors the netplay API.