### PR TITLE
Fix Playmatch health check failing on plain-text response

### DIFF
--- a/backend/handler/metadata/playmatch_handler.py
+++ b/backend/handler/metadata/playmatch_handler.py
@@ -117,13 +117,22 @@ class PlaymatchHandler(MetadataHandler):
         if not self.is_enabled():
             return False
 
+        # The /health endpoint returns a plain-text body ("Healthy"), not
+        # JSON, so any 2xx response is enough to consider the service up.
+        httpx_client = ctx_httpx_client.get()
         try:
-            response = await self._request(self.healthcheck_url, {})
+            await _rate_limiter.acquire()
+            res = await httpx_client.get(
+                self.healthcheck_url,
+                headers={"user-agent": f"RomM/{get_version()}"},
+                timeout=60,
+            )
+            res.raise_for_status()
         except Exception as e:
             log.error("Error checking Playmatch API: %s", e)
             return False
 
-        return bool(response)
+        return True
 
     async def _request(self, url: str, query: dict) -> dict:
         """

--- a/backend/tests/handler/metadata/test_playmatch_handler.py
+++ b/backend/tests/handler/metadata/test_playmatch_handler.py
@@ -1,15 +1,22 @@
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
 
 from handler.metadata.playmatch_handler import PlaymatchHandler
 from utils import get_version
 
 
 @patch("handler.metadata.playmatch_handler.ctx_httpx_client")
-async def test_heartbeat_requests_health_without_query(mock_ctx_httpx_client):
+async def test_heartbeat_accepts_plain_text_health_response(mock_ctx_httpx_client):
+    # /health returns a 200 with the plain-text body "Healthy", not JSON.
     handler = PlaymatchHandler()
     mock_client = AsyncMock()
     mock_response = MagicMock()
-    mock_response.json.return_value = {"status": "ok"}
+    mock_response.text = "Healthy"
+    mock_response.json.side_effect = json.JSONDecodeError(
+        "Expecting value", "Healthy", 0
+    )
     mock_client.get.return_value = mock_response
     mock_ctx_httpx_client.get.return_value = mock_client
 
@@ -28,3 +35,30 @@ async def test_heartbeat_requests_health_without_query(mock_ctx_httpx_client):
         timeout=60,
     )
     mock_response.raise_for_status.assert_called_once()
+
+
+@patch("handler.metadata.playmatch_handler.ctx_httpx_client")
+async def test_heartbeat_returns_false_on_http_error(mock_ctx_httpx_client):
+    handler = PlaymatchHandler()
+    mock_client = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Service Unavailable", request=MagicMock(), response=MagicMock()
+    )
+    mock_client.get.return_value = mock_response
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    with (
+        patch.object(handler, "is_enabled", return_value=True),
+        patch(
+            "handler.metadata.playmatch_handler._rate_limiter.acquire",
+            new_callable=AsyncMock,
+        ),
+    ):
+        assert await handler.heartbeat() is False
+
+
+async def test_heartbeat_returns_false_when_disabled():
+    handler = PlaymatchHandler()
+    with patch.object(handler, "is_enabled", return_value=False):
+        assert await handler.heartbeat() is False


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3913

The Playmatch `/api/v2/health` endpoint returns HTTP 200 with the plain-text body `Healthy` (verified with curl), not JSON. `heartbeat()` routed the health check through the JSON-parsing `_request()`, so `res.json()` raised `JSONDecodeError`, the error was logged ("Error decoding JSON response from Playmatch"), and the swallowed `{}` made the Metadata Sources page show "Connection failed" for a perfectly healthy service.

`heartbeat()` now performs a raw GET (rate-limited, with the RomM user agent) and treats any 2xx as healthy, mirroring the Hasheous handler's health-check pattern. `_request()` is unchanged for the actual lookup endpoints, which do return JSON.

The previous test baked in the wrong assumption that `/health` returns JSON; it is replaced with a regression test simulating the real plain-text response, plus HTTP-error and disabled cases.

AI disclosure: this fix was investigated, implemented, and tested with AI assistance (Claude Code); the change was reviewed before submission.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)