### PR TITLE
fix(nginx): cache only fingerprinted assets, revalidate the rest

### DIFF
--- a/backend/tests/test_nginx_cache_headers.py
+++ b/backend/tests/test_nginx_cache_headers.py
@@ -1,0 +1,286 @@
+"""Guards the asset caching policy in the nginx template (issue #3890).
+
+The Docker image's nginx serves the whole frontend. Assets fall into caching
+classes and the template must sort each request into the right one:
+
+  * Frozen forever (fingerprinted): content-hashed Vite bundles
+    (``index-<hash>.js``) and library resources requested with a cache-busting
+    query (covers ``?ts=``, manuals ``?v=``). The URL changes when the file
+    does, so a cached copy is never stale.
+  * Revalidating (stable URLs across image upgrades / re-scrapes): the bundled
+    EmulatorJS/Ruffle runtimes, icons/fonts/logos, and the query-less resources
+    (screenshots, RA badges, which reuse names like ``0.jpg`` and are
+    overwritten in place).
+  * ``no-cache`` (must always be fresh): ``index.html``, the service worker,
+    and the root favicons/manifest.
+
+The resources bucket splits on whether a recognized version param (``ts``/``v``)
+is present, via the ``$resources_cache_control`` map (an unrelated query like
+``?download=1`` must not freeze a stable file). Rather than grepping the
+template for a string, this parses the ``location`` and ``map`` blocks and
+replays nginx's matching for representative URLs, asserting the
+``Cache-Control`` each resolves to.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+NGINX_TEMPLATE = (
+    Path(__file__).resolve().parents[2]
+    / "docker"
+    / "nginx"
+    / "templates"
+    / "default.conf.template"
+)
+
+IMMUTABLE_MAX_AGE = 31536000  # one year, in seconds
+# Any revalidating cache must stay well under this so upgrades/re-scrapes show.
+MAX_REVALIDATING_AGE = 86400  # one day, in seconds
+
+
+def _read_block(text: str, start: int) -> tuple[str, int]:
+    """Return (body, end) for a brace block whose opening ``{`` is at start-1,
+    scanning to the matching ``}``. Blocks in this template do not nest."""
+    depth = 1
+    i = start
+    while i < len(text) and depth:
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+        i += 1
+    return text[start : i - 1], i
+
+
+class Location:
+    """A parsed nginx ``location``: modifier, match, and the Cache-Control it
+    sets (a quoted literal, or a ``$variable`` resolved through a map)."""
+
+    def __init__(self, modifier: str, match: str, body: str):
+        self.modifier = modifier
+        self.match = match
+        cache = re.search(
+            r'add_header\s+Cache-Control\s+(?:"([^"]*)"|(\$[A-Za-z0-9_]+))',
+            body,
+            re.IGNORECASE,
+        )
+        self.cache_control = (
+            (cache.group(1) if cache.group(1) is not None else cache.group(2))
+            if cache
+            else None
+        )
+
+    @property
+    def is_regex(self) -> bool:
+        return self.modifier in ("~", "~*")
+
+    @property
+    def is_prefix(self) -> bool:
+        return self.modifier in ("", "^~")
+
+
+def _parse_locations(text: str) -> list[Location]:
+    """Extract every ``location`` block, preserving file order (nginx evaluates
+    regex locations in the order they appear)."""
+    locations: list[Location] = []
+    header = re.compile(r'location\s+(=|\^~|~\*|~)?\s*(?:"([^"]+)"|(\S+))\s*\{')
+    for m in header.finditer(text):
+        modifier = m.group(1) or ""
+        match = m.group(2) if m.group(2) is not None else m.group(3)
+        body, _ = _read_block(text, m.end())
+        locations.append(Location(modifier, match, body))
+    return locations
+
+
+def _parse_maps(text: str) -> dict[str, tuple[str, dict[str, str]]]:
+    """Parse ``map $in $out { key value; ... }`` -> {out: ($in, {key: value})}."""
+    maps: dict[str, tuple[str, dict[str, str]]] = {}
+    entry = re.compile(r'(?:"([^"]*)"|(\S+))\s+(?:"([^"]*)"|(\S+))\s*;')
+    for m in re.finditer(r"map\s+(\$[A-Za-z0-9_]+)\s+\$([A-Za-z0-9_]+)\s*\{", text):
+        input_var, output_var = m.group(1), m.group(2)
+        body, _ = _read_block(text, m.end())
+        entries: dict[str, str] = {}
+        for e in entry.finditer(body):
+            key = e.group(1) if e.group(1) is not None else e.group(2)
+            value = e.group(3) if e.group(3) is not None else e.group(4)
+            entries[key] = value
+        maps[output_var] = (input_var, entries)
+    return maps
+
+
+def _input_value(input_var: str, url: str) -> str:
+    """The nginx source a map keys on. Only ``$args`` is used here."""
+    query = url.split("?", 1)[1] if "?" in url else ""
+    if input_var == "$args":
+        return query
+    if input_var == "$is_args":
+        return "?" if query else ""
+    raise NotImplementedError(f"map input {input_var} not modelled")
+
+
+def _eval_map(input_var: str, entries: dict[str, str], url: str) -> str | None:
+    """Resolve an nginx ``map`` for ``url``, mirroring nginx precedence: exact
+    keys first, then regex keys (``~``/``~*``) in order, else ``default``."""
+    value = _input_value(input_var, url)
+    for key, out in entries.items():
+        if key != "default" and not key.startswith("~") and key == value:
+            return out
+    for key, out in entries.items():
+        if key.startswith("~"):
+            pattern = key[1:]
+            flags = re.IGNORECASE if pattern.startswith("*") else 0
+            if re.search(pattern.lstrip("*"), value, flags):
+                return out
+    return entries.get("default")
+
+
+def _resolve(locations: list[Location], path: str) -> Location | None:
+    """Replay nginx's location selection for ``path`` (query stripped): exact,
+    then longest prefix, then first matching regex, else that prefix."""
+    for loc in locations:
+        if loc.modifier == "=" and loc.match == path:
+            return loc
+
+    best_prefix: Location | None = None
+    for loc in locations:
+        if loc.is_prefix and path.startswith(loc.match):
+            if best_prefix is None or len(loc.match) > len(best_prefix.match):
+                best_prefix = loc
+
+    if best_prefix is not None and best_prefix.modifier == "^~":
+        return best_prefix
+
+    for loc in locations:
+        if loc.is_regex:
+            flags = re.IGNORECASE if loc.modifier == "~*" else 0
+            if re.search(loc.match, path, flags):
+                return loc
+
+    return best_prefix
+
+
+@pytest.fixture(scope="module")
+def config() -> tuple[list[Location], dict[str, tuple[str, dict[str, str]]]]:
+    text = NGINX_TEMPLATE.read_text()
+    return _parse_locations(text), _parse_maps(text)
+
+
+def _cache_control_for(config, url: str) -> str | None:
+    locations, maps = config
+    loc = _resolve(locations, url.split("?", 1)[0])
+    assert loc is not None, f"no location matched {url}"
+    cc = loc.cache_control
+    if cc is not None and cc.startswith("$"):
+        input_var, entries = maps[cc[1:]]
+        cc = _eval_map(input_var, entries, url)
+    return cc
+
+
+# Fingerprinted -> safe to cache immutably forever. Library resources qualify
+# only when they carry a cache-busting query (covers ?ts=, manuals ?v=).
+IMMUTABLE_URLS = [
+    "/assets/index-C-Cea5tF.js",
+    "/assets/index-C-Cea5tF.css",
+    "/assets/EmulatorJS--ZSfrbCp.js",  # hashed vite chunk with hyphens in name
+    "/assets/emulatorjs-logotype-COnXko2R.svg",
+    "/assets/inter-latin-Ckm5tF12.woff2",
+    "/assets/romm/resources/roms/1/1/cover/small.png?ts=2026-01-01T00:00:00",
+    "/assets/romm/resources/roms/1/1/cover/big.png?ts=1700000000",
+    "/assets/romm/resources/roms/1/1/manual/1.pdf?v=1700000000",
+]
+
+# Stable URLs that must revalidate so an upgrade / re-scrape is picked up. This
+# includes query-less resources: screenshots and RA badges reuse fixed names
+# and are overwritten in place, so they are NOT safe to freeze.
+REVALIDATING_URLS = [
+    "/assets/emulatorjs/data/loader.js",  # bundled EmulatorJS runtime
+    "/assets/emulatorjs/data/cores/snes9x-wasm.data",
+    "/assets/ruffle/ruffle.js",
+    "/assets/scrappers/ss.png",
+    "/assets/platforms/default.ico",
+    "/assets/isotipo.png",  # non-hashed file directly under /assets
+    "/assets/patcherjs/patcherjs.png",
+    "/assets/romm/resources/roms/1/1/screenshots/0.jpg",  # overwritten on re-scrape
+    "/assets/romm/resources/roms/1/1/screenshots/1.jpg",
+    "/assets/romm/resources/roms/1/1/ra/badges/12345.png",  # RA badge, no query
+    # An unrelated query must NOT be mistaken for a version bust and frozen.
+    "/assets/romm/resources/roms/1/1/screenshots/0.jpg?download=1",
+]
+
+# Served from ``location /`` (not /assets): index.html, the service worker and
+# the favicons/manifest all keep stable names, so they must revalidate rather
+# than be frozen. A stale index.html could point at purged, hashed bundles.
+ROOT_REVALIDATING_URLS = [
+    "/",
+    "/index.html",
+    "/library",  # SPA route -> index.html
+    "/favicon.ico",
+    "/favicon.svg",
+    "/site.webmanifest",
+    "/manifest.webmanifest",
+    "/sw.js",
+    "/apple-touch-icon.png",
+]
+
+
+@pytest.mark.parametrize("url", IMMUTABLE_URLS)
+def test_fingerprinted_assets_are_immutable(config, url):
+    cc = _cache_control_for(config, url)
+    assert cc is not None, f"{url} has no Cache-Control"
+    assert "immutable" in cc, f"{url} should be immutable, got: {cc!r}"
+    max_age = re.search(r"max-age=(\d+)", cc)
+    assert (
+        max_age and int(max_age.group(1)) == IMMUTABLE_MAX_AGE
+    ), f"{url} should cache for a year, got: {cc!r}"
+
+
+@pytest.mark.parametrize("url", REVALIDATING_URLS)
+def test_non_fingerprinted_assets_revalidate(config, url):
+    cc = _cache_control_for(config, url)
+    assert cc is not None, f"{url} should still be cacheable, got no Cache-Control"
+    assert (
+        "immutable" not in cc
+    ), f"{url} keeps a stable URL across upgrades and must not be immutable: {cc!r}"
+    assert (
+        "must-revalidate" in cc
+    ), f"{url} must revalidate so upgrades/re-scrapes propagate, got: {cc!r}"
+    max_age = re.search(r"max-age=(\d+)", cc)
+    assert (
+        max_age and int(max_age.group(1)) <= MAX_REVALIDATING_AGE
+    ), f"{url} cache window is too long to catch an upgrade: {cc!r}"
+
+
+def test_resources_freeze_only_when_cache_busted(config):
+    # Same resource tree: only a recognized version param (ts/v) freezes a
+    # resource. A stable name with no query, or with an unrelated query, must
+    # revalidate. This is why the resources bucket can't be a blanket immutable
+    # rule, and why it keys on the param name rather than on "any query".
+    cover = _cache_control_for(
+        config, "/assets/romm/resources/roms/1/1/cover/small.png?ts=123"
+    )
+    screenshot = _cache_control_for(
+        config, "/assets/romm/resources/roms/1/1/screenshots/0.jpg"
+    )
+    unrelated = _cache_control_for(
+        config, "/assets/romm/resources/roms/1/1/screenshots/0.jpg?download=1"
+    )
+    assert cover is not None and screenshot is not None and unrelated is not None
+    assert "immutable" in cover, f"cover should freeze, got: {cover!r}"
+    assert (
+        "immutable" not in screenshot and "must-revalidate" in screenshot
+    ), f"queryless screenshot must revalidate, got: {screenshot!r}"
+    assert (
+        "immutable" not in unrelated and "must-revalidate" in unrelated
+    ), f"unrelated ?download= must not freeze, got: {unrelated!r}"
+
+
+@pytest.mark.parametrize("url", ROOT_REVALIDATING_URLS)
+def test_root_files_revalidate(config, url):
+    cc = _cache_control_for(config, url)
+    assert cc is not None, f"{url} should carry a revalidating Cache-Control"
+    assert "immutable" not in cc, f"{url} must not be immutable, got: {cc!r}"
+    assert (
+        "no-cache" in cc or "must-revalidate" in cc
+    ), f"{url} must revalidate so deploys/updates propagate, got: {cc!r}"

--- a/docker/nginx/templates/default.conf.template
+++ b/docker/nginx/templates/default.conf.template
@@ -28,6 +28,17 @@ map $request_uri $coop_header {
     ~^/console/rom/[0-9]+/play "same-origin";
 }
 
+# Library resources under /assets/romm/resources/ are a mix. Covers (?ts=) and
+# manuals (?v=) are versioned by a known cache-busting query, so they can be
+# frozen; screenshots and RA badges reuse stable filenames (0.jpg, ...) and are
+# overwritten on re-scrape, so they must revalidate. Freeze only when a
+# recognized version param (ts or v) is present, not on any arbitrary query
+# (e.g. ?download=1 must not pin a screenshot for a year).
+map $args $resources_cache_control {
+    default         "public, max-age=3600, must-revalidate";
+    "~(^|&)(ts|v)=" "public, max-age=31536000, immutable";
+}
+
 server {
     root /var/www/html;
     listen ${ROMM_PORT};
@@ -44,6 +55,11 @@ server {
     location / {
         try_files $uri $uri/ /index.html;
         proxy_redirect off;
+        # index.html, the service worker and the root favicons/manifest all keep
+        # stable names, so revalidate them (cheap 304s) instead of caching long.
+        # This is what lets a new deploy's fingerprinted bundles get picked up at
+        # once; a max-age here could serve a stale index.html for its duration.
+        add_header Cache-Control "no-cache";
         add_header Access-Control-Allow-Origin *;
         add_header Access-Control-Allow-Methods *;
         add_header Access-Control-Allow-Headers *;
@@ -51,8 +67,28 @@ server {
         add_header Cross-Origin-Opener-Policy $coop_header;
     }
 
-    # Static files
+    # Content-hashed frontend bundles (e.g. index-C-Cea5tF.js): the name only
+    # ever maps to one payload, so freeze them. This regex matches fingerprinted
+    # files directly under /assets, never the stable-named runtimes in subfolders.
+    location ~* "^/assets/[^/]+-[A-Za-z0-9_-]{8,}\.(js|mjs|css|map|woff2?|ttf|otf|eot|svg|png|jpe?g|gif|webp|avif|ico|json|wasm)$" {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri $uri/ =404;
+    }
+
+    # Library resources (covers, manuals, screenshots, RA badges). Freeze only
+    # the ones carrying a cache-busting query; revalidate the query-less ones
+    # (see the $resources_cache_control map above).
+    location /assets/romm/resources/ {
+        add_header Cache-Control $resources_cache_control;
+        try_files $uri $uri/ =404;
+    }
+
+    # Everything else under /assets keeps a stable URL across image upgrades
+    # (bundled EmulatorJS/Ruffle runtimes, scraper/platform icons, fonts, logos).
+    # Cache it, but revalidate so an upgrade is picked up promptly instead of
+    # serving a stale (and possibly skewed) runtime for a year.
     location /assets {
+        add_header Cache-Control "public, max-age=3600, must-revalidate";
         try_files $uri $uri/ =404;
     }
 

--- a/docker/nginx/templates/default.conf.template
+++ b/docker/nginx/templates/default.conf.template
@@ -55,10 +55,6 @@ server {
     location / {
         try_files $uri $uri/ /index.html;
         proxy_redirect off;
-        # index.html, the service worker and the root favicons/manifest all keep
-        # stable names, so revalidate them (cheap 304s) instead of caching long.
-        # This is what lets a new deploy's fingerprinted bundles get picked up at
-        # once; a max-age here could serve a stale index.html for its duration.
         add_header Cache-Control "no-cache";
         add_header Access-Control-Allow-Origin *;
         add_header Access-Control-Allow-Methods *;
@@ -67,26 +63,19 @@ server {
         add_header Cross-Origin-Opener-Policy $coop_header;
     }
 
-    # Content-hashed frontend bundles (e.g. index-C-Cea5tF.js): the name only
-    # ever maps to one payload, so freeze them. This regex matches fingerprinted
-    # files directly under /assets, never the stable-named runtimes in subfolders.
+    # Freeze content-hashed frontend bundles (fingerprinted files under /assets)
     location ~* "^/assets/[^/]+-[A-Za-z0-9_-]{8,}\.(js|mjs|css|map|woff2?|ttf|otf|eot|svg|png|jpe?g|gif|webp|avif|ico|json|wasm)$" {
         add_header Cache-Control "public, max-age=31536000, immutable";
         try_files $uri $uri/ =404;
     }
 
-    # Library resources (covers, manuals, screenshots, RA badges). Freeze only
-    # the ones carrying a cache-busting query; revalidate the query-less ones
-    # (see the $resources_cache_control map above).
+    # Freeze library resources carrying cache-busting query
     location /assets/romm/resources/ {
         add_header Cache-Control $resources_cache_control;
         try_files $uri $uri/ =404;
     }
 
     # Everything else under /assets keeps a stable URL across image upgrades
-    # (bundled EmulatorJS/Ruffle runtimes, scraper/platform icons, fonts, logos).
-    # Cache it, but revalidate so an upgrade is picked up promptly instead of
-    # serving a stale (and possibly skewed) runtime for a year.
     location /assets {
         add_header Cache-Control "public, max-age=3600, must-revalidate";
         try_files $uri $uri/ =404;


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3890.

## Summary (what and why)

RomM's bundled nginx served everything under `/assets` (the frontend JS/CSS bundle and every cover, screenshot, and manual), plus the root favicons and web manifest, with **no `Cache-Control` header**. Browsers therefore re-fetch or revalidate (a `304` round-trip) each of these on every repeat visit. It is most visible in the library grid, where each ~100 KB cover is re-checked; a long scroll is tens of MB of covers alone.

A blanket `immutable` rule is unsafe, because `/assets` mixes assets with different versioning. This change caches **by fingerprint**:

| Assets | `Cache-Control` | Why it is safe |
| --- | --- | --- |
| Content-hashed build output (`index-<hash>.js`) | `public, max-age=31536000, immutable` | The filename changes whenever the content changes |
| Library resources with a recognized version param: covers (`?ts=`) and manuals (`?v=`) | `public, max-age=31536000, immutable` | The URL changes whenever the file changes |
| Query-less library resources (metadata screenshots, RA badges), the bundled EmulatorJS/Ruffle runtimes, and other static files under `/assets` | `public, max-age=3600, must-revalidate` | Stable URLs across image upgrades or re-scrapes; revalidate to pick up a change promptly |
| `index.html`, the service worker, and the root favicons/manifest (served from `location /`) | `no-cache` | A new deploy's fingerprinted bundles and any updated runtime must load at once |

The library-resources split is driven by an `$args` map that recognizes the `ts` and `v` version params: a resource is frozen only when one of those is present, not on any arbitrary query (an unrelated query such as `?download=1` does not freeze a stable file). Covers carry `?ts=` and manuals carry `?v=`; metadata screenshots and RA badges reuse stable filenames like `0.jpg` and are overwritten in place, so they revalidate.

## A note on "screenshots" (avoiding an ambiguity)

RomM has two distinct "screenshot" concepts, and only one is affected here:

- **Metadata screenshots** (`Rom.merged_screenshots`): scraped game media, written to `/assets/romm/resources/roms/<platform>/<rom>/screenshots/<idx>.jpg` with a stable name and no query. These are covered by this change and now `must-revalidate`, so a re-scrape that overwrites `0.jpg` is picked up.
- **User-uploaded (gallery) screenshots** (the `Screenshot` asset): served from `/api/screenshots/<id>/content?timestamp=<updated_at>`, which nginx proxies to the backend. These are **not** under `/assets` and are **not** touched by this change.

So no user-uploaded content is affected by the `/assets` rules. Note that user-uploaded covers and manuals do live under `/assets/romm/resources/`, but they carry `?ts=` / `?v=` and so remain correctly `immutable` (the query changes when `updated_at` bumps on re-upload).

## Files modified

- **`docker/nginx/templates/default.conf.template`**
  - Added a `map $args $resources_cache_control` that yields `immutable` only when a recognized version param (`ts` or `v`) is present, and `must-revalidate` otherwise (so an unrelated query does not freeze a stable file).
  - Split the single `location /assets { try_files ... }` into three: a regex `location` that freezes content-hashed bundles as `immutable`, a `location /assets/romm/resources/` that applies the map above, and the existing `location /assets` as the `must-revalidate` catch-all for stable-named runtimes and icons.
  - Added `add_header Cache-Control "no-cache";` to `location /` so `index.html`, the service worker, and the root favicons/manifest revalidate. All pre-existing headers on that block (CORS and COEP/COOP) are unchanged.
- **`backend/tests/test_nginx_cache_headers.py`** (new)
  - Parses the template's `location` and `map` blocks and replays nginx's location selection (exact, longest-prefix, first-matching-regex) plus the `$args` version-param map, asserting the `Cache-Control` each representative URL resolves to. Covers hashed bundles, cover/manual (`?ts=` / `?v=`), metadata screenshots and RA badges (query-less and unrelated-query), the EmulatorJS/Ruffle runtimes, `index.html`, and the root favicons/manifest/service worker. Pure static parsing, so it is DB-agnostic.

## Testing

- **Unit test:** 29 cases, all pass. Runs in the existing pytest workflow (MariaDB and PostgreSQL matrices).
- **Real nginx validation:** rendered the template with `envsubst` inside the shipped image `rommapp/romm:5.1.0-alpha.1` (which carries the custom js/zip modules), ran `nginx -t` (syntax OK), then started nginx and curled each URL class, including the unrelated-query edge case:

```text
/assets/index-C-Cea5tF.js                            -> public, max-age=31536000, immutable
/assets/romm/resources/.../cover/small.png?ts=123    -> public, max-age=31536000, immutable
/assets/romm/resources/.../manual/1.pdf?v=123        -> public, max-age=31536000, immutable
/assets/romm/resources/.../screenshots/0.jpg         -> public, max-age=3600, must-revalidate
/assets/romm/resources/.../screenshots/0.jpg?download=1 -> public, max-age=3600, must-revalidate
/assets/romm/resources/.../ra/badges/12345.png       -> public, max-age=3600, must-revalidate
/assets/emulatorjs/data/loader.js                    -> public, max-age=3600, must-revalidate
/  /index.html  /favicon.ico  /site.webmanifest  /sw.js  -> no-cache
```

- **Full backend suite:** `uv run pytest -n 4` green (2304 passed, 0 failed).
- **Lint:** `trunk fmt && trunk check` clean (ruff, black, isort, mypy).

## Reviewer notes

- **No dropped headers.** `/assets` had no `add_header` on `master`, so nothing is removed; `location /` retains its CORS and COEP/COOP headers and only gains `Cache-Control`. The EmulatorJS player's cross-origin isolation is unaffected (same-origin runtime files need no CORP under `require-corp`).
- **Resources are a mix, matched by param name.** Only covers (`?ts=`) and manuals (`?v=`) carry a recognized version param and are frozen; metadata screenshots and RA badges are query-less and revalidate. The map matches the `ts`/`v` param names at a boundary (`(^|&)(ts|v)=`), so an unrelated query such as `?download=1` does not freeze a stable resource. See the "screenshots" note above for the metadata-vs-upload distinction.
- **Two revalidation policies by design.** `must-revalidate` with a 1h `max-age` for the `/assets` bulk avoids a `304` storm across many small icons, while `no-cache` on `location /` keeps `index.html` and `sw.js` always fresh (a `max-age` there could serve a stale `index.html` referencing purged bundles).
- **Vite hash assumption.** The immutable regex expects Vite's default 8+ char hash. A shorter hash would simply route a bundle to the `must-revalidate` bucket: safe and non-breaking, never stale.
- **Test placement.** There is no existing infra-config test harness, so the guard lives under `backend/tests/` (the available runner). It is a fast regression check; the authoritative verification is the `nginx -t` and curl run above.
- **Reverse proxies.** These headers reach the browser as long as a proxy passes them through (the default). Anyone who previously worked around the missing headers with a blanket cache rule at their proxy should drop it so these per-type headers govern.

## AI assistance disclosure

This change was implemented with AI assistance (Claude). The nginx caching policy, the test, and the commits were AI-authored under maintainer direction, reviewed locally, and verified empirically against the shipped nginx image as described above.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A. This is a response-header change; the `curl` output above is the relevant evidence.
