### PR TITLE
 fix(roms): list the smart collections a ROM belongs to on its detail view

### DIFF
--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -495,11 +495,11 @@ class UserCollectionSchema(BaseModel):
         ]
 
     @classmethod
-    def smart_for_user(
-        cls, user_id: int, rom_id: int, smart_collections: Sequence[SmartCollection]
+    def from_smart_collections(
+        cls, smart_collections: Sequence[SmartCollection]
     ) -> list["UserCollectionSchema"]:
-        # Smart collections have no reverse join: membership is a cached list of
-        # rom ids, so keep the ones that include this rom (and are visible).
+        # Membership + visibility are already filtered at the SQL layer by
+        # get_smart_collections_for_rom, so this is a plain mapping (see #3934).
         return [
             UserCollectionSchema(
                 id=c.id,
@@ -507,7 +507,6 @@ class UserCollectionSchema(BaseModel):
                 is_smart=True,
             )
             for c in smart_collections
-            if rom_id in c.rom_ids and (c.user_id == user_id or c.is_public)
         ]
 
 
@@ -555,14 +554,15 @@ class DetailedRomSchema(RomSchema):
         ]
         from handler.database import db_collection_handler
 
-        # Standard collections come off the join relationship; smart collections
-        # are matched by their cached rom-id membership (see #3934).
+        # Standard collections come off the already-loaded join relationship;
+        # smart collections have no reverse join, so match them by their cached
+        # rom-id membership at the SQL layer (see #3934).
         db_rom.user_collections = [  # type: ignore[assignment]
             *UserCollectionSchema.for_user(user_id, db_rom.collections),
-            *UserCollectionSchema.smart_for_user(
-                user_id,
-                db_rom.id,
-                db_collection_handler.get_smart_collections(user_id=user_id),
+            *UserCollectionSchema.from_smart_collections(
+                db_collection_handler.get_smart_collections_for_rom(
+                    rom_id=db_rom.id, user_id=user_id
+                )
             ),
         ]
 

--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -25,7 +25,7 @@ from handler.metadata.launchbox_handler.types import LaunchboxMetadata
 from handler.metadata.moby_handler import MobyMetadata
 from handler.metadata.ra_handler import RAMetadata
 from handler.metadata.ss_handler import SSMetadata
-from models.collection import Collection
+from models.collection import Collection, SmartCollection
 from models.rom import Rom, RomArchiveMember, RomFile, RomFileCategory, RomUserStatus
 
 from .base import BaseModel, UTCDatetime
@@ -479,6 +479,7 @@ class SimpleRomSchema(RomSchema):
 class UserCollectionSchema(BaseModel):
     id: int
     name: str
+    is_smart: bool = False
 
     @classmethod
     def for_user(
@@ -491,6 +492,22 @@ class UserCollectionSchema(BaseModel):
             )
             for c in collections
             if c.user_id == user_id or c.is_public
+        ]
+
+    @classmethod
+    def smart_for_user(
+        cls, user_id: int, rom_id: int, smart_collections: Sequence[SmartCollection]
+    ) -> list["UserCollectionSchema"]:
+        # Smart collections have no reverse join: membership is a cached list of
+        # rom ids, so keep the ones that include this rom (and are visible).
+        return [
+            UserCollectionSchema(
+                id=c.id,
+                name=c.name,
+                is_smart=True,
+            )
+            for c in smart_collections
+            if rom_id in c.rom_ids and (c.user_id == user_id or c.is_public)
         ]
 
 
@@ -536,9 +553,18 @@ class DetailedRomSchema(RomSchema):
             for s in db_rom.screenshots
             if s.user_id == user_id
         ]
-        db_rom.user_collections = UserCollectionSchema.for_user(  # type: ignore[assignment]
-            user_id, db_rom.collections
-        )
+        from handler.database import db_collection_handler
+
+        # Standard collections come off the join relationship; smart collections
+        # are matched by their cached rom-id membership (see #3934).
+        db_rom.user_collections = [  # type: ignore[assignment]
+            *UserCollectionSchema.for_user(user_id, db_rom.collections),
+            *UserCollectionSchema.smart_for_user(
+                user_id,
+                db_rom.id,
+                db_collection_handler.get_smart_collections(user_id=user_id),
+            ),
+        ]
 
         # Load notes separately using the database handler to avoid lazy loading issues
         from handler.database import db_rom_handler

--- a/backend/handler/database/collections_handler.py
+++ b/backend/handler/database/collections_handler.py
@@ -22,6 +22,7 @@ from models.collection import (
     VirtualCollection,
 )
 from models.rom import Rom
+from utils.database import json_array_contains_value
 
 from .base_handler import DBBaseHandler
 
@@ -314,6 +315,41 @@ class DBCollectionsHandler(DBBaseHandler):
             query = query.options(load_only(*only_fields))
 
         return session.scalars(query).unique().all()
+
+    @begin_session
+    def get_smart_collections_for_rom(
+        self,
+        rom_id: int,
+        user_id: int,
+        session: Session = None,  # type: ignore
+    ) -> Sequence[SmartCollection]:
+        # Membership is a cached JSON array of rom ids on the collection, so
+        # push containment + visibility into SQL rather than loading every
+        # collection's rom_ids blob into Python and scanning it (see #3934).
+        return (
+            session.scalars(
+                select(SmartCollection)
+                .where(
+                    json_array_contains_value(
+                        SmartCollection.rom_ids, rom_id, session=session
+                    ),
+                    or_(
+                        SmartCollection.user_id == user_id,
+                        SmartCollection.is_public,
+                    ),
+                )
+                .options(
+                    load_only(
+                        SmartCollection.id,
+                        SmartCollection.name,
+                        SmartCollection.is_public,
+                    )
+                )
+                .order_by(SmartCollection.name.asc())
+            )
+            .unique()
+            .all()
+        )
 
     @begin_session
     def update_smart_collection(

--- a/backend/tests/endpoints/roms/test_rom.py
+++ b/backend/tests/endpoints/roms/test_rom.py
@@ -16,7 +16,7 @@ from handler.metadata.launchbox_handler.types import LaunchboxRom
 from handler.metadata.moby_handler import MobyGamesHandler, MobyGamesRom
 from handler.metadata.ra_handler import RAGameRom, RAHandler
 from handler.metadata.ss_handler import SSHandler, SSRom
-from models.collection import Collection
+from models.collection import Collection, SmartCollection
 from models.permission import HiddenEntity, PermEntity
 from models.platform import Platform
 from models.rom import Rom, RomFile, compute_name_sort_key
@@ -68,6 +68,120 @@ def test_get_rom_simple_missing_returns_404(client: TestClient, access_token: st
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def _user_collections_by_name(body: dict) -> dict:
+    return {c["name"]: c for c in body["user_collections"]}
+
+
+def test_get_rom_lists_standard_and_smart_collections(
+    client: TestClient, access_token: str, admin_user: User, rom: Rom
+):
+    """The detail response lists both standard and smart collections the ROM
+    belongs to, tagging smart ones with `is_smart` (issue #3934)."""
+    standard = db_collection_handler.add_collection(
+        Collection(name="My Standard", description="", user_id=admin_user.id)
+    )
+    db_collection_handler.add_roms_to_collection(standard.id, [rom.id])
+
+    smart = db_collection_handler.add_smart_collection(
+        SmartCollection(
+            name="My Smart",
+            description="",
+            user_id=admin_user.id,
+            rom_ids=[rom.id],
+            filter_criteria={},
+        )
+    )
+
+    response = client.get(
+        f"/api/roms/{rom.id}",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    collections = _user_collections_by_name(response.json())
+    assert set(collections) == {"My Standard", "My Smart"}
+    assert collections["My Standard"]["id"] == standard.id
+    assert collections["My Standard"]["is_smart"] is False
+    assert collections["My Smart"]["id"] == smart.id
+    assert collections["My Smart"]["is_smart"] is True
+
+
+def test_get_rom_omits_smart_collection_without_rom(
+    client: TestClient, access_token: str, admin_user: User, rom: Rom
+):
+    """A smart collection whose membership doesn't include the ROM is not listed."""
+    db_collection_handler.add_smart_collection(
+        SmartCollection(
+            name="Unrelated Smart",
+            description="",
+            user_id=admin_user.id,
+            rom_ids=[rom.id + 999],
+            filter_criteria={},
+        )
+    )
+
+    response = client.get(
+        f"/api/roms/{rom.id}",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    assert "Unrelated Smart" not in _user_collections_by_name(response.json())
+
+
+def test_get_rom_omits_other_users_private_smart_collection(
+    client: TestClient, access_token: str, viewer_user: User, rom: Rom
+):
+    """A private smart collection owned by another user is hidden even when it
+    contains the ROM."""
+    db_collection_handler.add_smart_collection(
+        SmartCollection(
+            name="Private Smart",
+            description="",
+            user_id=viewer_user.id,
+            is_public=False,
+            rom_ids=[rom.id],
+            filter_criteria={},
+        )
+    )
+
+    response = client.get(
+        f"/api/roms/{rom.id}",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    assert "Private Smart" not in _user_collections_by_name(response.json())
+
+
+def test_get_rom_lists_public_smart_collection_from_other_user(
+    client: TestClient, access_token: str, viewer_user: User, rom: Rom
+):
+    """A public smart collection owned by another user is listed when it contains
+    the ROM."""
+    smart = db_collection_handler.add_smart_collection(
+        SmartCollection(
+            name="Public Smart",
+            description="",
+            user_id=viewer_user.id,
+            is_public=True,
+            rom_ids=[rom.id],
+            filter_criteria={},
+        )
+    )
+
+    response = client.get(
+        f"/api/roms/{rom.id}",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    collections = _user_collections_by_name(response.json())
+    assert "Public Smart" in collections
+    assert collections["Public Smart"]["id"] == smart.id
+    assert collections["Public Smart"]["is_smart"] is True
 
 
 def test_download_multi_file_rom_content(

--- a/frontend/src/__generated__/models/UserCollectionSchema.ts
+++ b/frontend/src/__generated__/models/UserCollectionSchema.ts
@@ -5,5 +5,6 @@
 export type UserCollectionSchema = {
     id: number;
     name: string;
+    is_smart?: boolean;
 };
 

--- a/frontend/src/v2/components/Collections/CollectionTile.vue
+++ b/frontend/src/v2/components/Collections/CollectionTile.vue
@@ -16,7 +16,7 @@ import {
 defineOptions({ inheritAttrs: false });
 
 type Variant = "row" | "grid";
-type Kind = "regular" | "virtual" | "smart";
+export type Kind = "regular" | "virtual" | "smart";
 
 interface Props {
   name: string;

--- a/frontend/src/v2/components/Gallery/CollectionSettingsTab.vue
+++ b/frontend/src/v2/components/Gallery/CollectionSettingsTab.vue
@@ -43,6 +43,7 @@ import storeCollections, {
 import storePlatforms from "@/stores/platforms";
 import type { Events } from "@/types/emitter";
 import CollectionMosaic from "@/v2/components/Collections/CollectionMosaic.vue";
+import type { Kind as CollectionKind } from "@/v2/components/Collections/CollectionTile.vue";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
 import { useWebpSupport } from "@/v2/composables/useWebpSupport";
 import storeGalleryRoms from "@/v2/stores/galleryRoms";
@@ -53,10 +54,8 @@ import {
 
 defineOptions({ inheritAttrs: false });
 
-type Kind = "regular" | "smart";
-
 const props = defineProps<{
-  kind: Kind;
+  kind: CollectionKind;
   collection: Collection | SmartCollection;
   deleting?: boolean;
 }>();

--- a/frontend/src/v2/components/GameDetails/OverviewTab.vue
+++ b/frontend/src/v2/components/GameDetails/OverviewTab.vue
@@ -77,11 +77,13 @@ const hasHltb = computed(() => {
   );
 });
 
-// Enrich the slim `{ id, name }` user_collections payload from the
-// ROM with the full Collection record (cover paths, rom_count) the
-// store already holds — so we can render real CollectionTile mosaics
-// instead of stripped chips. Falls back to a bare entry if the store
-// is empty (e.g. deep-link before the AppLayout fetch resolves).
+// Enrich the slim `{ id, name, is_smart }` user_collections payload from
+// the ROM with the full record (cover paths, rom_count) the store already
+// holds — so we can render real CollectionTile mosaics instead of stripped
+// chips. Smart collections (#3934) resolve from their own store slice and
+// route, and carry the "smart" kind so the tile shows its flash badge.
+// Falls back to a bare entry if the store is empty (e.g. deep-link before
+// the AppLayout fetch resolves).
 const { t } = useI18n();
 const collectionsStore = storeCollections();
 const { toWebp } = useWebpSupport();
@@ -95,21 +97,39 @@ const videos = computed(() =>
 
 type CollectionTileEntry = {
   id: number;
+  // Regular and smart collection ids come from separate tables and can
+  // collide, so the render key folds in the kind to stay unique.
+  key: string;
   name: string;
   rom_count: number;
   covers: string[];
   link: string;
+  kind: "regular" | "smart";
 };
 
 const userCollectionTiles = computed<CollectionTileEntry[]>(() =>
   props.userCollections.map((c) => {
+    if (c.is_smart) {
+      const full = collectionsStore.getSmartCollection(c.id);
+      return {
+        id: c.id,
+        key: `smart-${c.id}`,
+        name: full?.name ?? c.name,
+        rom_count: full?.rom_count ?? 0,
+        covers: full ? collectionCoverList(full, toWebp) : [],
+        link: `/collection/smart/${c.id}`,
+        kind: "smart",
+      };
+    }
     const full = collectionsStore.getCollection(c.id);
     return {
       id: c.id,
+      key: `regular-${c.id}`,
       name: full?.name ?? c.name,
       rom_count: full?.rom_count ?? 0,
       covers: full ? collectionCoverList(full, toWebp) : [],
       link: `/collection/${c.id}`,
+      kind: "regular",
     };
   }),
 );
@@ -214,12 +234,12 @@ const coverSource = computed(() => {
           <CollectionTile
             v-for="c in userCollectionTiles"
             :id="c.id"
-            :key="c.id"
+            :key="c.key"
             :to="c.link"
             :name="c.name"
             :rom-count="c.rom_count"
             :covers="c.covers"
-            kind="regular"
+            :kind="c.kind"
             variant="row"
           />
         </div>

--- a/frontend/src/v2/components/GameDetails/OverviewTab.vue
+++ b/frontend/src/v2/components/GameDetails/OverviewTab.vue
@@ -28,7 +28,9 @@ import type {
 } from "@/__generated__";
 import storeCollections from "@/stores/collections";
 import type { DetailedRom } from "@/stores/roms";
-import CollectionTile from "@/v2/components/Collections/CollectionTile.vue";
+import CollectionTile, {
+  type Kind,
+} from "@/v2/components/Collections/CollectionTile.vue";
 import AgeRatingBadges from "@/v2/components/GameDetails/AgeRatingBadges.vue";
 import HLTBStrip from "@/v2/components/GameDetails/HLTBStrip.vue";
 import type { InfoGridSection } from "@/v2/components/GameDetails/InfoGrid.vue";
@@ -97,39 +99,28 @@ const videos = computed(() =>
 
 type CollectionTileEntry = {
   id: number;
-  // Regular and smart collection ids come from separate tables and can
-  // collide, so the render key folds in the kind to stay unique.
   key: string;
   name: string;
   rom_count: number;
   covers: string[];
   link: string;
-  kind: "regular" | "smart";
+  kind: Kind;
 };
 
 const userCollectionTiles = computed<CollectionTileEntry[]>(() =>
   props.userCollections.map((c) => {
-    if (c.is_smart) {
-      const full = collectionsStore.getSmartCollection(c.id);
-      return {
-        id: c.id,
-        key: `smart-${c.id}`,
-        name: full?.name ?? c.name,
-        rom_count: full?.rom_count ?? 0,
-        covers: full ? collectionCoverList(full, toWebp) : [],
-        link: `/collection/smart/${c.id}`,
-        kind: "smart",
-      };
-    }
-    const full = collectionsStore.getCollection(c.id);
+    const full = c.is_smart
+      ? collectionsStore.getSmartCollection(c.id)
+      : collectionsStore.getCollection(c.id);
+
     return {
       id: c.id,
-      key: `regular-${c.id}`,
+      key: c.is_smart ? `smart-${c.id}` : `regular-${c.id}`,
       name: full?.name ?? c.name,
       rom_count: full?.rom_count ?? 0,
       covers: full ? collectionCoverList(full, toWebp) : [],
-      link: `/collection/${c.id}`,
-      kind: "regular",
+      link: c.is_smart ? `/collection/smart/${c.id}` : `/collection/${c.id}`,
+      kind: c.is_smart ? "smart" : "regular",
     };
   }),
 );

--- a/frontend/src/v2/layouts/AppLayout.vue
+++ b/frontend/src/v2/layouts/AppLayout.vue
@@ -131,6 +131,12 @@ onMounted(() => {
   if (collectionsStore.allCollections.length === 0) {
     void collectionsStore.fetchCollections();
   }
+  // Smart collections too, so GameDetails can enrich a ROM's smart-collection
+  // tiles (cover mosaic + rom count) on direct navigation instead of falling
+  // back to a countless, coverless entry.
+  if (collectionsStore.smartCollections.length === 0) {
+    void collectionsStore.fetchSmartCollections();
+  }
   // Hydrate platforms for the same reason — views like MissingGames,
   // GameDetails, etc. read `platformsStore.get(id)` to resolve a
   // platform's display name and slug. Without this, direct loads of

--- a/frontend/src/v2/views/Gallery/Collection.vue
+++ b/frontend/src/v2/views/Gallery/Collection.vue
@@ -27,6 +27,7 @@ import storeCollections, {
   type SmartCollection,
   type VirtualCollection,
 } from "@/stores/collections";
+import type { Kind as CollectionKind } from "@/v2/components/Collections/CollectionTile.vue";
 import CollectionHead from "@/v2/components/Gallery/CollectionHead.vue";
 import CollectionSettingsTab from "@/v2/components/Gallery/CollectionSettingsTab.vue";
 import GalleryShell from "@/v2/components/Gallery/GalleryShell.vue";
@@ -38,7 +39,6 @@ import storeGalleryRoms from "@/v2/stores/galleryRoms";
 import { collectionCoverList } from "@/v2/utils/collectionCovers";
 
 type AnyCollection = Collection | VirtualCollection | SmartCollection;
-type CollectionKind = "regular" | "virtual" | "smart";
 
 const { t } = useI18n();
 const route = useRoute();
@@ -60,7 +60,7 @@ const canDownload = useCan("rom.download");
 
 // Virtual collections are computed (no editable fields) — only
 // regular / smart get the Settings tab.
-const editableKind = computed<"regular" | "smart" | null>(() => {
+const editableKind = computed<CollectionKind | null>(() => {
   if (currentKind.value === "regular") return "regular";
   if (currentKind.value === "smart") return "smart";
   return null;


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3934.

The ROM detail overview's "Collections" row only listed **standard** collections a
ROM belonged to; smart collections were silently omitted. Standard collections are
resolved off the `collections` join relationship, but smart collections have no
reverse join, membership is a cached list of ROM ids on the collection itself, so
they were never considered.

This PR includes the smart collections a ROM belongs to in the detail response and
renders them as real tiles in v2:

- **Backend:** `UserCollectionSchema` gains an `is_smart` flag (defaults to `false`,
  so standard collections are unaffected). `DetailedRomSchema.from_orm_with_request`
  now merges standard collections (off the loaded join) with the smart collections a
  ROM belongs to. Smart-collection membership and visibility are resolved in SQL via
  a new `get_smart_collections_for_rom` handler, so a private smart collection owned
  by another user stays hidden while a public one is shown, matching standard
  collections exactly.
- **Frontend (v2):** `OverviewTab` resolves smart-collection tiles from the smart
  slice of the collections store, links them to `/collection/smart/:id`, and tags
  them with the `smart` kind so `CollectionTile` shows its flash badge and cover
  mosaic. `AppLayout` now also hydrates smart collections on mount so a direct/deep
  link to a ROM can enrich the tiles (cover mosaic + count) instead of falling back
  to a countless, coverless entry.

Because regular and smart collection ids come from separate tables and can collide,
the tile render `key` folds in the collection kind to stay unique.

**Performance:** smart collections carry a cached `rom_ids` JSON array whose length
grows with library size. Rather than loading every own/public smart collection and
scanning that list in Python on each detail load, membership is pushed into the query
with the existing cross-DB `json_array_contains_value` helper (`JSON_CONTAINS` on
MariaDB/MySQL, `@>`/`?` on Postgres, the same one used for `RomNote.tags`), returning
only the matching rows with `id`/`name`/`is_public`. Cost no longer scales with
library size.

**Files modified**

- `backend/handler/database/collections_handler.py` — new
  `get_smart_collections_for_rom(rom_id, user_id)`: SQL-level membership
  (`json_array_contains_value`) + visibility filter, returning only `id/name/is_public`.
- `backend/endpoints/responses/rom.py` — add `is_smart` to `UserCollectionSchema`;
  add the `from_smart_collections` mapper (filtering now happens in SQL); merge
  standard + smart collections in `DetailedRomSchema.from_orm_with_request`.
- `backend/tests/endpoints/roms/test_rom.py` — 4 new endpoint tests: lists both kinds
  with correct `is_smart`, omits a smart collection that doesn't contain the ROM,
  hides another user's private smart collection, lists another user's public one.
- `frontend/src/__generated__/models/UserCollectionSchema.ts` — regenerated: adds
  optional `is_smart?: boolean`.
- `frontend/src/v2/components/GameDetails/OverviewTab.vue` — resolve smart tiles from
  the store, `smart` kind, `/collection/smart/:id` link, and a kind-scoped render key.
- `frontend/src/v2/layouts/AppLayout.vue` — hydrate smart collections on mount (guarded
  on an empty store) so detail tiles enrich on direct navigation.

**Testing notes**

- `uv run pytest tests/endpoints/roms/test_rom.py` and the collections handler suite:
  74 passed. The 4 new tests run on MariaDB, exercising the `JSON_CONTAINS` path (the
  helper has no SQLite branch).
- `npm run typecheck`: clean. `trunk check` on the changed files: clean.
- Manually verified in the v2 detail view (light + dark): a ROM that belongs to both
  a standard and a smart collection shows both tiles, the smart tile carries the flash
  badge and a cover mosaic, and clicking it navigates to the smart collection.

AI assistance: this change was written with AI assistance (Claude), reviewed and
verified locally by the author.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)
<img width="1522" height="868" alt="image" src="https://github.com/user-attachments/assets/b677a679-001e-4904-8c5a-05cebd3d45cc" />

---

**Reviewer notes**

- Smart-collection membership is resolved in SQL via `json_array_contains_value`
  (`JSON_CONTAINS` on MariaDB/MySQL, `@>`/`?` on Postgres, same helper used for
  `RomNote.tags`), returning only matching rows with `load_only(id, name, is_public)`.
  This runs only on single-ROM detail endpoints (list endpoints use `SimpleRomSchema`),
  so there's no N+1 and no full-blob scan.
- Visibility is intentionally identical to standard collections: private collections
  from other users are hidden; public ones are shown (both covered by tests).
