### PR TITLE
fix(archives): read RAR archives through bsdtar so they can be hashed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     libmagic-dev \
     7zip \
+    libarchive-tools \
     tzdata \
     libbz2-dev \
     libssl-dev \

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -22,9 +22,11 @@ from exceptions.fs_exceptions import (
     RomsNotFoundException,
 )
 from handler.metadata.base_handler import UniversalPlatformSlug as UPS
+from logger.logger import log
 from models.platform import Platform
 from models.rom import Rom, RomFile, RomFileCategory, TrackMeta
 from utils.archives import (
+    ArchiveReadError,
     detect_mime_type,
     extract_chd_hash,
     is_chd_file,
@@ -459,39 +461,47 @@ class FSRomsHandler(FSHandler):
 
             def _hash_archive_entries(
                 crc: int, md5_h: Any, sha1_h: Any
-            ) -> tuple[list[dict[str, Any]], int]:
+            ) -> tuple[list[dict[str, Any]], int, Any, Any]:
+                # Accumulate into copies so an archive we can't read in full
+                # leaves the caller's hashers untouched for the raw fallback.
+                original_crc, md5_h, sha1_h = crc, md5_h.copy(), sha1_h.copy()
                 members: list[dict[str, Any]] = []
-                for name, size, chunks in ARCHIVE_READERS[rom_ext](
-                    rom_dir,
-                    DEFAULT_EXCLUDED_FILES,
-                    DEFAULT_EXCLUDED_EXTENSIONS,
-                ):
-                    member_crc = 0
-                    member_md5 = hashlib.md5(usedforsecurity=False)
-                    member_sha1 = hashlib.sha1(usedforsecurity=False)
-                    for chunk in chunks:
-                        crc = binascii.crc32(chunk, crc)
-                        md5_h.update(chunk)
-                        sha1_h.update(chunk)
-                        member_crc = binascii.crc32(chunk, member_crc)
-                        member_md5.update(chunk)
-                        member_sha1.update(chunk)
-                    members.append(
-                        {
-                            "name": name,
-                            "size": size,
-                            "crc_hash": crc32_to_hex(member_crc),
-                            "md5_hash": member_md5.hexdigest(),
-                            "sha1_hash": member_sha1.hexdigest(),
-                        }
-                    )
-                return members, crc
+                try:
+                    for name, size, chunks in ARCHIVE_READERS[rom_ext](
+                        rom_dir,
+                        DEFAULT_EXCLUDED_FILES,
+                        DEFAULT_EXCLUDED_EXTENSIONS,
+                    ):
+                        member_crc = 0
+                        member_md5 = hashlib.md5(usedforsecurity=False)
+                        member_sha1 = hashlib.sha1(usedforsecurity=False)
+                        for chunk in chunks:
+                            crc = binascii.crc32(chunk, crc)
+                            md5_h.update(chunk)
+                            sha1_h.update(chunk)
+                            member_crc = binascii.crc32(chunk, member_crc)
+                            member_md5.update(chunk)
+                            member_sha1.update(chunk)
+                        members.append(
+                            {
+                                "name": name,
+                                "size": size,
+                                "crc_hash": crc32_to_hex(member_crc),
+                                "md5_hash": member_md5.hexdigest(),
+                                "sha1_hash": member_sha1.hexdigest(),
+                            }
+                        )
+                except ArchiveReadError as e:
+                    log.error(f"Incomplete read of archive {rom_dir}: {e}")
+                    return [], original_crc, None, None
+                return members, crc, md5_h, sha1_h
 
-            members, rom_crc_c = await asyncio.to_thread(
+            members, rom_crc_c, archive_md5_h, archive_sha1_h = await asyncio.to_thread(
                 _hash_archive_entries, rom_crc_c, rom_md5_h, rom_sha1_h
             )
 
             if members:
+                rom_md5_h, rom_sha1_h = archive_md5_h, archive_sha1_h
                 if calculate_hashes:
                     ra_platform = meta_ra_handler.get_platform(rom.platform_slug)
                     if ra_platform and ra_platform["ra_id"]:
@@ -510,7 +520,7 @@ class FSRomsHandler(FSHandler):
                     )
                 )
             else:
-                # Empty, malformed, or all-excluded archive: hash the archive
+                # Empty, malformed, unreadable, or all-excluded archive: hash the archive
                 # file's raw bytes. We avoid `_calculate_rom_hashes` here because
                 # it would decompress based on extension and end up hashing the
                 # largest internal member, not the archive itself — and would

--- a/backend/tests/utils/test_archives.py
+++ b/backend/tests/utils/test_archives.py
@@ -2,6 +2,8 @@ import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from utils import archives
 
 
@@ -96,9 +98,9 @@ def test_stream_7z_chunks_timeout_terminates_and_signals_once():
     process.terminate.assert_called_once()
 
 
-def test_read_7z_archive_files_timeout_logs_once_without_spam(monkeypatch):
+def test_read_7z_archive_files_timeout_raises_without_spawning_per_member(monkeypatch):
     """Once the shared budget is spent, no subprocess is spawned per remaining
-    member and the timeout is logged a single time, not once per entry."""
+    member and the caller is told the archive was not read in full."""
     names = [f"file{i:02d}.bin" for i in range(20)]
     listing = MagicMock(stdout=_fake_7z_listing(names))
 
@@ -108,13 +110,29 @@ def test_read_7z_archive_files_timeout_logs_once_without_spam(monkeypatch):
     with (
         patch.object(archives.subprocess, "run", return_value=listing),
         patch.object(archives.subprocess, "Popen") as popen_patch,
-        patch.object(archives.log, "error") as log_error,
+        pytest.raises(archives.ArchiveReadError),
     ):
-        results = list(archives.read_7z_archive_files(Path("/fake.7z"), [], []))
+        list(archives.read_7z_archive_files(Path("/fake.7z"), [], []))
 
-    assert results == []
     popen_patch.assert_not_called()
-    assert log_error.call_count == 1
+
+
+def test_read_7z_archive_files_raises_when_a_member_fails_midway():
+    """A member that fails after earlier ones streamed must not leave the
+    caller with a usable-looking partial result."""
+    listing = MagicMock(stdout=_fake_7z_listing(["a.bin", "b.bin"]))
+
+    popen = _mock_popen_streaming([[b"aaa"], [b"bbb"]], [0, 2])
+
+    with (
+        patch.object(archives.subprocess, "run", return_value=listing),
+        patch.object(archives.subprocess, "Popen", popen),
+        pytest.raises(archives.ArchiveReadError),
+    ):
+        for _name, _size, chunks in archives.read_7z_archive_files(
+            Path("/fake.7z"), [], []
+        ):
+            list(chunks)
 
 
 class TestExtractLargestArchiveMember:

--- a/backend/tests/utils/test_archives.py
+++ b/backend/tests/utils/test_archives.py
@@ -27,6 +27,12 @@ def _fake_7z_listing_sized(
     return "\n".join(blocks)
 
 
+def _fake_mtree_listing(lines: list[str]) -> bytes:
+    """Build a `bsdtar --format=mtree` style listing (always bytes, ASCII-only:
+    libarchive octal-escapes every other byte)."""
+    return ("#mtree\n" + "\n".join(lines) + "\n").encode()
+
+
 def _mock_popen_streaming(
     chunk_streams: list[list[bytes]],
     returncodes: list[int],
@@ -258,9 +264,9 @@ class TestExtractLargestArchiveMember:
         assert result is None
 
     def test_returns_none_and_cleans_up_on_extract_failure(self, tmp_path):
-        """A codec the 7zz build can't decompress (e.g. RAR) streams nothing
-        and exits non-zero; no partial file may be left behind, and the 7zz
-        reason must reach the error log so scans explain the missing hash."""
+        """A codec the extractor can't decompress streams nothing and exits
+        non-zero; no partial file may be left behind, and the reason must reach
+        the error log so scans explain the missing hash."""
         listing = MagicMock(stdout=_fake_7z_listing_sized([("game.gba", 500)]))
         popen = _mock_popen_streaming(
             [[]], [2], stderr=b"ERROR: Unsupported Method : game.gba"
@@ -272,7 +278,7 @@ class TestExtractLargestArchiveMember:
             patch.object(archives.log, "error") as log_error,
         ):
             result = archives.extract_largest_archive_member(
-                Path("/fake/game.rar"), tmp_path
+                Path("/fake/game.7z"), tmp_path
             )
 
         assert result is None
@@ -294,3 +300,149 @@ class TestExtractLargestArchiveMember:
 
         assert result is None
         assert list(tmp_path.iterdir()) == []
+
+
+class TestRarArchives:
+    """RAR reading through bsdtar/libarchive: the bundled 7zz is built without
+    the RAR codec, so it can neither list nor extract RAR members (GitHub issue
+    #3884)."""
+
+    def test_lists_file_members_with_sizes(self):
+        listing = MagicMock(
+            stdout=_fake_mtree_listing(
+                [
+                    "./game.gba type=file size=500",
+                    "./readme.txt type=file size=12",
+                ]
+            )
+        )
+
+        with patch.object(archives.subprocess, "run", return_value=listing) as run:
+            members = archives._list_rar_file_members(Path("/fake/game.rar"))
+
+        # The archive-root "./" prefix is not part of the stored member name.
+        assert members == [("game.gba", 500), ("readme.txt", 12)]
+        assert run.call_args[0][0][0] == archives.BSDTAR_PATH
+        assert "@/fake/game.rar" in run.call_args[0][0]
+
+    def test_directories_and_links_are_ignored(self):
+        listing = MagicMock(
+            stdout=_fake_mtree_listing(
+                [
+                    "./subdir type=dir",
+                    "./subdir/link type=link",
+                    "./subdir/game.gba type=file size=500",
+                ]
+            )
+        )
+
+        with patch.object(archives.subprocess, "run", return_value=listing):
+            members = archives._list_rar_file_members(Path("/fake/game.rar"))
+
+        assert members == [("subdir/game.gba", 500)]
+
+    def test_escaped_member_names_are_decoded(self):
+        """libarchive octal-escapes the backslash and every byte outside
+        printable ASCII, so a UTF-8 name comes back byte by byte."""
+        listing = MagicMock(
+            stdout=_fake_mtree_listing(
+                [r"./caf\303\251\040\0431\134x.gba type=file size=500"]
+            )
+        )
+
+        with patch.object(archives.subprocess, "run", return_value=listing):
+            members = archives._list_rar_file_members(Path("/fake/game.rar"))
+
+        assert members == [("café #1\\x.gba", 500)]
+
+    def test_returns_no_members_when_listing_fails(self):
+        """Encrypted headers and corrupt archives make bsdtar exit non-zero."""
+        with (
+            patch.object(
+                archives.subprocess,
+                "run",
+                side_effect=archives.subprocess.CalledProcessError(1, "bsdtar"),
+            ),
+            patch.object(archives.log, "error") as log_error,
+        ):
+            members = archives._list_rar_file_members(Path("/fake/game.rar"))
+
+        assert members == []
+        log_error.assert_called_once()
+
+    def test_member_pattern_escapes_glob_metacharacters(self):
+        """bsdtar matches member arguments as globs, so a stored name holding
+        "*" or "?" would otherwise select (and concatenate) other members."""
+        assert archives._bsdtar_member_pattern("g*me?[1].gba") == r"g\*me\?\[1\].gba"
+        assert archives._bsdtar_member_pattern("back\\slash.gba") == r"back\\slash.gba"
+
+    def test_extraction_command_is_chosen_by_extension(self):
+        rar_command = archives._archive_member_command(Path("/fake/GAME.RAR"), "a.gba")
+        assert rar_command == [archives.BSDTAR_PATH, "-xOf", "/fake/GAME.RAR", "a.gba"]
+
+        seven_zip_command = archives._archive_member_command(
+            Path("/fake/game.7z"), "a.gba"
+        )
+        assert seven_zip_command[0] == archives.SEVEN_ZIP_PATH
+
+    def test_read_rar_archive_files_streams_members_in_ascii_order(self):
+        listing = MagicMock(
+            stdout=_fake_mtree_listing(
+                [
+                    "./b.gba type=file size=3",
+                    "./a.gba type=file size=3",
+                    "./skip.nfo type=file size=3",
+                    "./cover.jpg type=file size=3",
+                ]
+            )
+        )
+        popen = _mock_popen_streaming([[b"aaa"], [b"bbb"]], [0, 0])
+
+        with (
+            patch.object(archives.subprocess, "run", return_value=listing),
+            patch.object(archives.subprocess, "Popen", popen),
+        ):
+            results = [
+                (name, size, b"".join(chunks))
+                for name, size, chunks in archives.read_rar_archive_files(
+                    Path("/fake/game.rar"), ["cover.jpg"], ["nfo"]
+                )
+            ]
+
+        assert results == [("a.gba", 3, b"aaa"), ("b.gba", 3, b"bbb")]
+        assert popen.call_args_list[0][0][0][:3] == [
+            archives.BSDTAR_PATH,
+            "-xOf",
+            "/fake/game.rar",
+        ]
+
+    def test_largest_member_is_extracted_through_bsdtar(self, tmp_path):
+        """RAHasher is fed a real ROM extracted from the RAR (GitHub issue
+        #3808 left this broken for RAR only)."""
+        listing = MagicMock(
+            stdout=_fake_mtree_listing(
+                [
+                    "./readme.txt type=file size=12",
+                    "./game.gba type=file size=500",
+                ]
+            )
+        )
+        popen = _mock_popen_streaming([[b"abc", b"def"]], [0])
+
+        with (
+            patch.object(archives.subprocess, "run", return_value=listing),
+            patch.object(archives.subprocess, "Popen", popen),
+        ):
+            result = archives.extract_largest_archive_member(
+                Path("/fake/game.rar"), tmp_path
+            )
+
+        assert result is not None
+        assert result == tmp_path / "game.gba"
+        assert result.read_bytes() == b"abcdef"
+        assert popen.call_args[0][0] == [
+            archives.BSDTAR_PATH,
+            "-xOf",
+            "/fake/game.rar",
+            "game.gba",
+        ]

--- a/backend/tests/utils/test_archives.py
+++ b/backend/tests/utils/test_archives.py
@@ -396,7 +396,13 @@ class TestRarArchives:
 
     def test_extraction_command_is_chosen_by_extension(self):
         rar_command = archives._archive_member_command(Path("/fake/GAME.RAR"), "a.gba")
-        assert rar_command == [archives.BSDTAR_PATH, "-xOf", "/fake/GAME.RAR", "a.gba"]
+        assert rar_command == [
+            archives.BSDTAR_PATH,
+            "-xOf",
+            "/fake/GAME.RAR",
+            "--",
+            "a.gba",
+        ]
 
         seven_zip_command = archives._archive_member_command(
             Path("/fake/game.7z"), "a.gba"
@@ -462,5 +468,6 @@ class TestRarArchives:
             archives.BSDTAR_PATH,
             "-xOf",
             "/fake/game.rar",
+            "--",
             "game.gba",
         ]

--- a/backend/utils/archives.py
+++ b/backend/utils/archives.py
@@ -3,6 +3,7 @@
 import bz2
 import fnmatch
 import os
+import re
 import subprocess
 import tarfile
 import tempfile
@@ -21,6 +22,19 @@ from logger.logger import log
 from utils.filesystem import COMPRESSED_FILE_EXTENSIONS
 
 SEVEN_ZIP_PATH = "/usr/bin/7zz"
+# The bundled 7zz is built without the RAR codec (it is under the restrictive
+# unRAR license), so RAR archives are read through libarchive's bsdtar instead.
+BSDTAR_PATH = "/usr/bin/bsdtar"
+
+RAR_FILE_EXTENSIONS: Final = (".rar",)
+
+# libarchive escapes the backslash and every byte outside printable ASCII as a
+# 3-digit octal sequence in the mtree listings we parse RAR members from.
+_MTREE_OCTAL_ESCAPE: Final = re.compile(rb"\\([0-7]{3})")
+
+# bsdtar treats member arguments as glob patterns, where a backslash escapes
+# the character that follows it.
+_BSDTAR_GLOB_METACHARACTERS: Final = frozenset("\\*?[]")
 
 # Known compressed file MIME types
 COMPRESSED_MIME_TYPES: Final = frozenset(
@@ -296,64 +310,31 @@ def _stream_7z_chunks(
         yield chunk
 
 
-def read_7z_archive_files(
-    file_path: Path,
+def _is_member_excluded(
+    member: str,
     excluded_names: list[str],
     excluded_exts: list[str],
+) -> bool:
+    base_name = Path(member).name
+    lower = base_name.lower()
+    if any(lower.endswith("." + ext) for ext in excluded_exts):
+        return True
+    return any(
+        base_name == exc or fnmatch.fnmatch(base_name, exc) for exc in excluded_names
+    )
+
+
+def _stream_archive_members(
+    file_path: Path,
+    entries: list[tuple[str, int]],
 ) -> Iterator[tuple[str, int, Iterator[bytes]]]:
-    """Yield eligible files from a 7z archive in ASCII path order.
+    """Stream each listed member of an archive, one subprocess at a time.
 
-    Each yielded `(internal_name, file_size_bytes, chunks)` streams its
-    member's bytes lazily; chunks must be fully consumed before advancing
-    to the next entry, since the underlying subprocess is reaped at that point.
+    Members are yielded in ASCII path order under a single time budget shared
+    by the whole archive.
     """
-    try:
-        result = subprocess.run(
-            [SEVEN_ZIP_PATH, "l", "-slt", "-ba", str(file_path)],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=SEVEN_ZIP_TIMEOUT,
-            shell=False,  # trunk-ignore(bandit/B603)
-        )
-    except (
-        subprocess.TimeoutExpired,
-        subprocess.CalledProcessError,
-        FileNotFoundError,
-    ) as e:
-        log.error(f"Error listing 7z archive {file_path}: {e}")
-        return
+    entries = sorted(entries, key=lambda e: e[0])
 
-    entries: list[tuple[str, int]] = []
-    current_file: str | None = None
-    current_size = 0
-
-    for line in result.stdout.split("\n"):
-        line = line.lstrip()
-        if line.startswith("Path = "):
-            current_file = line.split(" = ", 1)[1]
-        elif line.startswith("Size = "):
-            try:
-                current_size = int(line.split(" = ")[1].strip())
-            except ValueError:
-                current_size = 0
-        elif line.startswith("Attributes = "):
-            attrs = line.split(" = ")[1].strip()
-            if current_file and not attrs.startswith("D"):
-                base_name = Path(current_file).name
-                lower = base_name.lower()
-                if not any(lower.endswith("." + ext) for ext in excluded_exts):
-                    if not any(
-                        base_name == exc or fnmatch.fnmatch(base_name, exc)
-                        for exc in excluded_names
-                    ):
-                        entries.append((current_file, current_size))
-            current_file = None
-            current_size = 0
-
-    entries.sort(key=lambda e: e[0])
-
-    # Single time budget for reading every member of this archive.
     deadline = time.monotonic() + SEVEN_ZIP_TIMEOUT
     timed_out = False
 
@@ -370,7 +351,7 @@ def read_7z_archive_files(
             break
         try:
             with subprocess.Popen(
-                [SEVEN_ZIP_PATH, "e", str(file_path), name, "-so", "-y", "-spd"],
+                _archive_member_command(file_path, name),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 shell=False,  # trunk-ignore(bandit/B603)
@@ -382,7 +363,8 @@ def read_7z_archive_files(
             # expected then and is covered by the single log below.
             if not timed_out and process.returncode != 0:
                 log.error(
-                    f"7z extraction of {name} failed with code {process.returncode}"
+                    f"Extraction of {name} from {file_path} failed "
+                    f"with code {process.returncode}"
                 )
                 return
         except (OSError, ValueError) as e:
@@ -390,7 +372,26 @@ def read_7z_archive_files(
             continue
 
     if timed_out:
-        log.error(f"7z extraction timed out reading members of {file_path}")
+        log.error(f"Extraction timed out reading members of {file_path}")
+
+
+def read_7z_archive_files(
+    file_path: Path,
+    excluded_names: list[str],
+    excluded_exts: list[str],
+) -> Iterator[tuple[str, int, Iterator[bytes]]]:
+    """Yield eligible files from a 7z archive in ASCII path order.
+
+    Each yielded `(internal_name, file_size_bytes, chunks)` streams its
+    member's bytes lazily; chunks must be fully consumed before advancing
+    to the next entry, since the underlying subprocess is reaped at that point.
+    """
+    entries = [
+        (name, size)
+        for name, size in _list_archive_file_members(file_path)
+        if not _is_member_excluded(name, excluded_names, excluded_exts)
+    ]
+    yield from _stream_archive_members(file_path, entries)
 
 
 def read_rar_archive_files(
@@ -398,13 +399,104 @@ def read_rar_archive_files(
     excluded_names: list[str],
     excluded_exts: list[str],
 ) -> Iterator[tuple[str, int, Iterator[bytes]]]:
-    """Yield eligible files from a RAR archive, sorted by internal path (ASCII).
+    """Yield eligible files from a RAR archive in ASCII path order.
 
-    Delegates to the 7zz binary. Listing RAR members always works, but
-    streaming their contents requires a 7zz build with the RAR codec; the
-    bundled Alpine build lacks it, so content reads fail and log an error.
+    Same contract as `read_7z_archive_files`, but listing and extraction go
+    through bsdtar since the bundled 7zz has no RAR codec.
     """
-    return read_7z_archive_files(file_path, excluded_names, excluded_exts)
+    entries = [
+        (name, size)
+        for name, size in _list_rar_file_members(file_path)
+        if not _is_member_excluded(name, excluded_names, excluded_exts)
+    ]
+    yield from _stream_archive_members(file_path, entries)
+
+
+def _is_rar_archive(file_path: Path) -> bool:
+    return str(file_path).lower().endswith(RAR_FILE_EXTENSIONS)
+
+
+def _bsdtar_member_pattern(member: str) -> str:
+    """Escape a member name so bsdtar matches it literally.
+
+    Without this, a stored name containing `*` or `?` is a glob that can
+    select (and concatenate) other members of the same archive.
+    """
+    return "".join(
+        f"\\{char}" if char in _BSDTAR_GLOB_METACHARACTERS else char for char in member
+    )
+
+
+def _unescape_mtree_path(raw: bytes) -> str:
+    unescaped = _MTREE_OCTAL_ESCAPE.sub(lambda m: bytes([int(m.group(1), 8)]), raw)
+    # surrogateescape round-trips names that aren't valid UTF-8, so they still
+    # encode back to the original bytes when passed to bsdtar.
+    return unescaped.decode("utf-8", errors="surrogateescape")
+
+
+def _list_rar_file_members(file_path: Path) -> list[tuple[str, int]]:
+    """List `(member_path, size)` for every file member of a RAR archive.
+
+    Rewriting the archive as an mtree listing on stdout is libarchive's only
+    machine-readable listing; `bsdtar -tv` output is ls-style and ambiguous
+    for names containing spaces. Only headers are read, so listing stays cheap
+    regardless of archive size.
+    """
+    try:
+        result = subprocess.run(
+            [
+                BSDTAR_PATH,
+                "-cf",
+                "-",
+                "--format=mtree",
+                "--options=!all,type,size",
+                f"@{file_path}",
+            ],
+            capture_output=True,
+            check=True,
+            timeout=SEVEN_ZIP_TIMEOUT,
+            shell=False,  # trunk-ignore(bandit/B603): bsdtar path is hardcoded, args are validated
+        )
+    except (
+        subprocess.TimeoutExpired,
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+    ) as e:
+        log.error(f"Error listing RAR archive {file_path}: {e}")
+        return []
+
+    entries: list[tuple[str, int]] = []
+    for line in result.stdout.splitlines():
+        # "#" starts a comment, "/" an mtree directive; neither is an entry.
+        if not line or line.startswith((b"#", b"/")):
+            continue
+        raw_path, _, keywords = line.partition(b" ")
+        fields = dict(
+            field.split(b"=", 1) for field in keywords.split() if b"=" in field
+        )
+        if fields.get(b"type") != b"file":
+            continue
+        try:
+            size = int(fields.get(b"size", b"0"))
+        except ValueError:
+            size = 0
+        # mtree paths are archive-root relative ("./game.gba"), stored member
+        # names are not.
+        name = _unescape_mtree_path(raw_path).removeprefix("./")
+        if name:
+            entries.append((name, size))
+
+    return entries
+
+
+def _archive_member_command(file_path: Path, member: str) -> list[str]:
+    """Build the command streaming a single archive member to stdout."""
+    if _is_rar_archive(file_path):
+        return [BSDTAR_PATH, "-xOf", str(file_path), _bsdtar_member_pattern(member)]
+
+    # "-spd" disables wildcard matching so a member name containing "*" or "?"
+    # can't select (and concatenate) other members.
+    return [SEVEN_ZIP_PATH, "e", str(file_path), member, "-so", "-y", "-spd"]
 
 
 def _list_archive_file_members(file_path: Path) -> list[tuple[str, int]]:
@@ -414,6 +506,9 @@ def _list_archive_file_members(file_path: Path) -> list[tuple[str, int]]:
     entry is committed when the next `Path =` starts or the listing ends,
     and only dropped when its attributes mark it as a directory.
     """
+    if _is_rar_archive(file_path):
+        return _list_rar_file_members(file_path)
+
     try:
         result = subprocess.run(
             [SEVEN_ZIP_PATH, "l", "-slt", "-ba", str(file_path)],
@@ -464,24 +559,22 @@ def _extract_member_to_dir(
 ) -> Path | None:
     """Stream one archive member into `dest_dir`, named after its basename.
 
-    Returns None (leaving no partial file) when extraction fails, exceeds
-    the deadline, or the 7zz build lacks the codec (it then streams nothing
-    and exits non-zero, e.g. for RAR).
+    Returns None (leaving no partial file) when extraction fails or exceeds
+    the deadline.
     """
     dest_path = dest_dir / Path(member).name
     try:
         # stderr goes to an unlinked temp file rather than a pipe: a pipe can
-        # fill and block 7zz while this thread waits on stdout, stalling past
-        # the deadline. "-spd" disables wildcard matching so a member name
-        # containing "*" or "?" can't select (and concatenate) other members.
+        # fill and block the extractor while this thread waits on stdout,
+        # stalling past the deadline.
         with tempfile.TemporaryFile() as stderr_file:
             with (
                 open(dest_path, "wb") as dest_file,
                 subprocess.Popen(
-                    [SEVEN_ZIP_PATH, "e", str(file_path), member, "-so", "-y", "-spd"],
+                    _archive_member_command(file_path, member),
                     stdout=subprocess.PIPE,
                     stderr=stderr_file,
-                    shell=False,  # trunk-ignore(bandit/B603): 7z path is hardcoded, args are validated
+                    shell=False,  # trunk-ignore(bandit/B603): binary paths are hardcoded, args are validated
                 ) as process,
             ):
                 assert process.stdout is not None
@@ -494,9 +587,8 @@ def _extract_member_to_dir(
                     dest_file.write(chunk)
 
             if process.returncode != 0:
-                # Surface the 7zz reason (e.g. "Unsupported Method" from a
-                # build without the RAR codec) so scan logs explain the
-                # missing hash.
+                # Surface the extractor's own reason (e.g. "Unsupported
+                # Method") so scan logs explain the missing hash.
                 stderr_file.seek(0)
                 detail = stderr_file.read().decode(errors="replace").strip()
                 log.error(

--- a/backend/utils/archives.py
+++ b/backend/utils/archives.py
@@ -21,9 +21,9 @@ from config import SEVEN_ZIP_TIMEOUT
 from logger.logger import log
 from utils.filesystem import COMPRESSED_FILE_EXTENSIONS
 
+# 7zip archives are read through 7zz.
 SEVEN_ZIP_PATH = "/usr/bin/7zz"
-# The bundled 7zz is built without the RAR codec (it is under the restrictive
-# unRAR license), so RAR archives are read through libarchive's bsdtar instead.
+# RAR archives are read through bsdtar.
 BSDTAR_PATH = "/usr/bin/bsdtar"
 
 RAR_FILE_EXTENSIONS: Final = (".rar",)
@@ -499,7 +499,13 @@ def _list_rar_file_members(file_path: Path) -> list[tuple[str, int]]:
 def _archive_member_command(file_path: Path, member: str) -> list[str]:
     """Build the command streaming a single archive member to stdout."""
     if _is_rar_archive(file_path):
-        return [BSDTAR_PATH, "-xOf", str(file_path), _bsdtar_member_pattern(member)]
+        return [
+            BSDTAR_PATH,
+            "-xOf",
+            str(file_path),
+            "--",
+            _bsdtar_member_pattern(member),
+        ]
 
     # "-spd" disables wildcard matching so a member name containing "*" or "?"
     # can't select (and concatenate) other members.

--- a/backend/utils/archives.py
+++ b/backend/utils/archives.py
@@ -65,6 +65,10 @@ _MIME_DETECTOR = magic.Magic(mime=True)
 _MIME_DETECTOR_LOCK = threading.Lock()
 
 
+class ArchiveReadError(Exception):
+    """An archive's members could not be fully read."""
+
+
 def detect_mime_type(file_path: os.PathLike[str] | str) -> str:
     """Detect MIME type via libmagic; returns empty string on error."""
     try:
@@ -331,7 +335,8 @@ def _stream_archive_members(
     """Stream each listed member of an archive, one subprocess at a time.
 
     Members are yielded in ASCII path order under a single time budget shared
-    by the whole archive.
+    by the whole archive. Raises `ArchiveReadError` if any member fails or the
+    budget is spent, so callers never mistake a partial read for a complete one.
     """
     entries = sorted(entries, key=lambda e: e[0])
 
@@ -360,19 +365,19 @@ def _stream_archive_members(
                     continue
                 yield name, size, _stream_7z_chunks(process, deadline, _mark_timed_out)
             # A timeout terminates the subprocess, so a non-zero return code is
-            # expected then and is covered by the single log below.
+            # expected then and is covered by the single raise below.
             if not timed_out and process.returncode != 0:
-                log.error(
+                raise ArchiveReadError(
                     f"Extraction of {name} from {file_path} failed "
                     f"with code {process.returncode}"
                 )
-                return
         except (OSError, ValueError) as e:
-            log.error(f"Error extracting {name} from {file_path}: {e}")
-            continue
+            raise ArchiveReadError(
+                f"Error extracting {name} from {file_path}: {e}"
+            ) from e
 
     if timed_out:
-        log.error(f"Extraction timed out reading members of {file_path}")
+        raise ArchiveReadError(f"Extraction timed out reading members of {file_path}")
 
 
 def read_7z_archive_files(
@@ -385,6 +390,8 @@ def read_7z_archive_files(
     Each yielded `(internal_name, file_size_bytes, chunks)` streams its
     member's bytes lazily; chunks must be fully consumed before advancing
     to the next entry, since the underlying subprocess is reaped at that point.
+
+    Raises `ArchiveReadError` if any member cannot be read in full.
     """
     entries = [
         (name, size)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -165,8 +165,11 @@ RUN git clone https://github.com/evanmiller/mod_zip.git && \
 FROM nginx:${NGINX_VERSION}-alpine${ALPINE_VERSION}@sha256:${NGINX_SHA256} AS production-stage
 ARG WEBSERVER_FOLDER=/var/www/html
 
+# libarchive-tools provides bsdtar, which reads RAR/RAR5 archives; Alpine's
+# 7zip is built without the RAR codec, so 7zz can neither list nor extract them
 RUN apk add --no-cache \
     bash \
+    libarchive-tools \
     libmagic \
     mariadb-connector-c \
     libpq \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -165,8 +165,6 @@ RUN git clone https://github.com/evanmiller/mod_zip.git && \
 FROM nginx:${NGINX_VERSION}-alpine${ALPINE_VERSION}@sha256:${NGINX_SHA256} AS production-stage
 ARG WEBSERVER_FOLDER=/var/www/html
 
-# libarchive-tools provides bsdtar, which reads RAR/RAR5 archives; Alpine's
-# 7zip is built without the RAR codec, so 7zz can neither list nor extract them
 RUN apk add --no-cache \
     bash \
     libarchive-tools \


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3884

RomM lists `.rar` as a supported archive format, but the bundled `7zz` is built without the RAR codec (it is under the restrictive unRAR license, which is why Alpine's 7-Zip omits it). `7zz` can therefore neither list nor extract RAR members, so every content-based match silently came up empty for a `.rar`-compressed ROM: no RetroAchievements hash, and no CRC/MD5/SHA-1 for hash-database providers like Hasheous. The same ROM in a `.zip` or `.7z` matched fine, and the only symptom was an ERROR line in the scan log. This is the follow-up #3813 deliberately deferred, since it needs an image-level dependency.

RAR listing and extraction now go through libarchive's `bsdtar`, added to the images as `libarchive-tools`. Both the content-hashing path (`ARCHIVE_READERS[".rar"]`) and the RetroAchievements path (`extract_largest_archive_member`) share the same command builder, so one decompressor fixes both.

Why `libarchive` over the alternatives the issue listed: it is BSD-licensed and in Alpine `main` (and Ubuntu `main` for the dev image), so it raises no redistribution question. `unrar` is not packaged in Alpine at all (verified: `apk search -x unrar` is empty on `alpine:3.23`), and shipping a RAR-capable 7-Zip build carries the same license problem that removed the codec in the first place.

**Files modified**

- `docker/Dockerfile` (production stage) and the root dev `Dockerfile`: add `libarchive-tools`.
- `backend/utils/archives.py`:
  - `_list_rar_file_members()` lists members via `bsdtar -cf - --format=mtree --options=!all,type,size @archive`. An mtree rewrite is libarchive's only machine-readable listing (`bsdtar -tv` is ls-style and ambiguous for names containing spaces); it reads headers only, so listing a 160 MB RAR takes ~0.2 s. The parser handles mtree's octal escaping (`\303\251`, `\040`, `\134`) and the archive-root `./` prefix, and keeps `type=file` entries only.
  - `_archive_member_command()` selects `bsdtar -xOf` for `.rar` and the existing `7zz e -so` otherwise. `read_rar_archive_files()`, `read_7z_archive_files()` and `_extract_member_to_dir()` all build their subprocess through it.
  - `_bsdtar_member_pattern()` escapes `\ * ? [ ]`: bsdtar matches member arguments as globs, the same hazard `-spd` covers on the 7zz side, so a stored name like `star*.bin` can't select and concatenate other members.
  - The listing/filtering/streaming shared by both readers is factored out (`_is_member_excluded`, `_stream_archive_members`), so 7z and RAR share one deadline-and-error implementation instead of `read_rar_archive_files` being an alias that could never work.
- `backend/tests/utils/test_archives.py`: 8 tests for the RAR paths (mtree parsing with sizes, dir/link entries skipped, octal-escaped names, listing failure, glob escaping, command dispatch by extension, ASCII-ordered streaming with exclusions, largest-member extraction). The existing test that asserted RAR extraction *fails* now uses a `.7z` path, since that failure is what this PR removes.

**Testing notes**

- End-to-end against real `bsdtar` 3.8.5 in `alpine:3.23` (the production version) with archives produced by real RAR 7.23: RAR5, solid RAR5, legacy RAR4, exclusion filtering, non-ASCII and backslash member names, members literally named `star*.bin` / `q?.bin` (each yields only its own bytes, no concatenation), corrupt and header-encrypted archives (clean failure, no partial files), and `extract_largest_archive_member` returning the ROM with the correct SHA-1. The 7z path was re-verified unchanged through the same harness.
- `apk add libarchive-tools` verified on the actual production base image (`nginx:1.29.5-alpine3.23`); `bsdtar` lands at `/usr/bin/bsdtar`.
- Full backend suite: 2281 passed, 2 skipped. `trunk check` clean.

**Reviewer attention**

- Non-Docker installs now need `bsdtar` on `PATH` at `/usr/bin/bsdtar` for RAR support. Without it, RAR listing logs an error and no hash is stored, which is exactly today's behavior, so nothing regresses.
- Header-encrypted RARs still can't be read (no password), and they fail at listing rather than extraction.
- Per-member extraction spawns one `bsdtar` per member, matching the existing 7z reader. For solid archives that re-decompresses from the start per member; the shared `SEVEN_ZIP_TIMEOUT` budget still bounds the whole archive.

**AI assistance disclosure**: this PR was developed with AI assistance (Claude Code / Claude Opus 4.8): root-cause analysis, implementation, tests, and the empirical verification against real RAR archives were AI-driven under my direction and review; I reviewed all changes and the verification methodology.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
