### PR TITLE
fix(v2): overlay body-scroll-lock leaks + Library Stats label clipping

### DIFF
--- a/frontend/src/v2/components/Home/Widgets/LibraryStatsWidget.vue
+++ b/frontend/src/v2/components/Home/Widgets/LibraryStatsWidget.vue
@@ -117,7 +117,7 @@ onMounted(async () => {
   <WidgetCard
     :title="t('home.widget-library-stats')"
     :loading="loading"
-    :width="mode === 'extended' ? '420px' : '220px'"
+    :width="mode === 'extended' ? 'max-content' : '220px'"
   >
     <div
       class="r-v2-widget-lib__stats"
@@ -146,11 +146,14 @@ onMounted(async () => {
 /* Extended mode — same card height as compact, but the card itself
    grows wider and the rows lay out in a 3-column grid so all 7 stats
    (3 base + 4 extended) fit in 3 rows inside the shared rail height.
-   Column gap is generous so the right-aligned values from one column
-   don't crowd the left-aligned labels of the next. */
+   Columns size to their content (`auto`, paired with the card's
+   `max-content` width) so labels never get clipped by large values;
+   the rail scrolls horizontally if the numbers get very wide. Column
+   gap is generous so the right-aligned values from one column don't
+   crowd the left-aligned labels of the next. */
 .r-v2-widget-lib__stats--multi-col {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, auto);
   column-gap: 20px;
   row-gap: 6px;
 }
@@ -169,10 +172,11 @@ onMounted(async () => {
   display: flex;
   align-items: center;
   gap: 5px;
+  /* Grow to fill the (content-sized) column so the value stays pinned
+     to the column's right edge across every row. */
+  flex: 1;
   min-width: 0;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .r-v2-widget-lib__val {

--- a/frontend/src/v2/lib/overlays/RDialog/RDialog.vue
+++ b/frontend/src/v2/lib/overlays/RDialog/RDialog.vue
@@ -17,6 +17,7 @@
 // REmptyState / RProgressCircular / RSpinner as needed.
 import { computed, nextTick, onBeforeUnmount, ref, useSlots, watch } from "vue";
 import RIcon from "@/v2/lib/primitives/RIcon/RIcon.vue";
+import { createBodyScrollLock, overlayCount } from "../bodyScrollLock";
 import {
   type EscapableEntry,
   popEscapable,
@@ -67,10 +68,12 @@ const panelRef = ref<HTMLElement | null>(null);
 // Element that had focus before the dialog opened — focus returns here
 // when the dialog closes so keyboard users don't lose their place.
 let previouslyFocused: HTMLElement | null = null;
-// Guards this instance so lock/unlock are idempotent
-let holdsLock = false;
 
-// Stack depth at the moment this dialog opened (number of OTHER dialogs
+// Shared, reference-counted body scroll lock (see bodyScrollLock.ts).
+const { lock: lockBodyScroll, unlock: unlockBodyScroll } =
+  createBodyScrollLock();
+
+// Stack depth at the moment this dialog opened (number of overlays
 // already open). Drives a per-instance z-index bump so a dialog opened
 // from inside another dialog always paints above its parent surface,
 // regardless of Teleport mount order. Reset to 0 on close.
@@ -105,45 +108,15 @@ const stackEntry: EscapableEntry = {
   },
 };
 
-// Body scroll lock, reference-counted so nested dialogs unlock
-// correctly when the outer one is still open.
-function lockBodyScroll() {
-  if (holdsLock) return;
-  holdsLock = true;
-  const cur = Number(document.body.dataset.rDialogOpenCount ?? "0") + 1;
-  document.body.dataset.rDialogOpenCount = String(cur);
-  if (cur === 1) {
-    // Remember whatever overflow was already in effect (e.g. a gallery
-    // view that locks the body for its whole lifetime) so we restore it
-    // on unlock instead of clobbering it to "".
-    document.body.dataset.rDialogPrevOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-  }
-}
-function unlockBodyScroll() {
-  if (!holdsLock) return;
-  holdsLock = false;
-  const cur = Math.max(
-    0,
-    Number(document.body.dataset.rDialogOpenCount ?? "0") - 1,
-  );
-  document.body.dataset.rDialogOpenCount = String(cur);
-  if (cur === 0) {
-    document.body.style.overflow =
-      document.body.dataset.rDialogPrevOverflow ?? "";
-    delete document.body.dataset.rDialogPrevOverflow;
-  }
-}
-
 watch(
   () => props.modelValue,
   (open) => {
     if (open) {
       previouslyFocused = document.activeElement as HTMLElement | null;
-      // Snapshot the open-dialog count BEFORE incrementing it via
+      // Snapshot the open-overlay count BEFORE incrementing it via
       // lockBodyScroll(), so the first dialog reads depth 0 and any
       // subsequent dialog sees the previous ones and stacks on top.
-      stackDepth.value = Number(document.body.dataset.rDialogOpenCount ?? "0");
+      stackDepth.value = overlayCount();
       lockBodyScroll();
       pushEscapable(stackEntry);
       // Defer to the next tick so the panel is mounted before we

--- a/frontend/src/v2/lib/overlays/RDialog/RDialog.vue
+++ b/frontend/src/v2/lib/overlays/RDialog/RDialog.vue
@@ -67,6 +67,8 @@ const panelRef = ref<HTMLElement | null>(null);
 // Element that had focus before the dialog opened — focus returns here
 // when the dialog closes so keyboard users don't lose their place.
 let previouslyFocused: HTMLElement | null = null;
+// Guards this instance so lock/unlock are idempotent
+let holdsLock = false;
 
 // Stack depth at the moment this dialog opened (number of OTHER dialogs
 // already open). Drives a per-instance z-index bump so a dialog opened
@@ -103,9 +105,11 @@ const stackEntry: EscapableEntry = {
   },
 };
 
-// ── Body scroll lock — reference-counted so nested dialogs unlock
-// correctly when the outer one is still open. ─────────────────────
+// Body scroll lock, reference-counted so nested dialogs unlock
+// correctly when the outer one is still open.
 function lockBodyScroll() {
+  if (holdsLock) return;
+  holdsLock = true;
   const cur = Number(document.body.dataset.rDialogOpenCount ?? "0") + 1;
   document.body.dataset.rDialogOpenCount = String(cur);
   if (cur === 1) {
@@ -117,6 +121,8 @@ function lockBodyScroll() {
   }
 }
 function unlockBodyScroll() {
+  if (!holdsLock) return;
+  holdsLock = false;
   const cur = Math.max(
     0,
     Number(document.body.dataset.rDialogOpenCount ?? "0") - 1,
@@ -166,9 +172,14 @@ watch(
 );
 
 // Safety net — if the component unmounts while still open (parent
-// teardown, route change), drop our stack entry so the global listener
-// never tries to close a destroyed instance.
-onBeforeUnmount(() => popEscapable(stackEntry));
+// teardown, route change, or a consumer nulling its `v-if` entity in the
+// same tick as `show`), drop our stack entry so the global listener never
+// tries to close a destroyed instance, and release the body scroll lock
+// the watcher's close branch never got to run.
+onBeforeUnmount(() => {
+  popEscapable(stackEntry);
+  unlockBodyScroll();
+});
 
 // ── Width / height resolution ───────────────────────────────────
 function asLength(v: number | string): string | undefined {

--- a/frontend/src/v2/lib/overlays/RDrawer/RDrawer.vue
+++ b/frontend/src/v2/lib/overlays/RDrawer/RDrawer.vue
@@ -24,6 +24,7 @@ import {
   popEscapable,
   pushEscapable,
 } from "../RDialog/escapeStack.js";
+import { createBodyScrollLock } from "../bodyScrollLock";
 
 defineOptions({ inheritAttrs: false });
 
@@ -66,8 +67,11 @@ const panelRef = ref<HTMLElement | null>(null);
 // Element that had focus before the drawer opened — focus returns here
 // when the drawer closes so keyboard users don't lose their place.
 let previouslyFocused: HTMLElement | null = null;
-// Guards this instance so lock/unlock are idempotent
-let holdsLock = false;
+
+// Shared, reference-counted body scroll lock (see bodyScrollLock.ts) so
+// stacking (a Dialog open over a Drawer) unlocks in the right order.
+const { lock: lockBodyScroll, unlock: unlockBodyScroll } =
+  createBodyScrollLock();
 
 function closeDrawer() {
   emit("update:modelValue", false);
@@ -77,37 +81,6 @@ function closeDrawer() {
 function onScrimClick() {
   if (props.persistent) return;
   closeDrawer();
-}
-
-// Body scroll lock, same reference-count pattern RDialog uses so
-// stacking (a Dialog open over a Drawer) unlocks in the right order.
-function lockBodyScroll() {
-  if (holdsLock) return;
-  holdsLock = true;
-  const cur = Number(document.body.dataset.rOverlayOpenCount ?? "0") + 1;
-  document.body.dataset.rOverlayOpenCount = String(cur);
-  if (cur === 1) {
-    // Remember whatever overflow was already in effect — a host view may
-    // lock the body for its whole lifetime (e.g. the gallery shell, whose
-    // only scrollbar is the virtualizer's). Restoring this on unlock
-    // instead of forcing "" keeps that lock intact after the drawer closes.
-    document.body.dataset.rOverlayPrevOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-  }
-}
-function unlockBodyScroll() {
-  if (!holdsLock) return;
-  holdsLock = false;
-  const cur = Math.max(
-    0,
-    Number(document.body.dataset.rOverlayOpenCount ?? "0") - 1,
-  );
-  document.body.dataset.rOverlayOpenCount = String(cur);
-  if (cur === 0) {
-    document.body.style.overflow =
-      document.body.dataset.rOverlayPrevOverflow ?? "";
-    delete document.body.dataset.rOverlayPrevOverflow;
-  }
 }
 
 // Shared escape-stack entry — register on open so a single global

--- a/frontend/src/v2/lib/overlays/RDrawer/RDrawer.vue
+++ b/frontend/src/v2/lib/overlays/RDrawer/RDrawer.vue
@@ -66,6 +66,8 @@ const panelRef = ref<HTMLElement | null>(null);
 // Element that had focus before the drawer opened — focus returns here
 // when the drawer closes so keyboard users don't lose their place.
 let previouslyFocused: HTMLElement | null = null;
+// Guards this instance so lock/unlock are idempotent
+let holdsLock = false;
 
 function closeDrawer() {
   emit("update:modelValue", false);
@@ -77,9 +79,11 @@ function onScrimClick() {
   closeDrawer();
 }
 
-// ── Body scroll lock — same reference-count pattern RDialog uses so
-// stacking (a Dialog open over a Drawer) unlocks in the right order. ──
+// Body scroll lock, same reference-count pattern RDialog uses so
+// stacking (a Dialog open over a Drawer) unlocks in the right order.
 function lockBodyScroll() {
+  if (holdsLock) return;
+  holdsLock = true;
   const cur = Number(document.body.dataset.rOverlayOpenCount ?? "0") + 1;
   document.body.dataset.rOverlayOpenCount = String(cur);
   if (cur === 1) {
@@ -92,6 +96,8 @@ function lockBodyScroll() {
   }
 }
 function unlockBodyScroll() {
+  if (!holdsLock) return;
+  holdsLock = false;
   const cur = Math.max(
     0,
     Number(document.body.dataset.rOverlayOpenCount ?? "0") - 1,
@@ -140,8 +146,12 @@ watch(
 );
 
 // Safety net — drop the stack entry if we tear down while open (route
-// change with the drawer still visible).
-onBeforeUnmount(() => popEscapable(escEntry));
+// change with the drawer still visible) and release the body scroll lock
+// the watcher's close branch never got to run.
+onBeforeUnmount(() => {
+  popEscapable(escEntry);
+  unlockBodyScroll();
+});
 
 // ── Width resolution ────────────────────────────────────────────
 function asLength(v: number | string): string {

--- a/frontend/src/v2/lib/overlays/bodyScrollLock.spec.ts
+++ b/frontend/src/v2/lib/overlays/bodyScrollLock.spec.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createBodyScrollLock, overlayCount } from "./bodyScrollLock";
+
+afterEach(() => {
+  document.body.style.overflow = "";
+  delete document.body.dataset.rOverlayOpenCount;
+  delete document.body.dataset.rOverlayPrevOverflow;
+});
+
+describe("createBodyScrollLock", () => {
+  it("locks the body on the first overlay and restores on the last", () => {
+    const { lock, unlock } = createBodyScrollLock();
+    lock();
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(overlayCount()).toBe(1);
+    unlock();
+    expect(document.body.style.overflow).toBe("");
+    expect(overlayCount()).toBe(0);
+  });
+
+  it("preserves an overflow the host set for its own lifetime", () => {
+    document.body.style.overflow = "clip";
+    const { lock, unlock } = createBodyScrollLock();
+    lock();
+    expect(document.body.style.overflow).toBe("hidden");
+    unlock();
+    expect(document.body.style.overflow).toBe("clip");
+  });
+
+  // The bug this module fixes: independent overlays (e.g. a dialog over a
+  // drawer) must share one count so the body only unlocks once the LAST
+  // one closes, regardless of close order.
+  it("keeps the lock while any overlay is still open, in any close order", () => {
+    const dialog = createBodyScrollLock();
+    const drawer = createBodyScrollLock();
+
+    dialog.lock();
+    drawer.lock();
+    expect(overlayCount()).toBe(2);
+    expect(document.body.style.overflow).toBe("hidden");
+
+    // Close the first-opened overlay first — the body must STAY locked.
+    dialog.unlock();
+    expect(overlayCount()).toBe(1);
+    expect(document.body.style.overflow).toBe("hidden");
+
+    drawer.unlock();
+    expect(overlayCount()).toBe(0);
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("is idempotent so an unmount safety-net never double-counts", () => {
+    const { lock, unlock } = createBodyScrollLock();
+    lock();
+    lock(); // duplicate open
+    expect(overlayCount()).toBe(1);
+    unlock();
+    unlock(); // watcher close + onBeforeUnmount
+    expect(overlayCount()).toBe(0);
+    expect(document.body.style.overflow).toBe("");
+  });
+});

--- a/frontend/src/v2/lib/overlays/bodyScrollLock.ts
+++ b/frontend/src/v2/lib/overlays/bodyScrollLock.ts
@@ -1,0 +1,55 @@
+// Shared, reference-counted body scroll lock for v2 overlays.
+//
+// Every overlay that covers the page (RDialog, RDrawer, ...) hides the
+// body scrollbar while open. They MUST share a single counter and a
+// single saved-overflow value: with per-type counters, a dialog stacked
+// over a drawer (or vice versa) would restore `body` overflow off its
+// own count and clobber the other's lock — leaving the page scrollable
+// while an overlay is still open, or permanently locked after all close.
+//
+// The first overlay to open snapshots whatever overflow was already in
+// effect (e.g. a gallery view that locks the body for its whole
+// lifetime) and forces "hidden"; the last one to close restores that
+// snapshot instead of clobbering it to "". State lives on
+// `document.body.dataset` so it survives across the many independent
+// component instances that share the count.
+
+const COUNT_KEY = "rOverlayOpenCount";
+const PREV_OVERFLOW_KEY = "rOverlayPrevOverflow";
+
+/** Number of overlays currently holding the lock. */
+export function overlayCount(): number {
+  return Number(document.body.dataset[COUNT_KEY] ?? "0");
+}
+
+// Each caller gets its own idempotent lock/unlock pair: `holdsLock`
+// guards against double-counting so an unmount safety net can always
+// call unlock() even when the close path already ran (and vice versa).
+export function createBodyScrollLock() {
+  let holdsLock = false;
+
+  function lock(): void {
+    if (holdsLock) return;
+    holdsLock = true;
+    const cur = overlayCount() + 1;
+    document.body.dataset[COUNT_KEY] = String(cur);
+    if (cur === 1) {
+      document.body.dataset[PREV_OVERFLOW_KEY] = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+    }
+  }
+
+  function unlock(): void {
+    if (!holdsLock) return;
+    holdsLock = false;
+    const cur = Math.max(0, overlayCount() - 1);
+    document.body.dataset[COUNT_KEY] = String(cur);
+    if (cur === 0) {
+      document.body.style.overflow =
+        document.body.dataset[PREV_OVERFLOW_KEY] ?? "";
+      delete document.body.dataset[PREV_OVERFLOW_KEY];
+    }
+  }
+
+  return { lock, unlock };
+}


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Three v2 bug fixes, two of them in the shared overlay body-scroll-lock.

**1. Page can no longer scroll after closing the Edit ROM dialog**

`RDialog` (and its sibling `RDrawer`) lock `body { overflow: hidden }` from their `modelValue` watcher, but only release it in the watcher's close branch. Consumers that null a `v-if` entity in the same tick as `show` (e.g. `EditRomDialog.closeDialog()` sets `show = false` and `rom = null` together) unmount the overlay before that branch can run, so the lock leaked and the body stayed `overflow: hidden` permanently.

Fix: guard each instance with a `holdsLock` flag so lock/unlock are idempotent (no double-decrement of the reference count), and release the lock in `onBeforeUnmount` as a safety net.

**2. Overlays clobber each other's scroll lock when stacked**

`RDialog` and `RDrawer` both mutate `body { overflow: hidden }` but tracked it with **separate** counters and saved-overflow keys (`rDialogOpenCount` vs `rOverlayOpenCount`). A dialog stacked over a drawer (or vice versa) would restore `overflow` off its own count when it closed and clobber the other overlay's lock, leaving the page scrollable while an overlay was still open, or permanently locked once all closed.

Fix: extract a single reference-counted lock (`createBodyScrollLock` in `bodyScrollLock.ts`) that every overlay shares, so the body only unlocks once the **last** overlay closes, in any close order. `RDialog`'s z-index stack depth now reads the shared overlay count (drawers sit below dialogs at z-index, so relative dialog ordering is unchanged). Covered by a new unit test.

**3. Library Stats widget clips labels in extended mode**

Extended mode packed 7 stats into a fixed 420px card with a `repeat(3, 1fr)` grid. Values have `flex-shrink: 0`, so with large libraries the numbers (e.g. `84,283`, `290.6 TB`) consumed the column width and the label absorbed the shortfall via `text-overflow: ellipsis` ("Screenshots" rendered as "Screens", "Size on Disk" as "Size o").

Fix: size the card to its content (`max-content`) with `auto` columns, and let the label flex to fill its column so values stay right-aligned but labels never truncate. The widget rail already scrolls horizontally, so a content-sized card is safe.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

Library Stats, extended mode, with a large library: labels render in full (`Screenshots` / `Size on Disk`) with values right-aligned, no truncation.

---

**AI assistance disclosure:** This PR was written with AI assistance (Claude Code). The root-cause analysis, the fixes, the unit test, and verification (typecheck, lint, vitest, and an isolated visual render of the stats layout) were AI-assisted and human-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)