### PR TITLE
fix(player): guard v2 EmulatorJS against stale saved disc id

### DIFF
--- a/frontend/src/v2/utils/playerDisc.test.ts
+++ b/frontend/src/v2/utils/playerDisc.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolveStoredDisc } from "./playerDisc";
+
+// Only `id` is read off each file; minimal stubs stand in for RomFileSchema.
+const files = (...ids: number[]) => ids.map((id) => ({ id }));
+
+describe("resolveStoredDisc", () => {
+  it("keeps a stored id that still belongs to the rom", () => {
+    expect(resolveStoredDisc("2", files(1, 2, 3))).toEqual({
+      discId: 2,
+      stale: false,
+    });
+  });
+
+  it("falls back to the first file and marks stale when the id is gone", () => {
+    // Classic post-rescan case: files were reimported with new ids.
+    expect(resolveStoredDisc("2", files(10, 11, 12))).toEqual({
+      discId: 10,
+      stale: true,
+    });
+  });
+
+  it("falls back to the first file without staleness when nothing was stored", () => {
+    expect(resolveStoredDisc(null, files(5, 6))).toEqual({
+      discId: 5,
+      stale: false,
+    });
+  });
+
+  it("treats a non-numeric stored value as stale garbage to forget", () => {
+    expect(resolveStoredDisc("not-a-number", files(1))).toEqual({
+      discId: 1,
+      stale: true,
+    });
+  });
+
+  it("returns a null disc id (and no staleness) for a rom with no files", () => {
+    expect(resolveStoredDisc(null, [])).toEqual({
+      discId: null,
+      stale: false,
+    });
+  });
+
+  it("still clears a stored id when the rom now has no files", () => {
+    expect(resolveStoredDisc("2", [])).toEqual({
+      discId: null,
+      stale: true,
+    });
+  });
+});

--- a/frontend/src/v2/utils/playerDisc.ts
+++ b/frontend/src/v2/utils/playerDisc.ts
@@ -1,0 +1,27 @@
+// Resolving which file ("disc") the EmulatorJS player should boot.
+//
+// The player persists the user's disc choice per game in localStorage under
+// `player:<romId>:disc`. After a rescan/reimport the rom's files get new
+// internal ids, so a saved id can point at a file that no longer exists. Booting
+// with that stale id makes the download endpoint 404, which EmulatorJS surfaces
+// as a generic "Network Error" (issue #3938). Validate the saved id against the
+// rom's current files before using it, and report when it must be forgotten.
+export interface ResolvedDisc {
+  // The file id to boot, or null when the rom has no files.
+  discId: number | null;
+  // True when a value was stored but no longer matches a current file, so the
+  // caller should drop the stale localStorage entry.
+  stale: boolean;
+}
+
+export function resolveStoredDisc(
+  storedDisc: string | null,
+  files: readonly { id: number }[],
+): ResolvedDisc {
+  const storedDiscId = storedDisc ? parseInt(storedDisc) : null;
+  if (storedDiscId !== null && files.some((f) => f.id === storedDiscId)) {
+    return { discId: storedDiscId, stale: false };
+  }
+  // NaN (non-numeric storage) counts as stored garbage worth forgetting.
+  return { discId: files[0]?.id ?? null, stale: storedDiscId !== null };
+}

--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -51,6 +51,7 @@ import { useInputModality } from "@/v2/composables/useInputModality";
 import { usePlaySession } from "@/v2/composables/usePlaySession";
 import type { SliderBtnGroupItem } from "@/v2/lib/primitives/RSliderBtnGroup/types";
 import storeGalleryRoms from "@/v2/stores/galleryRoms";
+import { resolveStoredDisc } from "@/v2/utils/playerDisc";
 import { installIOSFullscreenShim } from "@/views/Player/EmulatorJS/utils";
 
 // Reuse v1's heavy emulator integration — do NOT rewrite this. Lazy so the
@@ -388,12 +389,14 @@ onMounted(async () => {
   }
   isSavesTabSelected.value = !hasCompatibleState;
 
+  // Validate the saved disc against the rom's current files: a rescan can
+  // leave a stale id behind that would 404 the download (issue #3938).
   const storedDisc = localStorage.getItem(`player:${rom.value.id}:disc`);
-  if (storedDisc) {
-    selectedDisc.value = parseInt(storedDisc);
-  } else {
-    selectedDisc.value = rom.value.files[0]?.id ?? null;
+  const { discId, stale } = resolveStoredDisc(storedDisc, rom.value.files);
+  if (stale) {
+    localStorage.removeItem(`player:${rom.value.id}:disc`);
   }
+  selectedDisc.value = discId;
 
   // Prefer the core saved for this game, then the platform default, validating
   // each candidate so a stale entry falls through instead of masking the next


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3938.

The v2 EmulatorJS player restored the user's per-game disc choice from
`localStorage` (`player:<romId>:disc`) with a bare `parseInt` and never checked
that the saved id still existed. After a rescan/reimport the rom's file ids
change, so the player kept requesting a file that was no longer there: the
download endpoint 404s and EmulatorJS surfaces it as a generic **"Network
Error"**. Single-file games were hit hardest, since they have no disc picker to
recover from.

This ports the existing v1 guard (`d1696cd0`) to v2. A new pure helper,
`resolveStoredDisc`, keeps the saved id only when it still matches one of the
rom's current files; otherwise it falls back to the first file and flags the
entry as stale so the caller drops it from `localStorage`. The player now
validates before booting, so a rescan can no longer leave a dead disc id behind.

**What changed**

- `frontend/src/v2/utils/playerDisc.ts` (new) — `resolveStoredDisc(storedDisc, files)`
  returns `{ discId, stale }`. Keeps a still-valid saved id; otherwise falls back
  to the first file's id (or `null` when the rom has no files) and reports
  `stale: true` so the caller can clear the dead entry. Non-numeric storage is
  treated as stale garbage to forget.
- `frontend/src/v2/utils/playerDisc.test.ts` (new) — unit tests covering the
  valid-id, post-rescan fallback, nothing-stored, non-numeric-garbage,
  no-files, and no-files-with-stored-id cases.
- `frontend/src/v2/views/Player/EmulatorJS.vue` — replace the blind
  `parseInt(storedDisc)` restore in `onMounted` with `resolveStoredDisc`, and
  remove the stale `localStorage` key when the helper reports it.

**Testing notes**

- `npx vitest run src/v2/utils/playerDisc.test.ts` — 6/6 pass.
- Full v2 frontend suite green; `npm run typecheck` clean.
- Manual repro: launched a v2 game, picked a non-default disc (persisting the id),
  rescanned the library so the file ids changed, relaunched. Before: EmulatorJS
  failed with "Network Error"; the single-file case couldn't recover. After: the
  stale id is discarded, the player boots the first file, and the `localStorage`
  entry is cleared.

**Reviewer notes**

- Behavior is a faithful port of the v1 guard in
  `frontend/src/views/Player/EmulatorJS/Base.vue`, kept in a shared util so v2
  doesn't duplicate the logic. The write-back path (`Player.vue`) persists the
  validated selection, so an invalid id is never re-saved.
- v1 is not modified; no v1-frozen concern.
- No API/schema changes, so no type regeneration needed. No new user-visible
  strings, so no i18n changes.

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this change was written with AI assistance (Claude Code).
The author reviewed and tested the diff, and verified the fix against the
reported issue locally.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes