### PR TITLE
fix(v2): hide empty platforms in Server Stats breakdown

### DIFF
--- a/frontend/src/v2/components/Settings/PlatformsStatsSection.test.ts
+++ b/frontend/src/v2/components/Settings/PlatformsStatsSection.test.ts
@@ -1,0 +1,111 @@
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Platform } from "@/stores/platforms";
+import storePlatforms from "@/stores/platforms";
+import PlatformsStatsSection from "./PlatformsStatsSection.vue";
+
+// vue-i18n's `t` is stubbed to echo the key so the component mounts without
+// the full i18n plugin.
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+// The heartbeat store pulls in config + i18n; stub it down to the single
+// method this component calls.
+vi.mock("@/stores/heartbeat", () => ({
+  default: () => ({ getMetadataOptionsByPriority: () => [] }),
+}));
+
+function platform(overrides: Partial<Platform> = {}): Platform {
+  return {
+    id: 1,
+    slug: "snes",
+    fs_slug: "snes",
+    rom_count: 1,
+    name: "Super Nintendo",
+    igdb_slug: null,
+    moby_slug: null,
+    hltb_slug: null,
+    libretro_slug: null,
+    custom_name: "",
+    description: null,
+    created_at: "",
+    updated_at: "",
+    fs_size_bytes: 0,
+    is_unidentified: false,
+    is_identified: true,
+    missing_from_fs: false,
+    display_name: "Super Nintendo",
+    firmware_count: 0,
+    ...overrides,
+  } as Platform;
+}
+
+function mountSection(platforms: Platform[]) {
+  storePlatforms().set(platforms);
+  return mount(PlatformsStatsSection, {
+    props: { totalFilesize: 0, metadataCoverage: {}, regionBreakdown: {} },
+    global: {
+      stubs: {
+        RIcon: true,
+        RPlatformIcon: true,
+        RProgressLinear: true,
+        RSliderBtnGroup: true,
+        RTextField: true,
+      },
+    },
+  });
+}
+
+function renderedNames(wrapper: ReturnType<typeof mountSection>): string[] {
+  return wrapper.findAll(".r-v2-plat-stats__name").map((n) => n.text());
+}
+
+describe("PlatformsStatsSection", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("lists only platforms that contain games, hiding empty leftovers", () => {
+    const wrapper = mountSection([
+      platform({ id: 1, slug: "snes", name: "Super Nintendo", rom_count: 5 }),
+      // Ghost platform: emptied long ago, still in the DB with 0 games.
+      platform({
+        id: 2,
+        slug: "xbox360-hacks",
+        name: "Xbox360 Hacks",
+        display_name: "Xbox360 Hacks",
+        rom_count: 0,
+      }),
+      platform({
+        id: 3,
+        slug: "genesis",
+        name: "Genesis",
+        display_name: "Genesis",
+        rom_count: 3,
+      }),
+    ]);
+
+    const names = renderedNames(wrapper);
+    expect(names).toEqual(["Genesis", "Super Nintendo"]);
+    expect(names).not.toContain("Xbox360 Hacks");
+    expect(wrapper.findAll(".r-v2-plat-stats__row")).toHaveLength(2);
+  });
+
+  it("renders no rows when every platform is empty", () => {
+    const wrapper = mountSection([
+      platform({ id: 1, rom_count: 0 }),
+      platform({
+        id: 2,
+        slug: "genesis",
+        name: "Genesis",
+        display_name: "Genesis",
+        rom_count: 0,
+      }),
+    ]);
+
+    expect(wrapper.findAll(".r-v2-plat-stats__row")).toHaveLength(0);
+    expect(wrapper.find(".r-v2-plat-stats__empty").exists()).toBe(true);
+  });
+});

--- a/frontend/src/v2/components/Settings/PlatformsStatsSection.vue
+++ b/frontend/src/v2/components/Settings/PlatformsStatsSection.vue
@@ -37,10 +37,7 @@ const props = defineProps<Props>();
 
 const { t } = useI18n();
 const platformsStore = storePlatforms();
-// Only platforms that still contain games, matching the Platforms page, the
-// Home screen, and this page's own summary counter. Empty leftovers (0-game
-// platforms kept in the DB) are hidden everywhere else, so exclude them here
-// too instead of leaking through the raw list.
+// Only platforms that contain games should be displayed
 const { filledPlatforms } = storeToRefs(platformsStore);
 const heartbeat = storeHeartbeat();
 

--- a/frontend/src/v2/components/Settings/PlatformsStatsSection.vue
+++ b/frontend/src/v2/components/Settings/PlatformsStatsSection.vue
@@ -37,7 +37,11 @@ const props = defineProps<Props>();
 
 const { t } = useI18n();
 const platformsStore = storePlatforms();
-const { allPlatforms } = storeToRefs(platformsStore);
+// Only platforms that still contain games, matching the Platforms page, the
+// Home screen, and this page's own summary counter. Empty leftovers (0-game
+// platforms kept in the DB) are hidden everywhere else, so exclude them here
+// too instead of leaking through the raw list.
+const { filledPlatforms } = storeToRefs(platformsStore);
 const heartbeat = storeHeartbeat();
 
 type OrderBy = "name" | "size" | "count";
@@ -67,7 +71,7 @@ const orderItems = computed<SliderBtnGroupItem<OrderBy>[]>(() => [
 
 const sortedPlatforms = computed(() => {
   const q = searchQuery.value.trim().toLowerCase();
-  let list = [...allPlatforms.value];
+  let list = [...filledPlatforms.value];
   if (q) {
     list = list.filter(
       (p) =>


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3897

The Server Stats page (Settings → Server Stats) listed platforms with **0 games**, including ones removed from the library long ago (e.g. a leftover "Xbox360 Hacks" record). These empty platforms are hidden everywhere else in the app, and the "Platforms" total counter at the top of the same page already excludes them, so the per-platform list disagreed with its own summary and with the rest of the UI.

**Root cause:** `PlatformsStatsSection.vue` built its list from the platform store's raw `allPlatforms` (only a text-search filter applied), while the Platforms page and Home screen use the `filledPlatforms` getter (`rom_count > 0`), and the summary counter comes from backend stats that only count platforms with games.

**Fix:** switch the Server Stats breakdown to the shared `filledPlatforms` getter so the list is consistent by construction with the Platforms page, the Home screen, and this page's own summary counter. Empty (0-game) leftovers are no longer listed. One-line data-source change; no markup, styling, i18n, or API changes.

**Files modified**

- `frontend/src/v2/components/Settings/PlatformsStatsSection.vue` — source the breakdown list from `filledPlatforms` (rom_count > 0) instead of the raw `allPlatforms`; added a short "why" comment.
- `frontend/src/v2/components/Settings/PlatformsStatsSection.test.ts` (new) — regression tests: a mixed list hides the 0-game ghost and keeps only real platforms (sorted); an all-empty list renders no rows and shows the empty state.

**Testing**

- Added unit tests first (TDD): both failed against the original `allPlatforms` code, then passed after the fix.
- Full frontend suite green: `vitest run` — 34 files, 529 tests passing, no regressions.
- `vue-tsc` typecheck clean; `trunk fmt` + `trunk check` clean on both files.
- Manual: with a platform emptied to 0 games, the breakdown no longer lists it and the row count matches the "Platforms" summary counter.

**Notes for reviewers**

- Search in the breakdown now matches only filled platforms, so 0-game platforms are intentionally never surfaced here anymore (matches the rest of the app).
- Out of scope: the issue also notes there's no UI path to open/delete these ghost platforms since they're hidden everywhere. That deletion/cleanup flow is a separate concern and not addressed here; happy to follow up.

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this change was implemented with AI assistance (Claude Code). AI was used to root-cause the inconsistency, write the tests and fix, and draft this description. All changes were reviewed and verified locally by the author.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

<!-- Before: Server Stats lists a 0-game platform (e.g. "Xbox360 Hacks") absent from the Platforms page. After: it no longer appears and the list matches the "Platforms" counter. -->
