### PR TITLE
fix(scan): reconcile rom_files in place instead of purging them

### DIFF
--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -55,6 +55,7 @@ from models.platform import Platform
 from models.rom import Rom
 from tasks.tasks import update_job_meta
 from utils import emoji
+from utils.audio_tags import remove_persisted_cover
 from utils.context import initialize_context
 from utils.gamelist_exporter import GamelistExporter
 from utils.pegasus_exporter import PegasusExporter
@@ -431,8 +432,10 @@ async def _identify_rom(
         # Reconcile against the existing rows instead of replacing them, so file
         # ids survive a rescan and anything keyed on them (track metadata,
         # persisted soundtrack covers) stays valid.
-        saved_rom_files = db_rom_handler.sync_rom_files(_added_rom.id, fs_rom["files"])
-        for saved in saved_rom_files:
+        synced = db_rom_handler.sync_rom_files(_added_rom.id, fs_rom["files"])
+        for cover_path in synced.orphaned_cover_paths:
+            remove_persisted_cover(cover_path)
+        for saved in synced.files:
             persist_soundtrack_cover(saved, _added_rom)
 
     # Short circuit if the scan type is hashes

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -52,7 +52,7 @@ from logger.formatter import highlight as hl
 from logger.logger import log
 from models.firmware import Firmware
 from models.platform import Platform
-from models.rom import Rom, RomFile, TrackMeta
+from models.rom import Rom
 from tasks.tasks import update_job_meta
 from utils import emoji
 from utils.context import initialize_context
@@ -60,25 +60,6 @@ from utils.gamelist_exporter import GamelistExporter
 from utils.pegasus_exporter import PegasusExporter
 
 STOP_SCAN_FLAG: Final = "scan:stop"
-
-
-def _clone_track_meta(src: TrackMeta | None, rom_id: int) -> TrackMeta | None:
-    """Build a fresh TrackMeta from a scanned (transient) one for a new RomFile."""
-    if src is None:
-        return None
-    return TrackMeta(
-        rom_id=rom_id,
-        title=src.title,
-        artist=src.artist,
-        album=src.album,
-        genre=src.genre,
-        year=src.year,
-        track=src.track,
-        disc=src.disc,
-        duration_seconds=src.duration_seconds,
-        has_embedded_cover=src.has_embedded_cover,
-        cover_path=src.cover_path,
-    )
 
 
 @dataclass
@@ -447,29 +428,11 @@ async def _identify_rom(
         )
 
     if should_update_files:
-        # Delete the existing rom files in the DB
-        db_rom_handler.purge_rom_files(_added_rom.id)
-
-        # Create each file entry for the rom
-        new_rom_files = [
-            RomFile(
-                rom_id=_added_rom.id,
-                file_name=file.file_name,
-                file_path=file.file_path,
-                file_size_bytes=file.file_size_bytes,
-                last_modified=file.last_modified,
-                category=file.category,
-                track_meta=_clone_track_meta(file.track_meta, _added_rom.id),
-                crc_hash=file.crc_hash,
-                md5_hash=file.md5_hash,
-                sha1_hash=file.sha1_hash,
-                ra_hash=file.ra_hash,
-                chd_sha1_hash=file.chd_sha1_hash,
-            )
-            for file in fs_rom["files"]
-        ]
-        for new_rom_file in new_rom_files:
-            saved = db_rom_handler.add_rom_file(new_rom_file)
+        # Reconcile against the existing rows instead of replacing them, so file
+        # ids survive a rescan and anything keyed on them (track metadata,
+        # persisted soundtrack covers) stays valid.
+        saved_rom_files = db_rom_handler.sync_rom_files(_added_rom.id, fs_rom["files"])
+        for saved in saved_rom_files:
             persist_soundtrack_cover(saved, _added_rom)
 
     # Short circuit if the scan type is hashes

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -16,6 +16,9 @@ from sqlalchemy import (
     delete,
     false,
     func,
+)
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy import (
     literal,
     not_,
     or_,
@@ -177,6 +180,11 @@ TRACK_META_SCANNED_COLUMNS = (
     "has_embedded_cover",
     "cover_path",
 )
+
+
+@functools.cache
+def _nullable_columns(model: type) -> frozenset[str]:
+    return frozenset(c.key for c in sa_inspect(model).columns if c.nullable)
 
 
 class SyncedRomFiles(NamedTuple):
@@ -1772,6 +1780,8 @@ class DBRomsHandler(DBBaseHandler):
             # clears it (with its file) once the cover is gone.
             if column == "cover_path" and value is None:
                 continue
+            if value is None and column not in _nullable_columns(TrackMeta):
+                continue
             if getattr(meta, column) != value:
                 setattr(meta, column, value)
 
@@ -1786,6 +1796,11 @@ class DBRomsHandler(DBBaseHandler):
         """Returns the cover path this update orphaned, if any."""
         for column in ROM_FILE_SCANNED_COLUMNS:
             value = getattr(scanned, column)
+            # A column left unset on the scanned row reads as None, and the
+            # model default only applies on insert, so writing it through would
+            # break the NOT NULL columns on the update path.
+            if value is None and column not in _nullable_columns(RomFile):
+                continue
             if getattr(row, column) != value:
                 setattr(row, column, value)
 

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -187,6 +187,30 @@ def _nullable_columns(model: type) -> frozenset[str]:
     return frozenset(c.key for c in sa_inspect(model).columns if c.nullable)
 
 
+def _copy_scanned_columns(
+    source: RomFile | TrackMeta,
+    target: RomFile | TrackMeta,
+    columns: Sequence[str],
+    model: type,
+    keep_when_unset: frozenset[str] = frozenset(),
+) -> None:
+    """Copy scanned values onto a row, writing only the columns that changed.
+
+    A column left unset on the scanned row reads as None, and the model default
+    only applies on insert, so writing it through would break the NOT NULL
+    columns on the update path. `keep_when_unset` extends that protection to
+    nullable columns the scanner doesn't own.
+    """
+    for column in columns:
+        value = getattr(source, column)
+        if value is None and (
+            column in keep_when_unset or column not in _nullable_columns(model)
+        ):
+            continue
+        if getattr(target, column) != value:
+            setattr(target, column, value)
+
+
 class SyncedRomFiles(NamedTuple):
     files: list[RomFile]
     orphaned_cover_paths: list[str]
@@ -1755,13 +1779,22 @@ class DBRomsHandler(DBBaseHandler):
         session.flush()
         return merged
 
-    def _apply_scanned_track_meta(
+    def _apply_scanned_rom_file(
         self,
         row: RomFile,
-        scanned_meta: TrackMeta | None,
+        scanned: RomFile,
         rom_id: int,
     ) -> str | None:
-        """Returns the cover path this update orphaned, if any."""
+        """Copy a scanned file onto its row, with its track metadata.
+
+        Returns the cover path this update orphaned, if any.
+        """
+        _copy_scanned_columns(scanned, row, ROM_FILE_SCANNED_COLUMNS, RomFile)
+
+        if row.missing_from_fs:
+            row.missing_from_fs = False
+
+        scanned_meta = scanned.track_meta
         if scanned_meta is None:
             orphaned = row.track_meta.cover_path if row.track_meta else None
             row.track_meta = None
@@ -1773,41 +1806,16 @@ class DBRomsHandler(DBBaseHandler):
             row.track_meta = meta
 
         meta.rom_id = rom_id
-        for column in TRACK_META_SCANNED_COLUMNS:
-            value = getattr(scanned_meta, column)
-            # The scanner only flags whether a cover exists; the path is owned by
-            # `persist_soundtrack_cover`, which writes it after the row exists and
-            # clears it (with its file) once the cover is gone.
-            if column == "cover_path" and value is None:
-                continue
-            if value is None and column not in _nullable_columns(TrackMeta):
-                continue
-            if getattr(meta, column) != value:
-                setattr(meta, column, value)
+        # The scanner only flags whether a cover exists
+        _copy_scanned_columns(
+            scanned_meta,
+            meta,
+            TRACK_META_SCANNED_COLUMNS,
+            TrackMeta,
+            keep_when_unset=frozenset({"cover_path"}),
+        )
 
         return None
-
-    def _apply_scanned_rom_file(
-        self,
-        row: RomFile,
-        scanned: RomFile,
-        rom_id: int,
-    ) -> str | None:
-        """Returns the cover path this update orphaned, if any."""
-        for column in ROM_FILE_SCANNED_COLUMNS:
-            value = getattr(scanned, column)
-            # A column left unset on the scanned row reads as None, and the
-            # model default only applies on insert, so writing it through would
-            # break the NOT NULL columns on the update path.
-            if value is None and column not in _nullable_columns(RomFile):
-                continue
-            if getattr(row, column) != value:
-                setattr(row, column, value)
-
-        if row.missing_from_fs:
-            row.missing_from_fs = False
-
-        return self._apply_scanned_track_meta(row, scanned.track_meta, rom_id)
 
     @begin_session
     def sync_rom_files(

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -150,6 +150,45 @@ ROM_FILTERS_CACHE_VERSION_KEY = "filter_values:ver"
 ROM_FILTERS_CACHE_TTL = 60 * 60 * 24 * 7  # 7 days
 ROM_FILTERS_CACHE_SCHEMA_VERSION = get_version().replace(".", "_")
 
+# Columns copied from a scanned (transient) RomFile onto its database row.
+ROM_FILE_SCANNED_COLUMNS = (
+    "file_name",
+    "file_path",
+    "file_size_bytes",
+    "last_modified",
+    "crc_hash",
+    "md5_hash",
+    "sha1_hash",
+    "ra_hash",
+    "chd_sha1_hash",
+    "archive_members",
+    "category",
+)
+
+TRACK_META_SCANNED_COLUMNS = (
+    "title",
+    "artist",
+    "album",
+    "genre",
+    "year",
+    "track",
+    "disc",
+    "duration_seconds",
+    "has_embedded_cover",
+    "cover_path",
+)
+
+
+def _rom_file_content_key(rom_file: RomFile) -> tuple[str, str, str] | None:
+    """Identity of a file by content, or None when it can't be identified.
+
+    All three hashes are required, mirroring `get_matching_missing_rom`: a
+    partial match is not strong enough to move a row onto a different file.
+    """
+    if not (rom_file.crc_hash and rom_file.md5_hash and rom_file.sha1_hash):
+        return None
+    return (rom_file.crc_hash, rom_file.md5_hash, rom_file.sha1_hash)
+
 
 def _cache_value_to_str(value: Any) -> str | None:
     if value is None:
@@ -1703,6 +1742,128 @@ class DBRomsHandler(DBBaseHandler):
         session.flush()
         return merged
 
+    def _apply_scanned_track_meta(
+        self,
+        row: RomFile,
+        scanned_meta: TrackMeta | None,
+        rom_id: int,
+    ) -> None:
+        if scanned_meta is None:
+            row.track_meta = None
+            return
+
+        meta = row.track_meta
+        if meta is None:
+            meta = TrackMeta(rom_id=rom_id)
+            row.track_meta = meta
+
+        meta.rom_id = rom_id
+        for column in TRACK_META_SCANNED_COLUMNS:
+            value = getattr(scanned_meta, column)
+            # The scanner only flags that a cover exists; the path is written
+            # later by `persist_soundtrack_cover`, so don't clear it here.
+            if column == "cover_path" and value is None:
+                continue
+            if getattr(meta, column) != value:
+                setattr(meta, column, value)
+
+    def _apply_scanned_rom_file(
+        self,
+        row: RomFile,
+        scanned: RomFile,
+        rom_id: int,
+    ) -> None:
+        for column in ROM_FILE_SCANNED_COLUMNS:
+            value = getattr(scanned, column)
+            if getattr(row, column) != value:
+                setattr(row, column, value)
+
+        if row.missing_from_fs:
+            row.missing_from_fs = False
+
+        self._apply_scanned_track_meta(row, scanned.track_meta, rom_id)
+
+    @begin_session
+    def sync_rom_files(
+        self,
+        rom_id: int,
+        scanned_files: Sequence[RomFile],
+        session: Session = None,  # type: ignore
+    ) -> list[RomFile]:
+        """Reconcile a ROM's file rows against a fresh scan, preserving row ids.
+
+        Rows are matched by path first, then by content hash, so a file renamed
+        or moved inside the ROM keeps its id, its `created_at` and its track
+        metadata instead of being deleted and re-inserted. Rows left unmatched
+        are deleted, and only columns that actually changed are written, so
+        re-scanning an unchanged ROM issues no updates.
+
+        Returns the persisted rows, in scan order.
+        """
+        existing = (
+            session.scalars(
+                select(RomFile)
+                .options(selectinload(RomFile.track_meta))
+                .filter_by(rom_id=rom_id)
+            )
+            .unique()
+            .all()
+        )
+
+        unmatched = {row.id: row for row in existing}
+        by_path = {(row.file_path, row.file_name): row for row in existing}
+
+        pairs: list[tuple[RomFile, RomFile | None]] = []
+        unpaired_indexes: list[int] = []
+
+        for scanned in scanned_files:
+            row = by_path.get((scanned.file_path, scanned.file_name))
+            if row is not None and row.id in unmatched:
+                del unmatched[row.id]
+                pairs.append((scanned, row))
+            else:
+                unpaired_indexes.append(len(pairs))
+                pairs.append((scanned, None))
+
+        if unpaired_indexes and unmatched:
+            # Identical copies map to the same content key, so keep only keys
+            # that identify a single row rather than pairing them arbitrarily.
+            by_content: dict[tuple[str, str, str], RomFile | None] = {}
+            for row in unmatched.values():
+                key = _rom_file_content_key(row)
+                if key is not None:
+                    by_content[key] = None if key in by_content else row
+
+            for index in unpaired_indexes:
+                scanned, _ = pairs[index]
+                key = _rom_file_content_key(scanned)
+                if key is None:
+                    continue
+                row = by_content.get(key)
+                if row is None:
+                    continue
+                del unmatched[row.id]
+                by_content[key] = None
+                pairs[index] = (scanned, row)
+
+        saved: list[RomFile] = []
+        for scanned, row in pairs:
+            if row is None:
+                row = RomFile(rom_id=rom_id)
+                session.add(row)
+            self._apply_scanned_rom_file(row, scanned, rom_id)
+            saved.append(row)
+
+        if unmatched:
+            session.execute(
+                delete(RomFile)
+                .where(RomFile.id.in_(list(unmatched)))
+                .execution_options(synchronize_session="evaluate")
+            )
+
+        session.flush()
+        return saved
+
     @begin_session
     def get_rom_file_by_id(
         self,
@@ -2005,22 +2166,6 @@ class DBRomsHandler(DBBaseHandler):
             base.order_by(primary, col.asc()).limit(limit).offset(offset)
         ).all()
         return rows, total
-
-    @begin_session
-    def purge_rom_files(
-        self,
-        rom_id: int,
-        session: Session = None,  # type: ignore
-    ) -> Sequence[RomFile]:
-        purged_rom_files = (
-            session.scalars(select(RomFile).filter_by(rom_id=rom_id)).unique().all()
-        )
-        session.execute(
-            delete(RomFile)
-            .where(RomFile.rom_id == rom_id)
-            .execution_options(synchronize_session="evaluate")
-        )
-        return purged_rom_files
 
     @begin_session
     def delete_rom_file(

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -3,7 +3,7 @@ import json
 import re
 from collections.abc import Iterable, Sequence
 from datetime import datetime
-from typing import Any
+from typing import Any, NamedTuple
 
 from redis.exceptions import WatchError
 from sqlalchemy import (
@@ -177,6 +177,11 @@ TRACK_META_SCANNED_COLUMNS = (
     "has_embedded_cover",
     "cover_path",
 )
+
+
+class SyncedRomFiles(NamedTuple):
+    files: list[RomFile]
+    orphaned_cover_paths: list[str]
 
 
 def _rom_file_content_key(rom_file: RomFile) -> tuple[str, str, str] | None:
@@ -1747,10 +1752,12 @@ class DBRomsHandler(DBBaseHandler):
         row: RomFile,
         scanned_meta: TrackMeta | None,
         rom_id: int,
-    ) -> None:
+    ) -> str | None:
+        """Returns the cover path this update orphaned, if any."""
         if scanned_meta is None:
+            orphaned = row.track_meta.cover_path if row.track_meta else None
             row.track_meta = None
-            return
+            return orphaned
 
         meta = row.track_meta
         if meta is None:
@@ -1768,12 +1775,15 @@ class DBRomsHandler(DBBaseHandler):
             if getattr(meta, column) != value:
                 setattr(meta, column, value)
 
+        return None
+
     def _apply_scanned_rom_file(
         self,
         row: RomFile,
         scanned: RomFile,
         rom_id: int,
-    ) -> None:
+    ) -> str | None:
+        """Returns the cover path this update orphaned, if any."""
         for column in ROM_FILE_SCANNED_COLUMNS:
             value = getattr(scanned, column)
             if getattr(row, column) != value:
@@ -1782,7 +1792,7 @@ class DBRomsHandler(DBBaseHandler):
         if row.missing_from_fs:
             row.missing_from_fs = False
 
-        self._apply_scanned_track_meta(row, scanned.track_meta, rom_id)
+        return self._apply_scanned_track_meta(row, scanned.track_meta, rom_id)
 
     @begin_session
     def sync_rom_files(
@@ -1790,7 +1800,7 @@ class DBRomsHandler(DBBaseHandler):
         rom_id: int,
         scanned_files: Sequence[RomFile],
         session: Session = None,  # type: ignore
-    ) -> list[RomFile]:
+    ) -> SyncedRomFiles:
         """Reconcile a ROM's file rows against a fresh scan, preserving row ids.
 
         Rows are matched by path first, then by content hash, so a file renamed
@@ -1799,7 +1809,8 @@ class DBRomsHandler(DBBaseHandler):
         are deleted, and only columns that actually changed are written, so
         re-scanning an unchanged ROM issues no updates.
 
-        Returns the persisted rows, in scan order.
+        Returns the persisted rows in scan order, plus the soundtrack covers
+        left behind by dropped track metadata for the caller to unlink.
         """
         existing = (
             session.scalars(
@@ -1848,14 +1859,24 @@ class DBRomsHandler(DBBaseHandler):
                 pairs[index] = (scanned, row)
 
         saved: list[RomFile] = []
+        orphaned_cover_paths: list[str] = []
         for scanned, row in pairs:
             if row is None:
                 row = RomFile(rom_id=rom_id)
                 session.add(row)
-            self._apply_scanned_rom_file(row, scanned, rom_id)
+            orphaned = self._apply_scanned_rom_file(row, scanned, rom_id)
+            if orphaned:
+                orphaned_cover_paths.append(orphaned)
             saved.append(row)
 
         if unmatched:
+            # Deleting a row cascades its track metadata, so its cover would
+            # otherwise be left on disk with nothing pointing at it.
+            orphaned_cover_paths.extend(
+                row.track_meta.cover_path
+                for row in unmatched.values()
+                if row.track_meta and row.track_meta.cover_path
+            )
             session.execute(
                 delete(RomFile)
                 .where(RomFile.id.in_(list(unmatched)))
@@ -1863,7 +1884,7 @@ class DBRomsHandler(DBBaseHandler):
             )
 
         session.flush()
-        return saved
+        return SyncedRomFiles(files=saved, orphaned_cover_paths=orphaned_cover_paths)
 
     @begin_session
     def get_rom_file_by_id(

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -1760,8 +1760,9 @@ class DBRomsHandler(DBBaseHandler):
         meta.rom_id = rom_id
         for column in TRACK_META_SCANNED_COLUMNS:
             value = getattr(scanned_meta, column)
-            # The scanner only flags that a cover exists; the path is written
-            # later by `persist_soundtrack_cover`, so don't clear it here.
+            # The scanner only flags whether a cover exists; the path is owned by
+            # `persist_soundtrack_cover`, which writes it after the row exists and
+            # clears it (with its file) once the cover is gone.
             if column == "cover_path" and value is None:
                 continue
             if getattr(meta, column) != value:

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -150,9 +150,10 @@ def persist_soundtrack_cover(rom_file: RomFile, rom: Rom) -> None:
         return
 
     if not track_meta.has_embedded_cover:
-        # The cover was stripped from the file since the last scan.
-        if track_meta.cover_path:
-            remove_persisted_cover(track_meta.cover_path)
+        # The cover was stripped from the file since the last scan. Keep the
+        # path when the unlink fails, so the next scan retries it rather than
+        # stranding the file with nothing pointing at it.
+        if track_meta.cover_path and remove_persisted_cover(track_meta.cover_path):
             db_rom_handler.upsert_track_meta(rom_file.id, rom.id, {"cover_path": None})
         return
 

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -51,7 +51,7 @@ from models.platform import Platform
 from models.rom import Rom, RomFile, RomFileCategory
 from models.user import User
 from utils import emoji
-from utils.audio_tags import persist_embedded_cover
+from utils.audio_tags import persist_embedded_cover, remove_persisted_cover
 
 LOGGER_MODULE_NAME = {"module_name": "scan"}
 
@@ -146,11 +146,14 @@ def persist_soundtrack_cover(rom_file: RomFile, rom: Rom) -> None:
     """Persist a scanned soundtrack file's embedded cover and record its path on
     the track_meta row. No-op for non-soundtrack files or ones without a cover."""
     track_meta = rom_file.track_meta
-    if not (
-        rom_file.category == RomFileCategory.SOUNDTRACK
-        and track_meta
-        and track_meta.has_embedded_cover
-    ):
+    if not (rom_file.category == RomFileCategory.SOUNDTRACK and track_meta):
+        return
+
+    if not track_meta.has_embedded_cover:
+        # The cover was stripped from the file since the last scan.
+        if track_meta.cover_path:
+            remove_persisted_cover(track_meta.cover_path)
+            db_rom_handler.upsert_track_meta(rom_file.id, rom.id, {"cover_path": None})
         return
 
     abs_audio_path = fs_rom_handler.validate_path(rom_file.full_path)

--- a/backend/tests/endpoints/sockets/test_scan.py
+++ b/backend/tests/endpoints/sockets/test_scan.py
@@ -537,6 +537,16 @@ class TestIdentifyRomReassociation:
         # No brand-new row is inserted; add_rom only persists the scan result.
         assert db.add_rom.call_count == 1
 
+    async def test_files_are_reconciled_in_place(self, patched):
+        db = patched
+        db.get_matching_missing_rom.return_value = None
+        db.sync_rom_files.return_value = []
+
+        await self._run(db)
+
+        # Rows are reconciled against the scan, so file ids survive the rescan.
+        db.sync_rom_files.assert_called_once_with(99, [])
+
     async def test_creates_new_entry_when_no_match(self, patched):
         db = patched
         db.get_matching_missing_rom.return_value = None

--- a/backend/tests/endpoints/sockets/test_scan.py
+++ b/backend/tests/endpoints/sockets/test_scan.py
@@ -14,6 +14,7 @@ from endpoints.sockets.scan import (
     stop_scan_handler,
 )
 from handler.auth.constants import Scope
+from handler.database.roms_handler import SyncedRomFiles
 from handler.filesystem.roms_handler import (
     FSRom,
     FSRomsHandler,
@@ -540,12 +541,26 @@ class TestIdentifyRomReassociation:
     async def test_files_are_reconciled_in_place(self, patched):
         db = patched
         db.get_matching_missing_rom.return_value = None
-        db.sync_rom_files.return_value = []
+        db.sync_rom_files.return_value = SyncedRomFiles(
+            files=[], orphaned_cover_paths=[]
+        )
 
         await self._run(db)
 
         # Rows are reconciled against the scan, so file ids survive the rescan.
         db.sync_rom_files.assert_called_once_with(99, [])
+
+    async def test_orphaned_soundtrack_covers_are_unlinked(self, patched, mocker):
+        db = patched
+        db.get_matching_missing_rom.return_value = None
+        db.sync_rom_files.return_value = SyncedRomFiles(
+            files=[], orphaned_cover_paths=["covers/track01.png"]
+        )
+        remove = mocker.patch.object(scan_module, "remove_persisted_cover")
+
+        await self._run(db)
+
+        remove.assert_called_once_with("covers/track01.png")
 
     async def test_creates_new_entry_when_no_match(self, patched):
         db = patched

--- a/backend/tests/handler/database/test_roms_handler.py
+++ b/backend/tests/handler/database/test_roms_handler.py
@@ -15,7 +15,7 @@ from handler.database import (
 )
 from models.assets import Save, State
 from models.platform import Platform
-from models.rom import Rom
+from models.rom import Rom, RomFile, RomFileCategory, TrackMeta
 from models.user import User
 
 
@@ -160,3 +160,157 @@ class TestHasSavesStatesFilter:
     ):
         self._add_state(rom, editor_user.id, is_public=False)
         assert rom.id not in self._rom_ids(user_id=admin_user.id, has_states=True)
+
+
+def _scanned_file(
+    rom: Rom,
+    file_name: str,
+    *,
+    file_path: str | None = None,
+    size: int = 100,
+    crc: str | None = "crc",
+    md5: str | None = "md5",
+    sha1: str | None = "sha1",
+    category: RomFileCategory | None = None,
+    track_meta: TrackMeta | None = None,
+) -> RomFile:
+    """A transient RomFile as the filesystem scanner builds it."""
+    return RomFile(
+        rom_id=rom.id,
+        file_name=file_name,
+        file_path=file_path if file_path is not None else rom.fs_path,
+        file_size_bytes=size,
+        crc_hash=crc,
+        md5_hash=md5,
+        sha1_hash=sha1,
+        category=category,
+        track_meta=track_meta,
+    )
+
+
+class TestSyncRomFiles:
+    """A rescan reconciles the file rows in place, so ids survive it. Anything
+    keyed on a file id (track metadata, persisted soundtrack covers) stays
+    valid instead of being orphaned by a purge-and-reinsert."""
+
+    def test_unchanged_file_keeps_its_id(self, rom: Rom):
+        first = db_rom_handler.sync_rom_files(rom.id, [_scanned_file(rom, "a.bin")])
+        second = db_rom_handler.sync_rom_files(rom.id, [_scanned_file(rom, "a.bin")])
+
+        assert [f.id for f in second] == [f.id for f in first]
+
+    def test_changed_metadata_updates_in_place(self, rom: Rom):
+        (first,) = db_rom_handler.sync_rom_files(rom.id, [_scanned_file(rom, "a.bin")])
+        (second,) = db_rom_handler.sync_rom_files(
+            rom.id, [_scanned_file(rom, "a.bin", size=200, sha1="new-sha1")]
+        )
+
+        assert second.id == first.id
+        assert second.file_size_bytes == 200
+        assert second.sha1_hash == "new-sha1"
+
+    def test_renamed_file_is_matched_by_content(self, rom: Rom):
+        (first,) = db_rom_handler.sync_rom_files(rom.id, [_scanned_file(rom, "a.bin")])
+        (second,) = db_rom_handler.sync_rom_files(rom.id, [_scanned_file(rom, "b.bin")])
+
+        assert second.id == first.id
+        assert second.file_name == "b.bin"
+
+    def test_moved_file_is_matched_by_content(self, rom: Rom):
+        (first,) = db_rom_handler.sync_rom_files(rom.id, [_scanned_file(rom, "a.bin")])
+        (second,) = db_rom_handler.sync_rom_files(
+            rom.id, [_scanned_file(rom, "a.bin", file_path=f"{rom.fs_path}/disc1")]
+        )
+
+        assert second.id == first.id
+        assert second.file_path == f"{rom.fs_path}/disc1"
+
+    def test_partial_hashes_do_not_match_by_content(self, rom: Rom):
+        (first,) = db_rom_handler.sync_rom_files(
+            rom.id, [_scanned_file(rom, "a.bin", sha1=None)]
+        )
+        (second,) = db_rom_handler.sync_rom_files(
+            rom.id, [_scanned_file(rom, "b.bin", sha1=None)]
+        )
+
+        # Without all three hashes the rename can't be proven, so a new row wins.
+        assert second.id != first.id
+
+    def test_identical_copies_are_not_paired_arbitrarily(self, rom: Rom):
+        db_rom_handler.sync_rom_files(
+            rom.id, [_scanned_file(rom, "a.bin"), _scanned_file(rom, "b.bin")]
+        )
+        renamed = db_rom_handler.sync_rom_files(
+            rom.id, [_scanned_file(rom, "c.bin"), _scanned_file(rom, "d.bin")]
+        )
+
+        assert {f.file_name for f in renamed} == {"c.bin", "d.bin"}
+        assert len(db_rom_handler.rom_files_for_rom_id(rom.id)) == 2
+
+    def test_new_file_is_inserted_and_vanished_file_deleted(self, rom: Rom):
+        db_rom_handler.sync_rom_files(
+            rom.id,
+            [
+                _scanned_file(rom, "a.bin"),
+                _scanned_file(rom, "b.bin", crc="crc2", md5="md52", sha1="sha12"),
+            ],
+        )
+        db_rom_handler.sync_rom_files(
+            rom.id,
+            [
+                _scanned_file(rom, "a.bin"),
+                _scanned_file(rom, "c.bin", crc="crc3", md5="md53", sha1="sha13"),
+            ],
+        )
+
+        assert {f.file_name for f in db_rom_handler.rom_files_for_rom_id(rom.id)} == {
+            "a.bin",
+            "c.bin",
+        }
+
+    def test_track_meta_survives_a_rescan(self, rom: Rom):
+        def scanned() -> RomFile:
+            return _scanned_file(
+                rom,
+                "track01.flac",
+                file_path=f"{rom.fs_path}/soundtrack",
+                category=RomFileCategory.SOUNDTRACK,
+                track_meta=TrackMeta(
+                    rom_id=rom.id, title="Green Hill", has_embedded_cover=True
+                ),
+            )
+
+        (first,) = db_rom_handler.sync_rom_files(rom.id, [scanned()])
+        db_rom_handler.upsert_track_meta(
+            first.id, rom.id, {"cover_path": "covers/track01.png"}
+        )
+
+        (second,) = db_rom_handler.sync_rom_files(rom.id, [scanned()])
+
+        assert second.id == first.id
+        reloaded = db_rom_handler.get_rom_file_by_id(second.id)
+        assert reloaded is not None
+        assert reloaded.track_meta is not None
+        assert reloaded.track_meta.title == "Green Hill"
+        # The scanner never reports the cover path, so the persisted one stands.
+        assert reloaded.track_meta.cover_path == "covers/track01.png"
+
+    def test_track_meta_dropped_when_file_no_longer_has_tags(self, rom: Rom):
+        (first,) = db_rom_handler.sync_rom_files(
+            rom.id,
+            [
+                _scanned_file(
+                    rom,
+                    "track01.flac",
+                    category=RomFileCategory.SOUNDTRACK,
+                    track_meta=TrackMeta(rom_id=rom.id, title="Green Hill"),
+                )
+            ],
+        )
+        db_rom_handler.sync_rom_files(
+            rom.id, [_scanned_file(rom, "track01.flac", category=RomFileCategory.GAME)]
+        )
+
+        reloaded = db_rom_handler.get_rom_file_by_id(first.id)
+        assert reloaded is not None
+        assert reloaded.track_meta is None

--- a/backend/tests/handler/database/test_roms_handler.py
+++ b/backend/tests/handler/database/test_roms_handler.py
@@ -208,8 +208,41 @@ class TestSyncRomFiles:
         (second,) = _sync(rom, [_scanned_file(rom, "a.bin", size=200, sha1="new-sha1")])
 
         assert second.id == first.id
-        assert second.file_size_bytes == 200
-        assert second.sha1_hash == "new-sha1"
+        reloaded = db_rom_handler.get_rom_file_by_id(first.id)
+        assert reloaded is not None
+        assert reloaded.file_size_bytes == 200
+        assert reloaded.sha1_hash == "new-sha1"
+
+    def test_retagged_track_meta_is_updated_in_place(self, rom: Rom):
+        def scanned(title: str, year: int) -> RomFile:
+            return _scanned_file(
+                rom,
+                "track01.flac",
+                category=RomFileCategory.SOUNDTRACK,
+                track_meta=TrackMeta(rom_id=rom.id, title=title, year=year),
+            )
+
+        (first,) = _sync(rom, [scanned("Green Hill", 1991)])
+        _sync(rom, [scanned("Green Hill Zone", 1992)])
+
+        reloaded = db_rom_handler.get_rom_file_by_id(first.id)
+        assert reloaded is not None
+        assert reloaded.track_meta is not None
+        assert reloaded.track_meta.title == "Green Hill Zone"
+        assert reloaded.track_meta.year == 1992
+
+    def test_unset_columns_do_not_overwrite_not_null_values(self, rom: Rom):
+        """A scanned row leaves unset columns as None, and the model defaults
+        only apply on insert. The update path has to skip them rather than
+        write NULL into a NOT NULL column."""
+        scanned = _scanned_file(rom, "a.bin", size=200)
+        _sync(rom, [scanned])
+
+        unset = _scanned_file(rom, "a.bin")
+        unset.file_size_bytes = None  # type: ignore[assignment]
+        (updated,) = _sync(rom, [unset])
+
+        assert updated.file_size_bytes == 200
 
     def test_renamed_file_is_matched_by_content(self, rom: Rom):
         (first,) = _sync(rom, [_scanned_file(rom, "a.bin")])

--- a/backend/tests/handler/database/test_roms_handler.py
+++ b/backend/tests/handler/database/test_roms_handler.py
@@ -188,75 +188,69 @@ def _scanned_file(
     )
 
 
+def _sync(rom: Rom, scanned: list[RomFile]) -> list[RomFile]:
+    return db_rom_handler.sync_rom_files(rom.id, scanned).files
+
+
 class TestSyncRomFiles:
     """A rescan reconciles the file rows in place, so ids survive it. Anything
     keyed on a file id (track metadata, persisted soundtrack covers) stays
     valid instead of being orphaned by a purge-and-reinsert."""
 
     def test_unchanged_file_keeps_its_id(self, rom: Rom):
-        first = db_rom_handler.sync_rom_files(rom.id, [_scanned_file(rom, "a.bin")])
-        second = db_rom_handler.sync_rom_files(rom.id, [_scanned_file(rom, "a.bin")])
+        first = _sync(rom, [_scanned_file(rom, "a.bin")])
+        second = _sync(rom, [_scanned_file(rom, "a.bin")])
 
         assert [f.id for f in second] == [f.id for f in first]
 
     def test_changed_metadata_updates_in_place(self, rom: Rom):
-        (first,) = db_rom_handler.sync_rom_files(rom.id, [_scanned_file(rom, "a.bin")])
-        (second,) = db_rom_handler.sync_rom_files(
-            rom.id, [_scanned_file(rom, "a.bin", size=200, sha1="new-sha1")]
-        )
+        (first,) = _sync(rom, [_scanned_file(rom, "a.bin")])
+        (second,) = _sync(rom, [_scanned_file(rom, "a.bin", size=200, sha1="new-sha1")])
 
         assert second.id == first.id
         assert second.file_size_bytes == 200
         assert second.sha1_hash == "new-sha1"
 
     def test_renamed_file_is_matched_by_content(self, rom: Rom):
-        (first,) = db_rom_handler.sync_rom_files(rom.id, [_scanned_file(rom, "a.bin")])
-        (second,) = db_rom_handler.sync_rom_files(rom.id, [_scanned_file(rom, "b.bin")])
+        (first,) = _sync(rom, [_scanned_file(rom, "a.bin")])
+        (second,) = _sync(rom, [_scanned_file(rom, "b.bin")])
 
         assert second.id == first.id
         assert second.file_name == "b.bin"
 
     def test_moved_file_is_matched_by_content(self, rom: Rom):
-        (first,) = db_rom_handler.sync_rom_files(rom.id, [_scanned_file(rom, "a.bin")])
-        (second,) = db_rom_handler.sync_rom_files(
-            rom.id, [_scanned_file(rom, "a.bin", file_path=f"{rom.fs_path}/disc1")]
+        (first,) = _sync(rom, [_scanned_file(rom, "a.bin")])
+        (second,) = _sync(
+            rom, [_scanned_file(rom, "a.bin", file_path=f"{rom.fs_path}/disc1")]
         )
 
         assert second.id == first.id
         assert second.file_path == f"{rom.fs_path}/disc1"
 
     def test_partial_hashes_do_not_match_by_content(self, rom: Rom):
-        (first,) = db_rom_handler.sync_rom_files(
-            rom.id, [_scanned_file(rom, "a.bin", sha1=None)]
-        )
-        (second,) = db_rom_handler.sync_rom_files(
-            rom.id, [_scanned_file(rom, "b.bin", sha1=None)]
-        )
+        (first,) = _sync(rom, [_scanned_file(rom, "a.bin", sha1=None)])
+        (second,) = _sync(rom, [_scanned_file(rom, "b.bin", sha1=None)])
 
         # Without all three hashes the rename can't be proven, so a new row wins.
         assert second.id != first.id
 
     def test_identical_copies_are_not_paired_arbitrarily(self, rom: Rom):
-        db_rom_handler.sync_rom_files(
-            rom.id, [_scanned_file(rom, "a.bin"), _scanned_file(rom, "b.bin")]
-        )
-        renamed = db_rom_handler.sync_rom_files(
-            rom.id, [_scanned_file(rom, "c.bin"), _scanned_file(rom, "d.bin")]
-        )
+        _sync(rom, [_scanned_file(rom, "a.bin"), _scanned_file(rom, "b.bin")])
+        renamed = _sync(rom, [_scanned_file(rom, "c.bin"), _scanned_file(rom, "d.bin")])
 
         assert {f.file_name for f in renamed} == {"c.bin", "d.bin"}
         assert len(db_rom_handler.rom_files_for_rom_id(rom.id)) == 2
 
     def test_new_file_is_inserted_and_vanished_file_deleted(self, rom: Rom):
-        db_rom_handler.sync_rom_files(
-            rom.id,
+        _sync(
+            rom,
             [
                 _scanned_file(rom, "a.bin"),
                 _scanned_file(rom, "b.bin", crc="crc2", md5="md52", sha1="sha12"),
             ],
         )
-        db_rom_handler.sync_rom_files(
-            rom.id,
+        _sync(
+            rom,
             [
                 _scanned_file(rom, "a.bin"),
                 _scanned_file(rom, "c.bin", crc="crc3", md5="md53", sha1="sha13"),
@@ -280,15 +274,16 @@ class TestSyncRomFiles:
                 ),
             )
 
-        (first,) = db_rom_handler.sync_rom_files(rom.id, [scanned()])
+        (first,) = _sync(rom, [scanned()])
         db_rom_handler.upsert_track_meta(
             first.id, rom.id, {"cover_path": "covers/track01.png"}
         )
 
-        (second,) = db_rom_handler.sync_rom_files(rom.id, [scanned()])
+        synced = db_rom_handler.sync_rom_files(rom.id, [scanned()])
 
-        assert second.id == first.id
-        reloaded = db_rom_handler.get_rom_file_by_id(second.id)
+        assert synced.files[0].id == first.id
+        assert synced.orphaned_cover_paths == []
+        reloaded = db_rom_handler.get_rom_file_by_id(first.id)
         assert reloaded is not None
         assert reloaded.track_meta is not None
         assert reloaded.track_meta.title == "Green Hill"
@@ -296,8 +291,8 @@ class TestSyncRomFiles:
         assert reloaded.track_meta.cover_path == "covers/track01.png"
 
     def test_track_meta_dropped_when_file_no_longer_has_tags(self, rom: Rom):
-        (first,) = db_rom_handler.sync_rom_files(
-            rom.id,
+        (first,) = _sync(
+            rom,
             [
                 _scanned_file(
                     rom,
@@ -307,10 +302,40 @@ class TestSyncRomFiles:
                 )
             ],
         )
-        db_rom_handler.sync_rom_files(
-            rom.id, [_scanned_file(rom, "track01.flac", category=RomFileCategory.GAME)]
+        db_rom_handler.upsert_track_meta(
+            first.id, rom.id, {"cover_path": "covers/track01.png"}
         )
 
+        synced = db_rom_handler.sync_rom_files(
+            rom.id,
+            [_scanned_file(rom, "track01.flac", category=RomFileCategory.GAME)],
+        )
+
+        # The cover has nothing pointing at it now, so the caller must unlink it.
+        assert synced.orphaned_cover_paths == ["covers/track01.png"]
         reloaded = db_rom_handler.get_rom_file_by_id(first.id)
         assert reloaded is not None
         assert reloaded.track_meta is None
+
+    def test_vanished_soundtrack_reports_its_orphaned_cover(self, rom: Rom):
+        (first,) = _sync(
+            rom,
+            [
+                _scanned_file(
+                    rom,
+                    "track01.flac",
+                    category=RomFileCategory.SOUNDTRACK,
+                    track_meta=TrackMeta(rom_id=rom.id, title="Green Hill"),
+                )
+            ],
+        )
+        db_rom_handler.upsert_track_meta(
+            first.id, rom.id, {"cover_path": "covers/track01.png"}
+        )
+
+        # Deleting the row cascades the track metadata, taking the only
+        # reference to the cover with it.
+        synced = db_rom_handler.sync_rom_files(rom.id, [])
+
+        assert synced.files == []
+        assert synced.orphaned_cover_paths == ["covers/track01.png"]

--- a/backend/tests/handler/test_persist_soundtrack_cover.py
+++ b/backend/tests/handler/test_persist_soundtrack_cover.py
@@ -31,7 +31,9 @@ class TestPersistSoundtrackCoverRemoval:
     now-orphaned resource."""
 
     def test_lost_cover_is_removed_and_cleared(self, mocker):
-        remove = mocker.patch.object(scan_handler, "remove_persisted_cover")
+        remove = mocker.patch.object(
+            scan_handler, "remove_persisted_cover", Mock(return_value=True)
+        )
         db = mocker.patch.object(scan_handler, "db_rom_handler")
 
         persist_soundtrack_cover(
@@ -40,6 +42,19 @@ class TestPersistSoundtrackCoverRemoval:
 
         remove.assert_called_once_with("covers/track01.png")
         db.upsert_track_meta.assert_called_once_with(21, 7, {"cover_path": None})
+
+    def test_failed_unlink_keeps_the_path_for_a_retry(self, mocker):
+        mocker.patch.object(
+            scan_handler, "remove_persisted_cover", Mock(return_value=False)
+        )
+        db = mocker.patch.object(scan_handler, "db_rom_handler")
+
+        persist_soundtrack_cover(
+            _soundtrack_file(has_cover=False, cover_path="covers/track01.png"), _rom()
+        )
+
+        # Clearing the path here would strand the file with nothing pointing at it.
+        db.upsert_track_meta.assert_not_called()
 
     def test_no_cover_and_no_path_is_a_noop(self, mocker):
         remove = mocker.patch.object(scan_handler, "remove_persisted_cover")

--- a/backend/tests/handler/test_persist_soundtrack_cover.py
+++ b/backend/tests/handler/test_persist_soundtrack_cover.py
@@ -1,0 +1,74 @@
+from unittest.mock import Mock
+
+import handler.scan_handler as scan_handler
+from handler.scan_handler import persist_soundtrack_cover
+from models.rom import Rom, RomFile, RomFileCategory, TrackMeta
+
+
+def _rom() -> Rom:
+    rom = Rom(platform_id=1)
+    rom.id = 7
+    return rom
+
+
+def _soundtrack_file(*, has_cover: bool, cover_path: str | None) -> RomFile:
+    rom_file = RomFile(
+        rom_id=7,
+        file_name="track01.flac",
+        file_path="test/roms/game/soundtrack",
+        category=RomFileCategory.SOUNDTRACK,
+        track_meta=TrackMeta(
+            rom_id=7, has_embedded_cover=has_cover, cover_path=cover_path
+        ),
+    )
+    rom_file.id = 21
+    return rom_file
+
+
+class TestPersistSoundtrackCoverRemoval:
+    """A rescan reuses the file row, so a cover stripped from the audio file
+    since the last scan must be cleared instead of being served forever from a
+    now-orphaned resource."""
+
+    def test_lost_cover_is_removed_and_cleared(self, mocker):
+        remove = mocker.patch.object(scan_handler, "remove_persisted_cover")
+        db = mocker.patch.object(scan_handler, "db_rom_handler")
+
+        persist_soundtrack_cover(
+            _soundtrack_file(has_cover=False, cover_path="covers/track01.png"), _rom()
+        )
+
+        remove.assert_called_once_with("covers/track01.png")
+        db.upsert_track_meta.assert_called_once_with(21, 7, {"cover_path": None})
+
+    def test_no_cover_and_no_path_is_a_noop(self, mocker):
+        remove = mocker.patch.object(scan_handler, "remove_persisted_cover")
+        db = mocker.patch.object(scan_handler, "db_rom_handler")
+
+        persist_soundtrack_cover(
+            _soundtrack_file(has_cover=False, cover_path=None), _rom()
+        )
+
+        remove.assert_not_called()
+        db.upsert_track_meta.assert_not_called()
+
+    def test_existing_cover_is_repersisted(self, mocker):
+        remove = mocker.patch.object(scan_handler, "remove_persisted_cover")
+        db = mocker.patch.object(scan_handler, "db_rom_handler")
+        mocker.patch.object(
+            scan_handler.fs_rom_handler, "validate_path", Mock(return_value="/audio")
+        )
+        mocker.patch.object(
+            scan_handler,
+            "persist_embedded_cover",
+            Mock(return_value="covers/track01.png"),
+        )
+
+        persist_soundtrack_cover(
+            _soundtrack_file(has_cover=True, cover_path="covers/track01.png"), _rom()
+        )
+
+        remove.assert_not_called()
+        db.upsert_track_meta.assert_called_once_with(
+            21, 7, {"cover_path": "covers/track01.png"}
+        )

--- a/backend/utils/audio_tags.py
+++ b/backend/utils/audio_tags.py
@@ -350,20 +350,27 @@ def persist_embedded_cover(
     return rel_path
 
 
-def remove_persisted_cover(cover_path: str | None) -> None:
+def remove_persisted_cover(cover_path: str | None) -> bool:
     """Delete a persisted soundtrack cover (relative path under
-    RESOURCES_BASE_PATH). Silently ignores missing files."""
+    RESOURCES_BASE_PATH). Silently ignores missing files.
+
+    Returns whether the file is gone, so a caller that is about to drop the
+    only reference to it can keep that reference and retry later instead.
+    """
     if not cover_path:
-        return
+        return True
     from config import RESOURCES_BASE_PATH
 
     abs_path = os.path.join(RESOURCES_BASE_PATH, cover_path)
     try:
         os.unlink(abs_path)
     except FileNotFoundError:
-        return
+        return True
     except OSError as exc:
         log.warning(f"[audio_tags] cover delete failed for {abs_path}: {exc}")
+        return False
+
+    return True
 
 
 def extract_embedded_cover(full_path: str) -> tuple[bytes, str] | None:


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Rescans purged and re-inserted every `rom_files` row for a ROM, so file ids churned on each scan even when the files on disk never changed. Anything keyed on a file id was collateral damage: `track_meta` rows were cloned onto new ids, and persisted soundtrack covers (whose path embeds the file id) were re-written under a new name every scan, leaving the old ones behind.

ROM rows already survive a rescan (and even a rename, via hash reassociation). This applies the same treatment to `rom_files`.

`DBRomsHandler.sync_rom_files(rom_id, scanned_files)` replaces the purge + per-file insert:

1. Existing rows are matched to scanned files by `(file_path, file_name)`.
2. Leftovers are paired by content hash, so a file renamed or moved *inside* the ROM keeps its row. Same strictness as `get_matching_missing_rom`: crc, md5 and sha1 must all be present and equal, and a hash shared by several rows (identical copies) is dropped rather than paired arbitrarily.
3. Only columns that actually changed are written, so re-scanning an unchanged ROM issues no updates and leaves `updated_at` a usable incremental signal.
4. Rows whose file is gone from disk are deleted, and genuinely new files are inserted.
5. `track_meta` is updated in place on the surviving row instead of being cloned. `cover_path` is preserved when the scan doesn't report one, since the scanner only flags `has_embedded_cover` and the path is written afterwards by `persist_soundtrack_cover`.

Two incidental fixes fall out of this:

- `archive_members` is now persisted. The hand-written copy in the scan loop never set it, so the column computed by the FS handler was always null after a scan.
- Soundtrack covers are written to a stable, file-id-keyed path instead of a new one per scan, and their lifecycle is now closed: `persist_soundtrack_cover` clears (and unlinks) the path when a track loses its embedded cover, and `sync_rom_files` reports the covers orphaned by dropped track metadata (a file that stopped carrying tags, or vanished from disk) so the scan can unlink them. The filesystem work stays out of the database handler.

`purge_rom_files` had no other callers and is removed.

Files that disappear from disk are still deleted rather than flagged `RomFile.missing_from_fs`. That column exists but nothing currently sets it true, and marking instead of deleting would leak phantom entries into file lists and downloads; that's a separate change if we want it.

**AI assistance disclosure**: this change was written with Claude Code (Opus 4.8). I directed the approach, and reviewed the implementation, tests and results.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Full backend suite passes (2335 passed, 2 skipped) and `trunk fmt && trunk check` is clean. 14 new tests: id stability across rescans, in-place column updates, rename/move matched by content, refusal to match on partial hashes, ambiguous identical copies, insert/delete of appeared/vanished files, `track_meta` (and its persisted cover path) surviving a rescan, `track_meta` dropped when a file stops carrying tags, orphaned covers reported for dropped and deleted rows, the three `persist_soundtrack_cover` branches, plus wiring tests on `_identify_rom`.

#### Screenshots (if applicable)

N/A, backend only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
