### PR TITLE
fix(v2): keep collection visibility toggle in sync after save

### DIFF
--- a/frontend/src/v2/components/Gallery/CollectionSettingsTab.vue
+++ b/frontend/src/v2/components/Gallery/CollectionSettingsTab.vue
@@ -122,9 +122,12 @@ const dirty = computed(() => {
 // Snapshot on mount AND whenever the underlying collection identity
 // changes (route swap, socket-driven backend update). Keeps the form
 // in sync with the canonical record without trampling in-flight edits
-// while a save is running.
-function snapshot() {
-  const c = props.collection;
+// while a save is running. Accepts an explicit source so `save()` can
+// re-sync from the update response — `props.collection` only receives
+// the fresh value asynchronously (store swap + parent reassign), so it
+// still holds the pre-save object at the moment `save()` snapshots.
+function snapshot(source: Collection | SmartCollection = props.collection) {
+  const c = source;
   form.value = {
     name: c.name,
     description: c.description ?? "",
@@ -240,6 +243,7 @@ async function save() {
   if (!dirty.value || saving.value || !canEdit.value) return;
   saving.value = true;
   try {
+    let saved: Collection | SmartCollection;
     if (props.kind === "smart") {
       const payload: SmartCollection = {
         ...(props.collection as SmartCollection),
@@ -254,6 +258,7 @@ async function save() {
       if (galleryRoms.currentSmartCollection?.id === data.id) {
         galleryRoms.setCurrentSmartCollection(data);
       }
+      saved = data;
       emit("saved", data);
     } else {
       const payload: UpdatedCollection = {
@@ -272,12 +277,16 @@ async function save() {
       if (galleryRoms.currentCollection?.id === data.id) {
         galleryRoms.setCurrentCollection(data);
       }
+      saved = data;
       emit("saved", data);
     }
     snackbar.success(t("collection.updated", "Collection updated"), {
       icon: "mdi-check-bold",
     });
-    snapshot();
+    // Re-sync from the response, not the prop — the prop hasn't been
+    // updated yet (see `snapshot` note), so snapshotting it would revert
+    // the form to the pre-save values and keep `dirty` true.
+    snapshot(saved);
   } catch (err) {
     const e = err as {
       response?: { data?: { msg?: string; detail?: string } };


### PR DESCRIPTION
**Description**

In the v2 collection **Settings** tab, toggling a collection's visibility (Private ⇄ Public) and clicking **Apply** persisted correctly on the backend, but the UI immediately reverted: the toggle snapped back to its old value and **Apply** stayed visible, making it look like the save failed. A reload confirmed the change was actually saved.

**Root cause**

`save()` re-snapshotted the local form from `props.collection` synchronously right after a successful PUT. That prop only receives the fresh value asynchronously (the store replaces the array entry and `Collection.vue` reassigns the ref on the next microtask), so at snapshot time it still held the pre-save object. `snapshot()` therefore reset `form.isPublic` to the old value, leaving `dirty` true and the Apply button visible. The only re-sync `watch` keys on `collection.id`, which doesn't change on a visibility edit, so it never re-fired.

**Fix**

Snapshot from the update **response** rather than the prop:

- `snapshot()` now accepts an optional source collection (defaulting to `props.collection`).
- Both branches of `save()` capture the returned `data` and call `snapshot(saved)`, so the form re-syncs from the just-persisted server response. `dirty` resolves to `false` once the prop propagates a tick later, so Apply/Discard disappear as expected.

Fixes #3864

**AI assistance disclosure**

This change was written with AI assistance (Claude Code): the diagnosis was guided by the detailed root-cause analysis in the issue, and the fix and PR were authored by the agent and reviewed by me.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)