### PR TITLE
fix: load selected file with correct extension for multi-file roms

### DIFF
--- a/frontend/src/utils/index.test.ts
+++ b/frontend/src/utils/index.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { SimpleRom } from "@/stores/roms";
+import { getDownloadPath } from "./index";
+
+function makeRom(overrides: Partial<SimpleRom>): SimpleRom {
+  return {
+    id: 1,
+    fs_name: "Game",
+    files: [],
+    ...overrides,
+  } as SimpleRom;
+}
+
+describe("getDownloadPath", () => {
+  it("uses fs_name when no file is selected", () => {
+    const rom = makeRom({ id: 14, fs_name: "Maniac Mansion (1989).adf" });
+    expect(getDownloadPath({ rom })).toBe(
+      "/api/roms/14/content/Maniac Mansion (1989).adf",
+    );
+  });
+
+  it("uses the selected file name (with extension) for a single file", () => {
+    // Multi-file rom: fs_name is the folder name with no extension. The URL
+    // path segment must carry the selected file's real name so the emulator
+    // receives a file with the correct extension.
+    const rom = makeRom({
+      id: 24,
+      fs_name: "B.A.T.",
+      files: [
+        { id: 29, file_name: "B.A.T. Disk1.adf" },
+        { id: 30, file_name: "B.A.T. Disk2.adf" },
+      ] as SimpleRom["files"],
+    });
+    expect(getDownloadPath({ rom, fileIDs: [29] })).toBe(
+      "/api/roms/24/content/B.A.T. Disk1.adf?file_ids=29",
+    );
+  });
+
+  it("falls back to fs_name when multiple files are selected (zip)", () => {
+    const rom = makeRom({
+      id: 24,
+      fs_name: "B.A.T.",
+      files: [
+        { id: 29, file_name: "B.A.T. Disk1.adf" },
+        { id: 30, file_name: "B.A.T. Disk2.adf" },
+      ] as SimpleRom["files"],
+    });
+    expect(getDownloadPath({ rom, fileIDs: [29, 30] })).toBe(
+      "/api/roms/24/content/B.A.T.?file_ids=29%2C30",
+    );
+  });
+
+  it("falls back to fs_name when the selected file id is unknown", () => {
+    const rom = makeRom({ id: 24, fs_name: "B.A.T." });
+    expect(getDownloadPath({ rom, fileIDs: [999] })).toBe(
+      "/api/roms/24/content/B.A.T.?file_ids=999",
+    );
+  });
+});

--- a/frontend/src/utils/index.test.ts
+++ b/frontend/src/utils/index.test.ts
@@ -32,7 +32,7 @@ describe("getDownloadPath", () => {
       ] as SimpleRom["files"],
     });
     expect(getDownloadPath({ rom, fileIDs: [29] })).toBe(
-      "/api/roms/24/content/B.A.T. Disk1.adf?file_ids=29",
+      "/api/roms/24/content/B.A.T.%20Disk1.adf?file_ids=29",
     );
   });
 

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -126,7 +126,17 @@ export function getDownloadPath({
     queryParams.append("file_ids", fileIDs.join(","));
   }
   const queryString = queryParams.toString();
-  return `/api/roms/${rom.id}/content/${rom.fs_name}${
+  // When a single file is selected, use its real name (extension included) as
+  // the path segment. EmulatorJS derives the on-disk filename, and therefore
+  // the file format handed to the core, from the URL. Multi-file roms have no
+  // root extension (`fs_name` is the folder name), so falling back to it would
+  // give the core an extension-less file and fail with "Unsupported file format".
+  const selectedFile =
+    fileIDs.length === 1
+      ? rom.files?.find((f) => f.id === fileIDs[0])
+      : undefined;
+  const contentName = selectedFile?.file_name ?? rom.fs_name;
+  return `/api/roms/${rom.id}/content/${contentName}${
     queryString ? `?${queryString}` : ""
   }`;
 }

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -135,7 +135,9 @@ export function getDownloadPath({
     fileIDs.length === 1
       ? rom.files?.find((f) => f.id === fileIDs[0])
       : undefined;
-  const contentName = selectedFile?.file_name ?? rom.fs_name;
+  const contentName = selectedFile
+    ? encodeURIComponent(selectedFile.file_name)
+    : rom.fs_name;
   return `/api/roms/${rom.id}/content/${contentName}${
     queryString ? `?${queryString}` : ""
   }`;

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -126,11 +126,8 @@ export function getDownloadPath({
     queryParams.append("file_ids", fileIDs.join(","));
   }
   const queryString = queryParams.toString();
-  // When a single file is selected, use its real name (extension included) as
-  // the path segment. EmulatorJS derives the on-disk filename, and therefore
-  // the file format handed to the core, from the URL. Multi-file roms have no
-  // root extension (`fs_name` is the folder name), so falling back to it would
-  // give the core an extension-less file and fail with "Unsupported file format".
+
+  // If a single file is selected, use its name for the download path
   const selectedFile =
     fileIDs.length === 1
       ? rom.files?.find((f) => f.id === fileIDs[0])
@@ -138,6 +135,7 @@ export function getDownloadPath({
   const contentName = selectedFile
     ? encodeURIComponent(selectedFile.file_name)
     : rom.fs_name;
+
   return `/api/roms/${rom.id}/content/${contentName}${
     queryString ? `?${queryString}` : ""
   }`;


### PR DESCRIPTION
**Description**

Multi-file roms (multi-disk games grouped in a subfolder, e.g. floppy-based Amiga games) failed to launch in the EmulatorJS player with the overlay error `Unsupported file format: ''`. Single-file roms on the same platform worked fine.

**Root cause**

EmulatorJS derives the filename it writes into the emulator's virtual filesystem from the last path segment of the game URL (`getBaseFileName(true)` → `gameUrl.split("/").pop().split("?")[0]`), and the libretro core (e.g. `puae`) determines the disk format from that filename's extension.

`getDownloadPath` built that URL using the ROM-level `fs_name`:

```
/api/roms/24/content/B.A.T.?file_ids=29
```

- Single-file rom: `fs_name` is the file name and carries the extension (`Maniac Mansion (1989).adf`) → core sees `.adf` → works.
- Multi-file rom: the rom is a folder, so `fs_name` is the folder name with no extension (`B.A.T.`, whose `fs_extension` is `""` by design) → the core gets an extension-less file → `Unsupported file format: ''`.

The backend was already correct: for a single `file_ids` value it serves the actual raw file, and the path segment is only used for zip/m3u naming.

**Fix**

When exactly one file is selected, use that file's real name (extension included) as the content path segment instead of the folder-level `fs_name`. This is the single shared helper used by all EmulatorJS entry points (v1/v2 `Player.vue` and the console `Play.vue`) as well as download buttons. Multi-file/zip downloads and no-selection cases fall back to `fs_name` unchanged.

**Scope note**

This fixes loading the selected disk. In-emulator disk swapping across all disks via an m3u playlist is a separate feature and is not addressed here.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The AI investigated the issue, traced the EmulatorJS 4.2.3 file-loading path, implemented the fix, and added unit tests. Changes were reviewed by the author.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Verification run: `vitest` (4 new cases pass), `npm run typecheck` clean, `trunk fmt` / `trunk check` clean. Not yet browser-tested end-to-end with a real multi-disk rom.

Fixes #3746

🤖 Generated with [Claude Code](https://claude.com/claude-code)