### PR TITLE
Add scan.priority.region_mode to let config regions drive media selection

### DIFF
--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -762,7 +762,10 @@ class ConfigManager:
             log.critical("Invalid config.yml: scan.priority.region must be a list")
             sys.exit(3)
 
-        if self.config.SCAN_REGION_MODE not in VALID_SCAN_REGION_MODES:
+        if (
+            not isinstance(self.config.SCAN_REGION_MODE, str)
+            or self.config.SCAN_REGION_MODE not in VALID_SCAN_REGION_MODES
+        ):
             log.warning(
                 f"Unknown scan.priority.region_mode value "
                 f"{self.config.SCAN_REGION_MODE!r}; falling back to "

--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -139,6 +139,11 @@ VALID_SCAN_PRIORITY_SOURCES = frozenset(
     }
 )
 
+# Valid values for scan.priority.region_mode. "prefer_rom_tags" keeps the
+# rom's filename region tags authoritative for media selection;
+# "prefer_config" makes scan.priority.region win over the rom's own tags.
+VALID_SCAN_REGION_MODES = frozenset({"prefer_rom_tags", "prefer_config"})
+
 
 class EjsControls(TypedDict):
     _0: dict[int, EjsControlsButton]  # button_number -> EjsControlsButton
@@ -192,6 +197,7 @@ class Config:
     SCAN_ARTWORK_PRIORITY: list[str]
     SCAN_ARTWORK_PRIORITY_OVERRIDES: dict[str, list[str]]
     SCAN_REGION_PRIORITY: list[str]
+    SCAN_REGION_MODE: str
     SCAN_LANGUAGE_PRIORITY: list[str]
     SCAN_MEDIA: list[str]
     GAMELIST_MEDIA_THUMBNAIL: MetadataMediaType
@@ -494,6 +500,11 @@ class ConfigManager:
                 "scan.priority.region",
                 ["us", "wor", "ss", "eu", "jp"],
             ),
+            SCAN_REGION_MODE=pydash.get(
+                self._raw_config,
+                "scan.priority.region_mode",
+                "prefer_rom_tags",
+            ),
             SCAN_LANGUAGE_PRIORITY=pydash.get(
                 self._raw_config,
                 "scan.priority.language",
@@ -751,6 +762,14 @@ class ConfigManager:
             log.critical("Invalid config.yml: scan.priority.region must be a list")
             sys.exit(3)
 
+        if self.config.SCAN_REGION_MODE not in VALID_SCAN_REGION_MODES:
+            log.warning(
+                f"Unknown scan.priority.region_mode value "
+                f"{self.config.SCAN_REGION_MODE!r}; falling back to "
+                f"'prefer_rom_tags'. Valid options: {sorted(VALID_SCAN_REGION_MODES)}."
+            )
+            self.config.SCAN_REGION_MODE = "prefer_rom_tags"
+
         if not isinstance(self.config.SCAN_LANGUAGE_PRIORITY, list):
             log.critical("Invalid config.yml: scan.priority.language must be a list")
             sys.exit(3)
@@ -878,6 +897,7 @@ class ConfigManager:
                         if field in self.config.SCAN_ARTWORK_PRIORITY_OVERRIDES
                     },
                     "region": self.config.SCAN_REGION_PRIORITY,
+                    "region_mode": self.config.SCAN_REGION_MODE,
                     "language": self.config.SCAN_LANGUAGE_PRIORITY,
                 },
                 "media": self.config.SCAN_MEDIA,

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -75,7 +75,9 @@ def add_ss_auth_to_url(url: str | None) -> str:
     )
 
 
-def get_preferred_regions(rom: Rom | None = None) -> list[str]:
+def get_preferred_regions(
+    rom: Rom | None = None, *, for_media: bool = False
+) -> list[str]:
     """Get preferred regions, prepending the rom's own region tags when available.
 
     When a rom is tagged with multiple regions (e.g. "(Japan, USA)"), the rom's
@@ -84,9 +86,11 @@ def get_preferred_regions(rom: Rom | None = None) -> list[str]:
     Filename-tagged regions not present in the priority list keep their relative
     order and follow the prioritized ones.
 
-    With SCAN_REGION_MODE set to "prefer_config", the configured priority is
-    authoritative instead: config regions come first and the rom's own tags
-    become the fallback when the config regions have no media.
+    With SCAN_REGION_MODE set to "prefer_config" and for_media=True, the
+    configured priority is authoritative instead: config regions come first and
+    the rom's own tags become the fallback when the config regions have no
+    media. The mode only applies to media selection; name and release-date
+    selection always keep the rom-tags-first ordering.
     """
     config = cm.get_config()
     priority = config.SCAN_REGION_PRIORITY
@@ -101,7 +105,7 @@ def get_preferred_regions(rom: Rom | None = None) -> list[str]:
             key=lambda code: priority.index(code) if code in priority else len(priority)
         )
 
-    if config.SCAN_REGION_MODE == "prefer_config":
+    if for_media and config.SCAN_REGION_MODE == "prefer_config":
         ordered = priority + rom_codes
     else:
         ordered = rom_codes + priority
@@ -274,7 +278,7 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
         video_normalized_path=None,
     )
 
-    for region in get_preferred_regions(rom):
+    for region in get_preferred_regions(rom, for_media=True):
         for media in game.get("medias", []):
             if media.get("region", "unk") != region or media.get("parent") != "jeu":
                 continue

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -83,6 +83,10 @@ def get_preferred_regions(rom: Rom | None = None) -> list[str]:
     user's preference wins among the regions the file is actually tagged as.
     Filename-tagged regions not present in the priority list keep their relative
     order and follow the prioritized ones.
+
+    With SCAN_REGION_MODE set to "prefer_config", the configured priority is
+    authoritative instead: config regions come first and the rom's own tags
+    become the fallback when the config regions have no media.
     """
     config = cm.get_config()
     priority = config.SCAN_REGION_PRIORITY
@@ -97,9 +101,14 @@ def get_preferred_regions(rom: Rom | None = None) -> list[str]:
             key=lambda code: priority.index(code) if code in priority else len(priority)
         )
 
-    return list(
-        dict.fromkeys(rom_codes + priority + ["us", "wor", "ss", "eu", "jp", "cus"])
-    ) + ["unk"]
+    if config.SCAN_REGION_MODE == "prefer_config":
+        ordered = priority + rom_codes
+    else:
+        ordered = rom_codes + priority
+
+    return list(dict.fromkeys(ordered + ["us", "wor", "ss", "eu", "jp", "cus"])) + [
+        "unk"
+    ]
 
 
 def get_preferred_languages() -> list[str]:

--- a/backend/tests/config/fixtures/config/config.yml
+++ b/backend/tests/config/fixtures/config/config.yml
@@ -48,6 +48,7 @@ scan:
       - jp
       - eu
       - wor
+    region_mode: prefer_config
     language:
       - jp
       - es

--- a/backend/tests/config/fixtures/config/forward_compat_config.yml
+++ b/backend/tests/config/fixtures/config/forward_compat_config.yml
@@ -3,6 +3,8 @@
 # tolerates unknown enum/option values instead of refusing to boot.
 
 scan:
+  priority:
+    region_mode: "some_future_region_mode"
   media:
     - box2d
     - some_future_media_type

--- a/backend/tests/config/test_config_loader.py
+++ b/backend/tests/config/test_config_loader.py
@@ -164,6 +164,18 @@ def test_forward_compat_unknown_values_are_tolerated():
     assert loader.config.SCAN_REGION_MODE == "prefer_rom_tags"
 
 
+def test_non_string_region_mode_falls_back_to_default(tmp_path):
+    """A list/mapping region_mode is unhashable and must not crash the
+    membership check against the valid-modes set."""
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(
+        "scan:\n  priority:\n    region_mode:\n      - prefer_config\n"
+    )
+    loader = ConfigManager(str(config_file))
+
+    assert loader.config.SCAN_REGION_MODE == "prefer_rom_tags"
+
+
 def test_malformed_yaml_falls_back_to_defaults():
     """A YAML parse error should log critically and leave the app on
     defaults, not crash."""

--- a/backend/tests/config/test_config_loader.py
+++ b/backend/tests/config/test_config_loader.py
@@ -80,6 +80,7 @@ def test_config_loader():
         "url_screenshots": ["igdb"],
     }
     assert loader.config.SCAN_REGION_PRIORITY == ["jp", "eu", "wor"]
+    assert loader.config.SCAN_REGION_MODE == "prefer_config"
     assert loader.config.SCAN_LANGUAGE_PRIORITY == ["jp", "es"]
     assert loader.config.GAMELIST_MEDIA_THUMBNAIL == "box3d"
     assert loader.config.GAMELIST_MEDIA_IMAGE == "title_screen"
@@ -125,6 +126,7 @@ def test_empty_config_loader():
     assert loader.config.EJS_SETTINGS == {}
     assert loader.config.EJS_CONTROLS == {}
     assert loader.config.SCAN_ARTWORK_PRIORITY_OVERRIDES == {}
+    assert loader.config.SCAN_REGION_MODE == "prefer_rom_tags"
     assert loader.config.GAMELIST_MEDIA_THUMBNAIL == "box2d"
     assert loader.config.GAMELIST_MEDIA_IMAGE == "screenshot"
 
@@ -158,6 +160,8 @@ def test_forward_compat_unknown_values_are_tolerated():
     # Unknown thumbnail/image values fall back to their defaults.
     assert loader.config.GAMELIST_MEDIA_THUMBNAIL == "box2d"
     assert loader.config.GAMELIST_MEDIA_IMAGE == "screenshot"
+    # Unknown region_mode values fall back to the default.
+    assert loader.config.SCAN_REGION_MODE == "prefer_rom_tags"
 
 
 def test_malformed_yaml_falls_back_to_defaults():
@@ -267,7 +271,9 @@ def test_config_updates_serialize_gamelist_media_as_plain_strings(tmp_path):
 
 def test_update_scan_settings_round_trip(tmp_path):
     config_file = tmp_path / "config.yml"
-    config_file.write_text("scan:\n  media:\n    - box2d\n")
+    config_file.write_text(
+        "scan:\n  priority:\n    region_mode: prefer_config\n  media:\n    - box2d\n"
+    )
     loader = ConfigManager(str(config_file))
 
     loader.update_scan_settings(
@@ -292,6 +298,8 @@ def test_update_scan_settings_round_trip(tmp_path):
     # Only the "cover" override was provided; the others fall back to artwork.
     assert reloaded.config.SCAN_ARTWORK_PRIORITY_OVERRIDES == {"url_cover": ["ss"]}
     assert reloaded.config.SCAN_REGION_PRIORITY == ["jp", "us"]
+    # region_mode is not runtime-editable but must survive the rewrite.
+    assert reloaded.config.SCAN_REGION_MODE == "prefer_config"
     assert reloaded.config.SCAN_LANGUAGE_PRIORITY == ["ja", "en"]
     assert reloaded.config.SCAN_MEDIA == ["box2d", "screenshot", "manual"]
     assert reloaded.config.GAMELIST_AUTO_EXPORT_ON_SCAN is True

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -27,9 +27,11 @@ from handler.redis_handler import async_cache
 def _make_config(
     region_priority: list[str] | None = None,
     scan_media: list[str] | None = None,
+    region_mode: str = "prefer_rom_tags",
 ) -> Config:
     """Build a minimal Config object for testing."""
     return Config(
+        SCAN_REGION_MODE=region_mode,
         EXCLUDED_PLATFORMS=[],
         EXCLUDED_SINGLE_EXT=[],
         EXCLUDED_SINGLE_FILES=[],
@@ -116,6 +118,39 @@ class TestGetPreferredRegions:
             regions = get_preferred_regions(rom)
 
         assert regions.index("jp") < regions.index("br")
+
+    def test_prefer_config_mode_config_region_outranks_rom_tags(self):
+        """With region_mode=prefer_config, a configured region wins even when
+        the file is not tagged with it."""
+        rom = MagicMock()
+        rom.regions = ["Europe"]
+        config = _make_config(region_priority=["fr", "eu"], region_mode="prefer_config")
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            regions = get_preferred_regions(rom)
+
+        assert regions.index("fr") < regions.index("eu")
+
+    def test_prefer_config_mode_rom_tags_follow_config(self):
+        """With region_mode=prefer_config, the rom's own tags still follow the
+        configured regions as fallback."""
+        rom = MagicMock()
+        rom.regions = ["Japan"]
+        config = _make_config(region_priority=["fr"], region_mode="prefer_config")
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            regions = get_preferred_regions(rom)
+
+        assert regions.index("fr") < regions.index("jp")
+        assert regions.index("jp") < regions.index("us")
+
+    def test_default_mode_rom_tags_still_win(self):
+        """Default prefer_rom_tags mode keeps the current behavior."""
+        rom = MagicMock()
+        rom.regions = ["Europe"]
+        config = _make_config(region_priority=["fr", "eu"])
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            regions = get_preferred_regions(rom)
+
+        assert regions.index("eu") < regions.index("fr")
 
 
 class TestExtractMediaFromSsGame:

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -126,7 +126,7 @@ class TestGetPreferredRegions:
         rom.regions = ["Europe"]
         config = _make_config(region_priority=["fr", "eu"], region_mode="prefer_config")
         with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
-            regions = get_preferred_regions(rom)
+            regions = get_preferred_regions(rom, for_media=True)
 
         assert regions.index("fr") < regions.index("eu")
 
@@ -137,10 +137,21 @@ class TestGetPreferredRegions:
         rom.regions = ["Japan"]
         config = _make_config(region_priority=["fr"], region_mode="prefer_config")
         with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
-            regions = get_preferred_regions(rom)
+            regions = get_preferred_regions(rom, for_media=True)
 
         assert regions.index("fr") < regions.index("jp")
         assert regions.index("jp") < regions.index("us")
+
+    def test_prefer_config_mode_only_applies_to_media(self):
+        """region_mode only affects media selection; name/date ordering keeps
+        the rom's own tags first."""
+        rom = MagicMock()
+        rom.regions = ["Europe"]
+        config = _make_config(region_priority=["fr", "eu"], region_mode="prefer_config")
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            regions = get_preferred_regions(rom)
+
+        assert regions.index("eu") < regions.index("fr")
 
     def test_default_mode_rom_tags_still_win(self):
         """Default prefer_rom_tags mode keeps the current behavior."""

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -117,19 +117,12 @@
 #       - ss
 #       - eu
 #       - jp
-#     # How the region priority interacts with the rom's filename region tags
-#     # when picking ScreenScraper media:
-#     #   prefer_rom_tags (default): the file's own region tags win, the
-#     #     priority list only reorders them
-#     #   prefer_config: the priority list wins even for regions the file is
-#     #     not tagged with, falling back to the file's tags when the
-#     #     configured regions have no media
-#     region_mode: prefer_rom_tags
+#     region_mode: prefer_rom_tags # Region tags win over priority list
 #     language: # Used by ScreenScraper for descriptions
 #       - en
 #       - fr
-#     # Media assets to download
-#     # Only used by Screenscraper and ES-DE gamelist.xml
+#   # Media assets to download
+#   # Only used by Screenscraper and ES-DE gamelist.xml
 #   media:
 #     # Used as alternative cover art
 #     - box2d  # Normal cover art (always enabled)

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -117,6 +117,14 @@
 #       - ss
 #       - eu
 #       - jp
+#     # How the region priority interacts with the rom's filename region tags
+#     # when picking ScreenScraper media:
+#     #   prefer_rom_tags (default): the file's own region tags win, the
+#     #     priority list only reorders them
+#     #   prefer_config: the priority list wins even for regions the file is
+#     #     not tagged with, falling back to the file's tags when the
+#     #     configured regions have no media
+#     region_mode: prefer_rom_tags
 #     language: # Used by ScreenScraper for descriptions
 #       - en
 #       - fr


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Closes #3912

Since #3367, ScreenScraper media region selection prefers the ROM's own filename region tags, with `scan.priority.region` only reordering those tags. That leaves no way to prefer a region that is not among the file's tags, e.g. getting the FR box for an `(Europe)` multi-language dump.

This adds an opt-in `scan.priority.region_mode` key:

```yaml
scan:
  priority:
    region:
      - "fr"
      - "eu"
    region_mode: "prefer_config" # default "prefer_rom_tags" = current behavior
```

With `prefer_config`, `get_preferred_regions()` puts the configured regions first and keeps the ROM's own tags right behind them. Because every caller takes the first region that actually has media, falling back to the current behavior when the preferred regions have no media is automatic. Identification (hash/name matching) is untouched; only which regional media variant gets picked changes.

Implementation notes:

- Parsed and validated in `config_manager.py`; unknown values warn and fall back to `prefer_rom_tags` (same forward-compat pattern as `scan.gamelist.media.*`), and the key survives runtime config-file rewrites.
- Config-file-only for now (no API/UI exposure), matching the issue's proposal, so no OpenAPI/type regeneration is needed.
- Documented in `examples/config.example.yml`.
- Tests: new `TestGetPreferredRegions` cases for both modes and the fallback ordering, plus config-loader coverage for parsing, the default, unknown-value fallback, and rewrite round-trip.

AI disclosure: this feature was investigated, implemented, and tested with AI assistance (Claude Code); the change was reviewed before submission.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)