### PR TITLE
fix(v2): take the hotkey-mute playing flag from EmulatorJS' start hook

### DIFF
--- a/frontend/src/v2/composables/useGlobalHotkeys/index.test.ts
+++ b/frontend/src/v2/composables/useGlobalHotkeys/index.test.ts
@@ -1,0 +1,119 @@
+import { mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, h } from "vue";
+
+const push = vi.fn();
+const playingStore = { playing: false };
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ push }),
+}));
+vi.mock("@/stores/playing", () => ({
+  default: () => playingStore,
+}));
+// The real module instantiates a router at import time.
+vi.mock("@/plugins/router", () => ({
+  ROUTES: {
+    SEARCH: "search",
+    HOME: "home",
+    PLATFORMS_INDEX: "platforms",
+    COLLECTIONS_INDEX: "collections",
+  },
+}));
+
+// `installed` is module state, so each test gets a fresh module and a fresh
+// window listener via a throwaway host component.
+async function install() {
+  vi.resetModules();
+  const { useGlobalHotkeys } = await import("./index");
+  const Host = defineComponent({
+    setup() {
+      useGlobalHotkeys().install();
+      return () => h("div");
+    },
+  });
+  return mount(Host);
+}
+
+function press(key: string, target: EventTarget = document.body) {
+  target.dispatchEvent(
+    new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }),
+  );
+}
+
+beforeEach(() => {
+  push.mockClear();
+  playingStore.playing = false;
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("useGlobalHotkeys", () => {
+  it("routes to search on '/'", async () => {
+    const host = await install();
+    press("/");
+    expect(push).toHaveBeenCalledWith({ name: "search" });
+    host.unmount();
+  });
+
+  it("ignores keys while the playing flag is set", async () => {
+    const host = await install();
+    playingStore.playing = true;
+    press("/");
+    press("g");
+    press("h");
+    expect(push).not.toHaveBeenCalled();
+    host.unmount();
+  });
+
+  it("ignores '/' typed into an emulator canvas (DOSBox mount commands)", async () => {
+    const host = await install();
+    const stage = document.createElement("div");
+    stage.id = "game";
+    const canvas = document.createElement("canvas");
+    stage.appendChild(canvas);
+    document.body.appendChild(stage);
+
+    press("/", canvas);
+    expect(push).not.toHaveBeenCalled();
+    host.unmount();
+  });
+
+  it("ignores keys while an element is fullscreen", async () => {
+    const host = await install();
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: document.createElement("div"),
+    });
+
+    press("/");
+    expect(push).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: null,
+    });
+    host.unmount();
+  });
+
+  it("ignores keys typed into form fields", async () => {
+    const host = await install();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    press("/", input);
+    expect(push).not.toHaveBeenCalled();
+    host.unmount();
+  });
+
+  it("still routes 'g h' outside a session", async () => {
+    const host = await install();
+    press("g");
+    press("h");
+    expect(push).toHaveBeenCalledWith({ name: "home" });
+    host.unmount();
+  });
+});

--- a/frontend/src/v2/composables/useGlobalHotkeys/index.test.ts
+++ b/frontend/src/v2/composables/useGlobalHotkeys/index.test.ts
@@ -69,33 +69,18 @@ describe("useGlobalHotkeys", () => {
     host.unmount();
   });
 
-  it("ignores '/' typed into an emulator canvas (DOSBox mount commands)", async () => {
+  // The DOSBox case: keys land on <body>, not on a form control, because the
+  // emulator canvas reads them off window. Only the playing flag tells them
+  // apart from a plain "/" pressed in the gallery.
+  it("ignores '/' pressed on the body while a game is running", async () => {
     const host = await install();
+    playingStore.playing = true;
     const stage = document.createElement("div");
     stage.id = "game";
-    const canvas = document.createElement("canvas");
-    stage.appendChild(canvas);
     document.body.appendChild(stage);
-
-    press("/", canvas);
-    expect(push).not.toHaveBeenCalled();
-    host.unmount();
-  });
-
-  it("ignores keys while an element is fullscreen", async () => {
-    const host = await install();
-    Object.defineProperty(document, "fullscreenElement", {
-      configurable: true,
-      value: document.createElement("div"),
-    });
 
     press("/");
     expect(push).not.toHaveBeenCalled();
-
-    Object.defineProperty(document, "fullscreenElement", {
-      configurable: true,
-      value: null,
-    });
     host.unmount();
   });
 

--- a/frontend/src/v2/composables/useGlobalHotkeys/index.ts
+++ b/frontend/src/v2/composables/useGlobalHotkeys/index.ts
@@ -9,8 +9,8 @@
 //   g c → collections index
 //
 // Two-key sequences (Gmail-style) have a 1.2s idle timeout. Everything is
-// guarded against input fields, contenteditable, and anything that owns the
-// keyboard (a running emulator), so hotkeys never fire mid-session.
+// guarded against input fields, contenteditable, and a running game
+// (the playing store flag), so hotkeys never fire mid-session.
 import { onBeforeUnmount } from "vue";
 import { useRouter } from "vue-router";
 import { ROUTES } from "@/plugins/router";
@@ -28,22 +28,6 @@ function isEditable(el: EventTarget | null): boolean {
     return true;
   }
   return el.isContentEditable;
-}
-
-// Emulator canvases (EmulatorJS/DOSBox, Ruffle) take keystrokes off
-// window/document rather than through a focused form control, so a DOS
-// prompt typing "mount A / -t floppy" looks exactly like a plain "/" on
-// <body>. The playing store flag is the primary signal, but it depends on
-// each player view keeping it current; these DOM signals hold even when it
-// goes stale.
-const KEYBOARD_OWNER_SELECTOR = "#game, #r-v2-ruffle-stage, canvas, video";
-
-function ownsKeyboard(target: EventTarget | null): boolean {
-  if (document.fullscreenElement) return true;
-  return [target, document.activeElement].some(
-    (node) =>
-      node instanceof Element && !!node.closest(KEYBOARD_OWNER_SELECTOR),
-  );
 }
 
 export function useGlobalHotkeys() {
@@ -65,7 +49,6 @@ export function useGlobalHotkeys() {
       // "h" are common game keys; without this gate a two-key sequence
       // (or "/") would navigate away and kill the session.
       if (playingStore.playing) return;
-      if (ownsKeyboard(e.target)) return;
 
       const now = performance.now();
       if (pendingPrefix && now - pendingAt > PREFIX_IDLE_MS) {

--- a/frontend/src/v2/composables/useGlobalHotkeys/index.ts
+++ b/frontend/src/v2/composables/useGlobalHotkeys/index.ts
@@ -9,8 +9,8 @@
 //   g c → collections index
 //
 // Two-key sequences (Gmail-style) have a 1.2s idle timeout. Everything is
-// guarded against input fields, contenteditable, and a running game
-// (the playing store flag), so hotkeys never fire mid-session.
+// guarded against input fields, contenteditable, and anything that owns the
+// keyboard (a running emulator), so hotkeys never fire mid-session.
 import { onBeforeUnmount } from "vue";
 import { useRouter } from "vue-router";
 import { ROUTES } from "@/plugins/router";
@@ -28,6 +28,22 @@ function isEditable(el: EventTarget | null): boolean {
     return true;
   }
   return el.isContentEditable;
+}
+
+// Emulator canvases (EmulatorJS/DOSBox, Ruffle) take keystrokes off
+// window/document rather than through a focused form control, so a DOS
+// prompt typing "mount A / -t floppy" looks exactly like a plain "/" on
+// <body>. The playing store flag is the primary signal, but it depends on
+// each player view keeping it current; these DOM signals hold even when it
+// goes stale.
+const KEYBOARD_OWNER_SELECTOR = "#game, #r-v2-ruffle-stage, canvas, video";
+
+function ownsKeyboard(target: EventTarget | null): boolean {
+  if (document.fullscreenElement) return true;
+  return [target, document.activeElement].some(
+    (node) =>
+      node instanceof Element && !!node.closest(KEYBOARD_OWNER_SELECTOR),
+  );
 }
 
 export function useGlobalHotkeys() {
@@ -49,6 +65,7 @@ export function useGlobalHotkeys() {
       // "h" are common game keys; without this gate a two-key sequence
       // (or "/") would navigate away and kill the session.
       if (playingStore.playing) return;
+      if (ownsKeyboard(e.target)) return;
 
       const now = performance.now();
       if (pendingPrefix && now - pendingAt > PREFIX_IDLE_MS) {

--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -383,6 +383,12 @@ window.EJS_onSaveState = async function ({
 };
 
 window.EJS_onGameStart = async () => {
+  // The emulator now owns the keyboard: every key, "/" included, belongs to
+  // the game (a DOS prompt typing "mount A / -t floppy" must not reach the
+  // global hotkeys). Callers flag this at launch too, but taking it from the
+  // emulator's own start hook keeps the flag true for any entry point.
+  playing.value = true;
+
   // Install netplay overrides synchronously, before any await below, so they
   // are in place before room polling or a Create/Join action can start.
   const netplay = window.EJS_emulator?.netplay;


### PR DESCRIPTION
**Description**

Fixes #3874.

Typing `/` at a DOSBox prompt (e.g. the documented `mount A / -t floppy`) navigated to the search page instead of reaching the emulator.

The root cause is already fixed on master: ef07ea5 (2026-07-19) gates `useGlobalHotkeys` on the `playing` store flag. It landed after the 5.0.0 release (2026-07-15) that the reporter is on, so the reported build simply predates the fix.

What's left, and what this PR does:

- `playing` was view-level bookkeeping: set in each player view's `onPlay`, cleared on unmount. Now EmulatorJS' own `EJS_onGameStart` hook sets it too, so the flag is true for any entry point into a running game rather than only the paths that remember to set it. Ruffle keeps flagging at launch (its `isPlaying` only turns true once autoplay actually starts, which would leave a click-to-start game unguarded).
- Adds unit tests for `useGlobalHotkeys`, which had none: `/` routes to search normally, muted while `playing`, muted for `/` pressed on `<body>` during a session (the DOSBox case - the keys never touch a form control, so the flag is the only signal), muted in form fields, and `g h` still navigating home.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Verified locally: new tests pass, all 15 v2 composable test files pass, `vue-tsc` clean, `trunk fmt` / `trunk check` clean. Not verified against a real DOS ROM in the browser (no DOS library at hand).

#### Screenshots (if applicable)

N/A - no visual changes.

---

**AI assistance disclosure:** this change was written with AI assistance (Claude Code). The diagnosis, implementation, and tests were AI-generated and reviewed by me before submission.