### PR TITLE
fix: don't re-stamp updated_at for unchanged ROMs during scans

### DIFF
--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -1533,7 +1533,12 @@ class DBRomsHandler(DBBaseHandler):
         rom_ids: list[int],
         session: Session = None,  # type: ignore
     ) -> None:
-        """Bulk set missing_from_fs=False for a list of ROM IDs."""
+        """Bulk set missing_from_fs=False for a list of ROM IDs.
+
+        Only rows that actually flip are written, so a re-scan of an
+        unchanged platform issues no updates and leaves `updated_at`
+        untouched, keeping it a usable incremental signal.
+        """
         if not rom_ids:
             return
 
@@ -1545,6 +1550,7 @@ class DBRomsHandler(DBBaseHandler):
                     and_(
                         Rom.platform_id == platform_id,
                         Rom.id.in_(chunk),
+                        Rom.missing_from_fs.is_(True),
                     )
                 )
                 .values(missing_from_fs=False)

--- a/backend/tests/handler/test_db_handler.py
+++ b/backend/tests/handler/test_db_handler.py
@@ -492,6 +492,53 @@ def test_bulk_mark_present(platform: Platform):
         assert updated.missing_from_fs is True
 
 
+def test_bulk_mark_present_skips_already_present(platform: Platform):
+    """bulk_mark_present leaves updated_at untouched for already-present ROMs.
+
+    Regression: an unchanged (already present) ROM must not be re-stamped on
+    each scan, so `updated_after`-based incremental consumers stay usable.
+    """
+    present = db_rom_handler.add_rom(
+        Rom(
+            platform_id=platform.id,
+            name="rom_present",
+            slug="rom-present",
+            fs_name="rom_present.zip",
+            fs_name_no_tags="rom_present",
+            fs_name_no_ext="rom_present",
+            fs_extension="zip",
+            fs_path=f"{platform.slug}/roms",
+            missing_from_fs=False,
+        )
+    )
+    missing = db_rom_handler.add_rom(
+        Rom(
+            platform_id=platform.id,
+            name="rom_missing",
+            slug="rom-missing",
+            fs_name="rom_missing.zip",
+            fs_name_no_tags="rom_missing",
+            fs_name_no_ext="rom_missing",
+            fs_extension="zip",
+            fs_path=f"{platform.slug}/roms",
+            missing_from_fs=True,
+        )
+    )
+
+    present_updated_at = db_rom_handler.get_rom(present.id).updated_at
+
+    db_rom_handler.bulk_mark_present(platform.id, [present.id, missing.id])
+
+    # Already-present ROM is not re-stamped.
+    present_after = db_rom_handler.get_rom(present.id)
+    assert present_after.missing_from_fs is False
+    assert present_after.updated_at == present_updated_at
+
+    # Actually-missing ROM is flipped to present.
+    missing_after = db_rom_handler.get_rom(missing.id)
+    assert missing_after.missing_from_fs is False
+
+
 def test_bulk_mark_present_empty_list(platform: Platform):
     """bulk_mark_present with an empty list is a no-op."""
     rom = db_rom_handler.add_rom(


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3836.

Every filesystem scan was bumping `roms.updated_at` for **all** present-and-skipped ROMs of the scanned platform, even when nothing about them changed. This defeated `updated_after`-based incremental consumers of `GET /api/roms` (with scheduled scans, `updated_at` stopped meaning "this ROM changed") and busted every cover URL (`?ts={updated_at}`) on each scan.

**Root cause:** `Rom.updated_at` inherits `onupdate=utc_now` from `BaseModel`. During a scan, skipped ROMs are handed to `bulk_mark_present`, which emitted an unconditional `UPDATE ... SET missing_from_fs=False` against every matched row, including rows already `False`, so `onupdate` fired and re-stamped every unchanged ROM. The missing side (`mark_missing_roms`) already reads-first and writes only actual flips; the present side lacked the equivalent guard.

**Fix:** restrict the `bulk_mark_present` UPDATE to rows that actually flip by adding `Rom.missing_from_fs.is_(True)` to the WHERE clause. A ROM that is already present is left untouched, so an unchanged platform issues no updates and `updated_at` stays a usable incremental signal. No behavior change otherwise.

Added a regression test (`test_bulk_mark_present_skips_already_present`) asserting an already-present ROM's `updated_at` is preserved while a genuinely-missing ROM still flips.

**AI assistance disclosure:** This change was written with AI assistance (Claude Code). The maintainer reviewed the diagnosis and fix.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

_N/A (backend-only change)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)