### PR TITLE
fix(migrations): pin device FK column collations to match devices.id

### DIFF
--- a/backend/alembic/versions/0082_save_origin_device.py
+++ b/backend/alembic/versions/0082_save_origin_device.py
@@ -9,20 +9,50 @@ Create Date: 2026-06-05 00:00:00.000000
 import sqlalchemy as sa
 from alembic import op
 
+from utils.database import is_postgresql
+
 revision = "0082_save_origin_device"
 down_revision = "0081_add_archive_members"
 branch_labels = None
 depends_on = None
 
 
+def _devices_id_collation(conn) -> str | None:
+    return conn.execute(
+        sa.text(
+            "SELECT COLLATION_NAME FROM information_schema.COLUMNS "
+            "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'devices' "
+            "AND COLUMN_NAME = 'id'"
+        )
+    ).scalar()
+
+
 def upgrade() -> None:
+    conn = op.get_bind()
+
+    # On MariaDB/MySQL an FK requires both VARCHAR columns to share a collation.
+    # A new column inherits the saves table's collation, which can differ from
+    # devices.id (e.g. saves predates the MariaDB 11.6+ uca1400 default while
+    # devices does not), so pin it to the referenced column's collation.
+    collation = None if is_postgresql(conn) else _devices_id_collation(conn)
+    column_type = sa.String(length=255, collation=collation)
+
     # Order matters on MariaDB: the index must exist before the FK (it backs the
     # constraint), so create column -> index -> FK.
     with op.batch_alter_table("saves", schema=None) as batch_op:
         batch_op.add_column(
-            sa.Column("origin_device_id", sa.String(length=255), nullable=True),
+            sa.Column("origin_device_id", column_type, nullable=True),
             if_not_exists=True,
         )
+        if collation is not None:
+            # Also fix the column when a previous run created it with a
+            # mismatched collation and then failed on the FK.
+            batch_op.alter_column(
+                "origin_device_id",
+                existing_type=sa.String(length=255),
+                type_=column_type,
+                existing_nullable=True,
+            )
         batch_op.create_index(
             "ix_saves_origin_device_id", ["origin_device_id"], if_not_exists=True
         )

--- a/backend/alembic/versions/0089_client_tokens_device_id.py
+++ b/backend/alembic/versions/0089_client_tokens_device_id.py
@@ -9,6 +9,8 @@ Create Date: 2026-04-24 00:00:00.000000
 import sqlalchemy as sa
 from alembic import op
 
+from utils.database import is_postgresql
+
 # revision identifiers, used by Alembic.
 revision = "0089_client_tokens_device_id"
 down_revision = "0088_devices_client_identifier"
@@ -16,12 +18,41 @@ branch_labels = None
 depends_on = None
 
 
+def _devices_id_collation(conn) -> str | None:
+    return conn.execute(
+        sa.text(
+            "SELECT COLLATION_NAME FROM information_schema.COLUMNS "
+            "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'devices' "
+            "AND COLUMN_NAME = 'id'"
+        )
+    ).scalar()
+
+
 def upgrade() -> None:
+    conn = op.get_bind()
+
+    # On MariaDB/MySQL an FK requires both VARCHAR columns to share a collation.
+    # A new column inherits the client_tokens table's collation, which can
+    # differ from devices.id when the tables were created under different
+    # server defaults (MariaDB 11.6+ switched utf8mb4 to uca1400), so pin it
+    # to the referenced column's collation.
+    collation = None if is_postgresql(conn) else _devices_id_collation(conn)
+    column_type = sa.String(length=255, collation=collation)
+
     with op.batch_alter_table("client_tokens", schema=None) as batch_op:
         batch_op.add_column(
-            sa.Column("device_id", sa.String(length=255), nullable=True),
+            sa.Column("device_id", column_type, nullable=True),
             if_not_exists=True,
         )
+        if collation is not None:
+            # Also fix the column when a previous run created it with a
+            # mismatched collation and then failed on the FK.
+            batch_op.alter_column(
+                "device_id",
+                existing_type=sa.String(length=255),
+                type_=column_type,
+                existing_nullable=True,
+            )
         batch_op.create_foreign_key(
             "fk_client_tokens_device_id",
             "devices",


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3915

On MariaDB/MySQL, a foreign key between VARCHAR columns requires both sides to share a collation. Migration `0082_save_origin_device` adds `saves.origin_device_id` (which inherits the `saves` table's collation) and creates an FK to `devices.id`. On databases where `saves` predates the MariaDB 11.6+ `utf8mb4_uca1400_ai_ci` default but `devices` was created under it (via `character_set_collations`), the two collations differ and the FK fails with:

```
sqlalchemy.exc.OperationalError: (mariadb.OperationalError) Can't create table `romm`.`saves` (errno: 150 "Foreign key constraint is incorrectly formed")
```

This leaves the container in a restart loop during upgrades. Migration `0089_client_tokens_device_id` has the identical pattern (`client_tokens.device_id` → `devices.id`), so it gets the same treatment.

The fix, in both migrations:

- Look up `devices.id`'s actual collation from `information_schema.COLUMNS` and create the referencing column with it pinned explicitly.
- If a previous partial run already created the column with a mismatched collation (the exact state from the issue: column and index exist, FK failed), re-pin it with an `alter_column` before creating the FK.
- No behavior change on PostgreSQL (no collation is pinned there).

Editing the shipped migrations in place is safe here: they only execute for databases where they currently fail, and the pinned collation resolves to the table default on healthy databases (no-op).

**Verification** (MariaDB 11.8, `character_set_collations` maps utf8mb4 → uca1400):

- Reproduced the exact error from the issue: `saves` at `utf8mb4_general_ci`, `devices` at `utf8mb4_uca1400_ai_ci`, FK creation fails with errno 150.
- With this fix, `alembic upgrade head` succeeds from that state, including the reporter's partially-applied state (column + index already present with the wrong collation). Both FKs are created and columns end up matching `devices.id`.
- `alembic downgrade` back through both migrations works, and re-upgrading succeeds.
- Fresh-install path unaffected (all tables share the same collation, the pin is a no-op).

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

---

**AI assistance disclosure:** This fix was investigated, implemented, and verified with Claude Code (root-cause analysis, reproduction on MariaDB 11.8, migration changes, and upgrade/downgrade testing), with human review of the resulting diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)