### PR TITLE
feat(platforms): add windows9x support

### DIFF
--- a/backend/handler/metadata/base_handler.py
+++ b/backend/handler/metadata/base_handler.py
@@ -754,6 +754,7 @@ class UniversalPlatformSlug(enum.StrEnum):
     WIIU = "wiiu"
     WIN = "win"
     WIN3X = "win3x"
+    WIN9X = "win9x"
     WINDOWS_APPS = "windows-apps"
     WINDOWS_MIXED_REALITY = "windows-mixed-reality"
     WINDOWS_MOBILE = "windows-mobile"

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -1112,6 +1112,7 @@ SCREENSAVER_PLATFORM_LIST: dict[UPS, SlugToSSId] = {
     UPS.WIIU: {"id": 18, "name": "Wii U"},
     UPS.WIN: {"id": 138, "name": "PC Windows"},
     UPS.WIN3X: {"id": 136, "name": "PC Win3.xx"},
+    UPS.WIN9X: {"id": 137, "name": "PC Win9X"},
     UPS.WASM_4: {"id": 262, "name": "WASM-4"},
     UPS.WONDERSWAN: {"id": 45, "name": "WonderSwan"},
     UPS.WONDERSWAN_COLOR: {"id": 46, "name": "WonderSwan Color"},

--- a/examples/config.es-de.example.yml
+++ b/examples/config.es-de.example.yml
@@ -117,6 +117,8 @@ system:
     wii: "wii" # Wii
     wiiu: "wiiu" # Wii U
     pc: "win" # PC (Microsoft Windows)
+    windows3x: "win3x" # Windows 3.x
+    windows9x: "win9x" # Windows 9x
     wonderswan: "wonderswan" # WonderSwan
     wonderswancolor: "wonderswan-color" # WonderSwan Color
     x1: "x1" # Sharp X1


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

RomM had `win` and `win3x` but no equivalent for what ES-DE calls `windows9x`, so Windows 9x libraries had nowhere to land. This adds it as a first-class platform.

- `WIN9X = "win9x"` added to `UniversalPlatformSlug`.
- Mapped to ScreenScraper system **137 ("PC Win9X")**, alongside the existing `win3x` → 136 and `win` → 138.
- `examples/config.es-de.example.yml` gains `windows9x: "win9x"`, plus the `windows3x: "win3x"` mapping that was also missing (both are real ES-DE system directories; the file only had `pc: "win"`).

**Provider coverage:** ScreenScraper is the only provider with a distinct Windows 9x platform. IGDB models Windows 95/98/Me as platform *versions* of `win` rather than standalone platforms, and MobyGames/LaunchBox stop at "Windows 3.x". `win3x` has the same sparse shape today, so this matches the existing precedent. Batocera/RetroBat have no equivalent system, so `config.batocera-retrobat.yml` is unchanged.

Two deliberate omissions, happy to add either if reviewers prefer:

- No `frontend/assets/platforms/win9x.*` icon, so it falls back to `default.ico` — same as `win3x` today.
- Not added to `NON_HASHABLE_PLATFORMS` (where `win` lives). Win9x ISOs can be large, but `dos`/`win3x` are hashable and hashes are what drive ScreenScraper lookups, so I matched those instead.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

Full backend suite green (2273 passed, 2 skipped), `trunk fmt` / `trunk check` clean, and `uv run python -m tools.generate_supported_platforms` emits the new row correctly. No new unit tests: the change is three declarative table entries, already covered by the existing platform-list tests that walk every `UniversalPlatformSlug`.

#### Screenshots (if applicable)

N/A — no UI changes.

---

**AI assistance disclosure:** this change was written with AI assistance (Claude Code). The AI located the existing `win3x` wiring, confirmed the ScreenScraper system ID, made the edits, and ran the test suite and linters. All changes were reviewed by me before submission.

Closes #3875