### PR TITLE
feat(backend): categorize Switch rom files by title ID

### DIFF
--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -21,7 +21,10 @@ from exceptions.fs_exceptions import (
     RomAlreadyExistsException,
     RomsNotFoundException,
 )
-from handler.metadata.base_handler import UniversalPlatformSlug as UPS
+from handler.metadata.base_handler import (
+    SWITCH_PRODUCT_ID_REGEX,
+    UniversalPlatformSlug as UPS,
+)
 from models.platform import Platform
 from models.rom import Rom, RomFile, RomFileCategory, TrackMeta
 from utils.archives import (
@@ -106,6 +109,30 @@ class FileHash(TypedDict):
 
 def category_matches(category: str, path_parts: list[str]):
     return category in path_parts or f"{category}s" in path_parts
+
+
+# Platforms whose files carry a Nintendo title ID we can categorize by.
+SWITCH_PLATFORMS = frozenset((UPS.SWITCH, UPS.SWITCH_2))
+
+
+def switch_title_id_category(file_name: str) -> RomFileCategory | None:
+    """Classify a Switch file as base game, update, or DLC from its title ID.
+
+    Nintendo title IDs are 16 hex digits. Relative to the base application,
+    updates set the low 12 bits to 0x800 and DLC increments the 4th-to-last
+    nibble (making it odd); base games leave the low 12 bits cleared with an
+    even 4th-to-last nibble. See https://switchbrew.org/wiki/Title_list.
+    """
+    match = SWITCH_PRODUCT_ID_REGEX.search(file_name)
+    if not match:
+        return None
+
+    title_id = int(match.group(1), 16)
+    if (title_id >> 12) & 1:
+        return RomFileCategory.DLC
+    if title_id & 0xFFF == 0x800:
+        return RomFileCategory.UPDATE
+    return RomFileCategory.GAME
 
 
 DEFAULT_CRC_C = 0
@@ -278,6 +305,12 @@ class FSRomsHandler(FSHandler):
             ),
             None,
         )
+
+        # Fall back to the Switch title ID in the file name when the directory
+        # layout doesn't categorize it, so base/update/DLC files sharing a game
+        # folder are still tagged individually.
+        if matching_category is None and rom.platform_slug in SWITCH_PLATFORMS:
+            matching_category = switch_title_id_category(file_name)
 
         track_meta = None
         if matching_category == RomFileCategory.SOUNDTRACK:

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -123,7 +123,7 @@ def switch_title_id_category(file_name: str) -> RomFileCategory | None:
     nibble (making it odd); base games leave the low 12 bits cleared with an
     even 4th-to-last nibble. See https://switchbrew.org/wiki/Title_list.
     """
-    match = SWITCH_PRODUCT_ID_REGEX.search(file_name)
+    match = SWITCH_PRODUCT_ID_REGEX.search(file_name.upper())
     if not match:
         return None
 

--- a/backend/tests/handler/filesystem/test_roms_handler.py
+++ b/backend/tests/handler/filesystem/test_roms_handler.py
@@ -17,6 +17,7 @@ from handler.filesystem.base_handler import (
 from handler.filesystem.roms_handler import (
     FileHash,
     FSRomsHandler,
+    switch_title_id_category,
 )
 from models.platform import Platform
 from models.rom import Rom, RomFile, RomFileCategory
@@ -406,6 +407,56 @@ class TestFSRomsHandler:
             # Clean up
             if test_file.exists():
                 test_file.unlink()
+
+    @pytest.mark.parametrize(
+        ("file_name", "expected"),
+        [
+            # Breath of the Wild base / update / DLC from issue #2526
+            ("Zelda BOTW [01007EF00011E000][v0].nsp", RomFileCategory.GAME),
+            ("Zelda BOTW [01007EF00011E800][v196608].nsp", RomFileCategory.UPDATE),
+            ("Zelda BOTW DLC1 [01007EF00011F001][v0].nsp", RomFileCategory.DLC),
+            ("Zelda BOTW DLC2 [01007EF00011F002][v0].nsp", RomFileCategory.DLC),
+            # No title ID in the name -> no classification
+            ("Some Homebrew.nro", None),
+        ],
+    )
+    def test_switch_title_id_category(self, file_name, expected):
+        assert switch_title_id_category(file_name) == expected
+
+    def test_build_rom_file_switch_title_id_category(self, handler: FSRomsHandler):
+        """Switch files sharing a game folder are categorized by title ID."""
+        switch = Platform(name="Nintendo Switch", slug="switch", fs_slug="switch")
+        rom = Rom(
+            id=10,
+            fs_name="Zelda BOTW",
+            fs_path="switch/roms",
+            fs_extension="",
+            platform=switch,
+            full_path="switch/roms/Zelda BOTW",
+        )
+        rom_path = Path("switch/roms/Zelda BOTW")
+        file_hash = FileHash(
+            {"crc_hash": "", "md5_hash": "", "sha1_hash": "", "chd_sha1_hash": ""}
+        )
+
+        os.makedirs(handler.base_path / rom_path, exist_ok=True)
+        cases = {
+            "Zelda BOTW [01007EF00011E800][v196608].nsp": RomFileCategory.UPDATE,
+            "Zelda BOTW DLC1 [01007EF00011F001][v0].nsp": RomFileCategory.DLC,
+        }
+        created = []
+        try:
+            for file_name, expected in cases.items():
+                test_file = handler.base_path / rom_path / file_name
+                test_file.write_text("content")
+                created.append(test_file)
+
+                rom_file = handler._build_rom_file(rom, rom_path, file_name, file_hash)
+                assert rom_file.category == expected
+        finally:
+            for test_file in created:
+                if test_file.exists():
+                    test_file.unlink()
 
     @pytest.mark.asyncio
     async def test_get_roms(self, handler: FSRomsHandler, platform, config):


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->

**Description**
Automatically categorizes Nintendo Switch / Switch 2 ROM files as base game, update, or DLC based on the title ID in their filename, so base + update(s) + DLC belonging to the same game can live loose in a single game folder and still be tagged individually, without requiring update/ or dlc/ subfolders.

Today, a file's RomFileCategory is derived only from the folder it sits in (e.g. a file under update/ becomes an UPDATE). This PR adds a fallback: when a Switch/Switch-2 file isn't already categorized by its directory layout, its 16-hex Nintendo title ID is parsed from the filename and classified per the rules from #2526:

- 4th-to-last nibble odd → DLC
- low 12 bits == 0x800 → UPDATE
- otherwise (low 12 bits cleared, even 4th-to-last nibble) → GAME

Example (Breath of the Wild):

┌────────┬──────────────────┬──────────┐
│  File  │     Title ID     │ Category │
├────────┼──────────────────┼──────────┤
│ Base   │ 01007EF00011E000 │ GAME     │
├────────┼──────────────────┼──────────┤
│ Update │ 01007EF00011E800 │ UPDATE   │
├────────┼──────────────────┼──────────┤
│ DLC 1  │ 01007EF00011F001 │ DLC      │
├────────┼──────────────────┼──────────┤
│ DLC 2  │ 01007EF00011F002 │ DLC      │
└────────┴──────────────────┴──────────┘

Notes / scope:

- Folder-based categorization still wins. Title-ID classification is only a fallback when the directory layout doesn't already assign a category, so existing update//dlc/ layouts are unchanged.
- Grouping onto a single game entry already works via RomM's multi-part ROM model (a directory = one Rom, its inner files = RomFiles). This change makes the loose-files-in-one-folder layout viable by tagging each file correctly.
- Tinfoil integration is unaffected. The Tinfoil feed emits one download URL per RomFile (filtered by extension, not category), so grouping/tagging files under one ROM entry doesn't change what Tinfoil sees.
- Gated strictly to the switch and switch-2 platforms; reuses the existing SWITCH_PRODUCT_ID_REGEX.

Implementation: a switch_title_id_category() helper plus a fallback branch in _build_rom_file, both in backend/handler/filesystem/roms_handler.py.

▎ AI assistance disclosure: This change was implemented with AI assistance (Claude Code). The title-ID classification logic, the fallback wiring in _build_rom_file, and the accompanying tests were AI-generated and reviewed/verified by me before submitting.

Closes #2526

Checklist
- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

