### PR TITLE
Fix/server stats duplicate slug key

### DIFF
--- a/frontend/src/v2/components/Settings/PlatformsStatsSection.test.ts
+++ b/frontend/src/v2/components/Settings/PlatformsStatsSection.test.ts
@@ -164,7 +164,7 @@ describe("PlatformsStatsSection", () => {
   // Re-sorting is a pure reorder of the same set. With a non-unique key, Vue
   // cannot match old rows to new ones and leaves stale DOM behind, so the row
   // count grows past the library size with every click. Each sort must simply
-  // reorder the same four rows.
+  // reorder the same six rows.
   it("keeps one row per platform when re-sorting a library with shared slugs", async () => {
     const wrapper = mountSection(duplicateSlugLibrary());
 

--- a/frontend/src/v2/components/Settings/PlatformsStatsSection.test.ts
+++ b/frontend/src/v2/components/Settings/PlatformsStatsSection.test.ts
@@ -1,0 +1,239 @@
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Platform } from "@/stores/platforms";
+import storePlatforms from "@/stores/platforms";
+import PlatformsStatsSection from "./PlatformsStatsSection.vue";
+
+// vue-i18n's `t` is stubbed to echo the key so the component mounts without
+// the full i18n plugin.
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+// The heartbeat store pulls in config + i18n; stub it down to the single
+// method this component calls.
+vi.mock("@/stores/heartbeat", () => ({
+  default: () => ({ getMetadataOptionsByPriority: () => [] }),
+}));
+
+function platform(overrides: Partial<Platform> = {}): Platform {
+  return {
+    id: 1,
+    slug: "snes",
+    fs_slug: "snes",
+    rom_count: 1,
+    name: "Super Nintendo",
+    igdb_slug: null,
+    moby_slug: null,
+    hltb_slug: null,
+    libretro_slug: null,
+    custom_name: "",
+    description: null,
+    created_at: "",
+    updated_at: "",
+    fs_size_bytes: 0,
+    is_unidentified: false,
+    is_identified: true,
+    missing_from_fs: false,
+    display_name: "Super Nintendo",
+    firmware_count: 0,
+    ...overrides,
+  } as Platform;
+}
+
+function mountSection(platforms: Platform[]) {
+  storePlatforms().set(platforms);
+  return mount(PlatformsStatsSection, {
+    props: { totalFilesize: 0, metadataCoverage: {}, regionBreakdown: {} },
+    global: {
+      stubs: {
+        RIcon: true,
+        RPlatformIcon: true,
+        RProgressLinear: true,
+        RSliderBtnGroup: true,
+        RTextField: true,
+      },
+    },
+  });
+}
+
+type Section = ReturnType<typeof mountSection>;
+
+function renderedNames(wrapper: Section): string[] {
+  return wrapper.findAll(".r-v2-plat-stats__name").map((n) => n.text());
+}
+
+function rowCount(wrapper: Section): number {
+  return wrapper.findAll(".r-v2-plat-stats__row").length;
+}
+
+async function setOrder(wrapper: Section, order: "name" | "size" | "count") {
+  (wrapper.vm as unknown as { orderBy: string }).orderBy = order;
+  await wrapper.vm.$nextTick();
+}
+
+async function setSearch(wrapper: Section, query: string) {
+  (wrapper.vm as unknown as { searchQuery: string }).searchQuery = query;
+  await wrapper.vm.$nextTick();
+}
+
+// Real-world libraries keep official and "(Unofficial)" / headered-vs-headerless
+// sets of the same system side by side. Those variants share one metadata slug
+// while their id and fs_slug stay unique, so this fixture reproduces the shared
+// slugs (nes x2, genesis x2) that broke keyed rendering. The unique-slug Atari
+// and Xbox bookends keep the shared-slug rows in the interior, where a search
+// narrowing corrupts the keyed list under a non-unique key.
+function duplicateSlugLibrary(): Platform[] {
+  return [
+    platform({
+      id: 1,
+      slug: "atari2600",
+      fs_slug: "atari2600",
+      name: "Atari 2600",
+      display_name: "Atari 2600",
+      rom_count: 3,
+      fs_size_bytes: 5,
+    }),
+    platform({
+      id: 2,
+      slug: "nes",
+      fs_slug: "nes",
+      name: "Nintendo Entertainment System",
+      display_name: "Nintendo Entertainment System",
+      rom_count: 5,
+      fs_size_bytes: 10,
+    }),
+    platform({
+      id: 3,
+      slug: "nes",
+      fs_slug: "nes-unofficial",
+      name: "Nintendo Entertainment System (Unofficial)",
+      display_name: "Nintendo Entertainment System (Unofficial)",
+      rom_count: 1,
+      fs_size_bytes: 40,
+    }),
+    platform({
+      id: 4,
+      slug: "genesis",
+      fs_slug: "genesis",
+      name: "Sega Genesis",
+      display_name: "Sega Genesis",
+      rom_count: 4,
+      fs_size_bytes: 20,
+    }),
+    platform({
+      id: 5,
+      slug: "genesis",
+      fs_slug: "genesis-unofficial",
+      name: "Sega Genesis (Unofficial)",
+      display_name: "Sega Genesis (Unofficial)",
+      rom_count: 2,
+      fs_size_bytes: 30,
+    }),
+    platform({
+      id: 6,
+      slug: "xbox",
+      fs_slug: "xbox",
+      name: "Xbox",
+      display_name: "Xbox",
+      rom_count: 6,
+      fs_size_bytes: 6,
+    }),
+  ];
+}
+
+describe("PlatformsStatsSection", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("renders one row per platform on initial load", () => {
+    const wrapper = mountSection(duplicateSlugLibrary());
+    expect(rowCount(wrapper)).toBe(6);
+    expect(renderedNames(wrapper)).toEqual([
+      "Atari 2600",
+      "Nintendo Entertainment System",
+      "Nintendo Entertainment System (Unofficial)",
+      "Sega Genesis",
+      "Sega Genesis (Unofficial)",
+      "Xbox",
+    ]);
+  });
+
+  // Re-sorting is a pure reorder of the same set. With a non-unique key, Vue
+  // cannot match old rows to new ones and leaves stale DOM behind, so the row
+  // count grows past the library size with every click. Each sort must simply
+  // reorder the same four rows.
+  it("keeps one row per platform when re-sorting a library with shared slugs", async () => {
+    const wrapper = mountSection(duplicateSlugLibrary());
+
+    await setOrder(wrapper, "size");
+    expect(rowCount(wrapper)).toBe(6);
+    expect(renderedNames(wrapper)).toEqual([
+      "Nintendo Entertainment System (Unofficial)", // 40
+      "Sega Genesis (Unofficial)", // 30
+      "Sega Genesis", // 20
+      "Nintendo Entertainment System", // 10
+      "Xbox", // 6
+      "Atari 2600", // 5
+    ]);
+
+    await setOrder(wrapper, "count");
+    expect(rowCount(wrapper)).toBe(6);
+    expect(renderedNames(wrapper)).toEqual([
+      "Xbox", // 6
+      "Nintendo Entertainment System", // 5
+      "Sega Genesis", // 4
+      "Atari 2600", // 3
+      "Sega Genesis (Unofficial)", // 2
+      "Nintendo Entertainment System (Unofficial)", // 1
+    ]);
+
+    await setOrder(wrapper, "name");
+    expect(rowCount(wrapper)).toBe(6);
+    expect(renderedNames(wrapper)).toEqual([
+      "Atari 2600",
+      "Nintendo Entertainment System",
+      "Nintendo Entertainment System (Unofficial)",
+      "Sega Genesis",
+      "Sega Genesis (Unofficial)",
+      "Xbox",
+    ]);
+  });
+
+  // Searching narrows then widens the list; widening back re-adds rows that
+  // share a slug with survivors, which is what stacks stale DOM under a
+  // non-unique key. Every state must show exactly the platforms that match.
+  it("keeps one row per platform when searching a library with shared slugs", async () => {
+    const wrapper = mountSection(duplicateSlugLibrary());
+
+    // Narrows the full list down to the two interior genesis rows.
+    await setSearch(wrapper, "sega");
+    expect(rowCount(wrapper)).toBe(2);
+    expect(renderedNames(wrapper)).toEqual([
+      "Sega Genesis",
+      "Sega Genesis (Unofficial)",
+    ]);
+
+    await setSearch(wrapper, "nintendo");
+    expect(rowCount(wrapper)).toBe(2);
+    expect(renderedNames(wrapper)).toEqual([
+      "Nintendo Entertainment System",
+      "Nintendo Entertainment System (Unofficial)",
+    ]);
+
+    // Clearing widens the list back to the full set; the re-added rows must not
+    // stack on top of the ones already on screen.
+    await setSearch(wrapper, "");
+    expect(rowCount(wrapper)).toBe(6);
+    expect(renderedNames(wrapper)).toEqual([
+      "Atari 2600",
+      "Nintendo Entertainment System",
+      "Nintendo Entertainment System (Unofficial)",
+      "Sega Genesis",
+      "Sega Genesis (Unofficial)",
+      "Xbox",
+    ]);
+  });
+});

--- a/frontend/src/v2/components/Settings/PlatformsStatsSection.vue
+++ b/frontend/src/v2/components/Settings/PlatformsStatsSection.vue
@@ -180,7 +180,7 @@ function coveragePercent(matched: number, total: number): string {
     <div class="r-v2-plat-stats">
       <div
         v-for="platform in sortedPlatforms"
-        :key="platform.slug"
+        :key="platform.id"
         class="r-v2-plat-stats__row"
       >
         <RPlatformIcon


### PR DESCRIPTION
**Description**

Fixes #3905.

## What changed and why

On **Settings → Server Stats**, the per-platform breakdown list corrupts itself
whenever the list updates: typing in **Search platforms** or clicking the
**Name / Games / Size** sort buttons fills the list with wrong/duplicate rows
that grow *past the size of the whole library*. It renders correctly on first
load; only updates break it, and each action stacks more stale rows on top.

Root cause: the breakdown `v-for` was keyed by `platform.slug`:

    <div v-for="platform in sortedPlatforms" :key="platform.slug" ...>

`slug` is the **metadata** slug and is **not unique** across platform records.
Variant sets share one slug while `id`/`fs_slug` stay unique, e.g. an official
set + an `(Unofficial)` set, or headered vs headerless NES. On a real 123-platform
library, 51 of 70 slugs are shared by 2-4 platforms. Vue's keyed reconciliation
needs unique keys to match old rows to new ones on update; with duplicate keys it
can't, so it leaves stale DOM behind and appends new rows, and the count grows
without bound. The production build strips Vue's duplicate-key warning, so it
fails completely silently.

The fix keys by the unique primary key instead:

    <div v-for="platform in sortedPlatforms" :key="platform.id" ...>

`platform.id` is the DB primary key (always present, unique) and is already used
elsewhere in the same template for the metadata-coverage and region lookups.

This is separate from #3897 (empty/ghost platforms); that fix does not touch the
key.

## Files modified

- `frontend/src/v2/components/Settings/PlatformsStatsSection.vue`
  One-line fix: `:key="platform.slug"` -> `:key="platform.id"` on the breakdown
  row `v-for`.
- `frontend/src/v2/components/Settings/PlatformsStatsSection.test.ts` (new)
  Unit tests covering the bug: initial render is one row per platform, and both
  re-sorting and searching keep exactly one row per matching platform (no stale
  or duplicate rows) on a library that has shared slugs.

## Testing notes

- Added tests are red on the old `:key="platform.slug"` (re-sort renders 8 rows
  instead of 6; search renders 3 instead of 2, with Vue's "Duplicate keys found"
  warning) and green after the fix.
- Full frontend suite: 530/530 passing (34 files).
- `npm run typecheck` (vue-tsc): clean.
- Trunk (eslint/prettier) on the changed files: no issues.
- Manual: reproduced in the browser on a 123-platform library (search + sort both
  corrupt on `master`); the fix makes searching narrow cleanly and the sort
  buttons simply reorder, each platform appearing exactly once.

## For reviewers

- The tests drive the component's internal `orderBy` / `searchQuery` refs via
  `wrapper.vm` rather than through the toolbar controls, because `RTextField` /
  `RSliderBtnGroup` are stubbed and don't emit. Deliberate, to keep the test
  light and focused on the keyed-list behavior.
- Reproducing the **search** corruption in a unit test requires the shared-slug
  rows to be in the list interior (the fixture uses unique-slug `atari` / `xbox`
  bookends). A shared-slug pair at the list edge self-corrects via Vue's
  prefix/suffix sync, so it would pass even while buggy. A **re-sort** reproduces
  unconditionally.
- Heads-up: the separate #3897 branch also adds a `PlatformsStatsSection.test.ts`
  and changes `allPlatforms` -> `filledPlatforms` in this component; whichever
  merges second will conflict on the test file (trivial to reconcile).

## AI assistance disclosure

This PR (code, tests, and description) was written primarily by Claude Code
(Opus 4.8), driven and reviewed by me.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes