### PR TITLE
fix(backend): make roms_facets/collection migrations idempotent

### DIFF
--- a/backend/alembic/versions/0100_roms_facets_table.py
+++ b/backend/alembic/versions/0100_roms_facets_table.py
@@ -20,6 +20,7 @@ Create Date: 2026-07-22 00:00:00.000000
 
 import sqlalchemy as sa
 from alembic import op  # type: ignore[attr-defined]
+from sqlalchemy import inspect
 
 from utils.database import CustomJSON, is_postgresql
 
@@ -48,11 +49,12 @@ _MIRRORED_COLUMNS = [
 _TARGET_COLUMNS = ", ".join(target for target, _ in _MIRRORED_COLUMNS)
 _SOURCE_COLUMNS = ", ".join(source for _, source in _MIRRORED_COLUMNS)
 
-# Backfilled into the empty table before the triggers exist, so no row can
-# conflict and no upsert guard is needed.
+# Backfilled before the triggers exist. The anti-join keeps it idempotent so a
+# re-run after a partial failure only fills the rows that are still missing.
 _BACKFILL_SQL = (
     f"INSERT INTO roms_facets (rom_id, {_TARGET_COLUMNS})\n"  # nosec B608
-    f"SELECT id, {_SOURCE_COLUMNS} FROM roms"
+    f"SELECT id, {_SOURCE_COLUMNS} FROM roms\n"
+    "WHERE id NOT IN (SELECT rom_id FROM roms_facets)"
 )
 
 _MYSQL_UPSERT_BODY = (
@@ -89,6 +91,11 @@ CREATE TRIGGER roms_facets_sync AFTER INSERT OR UPDATE ON roms
 
 
 def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Every step is guarded so a re-run after a partial failure recovers cleanly.
+    # MySQL/MariaDB auto-commit each DDL statement, so a crash mid-migration
+    # leaves objects behind without advancing the alembic version.
     op.create_table(
         "roms_facets",
         sa.Column(
@@ -120,16 +127,23 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             nullable=False,
         ),
+        if_not_exists=True,
     )
-    op.create_index("idx_roms_facets_platform_id", "roms_facets", ["platform_id"])
+
+    # MySQL has no CREATE INDEX IF NOT EXISTS, so check the catalog instead.
+    existing_indexes = {idx["name"] for idx in inspect(conn).get_indexes("roms_facets")}
+    if "idx_roms_facets_platform_id" not in existing_indexes:
+        op.create_index("idx_roms_facets_platform_id", "roms_facets", ["platform_id"])
 
     op.execute(_BACKFILL_SQL)
 
-    if is_postgresql(op.get_bind()):
+    if is_postgresql(conn):
         op.execute(_POSTGRES_SYNC_FN)
+        op.execute("DROP TRIGGER IF EXISTS roms_facets_sync ON roms")
         op.execute(_POSTGRES_TRIGGER)
     else:
         for name, timing in _MYSQL_TRIGGERS.items():
+            op.execute(f"DROP TRIGGER IF EXISTS {name}")
             op.execute(
                 f"CREATE TRIGGER {name} {timing} ON roms\n"
                 f"FOR EACH ROW\n{_MYSQL_UPSERT_BODY}"

--- a/backend/alembic/versions/0101_virtual_collection_roms.py
+++ b/backend/alembic/versions/0101_virtual_collection_roms.py
@@ -32,6 +32,7 @@ Create Date: 2026-07-22 00:00:00.000000
 
 import sqlalchemy as sa
 from alembic import op  # type: ignore[attr-defined]
+from sqlalchemy import inspect
 
 from utils.database import is_postgresql
 
@@ -186,6 +187,9 @@ def upgrade() -> None:
     connection = op.get_bind()
     pg = is_postgresql(connection)
 
+    # Every step is guarded so a re-run after a partial failure recovers cleanly.
+    # MySQL/MariaDB auto-commit each DDL statement, so a crash mid-migration
+    # leaves objects behind without advancing the alembic version.
     collation = None if pg else "utf8mb4_general_ci"
     op.create_table(
         TABLE,
@@ -202,21 +206,39 @@ def upgrade() -> None:
         sa.Column("updated_at", sa.TIMESTAMP(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(["rom_id"], ["roms.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("type", "name", "rom_id"),
+        if_not_exists=True,
     )
-    op.create_index(f"idx_{TABLE}_rom_id", TABLE, ["rom_id"])
 
-    op.execute(  # nosec B608
-        f"INSERT INTO {TABLE} ({_COLUMNS})\n"
-        + (_postgres_rows("r", True) if pg else _mysql_rows("r", True))
-    )
+    # MySQL has no CREATE INDEX IF NOT EXISTS, so check the catalog instead.
+    index_name = f"idx_{TABLE}_rom_id"
+    existing_indexes = {
+        index["name"] for index in inspect(connection).get_indexes(TABLE)
+    }
+    if index_name not in existing_indexes:
+        op.create_index(index_name, TABLE, ["rom_id"])
+
+    # The upsert semantics (INSERT IGNORE / ON CONFLICT DO NOTHING) keep the
+    # backfill idempotent so a re-run only fills the rows still missing.
+    if pg:
+        op.execute(  # nosec B608
+            f"INSERT INTO {TABLE} ({_COLUMNS})\n"
+            f"{_postgres_rows('r', True)}\nON CONFLICT DO NOTHING"
+        )
+    else:
+        op.execute(  # nosec B608
+            f"INSERT IGNORE INTO {TABLE} ({_COLUMNS})\n{_mysql_rows('r', True)}"
+        )
 
     if pg:
         op.execute(_postgres_trigger_function())
+        op.execute("DROP TRIGGER IF EXISTS virtual_collection_roms_aiu ON roms")
         op.execute(
             "CREATE TRIGGER virtual_collection_roms_aiu AFTER INSERT OR UPDATE ON roms\n"
             "FOR EACH ROW EXECUTE FUNCTION romm_sync_virtual_collection_roms()"
         )
     else:
+        op.execute("DROP TRIGGER IF EXISTS virtual_collection_roms_ai")
+        op.execute("DROP TRIGGER IF EXISTS virtual_collection_roms_au")
         for trigger in _mysql_triggers():
             op.execute(trigger)
 

--- a/backend/alembic/versions/0103_roms_facets_provider_ids.py
+++ b/backend/alembic/versions/0103_roms_facets_provider_ids.py
@@ -20,6 +20,7 @@ Create Date: 2026-07-23 00:00:00.000000
 
 import sqlalchemy as sa
 from alembic import op  # type: ignore[attr-defined]
+from sqlalchemy import inspect
 
 from utils.database import is_postgresql
 
@@ -133,8 +134,15 @@ def _backfill_sql() -> str:
 
 
 def upgrade() -> None:
+    # Guarded so a re-run after a partial failure skips columns already added.
+    # MySQL/MariaDB auto-commit each DDL, so a mid-migration crash can leave a
+    # subset of the columns behind without advancing the alembic version.
+    existing = {
+        col["name"] for col in inspect(op.get_bind()).get_columns("roms_facets")
+    }
     for name, column_type in _PROVIDER_COLUMNS:
-        op.add_column("roms_facets", sa.Column(name, column_type, nullable=True))
+        if name not in existing:
+            op.add_column("roms_facets", sa.Column(name, column_type, nullable=True))
 
     op.execute(_backfill_sql())
     _recreate_triggers(_FULL_MIRRORED_COLUMNS)


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

On the latest alpha, upgrading wedges the container in a permanent boot loop with:

```
sqlalchemy.exc.OperationalError: (mariadb.OperationalError) Table 'roms_facets' already exists
ERROR: [RomM][init] Failed to run database migrations
```

**Root cause:** MariaDB/MySQL auto-commit each DDL statement (no transactional DDL). When migration `0100` failed partway through (on the backfill or a `CREATE TRIGGER`), the `CREATE TABLE roms_facets` had already committed, but `alembic_version` never advanced past `0099`. Every subsequent boot re-ran `0100` from the top and died on `CREATE TABLE ... already exists`, so the instance could never recover on its own. Migrations `0100`, `0101`, and `0103` were all non-idempotent and share this failure mode; `0102` already guarded itself with `if_not_exists` / catalog checks.

**Changes** (bringing the whole `0100`-`0103` batch in line with `0102`):

- **`0100`**: `CREATE TABLE ... if_not_exists=True`; catalog-check the index (MySQL has no `CREATE INDEX IF NOT EXISTS`); make the backfill idempotent with a `WHERE id NOT IN (...)` anti-join; `DROP TRIGGER IF EXISTS` before each `CREATE TRIGGER` (MySQL and Postgres paths).
- **`0101`**: same treatment; backfill uses `INSERT IGNORE` / `ON CONFLICT DO NOTHING`, triggers are dropped before recreation (the view already drops first).
- **`0103`**: skip `add_column` for provider-id columns already present.

Each is now safe to re-run after a partial failure, so a wedged instance self-heals on the next boot with no manual SQL.

**Testing**

- Reproduced the exact wedged state (`alembic_version` at `0099` with an orphaned `roms_facets` table) and confirmed `alembic upgrade head` now recovers cleanly all the way to `0103` instead of crashing.
- Also verified a full rewind-to-`0099` with every later table/trigger/view left in place recovers to `0103` with no errors.
- Clean `0001 -> head` still works; `test_rom_facets.py` and `test_stats_handler.py` pass (14/14).
- `trunk check` clean on all three files.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

---

### AI assistance disclosure

This change was developed with AI assistance (Claude Code). The AI diagnosed the root cause, wrote the migration guards, and ran the recovery/regression tests; all changes were reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)