### PR TITLE
Default EmulatorJS netplay username to the RomM account

### DIFF
--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -393,6 +393,11 @@ window.EJS_onGameStart = async () => {
   // are in place before room polling or a Create/Join action can start.
   const netplay = window.EJS_emulator?.netplay;
   if (netplay) {
+    // EmulatorJS only prompts for a player name when netplay.name is unset,
+    // so presetting it adopts the RomM account username automatically.
+    if (!netplay.name && authStore.user?.username) {
+      netplay.name = authStore.user.username;
+    }
     netplay.getOpenRooms = async () => {
       try {
         const response = await fetch(


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Closes #3909

EmulatorJS keeps the netplay player name in memory only (`netplay.name`, no localStorage persistence, no `EJS_*` config option) and builds its name-entry popup only when `netplay.name` is falsy. Presetting it from the logged-in RomM user's username in the existing RomM netplay override block (inside `EJS_onGameStart`, before any room action can start) makes EmulatorJS skip the popup entirely and use the account name.

This implements the issue's primary request (always use the RomM username). The "prefilled but editable" alternative isn't feasible without patching the minified CDN bundle, since the popup input is constructed inside EmulatorJS's netplay menu code with no default-value hook; if editability is wanted later, the right path is upstreaming an `EJS_netplayName` option.

The change is 5 lines inside the RomM-authored override block in the v1 `Player.vue`, which the v2 player shell also mounts, so both UIs are covered.

AI disclosure: this feature was investigated, implemented, and tested with AI assistance (Claude Code); the change was reviewed before submission.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)