### PR TITLE
Apply config.yaml EmulatorJS defaults on fresh launches and after setting changes

### DIFF
--- a/frontend/src/console/views/Play.vue
+++ b/frontend/src/console/views/Play.vue
@@ -36,7 +36,10 @@ import {
   getDownloadPath,
 } from "@/utils";
 import { buildFormInput } from "@/utils/formData";
-import { invalidateEmulatorJSRomCacheIfRenamed } from "@/views/Player/EmulatorJS/utils";
+import {
+  installEJSDefaultOptionsTrap,
+  invalidateEmulatorJSRomCacheIfRenamed,
+} from "@/views/Player/EmulatorJS/utils";
 
 const { t } = useI18n();
 const createPlayerStorage = (romId: number, platformSlug: string) => ({
@@ -685,6 +688,8 @@ async function boot() {
       }
     })();
   };
+
+  installEJSDefaultOptionsTrap();
 
   // Allow route transition animation to settle
   await new Promise((r) => setTimeout(r, 50));

--- a/frontend/src/views/Player/EmulatorJS/Player.vue
+++ b/frontend/src/views/Player/EmulatorJS/Player.vue
@@ -30,6 +30,7 @@ import {
   loadEmulatorJSSave,
   loadEmulatorJSState,
   invalidateEmulatorJSRomCacheIfRenamed,
+  installEJSDefaultOptionsTrap,
   createQuickLoadButton,
   createSaveQuitButton,
   createExitEmulationButton,
@@ -156,7 +157,7 @@ window.EJS_Buttons = {
   // Disable the standard exit button to implement our own
   exitEmulation: false,
 };
-const coreOptions = configStore.getEJSCoreOptions(props.core);
+const coreOptions = configStore.getEJSCoreOptions(window.EJS_core);
 window.EJS_defaultOptions = {
   // Force saving saves and states to the browser
   "save-state-location": "browser",
@@ -189,6 +190,8 @@ window.EJS_DEBUG_XX = EJS_DEBUG;
 window.EJS_disableAutoUnload = EJS_DISABLE_AUTO_UNLOAD;
 window.EJS_disableBatchBootup = EJS_DISABLE_BATCH_BOOTUP;
 if (EJS_CACHE_LIMIT !== null) window.EJS_CacheLimit = EJS_CACHE_LIMIT;
+
+installEJSDefaultOptionsTrap();
 
 onMounted(() => {
   window.scrollTo(0, 0);
@@ -388,36 +391,6 @@ window.EJS_onGameStart = async () => {
   // global hotkeys). Callers flag this at launch too, but taking it from the
   // emulator's own start hook keeps the flag true for any entry point.
   playing.value = true;
-
-  // Patch the instance so unsaved keys still fall back to config defaults.
-  const originalPreGetSetting = window.EJS_emulator?.preGetSetting.bind(
-    window.EJS_emulator,
-  );
-  if (window.EJS_emulator) {
-    window.EJS_emulator.preGetSetting = (setting: string) => {
-      const value = originalPreGetSetting(setting);
-      if (value !== undefined && value !== null) return value;
-      const defaults = window.EJS_emulator.config?.defaultOptions ?? {};
-      return defaults[setting] !== undefined ? defaults[setting] : null;
-    };
-
-    window.EJS_emulator.rewindEnabled =
-      window.EJS_emulator.preGetSetting("rewindEnabled") === "enabled";
-
-    if (![0, 1, 2, 3].includes(window.EJS_emulator.config?.videoRotation)) {
-      window.EJS_emulator.videoRotation =
-        window.EJS_emulator.preGetSetting("videoRotation") || 0;
-    }
-
-    const webgl2Setting = window.EJS_emulator.preGetSetting("webgl2Enabled");
-    if (webgl2Setting === "disabled" || !window.EJS_emulator.supportsWebgl2) {
-      window.EJS_emulator.webgl2Enabled = false;
-    } else if (webgl2Setting === "enabled") {
-      window.EJS_emulator.webgl2Enabled = true;
-    } else {
-      window.EJS_emulator.webgl2Enabled = null;
-    }
-  }
 
   // Install netplay overrides synchronously, before any await below, so they
   // are in place before room polling or a Create/Join action can start.

--- a/frontend/src/views/Player/EmulatorJS/utils.test.ts
+++ b/frontend/src/views/Player/EmulatorJS/utils.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { installEJSDefaultOptionsTrap } from "./utils";
+
+const STORAGE_KEY = "ejs-7-n64-Test Game-settings";
+
+// Mimics the upstream EmulatorJS 4.2.3 instance closely enough to exercise
+// the two buggy code paths the trap patches: preGetSetting short-circuiting
+// to the saved-settings object, and getCoreSettings returning "" when
+// localStorage holds no saved entry.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function makeEmulator(defaultOptions: Record<string, unknown>): any {
+  return {
+    config: { defaultOptions, gameId: 7 },
+    supportsWebgl2: true,
+    rewindEnabled: false,
+    videoRotation: undefined,
+    webgl2Enabled: null,
+    getLocalStorageKey() {
+      return STORAGE_KEY;
+    },
+    preGetSetting(setting: string) {
+      const raw = localStorage.getItem(this.getLocalStorageKey());
+      try {
+        const coreSpecific = raw ? JSON.parse(raw) : null;
+        if (coreSpecific && coreSpecific.settings) {
+          return coreSpecific.settings[setting];
+        }
+      } catch {
+        // fall through, same as upstream
+      }
+      if (this.config.defaultOptions && this.config.defaultOptions[setting]) {
+        return this.config.defaultOptions[setting];
+      }
+      return null;
+    },
+    getCoreSettings() {
+      const raw = localStorage.getItem(this.getLocalStorageKey());
+      if (raw) {
+        const coreSpecific = JSON.parse(raw);
+        let rv = "";
+        for (const k in coreSpecific.settings) {
+          rv += `${k} = "${coreSpecific.settings[k]}"\n`;
+        }
+        return rv;
+      }
+      return "";
+    },
+  };
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+function saveSettings(settings: Record<string, unknown>) {
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ controlSettings: {}, settings, cheats: [] }),
+  );
+}
+
+describe("installEJSDefaultOptionsTrap", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    installEJSDefaultOptionsTrap();
+  });
+
+  afterEach(() => {
+    delete (window as { EJS_emulator?: unknown }).EJS_emulator;
+    localStorage.clear();
+  });
+
+  it("patches the instance when window.EJS_emulator is assigned", () => {
+    const emulator = makeEmulator({});
+    window.EJS_emulator = emulator;
+    expect(window.EJS_emulator.__rommSettingsPatched).toBe(true);
+  });
+
+  it("falls back to defaults for keys missing from saved settings", () => {
+    // Once any setting is saved, upstream preGetSetting returns undefined
+    // for every key the user never touched (issue #3908).
+    saveSettings({ shader: "crt-easymode.glslp" });
+    const emulator = makeEmulator({ vsync: "disabled" });
+    window.EJS_emulator = emulator;
+
+    expect(emulator.preGetSetting("shader")).toBe("crt-easymode.glslp");
+    expect(emulator.preGetSetting("vsync")).toBe("disabled");
+    expect(emulator.preGetSetting("unknown")).toBe(null);
+  });
+
+  it("includes default core options on a fresh launch", () => {
+    // Upstream getCoreSettings returns "" when localStorage has no saved
+    // entry, dropping config.yaml core options entirely (issue #3946).
+    const emulator = makeEmulator({
+      "mupen64plus-FXAA": "1",
+      "mupen64plus-OverscanTop": "11",
+    });
+    window.EJS_emulator = emulator;
+
+    const output = emulator.getCoreSettings();
+    expect(output).toContain("mupen64plus-FXAA = 1");
+    expect(output).toContain("mupen64plus-OverscanTop = 11");
+  });
+
+  it("lets saved settings override default core options", () => {
+    saveSettings({ "mupen64plus-FXAA": "0", shader: "crt-easymode.glslp" });
+    const emulator = makeEmulator({
+      "mupen64plus-FXAA": "1",
+      "mupen64plus-OverscanTop": "11",
+    });
+    window.EJS_emulator = emulator;
+
+    const output = emulator.getCoreSettings();
+    expect(output).toContain("mupen64plus-FXAA = 0");
+    expect(output).toContain("mupen64plus-OverscanTop = 11");
+    expect(output).toContain('shader = "crt-easymode.glslp"');
+  });
+
+  it("recomputes constructor-captured values from defaults", () => {
+    saveSettings({ shader: "crt-easymode.glslp" });
+    const emulator = makeEmulator({
+      rewindEnabled: "enabled",
+      webgl2Enabled: "enabled",
+    });
+    window.EJS_emulator = emulator;
+
+    expect(emulator.rewindEnabled).toBe(true);
+    expect(emulator.webgl2Enabled).toBe(true);
+  });
+
+  it("does not re-patch an already patched instance", () => {
+    const emulator = makeEmulator({});
+    window.EJS_emulator = emulator;
+    const patched = emulator.preGetSetting;
+    window.EJS_emulator = emulator;
+    expect(emulator.preGetSetting).toBe(patched);
+  });
+});

--- a/frontend/src/views/Player/EmulatorJS/utils.ts
+++ b/frontend/src/views/Player/EmulatorJS/utils.ts
@@ -168,6 +168,87 @@ export function invalidateEmulatorJSRomCacheIfRenamed(rom: {
   localStorage.setItem(fsNameStorageKey, rom.fs_name);
 }
 
+// EmulatorJS drops the config.yaml defaults (EJS_defaultOptions) in two spots:
+// - preGetSetting short-circuits to the saved-settings localStorage object
+//   once ANY setting or control was changed, returning undefined for keys the
+//   user never touched (webgl2Enabled, vsync, shader, ...).
+// - getCoreSettings builds the RetroArch core options file, but returns ""
+//   when localStorage is enabled and holds no saved entry yet, so on a fresh
+//   launch core options (e.g. mupen64plus-FXAA) never reach the core.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function installDefaultOptionsFallback(emulator: any) {
+  if (emulator.__rommSettingsPatched) return;
+  emulator.__rommSettingsPatched = true;
+
+  const originalPreGetSetting = emulator.preGetSetting.bind(emulator);
+  emulator.preGetSetting = (setting: string) => {
+    const value = originalPreGetSetting(setting);
+    if (value !== undefined && value !== null) return value;
+    const defaults = emulator.config?.defaultOptions ?? {};
+    return defaults[setting] !== undefined ? defaults[setting] : null;
+  };
+
+  emulator.getCoreSettings = () => {
+    const defaults: Record<string, unknown> =
+      emulator.config?.defaultOptions ?? {};
+    let saved: Record<string, unknown> = {};
+    if (window.localStorage && !emulator.config?.disableLocalStorage) {
+      try {
+        const raw = localStorage.getItem(emulator.getLocalStorageKey());
+        const parsed = raw ? JSON.parse(raw) : null;
+        if (parsed?.settings instanceof Object) saved = parsed.settings;
+      } catch (error) {
+        console.warn("Could not load previous settings", error);
+      }
+    }
+    const merged = { ...defaults, ...saved };
+    let output = "";
+    for (const key in merged) {
+      const value = merged[key];
+      // Match upstream formatting: numeric values unquoted, strings quoted.
+      const formatted = Number.isNaN(Number(value)) ? `"${value}"` : value;
+      output += `${key} = ${formatted}\n`;
+    }
+    return output;
+  };
+
+  // Recompute the values the constructor captured via the unpatched
+  // preGetSetting. They are consumed after this point: rewindEnabled when
+  // GameManager writes retroarch.cfg, webgl2Enabled when the core variant is
+  // picked during download, videoRotation on the first resize.
+  emulator.rewindEnabled =
+    emulator.preGetSetting("rewindEnabled") === "enabled";
+  if (![0, 1, 2, 3].includes(emulator.config?.videoRotation)) {
+    emulator.videoRotation = emulator.preGetSetting("videoRotation") || 0;
+  }
+  const webgl2Setting = emulator.preGetSetting("webgl2Enabled");
+  if (webgl2Setting === "disabled" || !emulator.supportsWebgl2) {
+    emulator.webgl2Enabled = false;
+  } else if (webgl2Setting === "enabled") {
+    emulator.webgl2Enabled = true;
+  } else {
+    emulator.webgl2Enabled = null;
+  }
+}
+
+// Trap the window.EJS_emulator assignment so the instance is patched right
+// after the constructor returns, before the async core download and boot
+// consume any of the patched values. Patching later (e.g. in EJS_onGameStart)
+// is too late: by then the GL context exists, retroarch.cfg and the core
+// options file are written, and saved settings were already applied.
+export function installEJSDefaultOptionsTrap() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let instance: any;
+  Object.defineProperty(window, "EJS_emulator", {
+    configurable: true,
+    get: () => instance,
+    set: (value) => {
+      instance = value;
+      if (value) installDefaultOptionsFallback(value);
+    },
+  });
+}
+
 const IOS_FULLSCREEN_NAV_SELECTOR =
   ".v-app-bar, .v-bottom-navigation, .v-navigation-drawer";
 const IOS_FULLSCREEN_STYLE = `


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3946
Fixes #3908

EmulatorJS drops the `EJS_defaultOptions` built from `config.yaml`'s `emulatorjs.settings` in two distinct places, matching the two symptoms in #3946:

1. **Core options are ignored on fresh launches.** RetroArch core options (`mupen64plus-FXAA`, overscan, etc.) don't go through `preGetSetting` at all. The core requests its `.opt` file during boot via `getCoreSettings()`, and upstream (both 4.2.3 and nightly) returns an **empty string** when localStorage is available but holds no saved entry yet, which is exactly the "cleared browser cache" scenario. Emulator-level settings from the `default:` section still applied because those go through `preGetSetting`, explaining the symptom split in the report.
2. **Defaults reset after the user changes any setting.** `preGetSetting` short-circuits to the saved-settings localStorage object once any setting or control was saved, returning `undefined` for every key the user never touched (#3908). The earlier fix (#3920) installed the fallback patch at the `window.EJS_emulator` assignment, but a later cleanup moved it into `EJS_onGameStart`, which fires after `Module.callMain()`. By then the GL context exists, and `retroarch.cfg` and the core options file are already written, so the patch had no effect. This PR restores the assignment-trap timing.

The fix is a shared `installEJSDefaultOptionsTrap()` in `views/Player/EmulatorJS/utils.ts` that traps the `window.EJS_emulator` assignment (right after the constructor, before the async core download/boot consumes anything) and patches:

- `preGetSetting`: falls back to `defaultOptions` for unsaved keys.
- `getCoreSettings`: rebuilt as defaults overlaid by saved settings, so core options survive both fresh launches and post-save launches.
- The constructor-captured values `rewindEnabled`, `videoRotation`, and `webgl2Enabled`.

Both the web player (`views/Player/EmulatorJS/Player.vue`) and the console player (`console/views/Play.vue`, which had no patch at all) install the trap. The web player also looks up core options by the resolved `window.EJS_core` instead of the nullable `core` prop, so a stale or missing core selection can't drop the core-specific config section.

**AI assistance disclosure:** This PR was written with AI assistance (Claude Code): root-cause analysis against the EmulatorJS 4.2.3/nightly sources, the implementation, and the unit tests. All changes were verified with the project's typecheck, lint, and test suites.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)