### PR TITLE
feat: add "Open in Flashpoint" game action

### DIFF
--- a/frontend/src/locales/bg_BG/rom.json
+++ b/frontend/src/locales/bg_BG/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "Обновена {date}",
   "now-playing": "Играна в момента",
   "open-game": "Отвори {name}",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "Отвори във Flashpoint",
   "paused": "На пауза",
   "pdf-toggle-sidebar": "Превключи страничната лента",
   "personal": "Лично",

--- a/frontend/src/locales/bg_BG/rom.json
+++ b/frontend/src/locales/bg_BG/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "Обновена {date}",
   "now-playing": "Играна в момента",
   "open-game": "Отвори {name}",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "На пауза",
   "pdf-toggle-sidebar": "Превключи страничната лента",
   "personal": "Лично",

--- a/frontend/src/locales/cs_CZ/rom.json
+++ b/frontend/src/locales/cs_CZ/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "Aktualizováno {date}",
   "now-playing": "Právě hraje",
   "open-game": "Otevřít {name}",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "Otevřít ve Flashpointu",
   "paused": "Pozastaveno",
   "pdf-toggle-sidebar": "Přepnout postranní panel",
   "personal": "Osobní",

--- a/frontend/src/locales/cs_CZ/rom.json
+++ b/frontend/src/locales/cs_CZ/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "Aktualizováno {date}",
   "now-playing": "Právě hraje",
   "open-game": "Otevřít {name}",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "Pozastaveno",
   "pdf-toggle-sidebar": "Přepnout postranní panel",
   "personal": "Osobní",

--- a/frontend/src/locales/de_DE/rom.json
+++ b/frontend/src/locales/de_DE/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "Aktualisiert {date}",
   "now-playing": "Derzeit gespielt",
   "open-game": "{name} öffnen",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "In Flashpoint öffnen",
   "paused": "Pausiert",
   "pdf-toggle-sidebar": "Seitenleiste umschalten",
   "personal": "Persönlich",

--- a/frontend/src/locales/de_DE/rom.json
+++ b/frontend/src/locales/de_DE/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "Aktualisiert {date}",
   "now-playing": "Derzeit gespielt",
   "open-game": "{name} öffnen",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "Pausiert",
   "pdf-toggle-sidebar": "Seitenleiste umschalten",
   "personal": "Persönlich",

--- a/frontend/src/locales/en_GB/rom.json
+++ b/frontend/src/locales/en_GB/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "Updated {date}",
   "now-playing": "Now playing",
   "open-game": "Open {name}",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "Paused",
   "pdf-toggle-sidebar": "Toggle sidebar",
   "personal": "Personal",

--- a/frontend/src/locales/en_US/rom.json
+++ b/frontend/src/locales/en_US/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "Updated {date}",
   "now-playing": "Now playing",
   "open-game": "Open {name}",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "Paused",
   "pdf-toggle-sidebar": "Toggle sidebar",
   "personal": "Personal",

--- a/frontend/src/locales/es_ES/rom.json
+++ b/frontend/src/locales/es_ES/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "Actualizada {date}",
   "now-playing": "Jugando",
   "open-game": "Abrir {name}",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "Pausado",
   "pdf-toggle-sidebar": "Mostrar/ocultar barra lateral",
   "personal": "Personal",

--- a/frontend/src/locales/es_ES/rom.json
+++ b/frontend/src/locales/es_ES/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "Actualizada {date}",
   "now-playing": "Jugando",
   "open-game": "Abrir {name}",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "Abrir en Flashpoint",
   "paused": "Pausado",
   "pdf-toggle-sidebar": "Mostrar/ocultar barra lateral",
   "personal": "Personal",

--- a/frontend/src/locales/fr_FR/rom.json
+++ b/frontend/src/locales/fr_FR/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "Mise à jour le {date}",
   "now-playing": "En train de jouer",
   "open-game": "Ouvrir {name}",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "En pause",
   "pdf-toggle-sidebar": "Basculer la barre latérale",
   "personal": "Personnel",

--- a/frontend/src/locales/fr_FR/rom.json
+++ b/frontend/src/locales/fr_FR/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "Mise à jour le {date}",
   "now-playing": "En train de jouer",
   "open-game": "Ouvrir {name}",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "Ouvrir dans Flashpoint",
   "paused": "En pause",
   "pdf-toggle-sidebar": "Basculer la barre latérale",
   "personal": "Personnel",

--- a/frontend/src/locales/hu_HU/rom.json
+++ b/frontend/src/locales/hu_HU/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "Frissítve: {date}",
   "now-playing": "Most játszott",
   "open-game": "{name} megnyitása",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "Megnyitás Flashpointban",
   "paused": "Szüneteltetve",
   "pdf-toggle-sidebar": "Oldalsáv ki/be",
   "personal": "Személyes",

--- a/frontend/src/locales/hu_HU/rom.json
+++ b/frontend/src/locales/hu_HU/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "Frissítve: {date}",
   "now-playing": "Most játszott",
   "open-game": "{name} megnyitása",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "Szüneteltetve",
   "pdf-toggle-sidebar": "Oldalsáv ki/be",
   "personal": "Személyes",

--- a/frontend/src/locales/it_IT/rom.json
+++ b/frontend/src/locales/it_IT/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "Aggiornata il {date}",
   "now-playing": "Stai giocando",
   "open-game": "Apri {name}",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "Apri in Flashpoint",
   "paused": "In pausa",
   "pdf-toggle-sidebar": "Mostra/nascondi barra laterale",
   "personal": "Personale",

--- a/frontend/src/locales/it_IT/rom.json
+++ b/frontend/src/locales/it_IT/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "Aggiornata il {date}",
   "now-playing": "Stai giocando",
   "open-game": "Apri {name}",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "In pausa",
   "pdf-toggle-sidebar": "Mostra/nascondi barra laterale",
   "personal": "Personale",

--- a/frontend/src/locales/ja_JP/rom.json
+++ b/frontend/src/locales/ja_JP/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "更新日 {date}",
   "now-playing": "プレイ中",
   "open-game": "{name}を開く",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "Flashpointで開く",
   "paused": "一時停止中",
   "pdf-toggle-sidebar": "サイドバーを切り替え",
   "personal": "マイステータス",

--- a/frontend/src/locales/ja_JP/rom.json
+++ b/frontend/src/locales/ja_JP/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "更新日 {date}",
   "now-playing": "プレイ中",
   "open-game": "{name}を開く",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "一時停止中",
   "pdf-toggle-sidebar": "サイドバーを切り替え",
   "personal": "マイステータス",

--- a/frontend/src/locales/ko_KR/rom.json
+++ b/frontend/src/locales/ko_KR/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "업데이트: {date}",
   "now-playing": "현재 플레이중",
   "open-game": "{name} 열기",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "Flashpoint에서 열기",
   "paused": "일시정지됨",
   "pdf-toggle-sidebar": "사이드바 전환",
   "personal": "개인",

--- a/frontend/src/locales/ko_KR/rom.json
+++ b/frontend/src/locales/ko_KR/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "업데이트: {date}",
   "now-playing": "현재 플레이중",
   "open-game": "{name} 열기",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "일시정지됨",
   "pdf-toggle-sidebar": "사이드바 전환",
   "personal": "개인",

--- a/frontend/src/locales/pl_PL/rom.json
+++ b/frontend/src/locales/pl_PL/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "Zaktualizowano {date}",
   "now-playing": "Aktualnie grane",
   "open-game": "Otwórz {name}",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "Otwórz w Flashpoint",
   "paused": "Wstrzymane",
   "pdf-toggle-sidebar": "Przełącz pasek boczny",
   "personal": "Osobiste",

--- a/frontend/src/locales/pl_PL/rom.json
+++ b/frontend/src/locales/pl_PL/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "Zaktualizowano {date}",
   "now-playing": "Aktualnie grane",
   "open-game": "Otwórz {name}",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "Wstrzymane",
   "pdf-toggle-sidebar": "Przełącz pasek boczny",
   "personal": "Osobiste",

--- a/frontend/src/locales/pt_BR/rom.json
+++ b/frontend/src/locales/pt_BR/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "Atualizada {date}",
   "now-playing": "Jogando agora",
   "open-game": "Abrir {name}",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "Pausado",
   "pdf-toggle-sidebar": "Alternar barra lateral",
   "personal": "Pessoal",

--- a/frontend/src/locales/pt_BR/rom.json
+++ b/frontend/src/locales/pt_BR/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "Atualizada {date}",
   "now-playing": "Jogando agora",
   "open-game": "Abrir {name}",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "Abrir no Flashpoint",
   "paused": "Pausado",
   "pdf-toggle-sidebar": "Alternar barra lateral",
   "personal": "Pessoal",

--- a/frontend/src/locales/ro_RO/rom.json
+++ b/frontend/src/locales/ro_RO/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "Actualizată {date}",
   "now-playing": "În curs de joc",
   "open-game": "Deschide {name}",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "Deschide în Flashpoint",
   "paused": "În pauză",
   "pdf-toggle-sidebar": "Comută bara laterală",
   "personal": "Personal",

--- a/frontend/src/locales/ro_RO/rom.json
+++ b/frontend/src/locales/ro_RO/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "Actualizată {date}",
   "now-playing": "În curs de joc",
   "open-game": "Deschide {name}",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "În pauză",
   "pdf-toggle-sidebar": "Comută bara laterală",
   "personal": "Personal",

--- a/frontend/src/locales/ru_RU/rom.json
+++ b/frontend/src/locales/ru_RU/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "Обновлено {date}",
   "now-playing": "Сейчас играют",
   "open-game": "Открыть {name}",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "Пауза",
   "pdf-toggle-sidebar": "Переключить боковую панель",
   "personal": "Личное",

--- a/frontend/src/locales/ru_RU/rom.json
+++ b/frontend/src/locales/ru_RU/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "Обновлено {date}",
   "now-playing": "Сейчас играют",
   "open-game": "Открыть {name}",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "Открыть в Flashpoint",
   "paused": "Пауза",
   "pdf-toggle-sidebar": "Переключить боковую панель",
   "personal": "Личное",

--- a/frontend/src/locales/tr_TR/rom.json
+++ b/frontend/src/locales/tr_TR/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "{date} tarihinde güncellendi",
   "now-playing": "Şu an oynanıyor",
   "open-game": "{name} oyununu aç",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "Duraklatıldı",
   "pdf-toggle-sidebar": "Kenar çubuğunu aç/kapat",
   "personal": "Kişisel",

--- a/frontend/src/locales/tr_TR/rom.json
+++ b/frontend/src/locales/tr_TR/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "{date} tarihinde güncellendi",
   "now-playing": "Şu an oynanıyor",
   "open-game": "{name} oyununu aç",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "Flashpoint'te aç",
   "paused": "Duraklatıldı",
   "pdf-toggle-sidebar": "Kenar çubuğunu aç/kapat",
   "personal": "Kişisel",

--- a/frontend/src/locales/zh_CN/rom.json
+++ b/frontend/src/locales/zh_CN/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "更新于 {date}",
   "now-playing": "正在游玩",
   "open-game": "打开 {name}",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "在 Flashpoint 中打开",
   "paused": "已暂停",
   "pdf-toggle-sidebar": "切换侧边栏",
   "personal": "私人",

--- a/frontend/src/locales/zh_CN/rom.json
+++ b/frontend/src/locales/zh_CN/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "更新于 {date}",
   "now-playing": "正在游玩",
   "open-game": "打开 {name}",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "已暂停",
   "pdf-toggle-sidebar": "切换侧边栏",
   "personal": "私人",

--- a/frontend/src/locales/zh_TW/rom.json
+++ b/frontend/src/locales/zh_TW/rom.json
@@ -252,7 +252,7 @@
   "notes-updated-at": "更新於 {date}",
   "now-playing": "正在遊玩",
   "open-game": "開啟 {name}",
-  "open-in-flashpoint": "Open in Flashpoint",
+  "open-in-flashpoint": "在 Flashpoint 中開啟",
   "paused": "已暫停",
   "pdf-toggle-sidebar": "切換側邊欄",
   "personal": "私人",

--- a/frontend/src/locales/zh_TW/rom.json
+++ b/frontend/src/locales/zh_TW/rom.json
@@ -252,6 +252,7 @@
   "notes-updated-at": "更新於 {date}",
   "now-playing": "正在遊玩",
   "open-game": "開啟 {name}",
+  "open-in-flashpoint": "Open in Flashpoint",
   "paused": "已暫停",
   "pdf-toggle-sidebar": "切換側邊欄",
   "personal": "私人",

--- a/frontend/src/v2/components/GameActions/GameActionBtn.vue
+++ b/frontend/src/v2/components/GameActions/GameActionBtn.vue
@@ -149,6 +149,8 @@ type Preset = {
   activeIcon: string | null;
   onClick: (() => void) | null;
   active: boolean;
+  /** Renders an <img> in place of the mdi glyph (e.g. the Flashpoint logo). */
+  image?: string;
 };
 
 // Presentation metadata per action — icon swaps when active, different
@@ -194,6 +196,7 @@ const preset = computed<Preset>(() => {
   if (props.action === "flashpoint") {
     return {
       icon: "mdi-rocket-launch-outline",
+      image: "/assets/scrappers/flashpoint.png",
       label: t("rom.open-in-flashpoint"),
       activeIcon: null,
       onClick: actions.openInFlashpoint,
@@ -499,7 +502,13 @@ function onClick(e: MouseEvent) {
     :aria-label="preset.label"
     @click="onClick"
   >
-    <RIcon :icon="displayedIcon" />
+    <img
+      v-if="preset.image"
+      :src="preset.image"
+      :alt="preset.label"
+      class="r-v2-game-btn__img"
+    />
+    <RIcon v-else :icon="displayedIcon" />
     <span v-if="withLabel" class="r-v2-game-btn__label">
       {{ preset.label }}
     </span>
@@ -559,6 +568,10 @@ function onClick(e: MouseEvent) {
 .r-v2-game-btn--x-small :deep(.mdi) {
   font-size: 14px;
 }
+.r-v2-game-btn--x-small :deep(img) {
+  width: 14px;
+  height: 14px;
+}
 .r-v2-game-btn--small {
   width: 28px;
   height: 28px;
@@ -566,6 +579,10 @@ function onClick(e: MouseEvent) {
 }
 .r-v2-game-btn--small :deep(.mdi) {
   font-size: 16px;
+}
+.r-v2-game-btn--small :deep(img) {
+  width: 16px;
+  height: 16px;
 }
 .r-v2-game-btn--default {
   width: 40px;
@@ -575,6 +592,10 @@ function onClick(e: MouseEvent) {
 .r-v2-game-btn--default :deep(.mdi) {
   font-size: 20px;
 }
+.r-v2-game-btn--default :deep(img) {
+  width: 20px;
+  height: 20px;
+}
 .r-v2-game-btn--large {
   width: 44px;
   height: 44px;
@@ -583,6 +604,10 @@ function onClick(e: MouseEvent) {
 .r-v2-game-btn--large :deep(.mdi) {
   font-size: 22px;
 }
+.r-v2-game-btn--large :deep(img) {
+  width: 22px;
+  height: 22px;
+}
 .r-v2-game-btn--x-large {
   width: 52px;
   height: 52px;
@@ -590,6 +615,10 @@ function onClick(e: MouseEvent) {
 }
 .r-v2-game-btn--x-large :deep(.mdi) {
   font-size: 26px;
+}
+.r-v2-game-btn--x-large :deep(img) {
+  width: 26px;
+  height: 26px;
 }
 
 /* Labelled — expands to a pill with text. Used by Play in the

--- a/frontend/src/v2/components/GameActions/GameActionBtn.vue
+++ b/frontend/src/v2/components/GameActions/GameActionBtn.vue
@@ -68,6 +68,7 @@ export type GameAction =
   | "download"
   | "copy-link"
   | "qr"
+  | "flashpoint"
   | "favorite"
   | "collection"
   | "status"
@@ -187,6 +188,15 @@ const preset = computed<Preset>(() => {
       label: t("rom.share-qr"),
       activeIcon: null,
       onClick: actions.shareQR,
+      active: false,
+    };
+  }
+  if (props.action === "flashpoint") {
+    return {
+      icon: "mdi-rocket-launch-outline",
+      label: t("rom.open-in-flashpoint"),
+      activeIcon: null,
+      onClick: actions.openInFlashpoint,
       active: false,
     };
   }

--- a/frontend/src/v2/components/GameActions/GameActions.vue
+++ b/frontend/src/v2/components/GameActions/GameActions.vue
@@ -86,6 +86,14 @@ useGridNav(rootEl, {
       variant="surface"
     />
     <GameActionBtn
+      v-if="actions.canOpenInFlashpoint.value"
+      :rom="rom"
+      action="flashpoint"
+      :size="btnSize"
+      variant="surface"
+      with-label
+    />
+    <GameActionBtn
       :rom="rom"
       action="favorite"
       :size="btnSize"

--- a/frontend/src/v2/components/GameActions/GameActions.vue
+++ b/frontend/src/v2/components/GameActions/GameActions.vue
@@ -91,7 +91,6 @@ useGridNav(rootEl, {
       action="flashpoint"
       :size="btnSize"
       variant="surface"
-      with-label
     />
     <GameActionBtn
       :rom="rom"

--- a/frontend/src/v2/components/GameActions/GameActionsList.vue
+++ b/frontend/src/v2/components/GameActions/GameActionsList.vue
@@ -56,6 +56,12 @@ function run(fn: () => void | Promise<void>) {
     icon="mdi-qrcode"
     @click="run(actions.shareQR)"
   />
+  <RMenuItem
+    v-if="actions.canOpenInFlashpoint.value"
+    :label="t('rom.open-in-flashpoint')"
+    icon="mdi-rocket-launch-outline"
+    @click="run(actions.openInFlashpoint)"
+  />
 
   <RDivider />
 

--- a/frontend/src/v2/composables/useGameActions/index.ts
+++ b/frontend/src/v2/composables/useGameActions/index.ts
@@ -39,10 +39,7 @@ export interface GameActionsOptions {
   coverEl?: () => HTMLElement | null;
 }
 
-// Flashpoint game IDs are UUIDs. Validate before feeding the value into the
-// `flashpoint://` URI so a malformed stored id (e.g. containing `#` or `?`,
-// which the URI parser would treat as a fragment/query) can't silently launch
-// the wrong title.
+// Validate flashpoint game IDs are UUIDs
 const FLASHPOINT_ID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -195,8 +192,6 @@ export function useGameActions(
     return rom ? isNintendoDSRom(rom) : false;
   });
 
-  // The stored `flashpoint_id` is the game's UUID, which the `flashpoint://`
-  // protocol handler resolves to launch the title locally.
   const canOpenInFlashpoint = computed(() => {
     const rom = getRom();
     return Boolean(
@@ -290,10 +285,7 @@ export function useGameActions(
     emitter?.emit("showQRCodeDialog", rom);
   }
 
-  // Hands the game's Flashpoint UUID to the OS `flashpoint://` protocol
-  // handler so the locally installed Flashpoint launcher starts it.
-  // We click a synthesized anchor rather than window.open so no blank
-  // tab is left behind when the handler takes over.
+  // Launch the game in installed Flashpoint
   function openInFlashpoint() {
     const rom = getRom();
     if (!rom?.flashpoint_id || !FLASHPOINT_ID_RE.test(rom.flashpoint_id))

--- a/frontend/src/v2/composables/useGameActions/index.ts
+++ b/frontend/src/v2/composables/useGameActions/index.ts
@@ -188,6 +188,13 @@ export function useGameActions(
     return rom ? isNintendoDSRom(rom) : false;
   });
 
+  // The stored `flashpoint_id` is the game's UUID, which the `flashpoint://`
+  // protocol handler resolves to launch the title locally.
+  const canOpenInFlashpoint = computed(() => {
+    const rom = getRom();
+    return Boolean(rom?.flashpoint_id);
+  });
+
   function play() {
     const rom = getRom();
     if (!rom) return;
@@ -272,6 +279,20 @@ export function useGameActions(
     const rom = getRom();
     if (!rom) return;
     emitter?.emit("showQRCodeDialog", rom);
+  }
+
+  // Hands the game's Flashpoint UUID to the OS `flashpoint://` protocol
+  // handler so the locally installed Flashpoint launcher starts it.
+  // We click a synthesized anchor rather than window.open so no blank
+  // tab is left behind when the handler takes over.
+  function openInFlashpoint() {
+    const rom = getRom();
+    if (!rom?.flashpoint_id) return;
+    const a = document.createElement("a");
+    a.href = `flashpoint://${rom.flashpoint_id}`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
   }
 
   // Copies the API download URL (origin + /api/roms/.../content/...) so
@@ -365,6 +386,7 @@ export function useGameActions(
     isFavorited,
     canManageCollections,
     canShareQR,
+    canOpenInFlashpoint,
     canPlay,
     canPlayStream,
     canRemoveFromContinuePlaying,
@@ -379,6 +401,7 @@ export function useGameActions(
     favorite,
     share,
     shareQR,
+    openInFlashpoint,
     copyDownloadLink,
     manageCollections,
     refreshMetadata,

--- a/frontend/src/v2/composables/useGameActions/index.ts
+++ b/frontend/src/v2/composables/useGameActions/index.ts
@@ -39,6 +39,13 @@ export interface GameActionsOptions {
   coverEl?: () => HTMLElement | null;
 }
 
+// Flashpoint game IDs are UUIDs. Validate before feeding the value into the
+// `flashpoint://` URI so a malformed stored id (e.g. containing `#` or `?`,
+// which the URI parser would treat as a fragment/query) can't silently launch
+// the wrong title.
+const FLASHPOINT_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export function useGameActions(
   getRom: () => SimpleRom | null | undefined,
   options: GameActionsOptions = {},
@@ -192,7 +199,9 @@ export function useGameActions(
   // protocol handler resolves to launch the title locally.
   const canOpenInFlashpoint = computed(() => {
     const rom = getRom();
-    return Boolean(rom?.flashpoint_id);
+    return Boolean(
+      rom?.flashpoint_id && FLASHPOINT_ID_RE.test(rom.flashpoint_id),
+    );
   });
 
   function play() {
@@ -287,7 +296,8 @@ export function useGameActions(
   // tab is left behind when the handler takes over.
   function openInFlashpoint() {
     const rom = getRom();
-    if (!rom?.flashpoint_id) return;
+    if (!rom?.flashpoint_id || !FLASHPOINT_ID_RE.test(rom.flashpoint_id))
+      return;
     const a = document.createElement("a");
     a.href = `flashpoint://${rom.flashpoint_id}`;
     document.body.appendChild(a);


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Adds a v2 game action, **Open in Flashpoint**, that launches a title in the locally installed [Flashpoint](https://flashpointarchive.org/) launcher.

When a ROM has a `flashpoint_id` (its Flashpoint game UUID, already present on the ROM schema), the action hands that UUID to the OS `flashpoint://<uuid>` protocol handler. The launch uses a synthesized, self-removing `<a>` element rather than `window.open`, so no blank tab is left behind when the handler takes over. The button/menu item only appears when the ROM actually has a `flashpoint_id`.

Changes:
- `useGameActions` composable: new `canOpenInFlashpoint` gate and `openInFlashpoint()` handler.
- `GameActionBtn.vue`: new `"flashpoint"` action + preset (`mdi-rocket-launch-outline`).
- `GameActions.vue` and `GameActionsList.vue`: render the action when available.
- Added the `rom.open-in-flashpoint` key to all 18 locales (English value; translators can localize later).

No backend changes are needed; `flashpoint_id` is already exposed on the ROM schema.

This is a frontend-v2-only feature, so it is gated behind the v2 UI.

**AI assistance disclosure:** This PR was implemented with AI assistance (Claude Code). The feature was reimplemented against the latest `master`, and all code and locale entries were AI-generated and human-reviewed.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)