### PR TITLE
Stop storing fanart and title_screen twice when screenshots are enabled

### DIFF
--- a/backend/handler/metadata/gamelist_handler.py
+++ b/backend/handler/metadata/gamelist_handler.py
@@ -438,18 +438,15 @@ class GamelistHandler(MetadataHandler):
                 if manual_url and MetadataMediaType.MANUAL in preferred_media_types:
                     rom_data["url_manual"] = manual_url
 
-                # Build list of screenshot URLs
+                # Build list of screenshot URLs. The title screen is stored in
+                # its own media folder via title_screen_path, so it must not
+                # also land in screenshots/.
                 url_screenshots = []
                 if (
                     rom_metadata["screenshot_url"]
                     and MetadataMediaType.SCREENSHOT in preferred_media_types
                 ):
                     url_screenshots.append(rom_metadata["screenshot_url"])
-                if (
-                    rom_metadata["title_screen_url"]
-                    and MetadataMediaType.TITLE_SCREEN in preferred_media_types
-                ):
-                    url_screenshots.append(rom_metadata["title_screen_url"])
                 rom_data["url_screenshots"] = url_screenshots
 
                 # Store by filename for matching

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -572,21 +572,13 @@ def build_ss_game(rom: Rom, game: SSGame) -> SSRom:
         if MetadataMediaType.MANUAL in preferred_media_types
         else None
     )
+    # Title screen and fanart are stored in their own dedicated media folders
+    # via their *_path entries, so they must not also land in screenshots/.
     url_screenshots = pydash.compact(
         [
             (
                 ss_metadata["screenshot_url"]
                 if MetadataMediaType.SCREENSHOT in preferred_media_types
-                else None
-            ),
-            (
-                ss_metadata["title_screen_url"]
-                if MetadataMediaType.TITLE_SCREEN in preferred_media_types
-                else None
-            ),
-            (
-                ss_metadata["fanart_url"]
-                if MetadataMediaType.FANART in preferred_media_types
                 else None
             ),
         ]

--- a/backend/tests/handler/metadata/test_gamelist_handler.py
+++ b/backend/tests/handler/metadata/test_gamelist_handler.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from defusedxml import ElementTree as ET
 
+from config.config_manager import MetadataMediaType
 from handler.metadata.gamelist_handler import (
     GamelistHandler,
     extract_metadata_from_gamelist_rom,
@@ -94,6 +95,49 @@ def test_parse_gamelist_xml_keeps_game_entries(tmp_path: Path, platform: Platfor
 
     assert "test-rom.zip" in roms_data
     assert roms_data["test-rom.zip"].get("name") == "Game Entry"
+
+
+def test_parse_gamelist_xml_title_screen_not_in_screenshots(
+    tmp_path: Path, platform: Platform
+):
+    """The title screen is stored in its dedicated media folder, so it must
+    not also land in url_screenshots (issue #3911)."""
+    gamelist_path = tmp_path / "gamelist.xml"
+    gamelist_path.write_text(
+        """<?xml version="1.0"?>
+<gameList>
+  <game>
+    <path>./test-rom.zip</path>
+    <name>Game Entry</name>
+  </game>
+</gameList>""",
+        encoding="utf-8",
+    )
+    handler = GamelistHandler()
+
+    metadata = dict(
+        MOCK_METADATA,
+        screenshot_url="file:///media/screenshot.png",
+        title_screen_url="file:///media/titlescreen.png",
+    )
+    with (
+        patch(
+            "handler.metadata.gamelist_handler.extract_metadata_from_gamelist_rom",
+            return_value=metadata,
+        ),
+        patch(
+            "handler.metadata.gamelist_handler.get_preferred_media_types",
+            return_value=[
+                MetadataMediaType.SCREENSHOT,
+                MetadataMediaType.TITLE_SCREEN,
+            ],
+        ),
+    ):
+        roms_data = handler._parse_gamelist_xml(gamelist_path, platform)
+
+    assert roms_data["test-rom.zip"]["url_screenshots"] == [
+        "file:///media/screenshot.png"
+    ]
 
 
 def test_extract_metadata_from_gamelist_rom_includes_sort_name(platform: Platform):

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -17,6 +17,7 @@ from handler.metadata.ss_handler import (
     _get_rom_type,
     _is_notgame,
     add_ss_auth_to_url,
+    build_ss_game,
     extract_media_from_ss_game,
     extract_metadata_from_ss_rom,
     get_preferred_regions,
@@ -453,6 +454,62 @@ class TestExtractMetadataFromSsRom:
             metadata = extract_metadata_from_ss_rom(rom, game)
 
         assert metadata["first_release_date"] == 593568000
+
+
+class TestBuildSSGame:
+    def _make_rom(self) -> MagicMock:
+        rom = MagicMock()
+        rom.platform_id = 1
+        rom.id = 100
+        rom.regions = None
+        return rom
+
+    def _make_media(self, media_type: str) -> dict:
+        return {
+            "type": media_type,
+            "parent": "jeu",
+            "region": "us",
+            "url": f"https://screenscraper.example.com/{media_type}(us)",
+            "crc": "aabbccdd",
+            "md5": "deadbeef",
+            "sha1": "cafebabe",
+            "size": "12345",
+            "format": "png",
+        }
+
+    def test_title_screen_and_fanart_not_duplicated_into_screenshots(self):
+        """Media stored in dedicated folders must not also land in
+        url_screenshots (issue #3911)."""
+        config = _make_config(
+            region_priority=["us"],
+            scan_media=["screenshot", "title_screen", "fanart"],
+        )
+        rom = self._make_rom()
+        game = cast(
+            SSGame,
+            {
+                "id": "42",
+                "medias": [
+                    self._make_media("ss"),
+                    self._make_media("sstitle"),
+                    self._make_media("fanart"),
+                ],
+            },
+        )
+
+        with (
+            patch("handler.metadata.ss_handler.cm.get_config", return_value=config),
+            patch(
+                "handler.metadata.ss_handler.fs_resource_handler.get_media_resources_path",
+                return_value="roms/1/100/media",
+            ),
+        ):
+            result = build_ss_game(rom, game)
+
+        assert result["url_screenshots"] == ["https://screenscraper.example.com/ss(us)"]
+        # Dedicated media folders are still populated.
+        assert result["ss_metadata"]["title_screen_path"]
+        assert result["ss_metadata"]["fanart_path"]
 
 
 class TestIsNotgame:

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -131,6 +131,7 @@
 #     - physical  # Disc, cartridge, etc.
 #     # Added to the screenshots carousel
 #     - screenshot  # Screenshot (enabled by default)
+#     # Shown in the artwork gallery
 #     - title_screen  # Title screen
 #     - fanart  # User uploaded artwork
 #     # Bezel displayed around the emulatorjs window


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3911

When fanart, title_screen, and screenshot scraping are all enabled, `build_ss_game()` appended the fanart and title-screen URLs to `url_screenshots` in addition to registering them as dedicated media (`fanart_path` / `title_screen_path`). Each image was then downloaded twice: once into `screenshots/<idx>.jpg` and once into `fanart/fanart.png` or `title_screen/title_screen.png`, doubling disk usage.

The dedicated media folders are the canonical storage (and what the artwork gallery renders from), so `url_screenshots` is now restricted to the actual screenshot media type. The gamelist (ES-DE) handler had the same pattern with `title_screen_url` and gets the same fix. Other providers (IGDB, MobyGames, LaunchBox, RA, Flashpoint, Hasheous) were checked and don't have this overlap.

Notes:

- Fanart and title screens no longer appear in the screenshots carousel; they render from their dedicated media in the artwork gallery instead (the `config.example.yml` comment is updated accordingly).
- This stops new duplication; files already duplicated by previous scans are only reconciled by a rescan.
- Tests: new `TestBuildSSGame` regression test asserting fanart/title_screen stay out of `url_screenshots` while their dedicated paths remain populated, plus the equivalent gamelist parser test.

AI disclosure: this fix was investigated, implemented, and tested with AI assistance (Claude Code); the change was reviewed before submission.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)