### PR TITLE
Surface never-scanned platform folders in the scan picker

### DIFF
--- a/backend/endpoints/platform.py
+++ b/backend/endpoints/platform.py
@@ -23,7 +23,7 @@ from logger.formatter import highlight as hl
 from logger.logger import log
 from models.permission import PermAction, PermEntity
 from models.platform import Platform
-from utils.platforms import get_supported_platforms
+from utils.platforms import get_filesystem_platforms, get_supported_platforms
 from utils.router import APIRouter
 
 router = APIRouter(
@@ -96,6 +96,18 @@ def get_supported_platforms_endpoint(request: Request) -> list[PlatformSchema]:
     """Retrieve the list of supported platforms."""
 
     return get_supported_platforms()
+
+
+@protected_route(router.get, "/filesystem", [Scope.PLATFORMS_READ])
+async def get_filesystem_platforms_endpoint(request: Request) -> list[PlatformSchema]:
+    """Retrieve platform folders on disk that have no database row yet.
+
+    These folders (created for a platform but not scanned yet) are invisible
+    to the scan picker because they have no ROMs imported, so they carry no
+    database row. Returning them lets the UI offer a first scan for them.
+    """
+
+    return await get_filesystem_platforms()
 
 
 @protected_route(

--- a/backend/endpoints/platform.py
+++ b/backend/endpoints/platform.py
@@ -100,12 +100,7 @@ def get_supported_platforms_endpoint(request: Request) -> list[PlatformSchema]:
 
 @protected_route(router.get, "/filesystem", [Scope.PLATFORMS_READ])
 async def get_filesystem_platforms_endpoint(request: Request) -> list[PlatformSchema]:
-    """Retrieve platform folders on disk that have no database row yet.
-
-    These folders (created for a platform but not scanned yet) are invisible
-    to the scan picker because they have no ROMs imported, so they carry no
-    database row. Returning them lets the UI offer a first scan for them.
-    """
+    """Retrieve platform folders on disk that have no database row yet."""
 
     return await get_filesystem_platforms()
 

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -709,8 +709,7 @@ async def scan_platforms(
         metadata_sources (list[str]): List of metadata sources to be used
         scan_type (ScanType): Type of scan to be performed.
         roms_ids (list[int], optional): List of selected roms to be scanned.
-        platform_fs_slugs (list[str], optional): Filesystem slugs of folders to
-            scan that have no database row yet (never-scanned platforms).
+        platform_fs_slugs (list[str], optional): Folders to scan with no database row.
     """
     if not roms_ids:
         roms_ids = []
@@ -744,12 +743,7 @@ async def scan_platforms(
     db_platforms = db_platform_handler.get_platforms()
     db_platforms_by_slug = {p.fs_slug: p for p in db_platforms}
 
-    # Selected platforms arrive as database ids (existing platforms) and/or
-    # filesystem slugs (a folder can be an existing platform or one on disk
-    # without a database row yet). Both resolve to a folder slug the scanner
-    # walks. Known database platforms are always accepted; a bare slug is only
-    # accepted when it maps to a folder on disk. When nothing is selected,
-    # every filesystem platform is scanned.
+    # Selected platforms arrive as database ids and/or filesystem slugs.
     selected_slugs = [p.fs_slug for p in db_platforms if p.id in platform_ids]
     for fs_slug in platform_fs_slugs:
         if fs_slug in selected_slugs:
@@ -757,7 +751,8 @@ async def scan_platforms(
         if fs_slug in db_platforms_by_slug or fs_slug in fs_platforms:
             selected_slugs.append(fs_slug)
 
-    platform_list = sorted(selected_slugs or fs_platforms)
+    has_selection = bool(platform_ids or platform_fs_slugs)
+    platform_list = sorted(selected_slugs if has_selection else fs_platforms)
 
     # A "new platforms" scan skips platforms that already exist in the database,
     # so they must be excluded from the totals to keep the tracker accurate. This

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -700,6 +700,7 @@ async def scan_platforms(
     roms_ids: list[int] | None = None,
     launchbox_remote_enabled: bool = True,
     playmatch_enabled: bool = True,
+    platform_fs_slugs: list[str] | None = None,
 ) -> ScanStats:
     """Scan all the listed platforms and fetch metadata from different sources
 
@@ -708,9 +709,14 @@ async def scan_platforms(
         metadata_sources (list[str]): List of metadata sources to be used
         scan_type (ScanType): Type of scan to be performed.
         roms_ids (list[int], optional): List of selected roms to be scanned.
+        platform_fs_slugs (list[str], optional): Filesystem slugs of folders to
+            scan that have no database row yet (never-scanned platforms).
     """
     if not roms_ids:
         roms_ids = []
+
+    if not platform_fs_slugs:
+        platform_fs_slugs = []
 
     socket_manager = _get_socket_manager()
     scan_stats = ScanStats()
@@ -738,10 +744,20 @@ async def scan_platforms(
     db_platforms = db_platform_handler.get_platforms()
     db_platforms_by_slug = {p.fs_slug: p for p in db_platforms}
 
-    platform_list = [
-        p.fs_slug for p in db_platforms if p.id in platform_ids
-    ] or fs_platforms
-    platform_list = sorted(platform_list)
+    # Selected platforms arrive as database ids (existing platforms) and/or
+    # filesystem slugs (a folder can be an existing platform or one on disk
+    # without a database row yet). Both resolve to a folder slug the scanner
+    # walks. Known database platforms are always accepted; a bare slug is only
+    # accepted when it maps to a folder on disk. When nothing is selected,
+    # every filesystem platform is scanned.
+    selected_slugs = [p.fs_slug for p in db_platforms if p.id in platform_ids]
+    for fs_slug in platform_fs_slugs:
+        if fs_slug in selected_slugs:
+            continue
+        if fs_slug in db_platforms_by_slug or fs_slug in fs_platforms:
+            selected_slugs.append(fs_slug)
+
+    platform_list = sorted(selected_slugs or fs_platforms)
 
     # A "new platforms" scan skips platforms that already exist in the database,
     # so they must be excluded from the totals to keep the tracker accurate. This
@@ -904,6 +920,7 @@ async def scan_handler(sid: str, options: dict[str, Any]):
     log.info(f"{emoji.EMOJI_MAGNIFYING_GLASS_TILTED_RIGHT} Scanning")
 
     platform_ids = options.get("platforms", [])
+    platform_fs_slugs = options.get("platform_fs_slugs", [])
     scan_type = ScanType[options.get("type", "quick").upper()]
     roms_ids = options.get("roms_ids", [])
     metadata_sources = options.get("apis", [])
@@ -918,6 +935,7 @@ async def scan_handler(sid: str, options: dict[str, Any]):
             roms_ids=roms_ids,
             launchbox_remote_enabled=launchbox_remote_enabled,
             playmatch_enabled=playmatch_enabled,
+            platform_fs_slugs=platform_fs_slugs,
         )
 
     return high_prio_queue.enqueue(
@@ -928,6 +946,7 @@ async def scan_handler(sid: str, options: dict[str, Any]):
         roms_ids=roms_ids,
         launchbox_remote_enabled=launchbox_remote_enabled,
         playmatch_enabled=playmatch_enabled,
+        platform_fs_slugs=platform_fs_slugs,
         job_timeout=SCAN_TIMEOUT,  # Timeout (default of 4 hours)
         result_ttl=TASK_RESULT_TTL,
         meta={

--- a/backend/tests/endpoints/sockets/test_scan.py
+++ b/backend/tests/endpoints/sockets/test_scan.py
@@ -159,6 +159,19 @@ class TestScanTotals:
         assert result.total_platforms == 3
         assert result.total_roms == 300
 
+    async def test_scan_selected_filesystem_slug(self, patched, mocker):
+        """A never-scanned folder can be targeted by its filesystem slug."""
+        result = await scan_platforms(
+            platform_ids=[],
+            metadata_sources=[],
+            scan_type=ScanType.QUICK,
+            platform_fs_slugs=["new1"],
+        )
+
+        # Only the selected folder is scanned, not every filesystem platform.
+        assert result.total_platforms == 1
+        assert result.total_roms == 100
+
 
 class TestShouldScanRom:
     def test_new_platforms_scan_with_no_rom(self):

--- a/backend/tests/endpoints/test_platform.py
+++ b/backend/tests/endpoints/test_platform.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from fastapi import status
 
 
@@ -12,6 +14,33 @@ def test_get_platforms(client, access_token, platform):
 
     platforms = response.json()
     assert len(platforms) == 1
+
+
+def test_get_filesystem_platforms(client, access_token, platform):
+    with patch(
+        "utils.platforms.fs_platform_handler.get_platforms"
+    ) as mock_get_platforms:
+        # A folder already backed by a database row is excluded; a brand-new
+        # folder with no database row is returned as an id -1 / 0-rom entry.
+        mock_get_platforms.return_value = [platform.fs_slug, "segacd"]
+
+        response = client.get("/api/platforms/filesystem")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+        response = client.get(
+            "/api/platforms/filesystem",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+    platforms = response.json()
+    fs_slugs = [p["fs_slug"] for p in platforms]
+    assert platform.fs_slug not in fs_slugs
+    assert "segacd" in fs_slugs
+
+    segacd = next(p for p in platforms if p["fs_slug"] == "segacd")
+    assert segacd["id"] == -1
+    assert segacd["rom_count"] == 0
 
 
 def test_update_platform_custom_name(client, access_token, platform):

--- a/backend/utils/platforms.py
+++ b/backend/utils/platforms.py
@@ -20,12 +20,7 @@ from models.platform import Platform
 
 
 def _build_unmatched_platform(slug: str, fs_slug: str, now: datetime) -> PlatformSchema:
-    """Build a PlatformSchema for a platform that has no database row yet.
-
-    Metadata is resolved from the local provider catalogs only (no network
-    calls). The entry carries id -1 and rom_count 0, matching the shape used
-    for unmatched supported platforms.
-    """
+    """Build a PlatformSchema for a platform that has no database row yet."""
     igdb_platform = meta_igdb_handler.get_platform(slug)
     moby_platform = meta_moby_handler.get_platform(slug)
     ss_platform = meta_ss_handler.get_platform(slug)
@@ -124,14 +119,7 @@ def get_supported_platforms() -> list[PlatformSchema]:
 
 
 async def get_filesystem_platforms() -> list[PlatformSchema]:
-    """Get platform folders that exist on disk but have no database row yet.
-
-    A folder created for a platform (optionally bound in Library Management)
-    has no database row until its first scan imports a ROM, so it is invisible
-    to the scan platform picker. Surfacing these folders lets a first scan
-    target a brand-new platform. Slugs are resolved through the platform
-    binding/version config; metadata is resolved locally (no network calls).
-    """
+    """Get platform folders that exist on disk but have no database row yet."""
     cnfg = cm.get_config()
     fs_slugs = await fs_platform_handler.get_platforms()
     existing_fs_slugs = {p.fs_slug for p in db_platform_handler.get_platforms()}
@@ -139,6 +127,7 @@ async def get_filesystem_platforms() -> list[PlatformSchema]:
     now = datetime.now(timezone.utc)
     filesystem_platforms = []
 
+    # Build a platform for each folder on disk
     for fs_slug in fs_slugs:
         if fs_slug in existing_fs_slugs:
             continue

--- a/backend/utils/platforms.py
+++ b/backend/utils/platforms.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timezone
 
+from config.config_manager import config_manager as cm
 from endpoints.responses.platform import PlatformSchema
 from handler.database import db_platform_handler
+from handler.filesystem import fs_platform_handler
 from handler.metadata import (
     meta_flashpoint_handler,
     meta_hasheous_handler,
@@ -15,6 +17,74 @@ from handler.metadata import (
 )
 from handler.metadata.base_handler import UniversalPlatformSlug as UPS
 from models.platform import Platform
+
+
+def _build_unmatched_platform(slug: str, fs_slug: str, now: datetime) -> PlatformSchema:
+    """Build a PlatformSchema for a platform that has no database row yet.
+
+    Metadata is resolved from the local provider catalogs only (no network
+    calls). The entry carries id -1 and rom_count 0, matching the shape used
+    for unmatched supported platforms.
+    """
+    igdb_platform = meta_igdb_handler.get_platform(slug)
+    moby_platform = meta_moby_handler.get_platform(slug)
+    ss_platform = meta_ss_handler.get_platform(slug)
+    ra_platform = meta_ra_handler.get_platform(slug)
+    launchbox_platform = meta_launchbox_handler.get_platform(slug)
+    hasheous_platform = meta_hasheous_handler.get_platform(slug)
+    tgdb_platform = meta_tgdb_handler.get_platform(slug)
+    flashpoint_platform = meta_flashpoint_handler.get_platform(slug)
+    hltb_platform = meta_hltb_handler.get_platform(slug)
+
+    platform_attrs = {
+        "id": -1,
+        "name": slug.replace("-", " ").title(),
+        "fs_slug": fs_slug,
+        "slug": slug,
+        "roms": [],
+        "rom_count": 0,
+        "created_at": now,
+        "updated_at": now,
+        "fs_size_bytes": 0,
+        "missing_from_fs": False,
+    }
+
+    platform_attrs.update(
+        {
+            **hltb_platform,
+            **flashpoint_platform,
+            **hasheous_platform,
+            **tgdb_platform,
+            **launchbox_platform,
+            **ra_platform,
+            **moby_platform,
+            **ss_platform,
+            **igdb_platform,
+            "igdb_id": igdb_platform.get("igdb_id")
+            or hasheous_platform.get("igdb_id")
+            or None,
+            "ra_id": ra_platform.get("ra_id") or hasheous_platform.get("ra_id") or None,
+            "tgdb_id": moby_platform.get("tgdb_id")
+            or hasheous_platform.get("tgdb_id")
+            or tgdb_platform.get("tgdb_id")
+            or None,
+            "name": igdb_platform.get("name")
+            or ss_platform.get("name")
+            or moby_platform.get("name")
+            or ra_platform.get("name")
+            or launchbox_platform.get("name")
+            or hasheous_platform.get("name")
+            or tgdb_platform.get("name")
+            or flashpoint_platform.get("name")
+            or hltb_platform.get("name")
+            or slug.replace("-", " ").title(),
+            "url_logo": igdb_platform.get("url_logo")
+            or tgdb_platform.get("url_logo")
+            or "",
+        }
+    )
+
+    return PlatformSchema.model_validate(Platform(**platform_attrs))
 
 
 def get_supported_platforms() -> list[PlatformSchema]:
@@ -48,67 +118,36 @@ def get_supported_platforms() -> list[PlatformSchema]:
             supported_platforms.append(PlatformSchema.model_validate(db_platform))
             continue
 
-        igdb_platform = meta_igdb_handler.get_platform(slug)
-        moby_platform = meta_moby_handler.get_platform(slug)
-        ss_platform = meta_ss_handler.get_platform(slug)
-        ra_platform = meta_ra_handler.get_platform(slug)
-        launchbox_platform = meta_launchbox_handler.get_platform(slug)
-        hasheous_platform = meta_hasheous_handler.get_platform(slug)
-        tgdb_platform = meta_tgdb_handler.get_platform(slug)
-        flashpoint_platform = meta_flashpoint_handler.get_platform(slug)
-        hltb_platform = meta_hltb_handler.get_platform(slug)
-
-        platform_attrs = {
-            "id": -1,
-            "name": slug.replace("-", " ").title(),
-            "fs_slug": slug,
-            "slug": slug,
-            "roms": [],
-            "rom_count": 0,
-            "created_at": now,
-            "updated_at": now,
-            "fs_size_bytes": 0,
-            "missing_from_fs": False,
-        }
-
-        platform_attrs.update(
-            {
-                **hltb_platform,
-                **flashpoint_platform,
-                **hasheous_platform,
-                **tgdb_platform,
-                **launchbox_platform,
-                **ra_platform,
-                **moby_platform,
-                **ss_platform,
-                **igdb_platform,
-                "igdb_id": igdb_platform.get("igdb_id")
-                or hasheous_platform.get("igdb_id")
-                or None,
-                "ra_id": ra_platform.get("ra_id")
-                or hasheous_platform.get("ra_id")
-                or None,
-                "tgdb_id": moby_platform.get("tgdb_id")
-                or hasheous_platform.get("tgdb_id")
-                or tgdb_platform.get("tgdb_id")
-                or None,
-                "name": igdb_platform.get("name")
-                or ss_platform.get("name")
-                or moby_platform.get("name")
-                or ra_platform.get("name")
-                or launchbox_platform.get("name")
-                or hasheous_platform.get("name")
-                or tgdb_platform.get("name")
-                or flashpoint_platform.get("name")
-                or hltb_platform.get("name")
-                or slug.replace("-", " ").title(),
-                "url_logo": igdb_platform.get("url_logo")
-                or tgdb_platform.get("url_logo")
-                or "",
-            }
-        )
-
-        platform = Platform(**platform_attrs)
-        supported_platforms.append(PlatformSchema.model_validate(platform))
+        supported_platforms.append(_build_unmatched_platform(slug, slug, now))
 
     return supported_platforms
+
+
+async def get_filesystem_platforms() -> list[PlatformSchema]:
+    """Get platform folders that exist on disk but have no database row yet.
+
+    A folder created for a platform (optionally bound in Library Management)
+    has no database row until its first scan imports a ROM, so it is invisible
+    to the scan platform picker. Surfacing these folders lets a first scan
+    target a brand-new platform. Slugs are resolved through the platform
+    binding/version config; metadata is resolved locally (no network calls).
+    """
+    cnfg = cm.get_config()
+    fs_slugs = await fs_platform_handler.get_platforms()
+    existing_fs_slugs = {p.fs_slug for p in db_platform_handler.get_platforms()}
+
+    now = datetime.now(timezone.utc)
+    filesystem_platforms = []
+
+    for fs_slug in fs_slugs:
+        if fs_slug in existing_fs_slugs:
+            continue
+
+        slug = (
+            cnfg.PLATFORMS_BINDING.get(fs_slug)
+            or cnfg.PLATFORMS_VERSIONS.get(fs_slug)
+            or fs_slug
+        )
+        filesystem_platforms.append(_build_unmatched_platform(slug, fs_slug, now))
+
+    return filesystem_platforms

--- a/frontend/src/locales/bg_BG/scan.json
+++ b/frontend/src/locales/bg_BG/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "Намерен фърмуер: {n} файл | Намерен фърмуер: {n} файла",
   "firmware-scanned-n": "Фърмуер: {n} сканирани",
   "firmware-scanned-with-details": "Фърмуер: {n_scanned_firmware} сканирани, от които {n_new_firmware} нови",
+  "folder-not-scanned": "Не сканирано",
   "hash-calculation-disabled": "Изчисляването на хешове е деактивирано",
   "hash-matchers": "Хеш разпознавачи",
   "hashes": "Преизчисли хешове",

--- a/frontend/src/locales/cs_CZ/scan.json
+++ b/frontend/src/locales/cs_CZ/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "Firmware nalezen: {n} soubor | Firmware nalezen: {n} soubory",
   "firmware-scanned-n": "Firmware: {n} naskenováno",
   "firmware-scanned-with-details": "Firmware: naskenováno {n_scanned_firmware}, z toho {n_new_firmware} nových",
+  "folder-not-scanned": "Neskenováno",
   "hash-calculation-disabled": "Výpočet hash je zakázán",
   "hash-matchers": "Párovače hashů",
   "hashes": "Přepočítat hashe",

--- a/frontend/src/locales/de_DE/scan.json
+++ b/frontend/src/locales/de_DE/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "Firmware gefunden: {n} Datei | Firmware gefunden: {n} Dateien",
   "firmware-scanned-n": "Firmware: {n} gescannt",
   "firmware-scanned-with-details": "Firmware: {n_scanned_firmware} gescannt, davon {n_new_firmware} neu",
+  "folder-not-scanned": "Nicht gescannt",
   "hash-calculation-disabled": "Hash-Berechnung ist deaktiviert",
   "hash-matchers": "Hash-Matcher",
   "hashes": "Hashes neu berechnen",

--- a/frontend/src/locales/en_GB/scan.json
+++ b/frontend/src/locales/en_GB/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "Firmware found: {n} file | Firmware found: {n} files",
   "firmware-scanned-n": "Firmware: {n} scanned",
   "firmware-scanned-with-details": "Firmware: {n_scanned_firmware} scanned, with {n_new_firmware} new",
+  "folder-not-scanned": "Not scanned",
   "hash-calculation-disabled": "Hash calculation is disabled",
   "hash-matchers": "Hash matchers",
   "hashes": "Recalculate hashes",

--- a/frontend/src/locales/en_US/scan.json
+++ b/frontend/src/locales/en_US/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "Firmware found: {n} file | Firmware found: {n} files",
   "firmware-scanned-n": "Firmware: {n} scanned",
   "firmware-scanned-with-details": "Firmware: {n_scanned_firmware} scanned, with {n_new_firmware} new",
+  "folder-not-scanned": "Not scanned",
   "hash-calculation-disabled": "Hash calculation is disabled",
   "hash-matchers": "Hash matchers",
   "hashes": "Recalculate hashes",

--- a/frontend/src/locales/es_ES/scan.json
+++ b/frontend/src/locales/es_ES/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "Firmware encontrado: {n} archivo | Firmware encontrado: {n} archivos",
   "firmware-scanned-n": "Firmware: {n} analizado",
   "firmware-scanned-with-details": "Firmware: {n_scanned_firmware} analizados, con {n_new_firmware} nuevos",
+  "folder-not-scanned": "Sin escanear",
   "hash-calculation-disabled": "El cálculo de hash está deshabilitado",
   "hash-matchers": "Emparejadores por hash",
   "hashes": "Recalcular hashes",

--- a/frontend/src/locales/fr_FR/scan.json
+++ b/frontend/src/locales/fr_FR/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "Firmware trouvé : {n} fichier | Firmware trouvé : {n} fichiers",
   "firmware-scanned-n": "Firmware : {n} analysé",
   "firmware-scanned-with-details": "Firmware : {n_scanned_firmware} analysés, dont {n_new_firmware} nouveaux",
+  "folder-not-scanned": "Non scanné",
   "hash-calculation-disabled": "Le calcul de hachage est désactivé",
   "hash-matchers": "Comparateurs par hachage",
   "hashes": "Recalculer les hachages",

--- a/frontend/src/locales/hu_HU/scan.json
+++ b/frontend/src/locales/hu_HU/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "Firmware található: {n} fájl | Firmware található: {n} fájl",
   "firmware-scanned-n": "Firmware: {n} beolvasva",
   "firmware-scanned-with-details": "Firmware: {n_scanned_firmware} beolvasva, ebből {n_new_firmware} új",
+  "folder-not-scanned": "Nincs beolvasva",
   "hash-calculation-disabled": "A hash számítás le van tiltva",
   "hash-matchers": "Hash-egyeztetők",
   "hashes": "Hash-értékek újraszámítása",

--- a/frontend/src/locales/it_IT/scan.json
+++ b/frontend/src/locales/it_IT/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "Firmware trovato: {n} file | Firmware trovati: {n} file",
   "firmware-scanned-n": "Firmware: {n} scansionato",
   "firmware-scanned-with-details": "Firmware: {n_scanned_firmware} scansionati, di cui {n_new_firmware} nuovi",
+  "folder-not-scanned": "Non scansionato",
   "hash-calculation-disabled": "Il calcolo dell'hash è disabilitato",
   "hash-matchers": "Matcher per hash",
   "hashes": "Ricalcola hash",

--- a/frontend/src/locales/ja_JP/scan.json
+++ b/frontend/src/locales/ja_JP/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "ファームウェアが見つかりました: {n} ファイル | ファームウェアが見つかりました: {n} ファイル",
   "firmware-scanned-n": "ファームウェア: {n} 件をスキャン",
   "firmware-scanned-with-details": "ファームウェア: {n_scanned_firmware} 件をスキャン、うち新規 {n_new_firmware} 件",
+  "folder-not-scanned": "未スキャン",
   "hash-calculation-disabled": "ハッシュ計算が無効になっています",
   "hash-matchers": "ハッシュマッチャー",
   "hashes": "ハッシュ値の再計算",

--- a/frontend/src/locales/ko_KR/scan.json
+++ b/frontend/src/locales/ko_KR/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "펌웨어 발견: {n}개 파일 | 펌웨어 발견: {n}개 파일",
   "firmware-scanned-n": "펌웨어: {n}개 스캔됨",
   "firmware-scanned-with-details": "펌웨어: {n_scanned_firmware}개 스캔됨, 새 항목 {n_new_firmware}개",
+  "folder-not-scanned": "스캔되지 않음",
   "hash-calculation-disabled": "해시 계산이 비활성화되어 있습니다",
   "hash-matchers": "해시 매처",
   "hashes": "해시",

--- a/frontend/src/locales/pl_PL/scan.json
+++ b/frontend/src/locales/pl_PL/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "Odnaleziono firmware: {n} plik | Odnaleziono firmware: {n} pliki",
   "firmware-scanned-n": "Firmware: zeskanowano {n}",
   "firmware-scanned-with-details": "Firmware: zeskanowano {n_scanned_firmware}, w tym {n_new_firmware} nowych",
+  "folder-not-scanned": "Nie zeskanowano",
   "hash-calculation-disabled": "Obliczanie skrótów jest wyłączone",
   "hash-matchers": "Dopasowywacze hashy",
   "hashes": "Przelicz sumy kontrolne",

--- a/frontend/src/locales/pt_BR/scan.json
+++ b/frontend/src/locales/pt_BR/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "Firmware encontrado: {n} arquivo | Firmware encontrado: {n} arquivos",
   "firmware-scanned-n": "Firmware: {n} escaneado",
   "firmware-scanned-with-details": "Firmware: {n_scanned_firmware} escaneados, com {n_new_firmware} novos",
+  "folder-not-scanned": "Não escaneado",
   "hash-calculation-disabled": "O cálculo de hash está desabilitado",
   "hash-matchers": "Correspondência por hash",
   "hashes": "Recalcular hashes",

--- a/frontend/src/locales/ro_RO/scan.json
+++ b/frontend/src/locales/ro_RO/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "Firmware găsit: {n} fișier | Firmware găsit: {n} fișiere",
   "firmware-scanned-n": "Firmware: {n} scanat",
   "firmware-scanned-with-details": "Firmware: {n_scanned_firmware} scanate, dintre care {n_new_firmware} noi",
+  "folder-not-scanned": "Nescanat",
   "hash-calculation-disabled": "Calculul hash-ului este dezactivat",
   "hash-matchers": "Asocieri pe bază de hash",
   "hashes": "Recalculează hash-urile",

--- a/frontend/src/locales/ru_RU/scan.json
+++ b/frontend/src/locales/ru_RU/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "Найдено прошивок: {n} файл | Найдено прошивок: {n} файлов",
   "firmware-scanned-n": "Прошивки: отсканировано {n}",
   "firmware-scanned-with-details": "Прошивки: отсканировано {n_scanned_firmware}, новых {n_new_firmware}",
+  "folder-not-scanned": "Не отсканировано",
   "hash-calculation-disabled": "Вычисление хешей отключено",
   "hash-matchers": "Сопоставители по хешу",
   "hashes": "Пересчитать хеши",

--- a/frontend/src/locales/tr_TR/scan.json
+++ b/frontend/src/locales/tr_TR/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "Firmware bulundu: {n} dosya | Firmware bulundu: {n} dosya",
   "firmware-scanned-n": "Firmware: {n} tarandı",
   "firmware-scanned-with-details": "Firmware: {n_scanned_firmware} tarandı, {n_new_firmware} yeni",
+  "folder-not-scanned": "Taranmadı",
   "hash-calculation-disabled": "Hash hesaplama devre dışı",
   "hash-matchers": "Hash eşleştiriciler",
   "hashes": "Hash değerlerini yeniden hesapla",

--- a/frontend/src/locales/zh_CN/scan.json
+++ b/frontend/src/locales/zh_CN/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "发现固件：{n} 个文件 | 发现固件：{n} 个文件",
   "firmware-scanned-n": "固件：已扫描 {n} 个",
   "firmware-scanned-with-details": "固件：已扫描 {n_scanned_firmware} 个，新增 {n_new_firmware} 个",
+  "folder-not-scanned": "未扫描",
   "hash-calculation-disabled": "哈希计算已禁用",
   "hash-matchers": "哈希匹配器",
   "hashes": "哈希",

--- a/frontend/src/locales/zh_TW/scan.json
+++ b/frontend/src/locales/zh_TW/scan.json
@@ -19,6 +19,7 @@
   "firmware-found": "發現韌體：{n} 個檔案 | 發現韌體：{n} 個檔案",
   "firmware-scanned-n": "韌體：已掃描 {n} 個",
   "firmware-scanned-with-details": "韌體：已掃描 {n_scanned_firmware} 個，新增 {n_new_firmware} 個",
+  "folder-not-scanned": "未掃描",
   "hash-calculation-disabled": "雜湊計算已停用",
   "hash-matchers": "雜湊匹配器",
   "hashes": "雜湊",

--- a/frontend/src/services/api/platform.ts
+++ b/frontend/src/services/api/platform.ts
@@ -25,6 +25,10 @@ async function getSupportedPlatforms() {
   return api.get<Platform[]>("/platforms/supported");
 }
 
+async function getFilesystemPlatforms() {
+  return api.get<Platform[]>("/platforms/filesystem");
+}
+
 async function updatePlatform({ platform }: { platform: Platform }) {
   return api.put<Platform>(`/platforms/${platform.id}`, {
     custom_name: platform.custom_name,
@@ -40,6 +44,7 @@ export default {
   getPlatforms,
   getPlatform,
   getSupportedPlatforms,
+  getFilesystemPlatforms,
   updatePlatform,
   deletePlatform,
 };

--- a/frontend/src/stores/platforms.ts
+++ b/frontend/src/stores/platforms.ts
@@ -8,6 +8,10 @@ export type Platform = PlatformSchema;
 export default defineStore("platforms", {
   state: () => ({
     allPlatforms: [] as Platform[],
+    // Folders on disk that have no database row yet (never-scanned
+    // platforms). Fetched on demand by the scan view so a first scan can
+    // target them. They carry id -1 and rom_count 0.
+    filesystemPlatforms: [] as Platform[],
     filterText: "" as string,
     fetchingPlatforms: false as boolean,
   }),
@@ -27,6 +31,14 @@ export default defineStore("platforms", {
             p.display_name.toLowerCase().includes(filterText.toLowerCase()),
         )
         .sort((a, b) => a.display_name.localeCompare(b.display_name)),
+    // Everything a scan can target: existing database platforms (including
+    // those with zero ROMs) plus unscanned folders on disk. Keyed by fs_slug
+    // downstream, so the two sets never overlap (a folder with a database row
+    // is excluded from filesystemPlatforms server-side).
+    scannablePlatforms: ({ allPlatforms: all, filesystemPlatforms: fs }) =>
+      [...all, ...fs].sort((a, b) =>
+        a.display_name.localeCompare(b.display_name),
+      ),
   },
 
   actions: {
@@ -55,6 +67,20 @@ export default defineStore("platforms", {
           });
       });
     },
+    fetchFilesystemPlatforms(): Promise<Platform[]> {
+      return new Promise((resolve, reject) => {
+        platformApi
+          .getFilesystemPlatforms()
+          .then(({ data: platforms }) => {
+            this.filesystemPlatforms = platforms;
+            resolve(platforms);
+          })
+          .catch((error) => {
+            console.error(error);
+            reject(error);
+          });
+      });
+    },
     set(platforms: Platform[]) {
       this.allPlatforms = platforms;
     },
@@ -80,6 +106,7 @@ export default defineStore("platforms", {
     },
     reset() {
       this.allPlatforms = [] as Platform[];
+      this.filesystemPlatforms = [] as Platform[];
       this.filterText = "";
     },
   },

--- a/frontend/src/stores/platforms.ts
+++ b/frontend/src/stores/platforms.ts
@@ -8,9 +8,6 @@ export type Platform = PlatformSchema;
 export default defineStore("platforms", {
   state: () => ({
     allPlatforms: [] as Platform[],
-    // Folders on disk that have no database row yet (never-scanned
-    // platforms). Fetched on demand by the scan view so a first scan can
-    // target them. They carry id -1 and rom_count 0.
     filesystemPlatforms: [] as Platform[],
     filterText: "" as string,
     fetchingPlatforms: false as boolean,
@@ -31,12 +28,9 @@ export default defineStore("platforms", {
             p.display_name.toLowerCase().includes(filterText.toLowerCase()),
         )
         .sort((a, b) => a.display_name.localeCompare(b.display_name)),
-    // Everything a scan can target: existing database platforms (including
-    // those with zero ROMs) plus unscanned folders on disk. Keyed by fs_slug
-    // downstream, so the two sets never overlap (a folder with a database row
-    // is excluded from filesystemPlatforms server-side).
+    // Existing database platforms + unscanned folders on disk
     scannablePlatforms: ({ allPlatforms: all, filesystemPlatforms: fs }) =>
-      [...all, ...fs].sort((a, b) =>
+      uniqBy([...all, ...fs], "fs_slug").sort((a, b) =>
         a.display_name.localeCompare(b.display_name),
       ),
   },

--- a/frontend/src/v2/components/shared/PlatformSelect.vue
+++ b/frontend/src/v2/components/shared/PlatformSelect.vue
@@ -80,9 +80,8 @@ interface Props {
   modelValue?: number | string | number[] | string[] | null;
   items: Platform[];
   /** Which Platform field the v-model binds to. Default `id`.
-   *  `slug` is used by FolderMapping (the table works in slug space);
-   *  `fs_slug` is used by Scan, whose list mixes database platforms and
-   *  never-scanned folders (which share no stable numeric id). */
+   *  `slug` is used by FolderMapping (the table works in slug space)
+   *  `fs_slug` is used by Scan (mixes database platforms and folders) */
   itemKey?: PlatformKey;
   multiple?: boolean;
   searchable?: boolean;
@@ -105,12 +104,9 @@ interface Props {
   prependInnerIcon?: string;
   /** Scan-style rich row — category icon, family, missing-fs, rom-count. */
   showMeta?: boolean;
-  /** Tag entries with no database row yet (id < 0) as never-scanned
-   *  folders. Opt-in so only the Scan picker, whose list includes
-   *  filesystem folders, shows the marker. Requires `showMeta`. */
+  /** Never-scanned folders. */
   markUnscanned?: boolean;
-  /** Label for the never-scanned marker (i18n comes from the caller since
-   *  primitives/shared composites take text via props). */
+  /** Label for the never-scanned marker */
   unscannedLabel?: string;
   /** Icon size inside list rows. Defaults to 28 (Scan uses 32, dialogs 22-24). */
   iconSize?: number;

--- a/frontend/src/v2/components/shared/PlatformSelect.vue
+++ b/frontend/src/v2/components/shared/PlatformSelect.vue
@@ -238,7 +238,7 @@ function onUpdate(v: unknown) {
     <!-- Item — consumer slot wins; otherwise icon + name (+ meta). -->
     <template #item="slotProps">
       <slot name="item" v-bind="slotProps">
-        <li v-bind="slotProps.props">
+        <li v-bind="slotProps.props" class="r-v2-platsel__row">
           <RPlatformIcon
             :key="(slotProps.item.raw as Platform).slug"
             :slug="(slotProps.item.raw as Platform).slug"
@@ -356,12 +356,31 @@ function onUpdate(v: unknown) {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.r-v2-platsel__row {
+  container-name: r-v2-platsel__row;
+  container-type: inline-size;
+}
 .r-v2-platsel__meta {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   margin-left: auto;
   color: var(--r-color-fg-muted);
+}
+
+/* Narrow: shed the low-priority descriptors. */
+@container r-v2-platsel__row (max-width: 560px) {
+  .r-v2-platsel__fs-slug,
+  .r-v2-platsel__family,
+  .r-v2-platsel__meta-icon {
+    display: none;
+  }
+}
+/* Narrower still: drop the scrapper match strip too. */
+@container r-v2-platsel__row (max-width: 400px) {
+  .r-v2-platsel__scrappers {
+    display: none;
+  }
 }
 .r-v2-platsel__meta-icon {
   flex-shrink: 0;

--- a/frontend/src/v2/components/shared/PlatformSelect.vue
+++ b/frontend/src/v2/components/shared/PlatformSelect.vue
@@ -74,13 +74,15 @@ function activeScrappers(p: Platform) {
 
 defineOptions({ inheritAttrs: false });
 
-type PlatformKey = "id" | "slug";
+type PlatformKey = "id" | "slug" | "fs_slug";
 
 interface Props {
   modelValue?: number | string | number[] | string[] | null;
   items: Platform[];
   /** Which Platform field the v-model binds to. Default `id`.
-   *  `slug` is used by FolderMapping (the table works in slug space). */
+   *  `slug` is used by FolderMapping (the table works in slug space);
+   *  `fs_slug` is used by Scan, whose list mixes database platforms and
+   *  never-scanned folders (which share no stable numeric id). */
   itemKey?: PlatformKey;
   multiple?: boolean;
   searchable?: boolean;
@@ -103,6 +105,13 @@ interface Props {
   prependInnerIcon?: string;
   /** Scan-style rich row — category icon, family, missing-fs, rom-count. */
   showMeta?: boolean;
+  /** Tag entries with no database row yet (id < 0) as never-scanned
+   *  folders. Opt-in so only the Scan picker, whose list includes
+   *  filesystem folders, shows the marker. Requires `showMeta`. */
+  markUnscanned?: boolean;
+  /** Label for the never-scanned marker (i18n comes from the caller since
+   *  primitives/shared composites take text via props). */
+  unscannedLabel?: string;
   /** Icon size inside list rows. Defaults to 28 (Scan uses 32, dialogs 22-24). */
   iconSize?: number;
 }
@@ -126,6 +135,8 @@ const props = withDefaults(defineProps<Props>(), {
   prefixLabel: undefined,
   prependInnerIcon: undefined,
   showMeta: false,
+  markUnscanned: false,
+  unscannedLabel: undefined,
   iconSize: 28,
 });
 
@@ -248,6 +259,18 @@ function onUpdate(v: unknown) {
                 class="r-v2-platsel__fs-slug"
                 :text="(slotProps.item.raw as Platform).fs_slug"
               />
+              <RTag
+                v-if="
+                  markUnscanned &&
+                  unscannedLabel &&
+                  (slotProps.item.raw as Platform).id < 0
+                "
+                size="x-small"
+                tone="info"
+                prepend-icon="mdi-folder-plus-outline"
+                class="r-v2-platsel__unscanned"
+                :text="unscannedLabel"
+              />
               <RIcon
                 v-if="(slotProps.item.raw as Platform).category"
                 :icon="
@@ -361,6 +384,9 @@ function onUpdate(v: unknown) {
   font-family: var(--r-font-family-mono);
   font-size: 10.5px;
   text-transform: lowercase;
+}
+.r-v2-platsel__unscanned {
+  flex-shrink: 0;
 }
 .r-v2-platsel__scrappers {
   display: inline-flex;

--- a/frontend/src/v2/views/Scan.vue
+++ b/frontend/src/v2/views/Scan.vue
@@ -75,13 +75,9 @@ const { scannablePlatforms } = storeToRefs(platformsStore);
 const configStore = storeConfig();
 const { config } = storeToRefs(configStore);
 const heartbeat = storeHeartbeat();
-// Selection is keyed by fs_slug: the scan list mixes database platforms
-// (including zero-ROM ones) and never-scanned folders that share no stable
-// numeric id, and the backend scans folder slugs regardless.
 const platformsToScan = ref<string[]>([]);
 
-// Never-scanned folders have no database row, so they are fetched on demand
-// rather than living in the globally-loaded platform list.
+// Never-scanned folders are fetched on demand.
 onMounted(() => {
   platformsStore.fetchFilesystemPlatforms();
 });

--- a/frontend/src/v2/views/Scan.vue
+++ b/frontend/src/v2/views/Scan.vue
@@ -43,7 +43,7 @@ import {
 } from "@v2/lib";
 import { useLocalStorage } from "@vueuse/core";
 import { storeToRefs } from "pinia";
-import { computed, nextTick, ref, useTemplateRef, watch } from "vue";
+import { computed, nextTick, onMounted, ref, useTemplateRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { ROUTES } from "@/plugins/router";
 import socket from "@/services/socket";
@@ -71,11 +71,20 @@ const { t } = useI18n();
 const scanningStore = storeScanning();
 const { scanning, scanningPlatforms, scanStats } = storeToRefs(scanningStore);
 const platformsStore = storePlatforms();
-const { filteredPlatforms } = storeToRefs(platformsStore);
+const { scannablePlatforms } = storeToRefs(platformsStore);
 const configStore = storeConfig();
 const { config } = storeToRefs(configStore);
 const heartbeat = storeHeartbeat();
-const platformsToScan = ref<number[]>([]);
+// Selection is keyed by fs_slug: the scan list mixes database platforms
+// (including zero-ROM ones) and never-scanned folders that share no stable
+// numeric id, and the backend scans folder slugs regardless.
+const platformsToScan = ref<string[]>([]);
+
+// Never-scanned folders have no database row, so they are fetched on demand
+// rather than living in the globally-loaded platform list.
+onMounted(() => {
+  platformsStore.fetchFilesystemPlatforms();
+});
 // IDs of platforms whose ScanPlatform panel is currently open.
 const openPlatforms = ref<Set<number>>(new Set());
 
@@ -90,7 +99,7 @@ const scanLog = useTemplateRef<HTMLDivElement>("scan-log");
 const infoDialogOpen = ref(false);
 
 const sortedPlatforms = computed(() =>
-  [...filteredPlatforms.value].sort((a, b) =>
+  [...scannablePlatforms.value].sort((a, b) =>
     a.display_name.localeCompare(b.display_name),
   ),
 );
@@ -445,7 +454,7 @@ function scan() {
   );
 
   socket.emit("scan", {
-    platforms: platformsToScan.value,
+    platform_fs_slugs: platformsToScan.value,
     type: scanType.value,
     apis,
     launchbox_remote_enabled: launchboxRemoteEnabled.value,
@@ -493,6 +502,7 @@ function stopScan() {
           <PlatformSelect
             v-model="platformsToScan"
             :items="sortedPlatforms"
+            item-key="fs_slug"
             :label="t('common.platforms')"
             prepend-inner-icon="mdi-controller"
             :icon-size="32"
@@ -501,6 +511,8 @@ function stopScan() {
             hide-details
             chips
             show-meta
+            mark-unscanned
+            :unscanned-label="t('scan.folder-not-scanned')"
             show-all-option
           />
         </section>


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3832.

A platform folder created on disk (and optionally bound in Library Management) has **no database row** until its first scan imports a ROM, so it was invisible to the Scan platform picker and a first scan could not be triggered for it. The picker also filtered to `rom_count > 0`, hiding even zero-ROM database platforms (e.g. ones created via `romm-cli`). The backend scanner already works in folder-slug space, so the gap was purely that a never-scanned folder could not be seen or targeted.

**Backend**

- `utils/platforms.py`: extracted the shared "build a `PlatformSchema` from local metadata" logic into `_build_unmatched_platform()`, and added `get_filesystem_platforms()` returning folders on disk without a database row yet (slug resolved via `PLATFORMS_BINDING`/`PLATFORMS_VERSIONS`, `id: -1`, `rom_count: 0`, no network calls).
- `endpoints/platform.py`: new `GET /platforms/filesystem` (scope `PLATFORMS_READ`), declared before `/{id}`.
- `endpoints/sockets/scan.py`: `scan_platforms()` and the `scan` socket handler accept `platform_fs_slugs`. Selected database platforms (by id or slug) are always honored; a bare slug is accepted when it maps to a folder on disk; an empty selection still scans everything.

**Frontend (v2, the default UI)**

- `services/api/platform.ts` + `stores/platforms.ts`: `getFilesystemPlatforms()`, a `filesystemPlatforms` state slice, `fetchFilesystemPlatforms()`, and a `scannablePlatforms` getter (all database platforms **including zero-ROM** plus unscanned folders).
- `v2/components/shared/PlatformSelect.vue`: supports `item-key="fs_slug"` and an opt-in `mark-unscanned` + `unscanned-label` marker for `id < 0` folders.
- `v2/views/Scan.vue`: the picker is keyed by `fs_slug`, fetches filesystem folders on mount, tags never-scanned folders, and emits `platform_fs_slugs`.
- Added the `scan.folder-not-scanned` key, translated across all 18 locales.

v1 (`src/views/Scan.vue`) is frozen and left unchanged; it keeps working against the backwards-compatible backend (it still sends platform ids).

**AI assistance disclosure**

This PR was written with AI assistance (Claude Code, Opus 4.8). The implementation, tests, and translations were AI-generated and reviewed by the author.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A — verified via typecheck, backend + frontend test suites, i18n parity/sort checks, and Trunk. A full in-browser pass (both themes / input modalities) was not run and is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)