### PR TITLE
fix(collections): lazy-load collection mosaic artwork

### DIFF
--- a/frontend/src/v2/components/Collections/CollectionMosaic.vue
+++ b/frontend/src/v2/components/Collections/CollectionMosaic.vue
@@ -52,7 +52,12 @@ const mosaicSlots = computed(() => {
       </div>
     </template>
     <template v-else-if="displayCovers.length === 1">
-      <img :src="displayCovers[0] ?? undefined" alt="" />
+      <img
+        :src="displayCovers[0] ?? undefined"
+        alt=""
+        loading="lazy"
+        decoding="async"
+      />
     </template>
     <template v-else>
       <img
@@ -60,6 +65,8 @@ const mosaicSlots = computed(() => {
         :key="`m-${i}`"
         :src="cover"
         alt=""
+        loading="lazy"
+        decoding="async"
       />
     </template>
   </div>


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The Collections tab renders every collection tile's artwork through `CollectionMosaic.vue`, but its `<img>` tags were missing `loading="lazy"` / `decoding="async"`. With hundreds of virtual collections, the browser eagerly fetched every cover for every tile (including off-screen ones), flooding the server with image requests.

This PR adds the same lazy-loading hints that `GameCover.vue` already uses to both `<img>` branches (single-cover and the 2×2 mosaic loop), so artwork is only fetched near the viewport. Because `CollectionListRow.vue` reuses this component, both the grid and list layouts benefit.

Scope note: this is the minimal fix targeting the cause. If native lazy loading proves insufficient at very large scale (thousands of tiles in the DOM), the follow-up would be windowing/virtualizing the grid so off-screen tiles aren't rendered at all.

Fixes #3865

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

---

*AI-assistance disclosure: this change was implemented with Claude Code (Opus 4.8). The diff and PR description are AI-generated; I reviewed them before opening.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)