### PR TITLE
Fix v2 gallery not refetching when filter logic operator changes

### DIFF
--- a/frontend/src/v2/components/Gallery/GalleryShell.vue
+++ b/frontend/src/v2/components/Gallery/GalleryShell.vue
@@ -253,8 +253,6 @@ watch(
     selectedMetadataProviders,
     selectedTags,
     selectedStatuses,
-    // Logic operators (any/all/none) also change the result set, e.g.
-    // switching statuses to "none" to invert the selection.
     genresLogic,
     franchisesLogic,
     collectionsLogic,

--- a/frontend/src/v2/components/Gallery/GalleryShell.vue
+++ b/frontend/src/v2/components/Gallery/GalleryShell.vue
@@ -173,6 +173,17 @@ const {
   selectedMetadataProviders,
   selectedTags,
   selectedStatuses,
+  genresLogic,
+  franchisesLogic,
+  collectionsLogic,
+  companiesLogic,
+  ageRatingsLogic,
+  regionsLogic,
+  languagesLogic,
+  playerCountsLogic,
+  metadataProvidersLogic,
+  tagsLogic,
+  statusesLogic,
 } = storeToRefs(galleryFilterStore);
 
 // Drawer open state — bound to FilterDrawer via v-model.
@@ -242,6 +253,19 @@ watch(
     selectedMetadataProviders,
     selectedTags,
     selectedStatuses,
+    // Logic operators (any/all/none) also change the result set, e.g.
+    // switching statuses to "none" to invert the selection.
+    genresLogic,
+    franchisesLogic,
+    collectionsLogic,
+    companiesLogic,
+    ageRatingsLogic,
+    regionsLogic,
+    languagesLogic,
+    playerCountsLogic,
+    metadataProvidersLogic,
+    tagsLogic,
+    statusesLogic,
   ],
   () => {
     galleryRoms.invalidateWindows();


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3798.

In the v2 gallery, filters expose a logic operator (any / all / none) alongside their selection. The "none" operator inverts a filter, e.g. selecting the "Finished" and "100%" statuses with `none` should show every ROM that is *not* in those states.

The refetch watcher in `GalleryShell.vue` only watched the filter *selection arrays* (`selectedStatuses`, `selectedGenres`, ...), not the per-filter `*Logic` operators. As a result, toggling a filter to its inverse updated the `galleryFilter` store but never triggered a refetch. The change only took effect when the selection itself was edited, or after a reload (URL hydration re-runs the initial fetch), which matches the report that the inverse "sometimes needs a reload to trigger".

The fetch layer (`galleryRoms`) already sends `statusesLogic` and the other operators to the backend, so the query was correct all along; only the client-side refetch trigger was missing.

Fix: watch all `*Logic` operators alongside their selections in `GalleryShell.vue`, so inverting a filter (or switching any/all/none) refetches immediately.

v1's `FilterDrawer/Base.vue` already emits a refetch on logic-toggle, so this was v2-specific.

**AI assistance disclosure**: This change was written with AI assistance (Claude Code). The maintainer reviewed the diagnosis and the fix.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)