### PR TITLE
Add Scan Settings to the user dropdown menu

### DIFF
--- a/frontend/src/v2/components/AppShell/UserMenu.vue
+++ b/frontend/src/v2/components/AppShell/UserMenu.vue
@@ -4,7 +4,8 @@
 // architecture so the user has the same mental model in both places:
 //
 //   • Account  — Profile, User interface
-//   • Library  — Library management, Metadata sources, Client API tokens
+//   • Library  — Library management, Scan settings, Metadata sources,
+//                Client API tokens
 //   • System   — Administration, Server stats
 //   • Tools    — Controller debug
 //   • Actions  — Scan, Upload (librarian actions, not settings)
@@ -72,6 +73,9 @@ const canSeeProfile = computed(
 const canScan = computed(() => scopes.value.includes("platforms.write"));
 const canUpload = computed(() => scopes.value.includes("roms.write"));
 const canSeeLibraryMgmt = computed(() =>
+  scopes.value.includes("platforms.write"),
+);
+const canSeeScanSettings = computed(() =>
   scopes.value.includes("platforms.write"),
 );
 const canSeeApiTokens = computed(() => scopes.value.includes("me.write"));
@@ -204,6 +208,13 @@ async function onLogout() {
         :to="{ name: ROUTES.LIBRARY_MANAGEMENT }"
         icon="mdi-table-cog"
         :label="t('common.library-management')"
+        @click="open = false"
+      />
+      <RMenuItem
+        v-if="canSeeScanSettings"
+        :to="{ name: ROUTES.SCAN_SETTINGS }"
+        icon="mdi-magnify-scan"
+        :label="t('settings.scan-settings')"
         @click="open = false"
       />
       <RMenuItem


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Closes #3914

Scan Settings was reachable only through the settings sidebar's Library group. This adds it to the v2 user dropdown (`UserMenu.vue`), whose contents mirror the SettingsSidebar's information architecture: it sits in the Library group between Library management and Metadata sources, with the same `mdi-magnify-scan` icon, the existing `settings.scan-settings` label (no new i18n keys), and the same `platforms.write` gate the sidebar and route guard use, so users who can't open the view don't see the entry.

AI disclosure: this change was implemented with AI assistance (Claude Code); the change was reviewed before submission.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)