### PR TITLE
fix: enforce hidden-ROM/platform visibility on asset download and streaming endpoints

### DIFF
--- a/backend/endpoints/saves.py
+++ b/backend/endpoints/saves.py
@@ -12,6 +12,7 @@ from endpoints.responses.assets import SaveSchema, SaveSummarySchema, SlotSummar
 from endpoints.responses.device import DeviceSyncSchema
 from exceptions.endpoint_exceptions import RomNotFoundInDatabaseException
 from handler.auth.constants import Scope
+from handler.auth.dependencies import assert_rom_visible
 from handler.database import (
     db_device_handler,
     db_device_save_sync_handler,
@@ -482,6 +483,13 @@ def download_save(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Save with ID {id} not found",
         )
+
+    # Sharing must not override the hidden-ROM/platform policy: a save on a ROM
+    # hidden from the caller stays 404-masked, just like the ROM itself.
+    assert_rom_visible(
+        request, save.rom, not_found_detail=f"Save with ID {id} not found"
+    )
+
     is_owner = save.user_id == request.user.id
 
     try:

--- a/backend/endpoints/screenshots.py
+++ b/backend/endpoints/screenshots.py
@@ -9,6 +9,7 @@ from decorators.auth import protected_route
 from endpoints.responses.assets import ScreenshotSchema
 from exceptions.endpoint_exceptions import RomNotFoundInDatabaseException
 from handler.auth.constants import Scope
+from handler.auth.dependencies import assert_rom_visible
 from handler.database import db_rom_handler, db_screenshot_handler
 from handler.filesystem import fs_asset_handler
 from handler.filesystem.assets_handler import build_asset_file_response
@@ -136,6 +137,10 @@ def download_screenshot(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Screenshot not found",
         )
+
+    # Sharing must not override the hidden-ROM/platform policy: a screenshot on a
+    # ROM hidden from the caller stays 404-masked, just like the ROM itself.
+    assert_rom_visible(request, screenshot.rom, not_found_detail="Screenshot not found")
 
     try:
         file_path = fs_asset_handler.validate_path(screenshot.full_path)

--- a/backend/endpoints/states.py
+++ b/backend/endpoints/states.py
@@ -8,6 +8,7 @@ from decorators.auth import protected_route
 from endpoints.responses.assets import StateSchema
 from exceptions.endpoint_exceptions import RomNotFoundInDatabaseException
 from handler.auth.constants import Scope
+from handler.auth.dependencies import assert_rom_visible
 from handler.database import db_rom_handler, db_screenshot_handler, db_state_handler
 from handler.filesystem import fs_asset_handler
 from handler.filesystem.assets_handler import build_asset_file_response
@@ -220,6 +221,12 @@ def download_state(request: Request, id: int) -> FileResponse:
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"State with ID {id} not found",
         )
+
+    # Sharing must not override the hidden-ROM/platform policy: a state on a ROM
+    # hidden from the caller stays 404-masked, just like the ROM itself.
+    assert_rom_visible(
+        request, state.rom, not_found_detail=f"State with ID {id} not found"
+    )
 
     try:
         file_path = fs_asset_handler.validate_path(state.full_path)

--- a/backend/endpoints/streaming.py
+++ b/backend/endpoints/streaming.py
@@ -15,6 +15,7 @@ from config import LIBRARY_BASE_PATH, STREAMING_BROKER_SECRET, STREAMING_SAVE_TI
 from config.config_manager import config_manager as cm
 from decorators.auth import protected_route
 from handler.auth.constants import Scope
+from handler.auth.dependencies import assert_rom_visible
 from handler.database import db_rom_handler
 from handler.redis_handler import async_cache
 from models.user import Role
@@ -506,6 +507,11 @@ async def claim_session(
     rom = db_rom_handler.get_rom(req.rom_id)
     if rom is None:
         raise HTTPException(status_code=404, detail="ROM not found")
+
+    # A hidden ROM/platform must not be launchable via its id: enforce the same
+    # visibility policy as the ROM detail/content endpoints before any broker
+    # launch. Raises a 404 that masks the hidden ROM's existence.
+    assert_rom_visible(request, rom, not_found_detail="ROM not found")
 
     container = _container_for_platform(rom.platform_slug)
     if container is None:

--- a/backend/tests/endpoints/test_saves.py
+++ b/backend/tests/endpoints/test_saves.py
@@ -13,11 +13,18 @@ from handler.database import (
     db_device_save_sync_handler,
     db_save_handler,
 )
+from handler.database.base_handler import sync_session
 from models.assets import Save
 from models.device import Device
+from models.permission import HiddenEntity, PermEntity
 from models.platform import Platform
 from models.rom import Rom
 from models.user import User
+
+
+def _hide(entity: PermEntity, entity_id: int, user_id: int) -> None:
+    with sync_session.begin() as s:
+        s.add(HiddenEntity(entity=entity, entity_id=entity_id, user_id=user_id))
 
 
 @pytest.fixture
@@ -1932,6 +1939,68 @@ class TestSaveDownload:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert "99999" in response.json()["detail"]
+
+    @mock.patch("endpoints.saves.fs_asset_handler.validate_path")
+    def test_other_user_downloads_public_save_on_visible_rom(
+        self,
+        mock_validate_path,
+        client,
+        viewer_access_token: str,
+        save: Save,
+        tmp_path,
+    ):
+        # Sanity: public sharing still works when the ROM is visible.
+        db_save_handler.update_save(save.id, {"is_public": True})
+        test_file = tmp_path / "test.sav"
+        test_file.write_bytes(b"SHARED_SAVE")
+        mock_validate_path.return_value = test_file
+
+        response = client.get(
+            f"/api/saves/{save.id}/content",
+            headers={"Authorization": f"Bearer {viewer_access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.content == b"SHARED_SAVE"
+
+    def test_hidden_rom_masks_public_save_download(
+        self,
+        client,
+        viewer_access_token: str,
+        viewer_user: User,
+        save: Save,
+        rom: Rom,
+    ):
+        # A public save on a ROM hidden from the caller must stay 404-masked;
+        # sharing cannot override the hidden-resource boundary.
+        db_save_handler.update_save(save.id, {"is_public": True})
+        _hide(PermEntity.ROMS, rom.id, viewer_user.id)
+
+        response = client.get(
+            f"/api/saves/{save.id}/content",
+            headers={"Authorization": f"Bearer {viewer_access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_hidden_platform_masks_public_save_download(
+        self,
+        client,
+        viewer_access_token: str,
+        viewer_user: User,
+        save: Save,
+        platform: Platform,
+    ):
+        # Hiding the parent platform cascades to its saves as well.
+        db_save_handler.update_save(save.id, {"is_public": True})
+        _hide(PermEntity.PLATFORMS, platform.id, viewer_user.id)
+
+        response = client.get(
+            f"/api/saves/{save.id}/content",
+            headers={"Authorization": f"Bearer {viewer_access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @mock.patch("endpoints.saves.fs_asset_handler.validate_path")
     def test_download_save_file_missing_on_disk(

--- a/backend/tests/endpoints/test_screenshots.py
+++ b/backend/tests/endpoints/test_screenshots.py
@@ -4,7 +4,9 @@ from unittest import mock
 from fastapi import status
 
 from handler.database import db_screenshot_handler
+from handler.database.base_handler import sync_session
 from models.assets import Screenshot
+from models.permission import HiddenEntity, PermEntity
 from models.platform import Platform
 from models.rom import Rom
 from models.user import User
@@ -12,6 +14,11 @@ from models.user import User
 
 def _auth(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
+
+
+def _hide(entity: PermEntity, entity_id: int, user_id: int) -> None:
+    with sync_session.begin() as s:
+        s.add(HiddenEntity(entity=entity, entity_id=entity_id, user_id=user_id))
 
 
 # ---------- POST /api/screenshots ----------
@@ -294,6 +301,49 @@ def test_other_user_downloads_public_screenshot(
     )
     assert response.status_code == status.HTTP_200_OK
     assert response.content == b"SHARED_SHOT"
+
+
+def test_hidden_rom_masks_public_screenshot_download(
+    client,
+    viewer_access_token: str,
+    viewer_user: User,
+    admin_user: User,
+    rom: Rom,
+    platform: Platform,
+):
+    # A public screenshot on a ROM hidden from the caller must stay 404-masked;
+    # sharing cannot override the hidden-resource boundary.
+    screenshot = _add_screenshot(
+        rom, platform, admin_user.id, "shot", is_gallery=True, is_public=True
+    )
+    _hide(PermEntity.ROMS, rom.id, viewer_user.id)
+
+    response = client.get(
+        f"/api/screenshots/{screenshot.id}/content",
+        headers=_auth(viewer_access_token),
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_hidden_platform_masks_public_screenshot_download(
+    client,
+    viewer_access_token: str,
+    viewer_user: User,
+    admin_user: User,
+    rom: Rom,
+    platform: Platform,
+):
+    # Hiding the parent platform cascades to its screenshots as well.
+    screenshot = _add_screenshot(
+        rom, platform, admin_user.id, "shot", is_gallery=True, is_public=True
+    )
+    _hide(PermEntity.PLATFORMS, platform.id, viewer_user.id)
+
+    response = client.get(
+        f"/api/screenshots/{screenshot.id}/content",
+        headers=_auth(viewer_access_token),
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_download_screenshot_not_found(client, access_token: str):

--- a/backend/tests/endpoints/test_states.py
+++ b/backend/tests/endpoints/test_states.py
@@ -3,7 +3,9 @@ from unittest import mock
 from fastapi import status
 
 from handler.database import db_screenshot_handler, db_state_handler
+from handler.database.base_handler import sync_session
 from models.assets import Screenshot, State
+from models.permission import HiddenEntity, PermEntity
 from models.platform import Platform
 from models.rom import Rom
 from models.user import User
@@ -11,6 +13,11 @@ from models.user import User
 
 def _auth(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
+
+
+def _hide(entity: PermEntity, entity_id: int, user_id: int) -> None:
+    with sync_session.begin() as s:
+        s.add(HiddenEntity(entity=entity, entity_id=entity_id, user_id=user_id))
 
 
 @mock.patch("endpoints.states.fs_asset_handler.validate_path")
@@ -51,6 +58,37 @@ def test_other_user_downloads_public_state(
     )
     assert response.status_code == status.HTTP_200_OK
     assert response.content == b"SHARED_STATE"
+
+
+def test_hidden_rom_masks_public_state_download(
+    client, viewer_access_token: str, viewer_user: User, state: State, rom: Rom
+):
+    # A public state on a ROM hidden from the caller must stay 404-masked;
+    # sharing cannot override the hidden-resource boundary.
+    db_state_handler.update_state(state.id, {"is_public": True})
+    _hide(PermEntity.ROMS, rom.id, viewer_user.id)
+
+    response = client.get(
+        f"/api/states/{state.id}/content", headers=_auth(viewer_access_token)
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_hidden_platform_masks_public_state_download(
+    client,
+    viewer_access_token: str,
+    viewer_user: User,
+    state: State,
+    platform: Platform,
+):
+    # Hiding the parent platform cascades to its states as well.
+    db_state_handler.update_state(state.id, {"is_public": True})
+    _hide(PermEntity.PLATFORMS, platform.id, viewer_user.id)
+
+    response = client.get(
+        f"/api/states/{state.id}/content", headers=_auth(viewer_access_token)
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_download_state_not_found(client, access_token: str):

--- a/backend/tests/endpoints/test_streaming.py
+++ b/backend/tests/endpoints/test_streaming.py
@@ -12,10 +12,17 @@ from main import app
 from config import LIBRARY_BASE_PATH, OAUTH_ACCESS_TOKEN_EXPIRE_SECONDS
 from handler.auth import oauth_handler
 from handler.database import db_platform_handler, db_rom_handler
+from handler.database.base_handler import sync_session
 from handler.redis_handler import async_cache
+from models.permission import HiddenEntity, PermEntity
 from models.platform import Platform
 from models.rom import Rom
 from models.user import User
+
+
+def _hide(entity: PermEntity, entity_id: int, user_id: int) -> None:
+    with sync_session.begin() as s:
+        s.add(HiddenEntity(entity=entity, entity_id=entity_id, user_id=user_id))
 
 
 @pytest.fixture
@@ -171,6 +178,32 @@ def test_claim_unknown_rom_returns_404(client, access_token):
     with _streaming():
         r = _claim(client, access_token, 999999)
     assert r.status_code == 404
+
+
+def test_claim_hidden_rom_is_404_masked(
+    client, viewer_access_token, viewer_user: User, rom: Rom
+):
+    """A user with roms.read cannot claim a session for a ROM hidden from them;
+    the launch must be 404-masked before any broker call."""
+    _hide(PermEntity.ROMS, rom.id, viewer_user.id)
+    with _streaming(_container_for(rom)):
+        # If the visibility check were missing this would 200 and launch.
+        with patch("endpoints.streaming._call_broker") as call_broker:
+            r = _claim(client, viewer_access_token, rom.id)
+    assert r.status_code == 404
+    call_broker.assert_not_called()
+
+
+def test_claim_rom_on_hidden_platform_is_404_masked(
+    client, viewer_access_token, viewer_user: User, rom: Rom, platform: Platform
+):
+    """Hiding the parent platform cascades: its ROMs cannot be streamed either."""
+    _hide(PermEntity.PLATFORMS, platform.id, viewer_user.id)
+    with _streaming(_container_for(rom)):
+        with patch("endpoints.streaming._call_broker") as call_broker:
+            r = _claim(client, viewer_access_token, rom.id)
+    assert r.status_code == 404
+    call_broker.assert_not_called()
 
 
 def test_claim_skips_container_with_schemeless_host(client, access_token, rom: Rom):


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes an object-level authorization bypass (IDOR) class that let a low-privileged authenticated user reach ROMs/assets that an admin had hidden from them via the hidden-entity permission system.

Four endpoints loaded a record by a caller-controlled id and authorized it by the `is_public` flag (or by the `roms.read` scope alone, for streaming) **without** re-checking whether the parent ROM or platform was hidden from the caller:

- `GET /api/saves/{id}/content` (`download_save`)
- `GET /api/states/{id}/content` (`download_state`)
- `GET /api/screenshots/{id}/content` (`download_screenshot`)
- `POST /api/streaming/sessions` (`claim_session`)

As a result, a user blocked from a ROM/platform could still download a public save/state/screenshot attached to it, or start a streaming session for it, by supplying the asset/ROM id directly.

**Fix:** route all four through the existing `assert_rom_visible()` 404-masking helper (the same one `GET /api/roms/{id}` and the ROM content endpoints already use), applied right after loading the record and **before** any filesystem access or broker launch. Hidden ROMs/platforms now return an indistinguishable 404, and the streaming broker is never contacted for a hidden ROM.

Audit note: for streaming, `claim_session` is the only endpoint that selects a ROM by caller-controlled id. The other session-control endpoints (`save-and-exit`, `volume`, `mute`, `save-state`, `load-state`, `release`) operate on an existing session resolved via `_resolve_owned_session`, which already enforces caller ownership, and a session can only be created by `claim_session`. So this one check closes the whole streaming flow.

**AI assistance disclosure:** This PR was written with AI assistance (Claude Code / Claude Opus 4.8). The vulnerability reports were provided by a human; the code changes, tests, and this description were AI-generated and human-reviewed.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Tests: added hidden-ROM and hidden-platform-cascade regression tests to `test_saves.py`, `test_states.py`, `test_screenshots.py`, and `test_streaming.py` (streaming tests also assert the broker is never called), plus a positive control confirming public sharing still works when the ROM is visible. All relevant endpoint suites pass locally (`test_saves`/`test_states`/`test_screenshots`: 110 passed; `test_streaming`: 29 passed).

#### Screenshots (if applicable)

N/A (backend-only authorization fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
