### PR TITLE
Show empty platforms in platform index

### DIFF
--- a/frontend/src/stores/platforms.test.ts
+++ b/frontend/src/stores/platforms.test.ts
@@ -25,7 +25,7 @@ describe("platform store lists", () => {
 
     store.set([filled, empty]);
 
-    expect(store.allPlatforms).toEqual([empty, filled]);
+    expect(store.allPlatforms).toEqual([filled, empty]);
     expect(store.filledPlatforms).toEqual([filled]);
   });
 });

--- a/frontend/src/stores/platforms.test.ts
+++ b/frontend/src/stores/platforms.test.ts
@@ -2,11 +2,7 @@ import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it } from "vitest";
 import storePlatforms, { type Platform } from "@/stores/platforms";
 
-function platform(
-  id: number,
-  displayName: string,
-  romCount: number,
-): Platform {
+function platform(id: number, displayName: string, romCount: number): Platform {
   return {
     id,
     display_name: displayName,
@@ -29,7 +25,7 @@ describe("platform store lists", () => {
 
     store.set([filled, empty]);
 
+    expect(store.allPlatforms).toEqual([empty, filled]);
     expect(store.filledPlatforms).toEqual([filled]);
-    expect(store.platformIndexPlatforms).toEqual([empty, filled]);
   });
 });

--- a/frontend/src/stores/platforms.test.ts
+++ b/frontend/src/stores/platforms.test.ts
@@ -1,0 +1,35 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it } from "vitest";
+import storePlatforms, { type Platform } from "@/stores/platforms";
+
+function platform(
+  id: number,
+  displayName: string,
+  romCount: number,
+): Platform {
+  return {
+    id,
+    display_name: displayName,
+    name: displayName,
+    slug: displayName.toLowerCase().replaceAll(" ", "-"),
+    fs_slug: displayName.toLowerCase().replaceAll(" ", "-"),
+    rom_count: romCount,
+  } as Platform;
+}
+
+describe("platform store lists", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("keeps empty platforms reachable from the Platforms index", () => {
+    const store = storePlatforms();
+    const empty = platform(1, "Game Boy", 0);
+    const filled = platform(2, "Nintendo 64", 12);
+
+    store.set([filled, empty]);
+
+    expect(store.filledPlatforms).toEqual([filled]);
+    expect(store.platformIndexPlatforms).toEqual([empty, filled]);
+  });
+});

--- a/frontend/src/stores/platforms.ts
+++ b/frontend/src/stores/platforms.ts
@@ -20,6 +20,8 @@ export default defineStore("platforms", {
       all
         .filter((p) => p.rom_count > 0)
         .sort((a, b) => a.display_name.localeCompare(b.display_name)),
+    platformIndexPlatforms: ({ allPlatforms: all }) =>
+      [...all].sort((a, b) => a.display_name.localeCompare(b.display_name)),
     filteredPlatforms: ({ allPlatforms: all, filterText }) =>
       all
         .filter(

--- a/frontend/src/stores/platforms.ts
+++ b/frontend/src/stores/platforms.ts
@@ -20,8 +20,6 @@ export default defineStore("platforms", {
       all
         .filter((p) => p.rom_count > 0)
         .sort((a, b) => a.display_name.localeCompare(b.display_name)),
-    platformIndexPlatforms: ({ allPlatforms: all }) =>
-      [...all].sort((a, b) => a.display_name.localeCompare(b.display_name)),
     filteredPlatforms: ({ allPlatforms: all, filterText }) =>
       all
         .filter(
@@ -40,7 +38,7 @@ export default defineStore("platforms", {
   actions: {
     _reorder() {
       this.allPlatforms = uniqBy(this.allPlatforms, "id").sort((a, b) => {
-        return a.name.localeCompare(b.name);
+        return a.display_name.localeCompare(b.display_name);
       });
     },
     fetchPlatforms(): Promise<Platform[]> {

--- a/frontend/src/v2/views/PlatformsIndex.test.ts
+++ b/frontend/src/v2/views/PlatformsIndex.test.ts
@@ -1,7 +1,7 @@
 import { mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
-import { defineComponent, ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, ref } from "vue";
 import storePlatforms, { type Platform } from "@/stores/platforms";
 import PlatformsIndex from "./PlatformsIndex.vue";
 
@@ -30,7 +30,7 @@ vi.mock("@/v2/components/Platforms/PlatformListRow.vue", () => ({
   default: defineComponent({
     props: ["displayName", "romCount"],
     template:
-      "<div class=\"platform-row\">{{ displayName }} {{ romCount }}</div>",
+      '<div class="platform-row">{{ displayName }} {{ romCount }}</div>',
   }),
 }));
 
@@ -38,21 +38,21 @@ vi.mock("@/v2/components/Platforms/PlatformTile.vue", () => ({
   default: defineComponent({
     props: ["displayName", "romCount"],
     template:
-      "<div class=\"platform-tile\">{{ displayName }} {{ romCount }}</div>",
+      '<div class="platform-tile">{{ displayName }} {{ romCount }}</div>',
   }),
 }));
 
 vi.mock("@/v2/components/shared/EmptyState.vue", () => ({
   default: defineComponent({
     props: ["message"],
-    template: "<div class=\"empty-state\">{{ message }}</div>",
+    template: '<div class="empty-state">{{ message }}</div>',
   }),
 }));
 
 vi.mock("@/v2/components/shared/IndexShell.vue", () => ({
   default: defineComponent({
     template:
-      "<main><slot name=\"header\" /><slot name=\"toolbar\" /><slot name=\"listHeader\" /><slot /></main>",
+      '<main><slot name="header" /><slot name="toolbar" /><slot name="listHeader" /><slot /></main>',
   }),
 }));
 
@@ -88,11 +88,7 @@ vi.mock("@/v2/composables/useWrapGridNav", () => ({
   useWrapGridNav: vi.fn(),
 }));
 
-function platform(
-  id: number,
-  displayName: string,
-  romCount: number,
-): Platform {
+function platform(id: number, displayName: string, romCount: number): Platform {
   return {
     id,
     display_name: displayName,
@@ -110,10 +106,7 @@ describe("PlatformsIndex", () => {
 
   it("renders empty database platforms so they remain reachable", () => {
     const platforms = storePlatforms();
-    platforms.set([
-      platform(2, "Nintendo 64", 12),
-      platform(1, "Game Boy", 0),
-    ]);
+    platforms.set([platform(2, "Nintendo 64", 12), platform(1, "Game Boy", 0)]);
 
     const wrapper = mount(PlatformsIndex);
 

--- a/frontend/src/v2/views/PlatformsIndex.test.ts
+++ b/frontend/src/v2/views/PlatformsIndex.test.ts
@@ -1,0 +1,124 @@
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { defineComponent, ref } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import storePlatforms, { type Platform } from "@/stores/platforms";
+import PlatformsIndex from "./PlatformsIndex.vue";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@v2/lib", () => ({
+  RDivider: defineComponent({ template: "<hr />" }),
+  RLetterHeading: defineComponent({
+    props: ["label"],
+    template: "<h2>{{ label }}</h2>",
+  }),
+  RSkeletonBlock: defineComponent({ template: "<div />" }),
+}));
+
+vi.mock("@/v2/components/Gallery/GalleryToolbar.vue", () => ({
+  default: defineComponent({ template: "<div />" }),
+}));
+
+vi.mock("@/v2/components/Platforms/PlatformListHeader.vue", () => ({
+  default: defineComponent({ template: "<div />" }),
+}));
+
+vi.mock("@/v2/components/Platforms/PlatformListRow.vue", () => ({
+  default: defineComponent({
+    props: ["displayName", "romCount"],
+    template:
+      "<div class=\"platform-row\">{{ displayName }} {{ romCount }}</div>",
+  }),
+}));
+
+vi.mock("@/v2/components/Platforms/PlatformTile.vue", () => ({
+  default: defineComponent({
+    props: ["displayName", "romCount"],
+    template:
+      "<div class=\"platform-tile\">{{ displayName }} {{ romCount }}</div>",
+  }),
+}));
+
+vi.mock("@/v2/components/shared/EmptyState.vue", () => ({
+  default: defineComponent({
+    props: ["message"],
+    template: "<div class=\"empty-state\">{{ message }}</div>",
+  }),
+}));
+
+vi.mock("@/v2/components/shared/IndexShell.vue", () => ({
+  default: defineComponent({
+    template:
+      "<main><slot name=\"header\" /><slot name=\"toolbar\" /><slot name=\"listHeader\" /><slot /></main>",
+  }),
+}));
+
+vi.mock("@/v2/components/shared/PageHeader.vue", () => ({
+  default: defineComponent({
+    props: ["title", "count"],
+    template: "<header>{{ title }} {{ count }}</header>",
+  }),
+}));
+
+vi.mock("@/v2/composables/useGalleryMode", () => ({
+  useGalleryMode: () => ({
+    groupBy: ref("none"),
+    layout: ref("grid"),
+  }),
+}));
+
+vi.mock("@/v2/composables/useGalleryViewModeUrl", () => ({
+  useGalleryViewModeUrl: vi.fn(),
+}));
+
+vi.mock("@/v2/composables/usePlatformPlayable", () => ({
+  usePlatformPlayableChecker: () => ({
+    isPlayable: ref(() => false),
+  }),
+}));
+
+vi.mock("@/v2/composables/useTileSearchUrl", () => ({
+  useTileSearchUrl: () => ref(""),
+}));
+
+vi.mock("@/v2/composables/useWrapGridNav", () => ({
+  useWrapGridNav: vi.fn(),
+}));
+
+function platform(
+  id: number,
+  displayName: string,
+  romCount: number,
+): Platform {
+  return {
+    id,
+    display_name: displayName,
+    name: displayName,
+    slug: displayName.toLowerCase().replaceAll(" ", "-"),
+    fs_slug: displayName.toLowerCase().replaceAll(" ", "-"),
+    rom_count: romCount,
+  } as Platform;
+}
+
+describe("PlatformsIndex", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("renders empty database platforms so they remain reachable", () => {
+    const platforms = storePlatforms();
+    platforms.set([
+      platform(2, "Nintendo 64", 12),
+      platform(1, "Game Boy", 0),
+    ]);
+
+    const wrapper = mount(PlatformsIndex);
+
+    expect(wrapper.text()).toContain("common.platforms 2");
+    expect(wrapper.text()).toContain("Game Boy 0");
+    expect(wrapper.text()).toContain("Nintendo 64 12");
+  });
+});

--- a/frontend/src/v2/views/PlatformsIndex.test.ts
+++ b/frontend/src/v2/views/PlatformsIndex.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable vue/one-component-per-file */
 import { mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -12,7 +13,7 @@ vi.mock("vue-i18n", () => ({
 vi.mock("@v2/lib", () => ({
   RDivider: defineComponent({ template: "<hr />" }),
   RLetterHeading: defineComponent({
-    props: ["label"],
+    props: { label: { type: String, default: "" } },
     template: "<h2>{{ label }}</h2>",
   }),
   RSkeletonBlock: defineComponent({ template: "<div />" }),
@@ -28,7 +29,10 @@ vi.mock("@/v2/components/Platforms/PlatformListHeader.vue", () => ({
 
 vi.mock("@/v2/components/Platforms/PlatformListRow.vue", () => ({
   default: defineComponent({
-    props: ["displayName", "romCount"],
+    props: {
+      displayName: { type: String, default: "" },
+      romCount: { type: Number, default: 0 },
+    },
     template:
       '<div class="platform-row">{{ displayName }} {{ romCount }}</div>',
   }),
@@ -36,7 +40,10 @@ vi.mock("@/v2/components/Platforms/PlatformListRow.vue", () => ({
 
 vi.mock("@/v2/components/Platforms/PlatformTile.vue", () => ({
   default: defineComponent({
-    props: ["displayName", "romCount"],
+    props: {
+      displayName: { type: String, default: "" },
+      romCount: { type: Number, default: 0 },
+    },
     template:
       '<div class="platform-tile">{{ displayName }} {{ romCount }}</div>',
   }),
@@ -44,7 +51,7 @@ vi.mock("@/v2/components/Platforms/PlatformTile.vue", () => ({
 
 vi.mock("@/v2/components/shared/EmptyState.vue", () => ({
   default: defineComponent({
-    props: ["message"],
+    props: { message: { type: String, default: "" } },
     template: '<div class="empty-state">{{ message }}</div>',
   }),
 }));
@@ -58,7 +65,10 @@ vi.mock("@/v2/components/shared/IndexShell.vue", () => ({
 
 vi.mock("@/v2/components/shared/PageHeader.vue", () => ({
   default: defineComponent({
-    props: ["title", "count"],
+    props: {
+      title: { type: String, default: "" },
+      count: { type: Number, default: 0 },
+    },
     template: "<header>{{ title }} {{ count }}</header>",
   }),
 }));

--- a/frontend/src/v2/views/PlatformsIndex.vue
+++ b/frontend/src/v2/views/PlatformsIndex.vue
@@ -41,8 +41,7 @@ import { useWrapGridNav } from "@/v2/composables/useWrapGridNav";
 
 const { t } = useI18n();
 const platformsStore = storePlatforms();
-const { platformIndexPlatforms, fetchingPlatforms } =
-  storeToRefs(platformsStore);
+const { allPlatforms, fetchingPlatforms } = storeToRefs(platformsStore);
 
 const { groupBy, layout } = useGalleryMode();
 useGalleryViewModeUrl();
@@ -62,7 +61,7 @@ useWrapGridNav(gridRoot, { cellSelector: ".plat-tile" });
 const playableById = computed(() => {
   const fn = isPlayable.value;
   const map = new Map<number | string, boolean>();
-  for (const p of platformIndexPlatforms.value) map.set(p.id, fn(p.slug));
+  for (const p of allPlatforms.value) map.set(p.id, fn(p.slug));
   return map;
 });
 
@@ -202,8 +201,8 @@ onMounted(() => {
 
 const filtered = computed<Platform[]>(() => {
   const term = searchTerm.value.trim().toLowerCase();
-  if (!term) return platformIndexPlatforms.value;
-  return platformIndexPlatforms.value.filter((p) =>
+  if (!term) return allPlatforms.value;
+  return allPlatforms.value.filter((p) =>
     p.display_name.toLowerCase().includes(term),
   );
 });
@@ -223,7 +222,7 @@ const sortedForList = computed<Platform[]>(() => {
   );
 });
 
-const totalCount = computed(() => platformIndexPlatforms.value.length);
+const totalCount = computed(() => allPlatforms.value.length);
 const noResults = computed(
   () =>
     !fetchingPlatforms.value &&

--- a/frontend/src/v2/views/PlatformsIndex.vue
+++ b/frontend/src/v2/views/PlatformsIndex.vue
@@ -41,7 +41,8 @@ import { useWrapGridNav } from "@/v2/composables/useWrapGridNav";
 
 const { t } = useI18n();
 const platformsStore = storePlatforms();
-const { filledPlatforms, fetchingPlatforms } = storeToRefs(platformsStore);
+const { platformIndexPlatforms, fetchingPlatforms } =
+  storeToRefs(platformsStore);
 
 const { groupBy, layout } = useGalleryMode();
 useGalleryViewModeUrl();
@@ -61,7 +62,7 @@ useWrapGridNav(gridRoot, { cellSelector: ".plat-tile" });
 const playableById = computed(() => {
   const fn = isPlayable.value;
   const map = new Map<number | string, boolean>();
-  for (const p of filledPlatforms.value) map.set(p.id, fn(p.slug));
+  for (const p of platformIndexPlatforms.value) map.set(p.id, fn(p.slug));
   return map;
 });
 
@@ -201,8 +202,8 @@ onMounted(() => {
 
 const filtered = computed<Platform[]>(() => {
   const term = searchTerm.value.trim().toLowerCase();
-  if (!term) return filledPlatforms.value;
-  return filledPlatforms.value.filter((p) =>
+  if (!term) return platformIndexPlatforms.value;
+  return platformIndexPlatforms.value.filter((p) =>
     p.display_name.toLowerCase().includes(term),
   );
 });
@@ -222,7 +223,7 @@ const sortedForList = computed<Platform[]>(() => {
   );
 });
 
-const totalCount = computed(() => filledPlatforms.value.length);
+const totalCount = computed(() => platformIndexPlatforms.value.length);
 const noResults = computed(
   () =>
     !fetchingPlatforms.value &&


### PR DESCRIPTION
## Summary

Show database-backed platforms with zero games on the Platforms index so they remain reachable from the UI.

Home and other filled-platform surfaces still only show platforms with games. Once an empty platform is opened from `/platforms`, the existing Settings → Delete platform action can remove it through the normal confirmation flow without deleting ROM files from disk.

Fixes #3902.

## Testing

- `npm test -- src/stores/platforms.test.ts src/v2/views/PlatformsIndex.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`

Also verified in a browser with a local mock API that an empty database platform appears on `/platforms`, opens normally, and exposes the existing Settings → Delete platform flow stating that files on disk are not deleted.

## Disclosure

I used AI assistance while developing and verifying this change.
