### PR TITLE
Enforce hidden-rom visibility on rom child routes

### DIFF
--- a/backend/endpoints/roms/manual.py
+++ b/backend/endpoints/roms/manual.py
@@ -13,6 +13,7 @@ from decorators.auth import protected_route
 from exceptions.endpoint_exceptions import RomNotFoundInDatabaseException
 from exceptions.fs_exceptions import RomAlreadyExistsException
 from handler.auth.constants import Scope
+from handler.auth.dependencies import assert_rom_visible
 from handler.database import db_rom_handler
 from handler.filesystem import fs_resource_handler, fs_rom_handler
 from handler.filesystem.resources_handler import ALLOWED_MANUAL_EXTENSIONS
@@ -56,6 +57,7 @@ async def add_rom_manuals(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
 
     if not _is_allowed_manual_file(filename):
         raise HTTPException(
@@ -145,6 +147,7 @@ async def redownload_rom_manual(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
 
     if not rom.url_manual:
         raise HTTPException(
@@ -199,6 +202,7 @@ async def add_rom_manual_file(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
 
     if rom.has_simple_single_file:
         try:
@@ -306,6 +310,7 @@ async def delete_rom_manual_file(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
 
     rom_file = db_rom_handler.get_rom_file_by_id(file_id)
     if (
@@ -359,6 +364,7 @@ async def delete_rom_manuals(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
 
     if not fs_resource_handler.manual_exists(rom):
         raise HTTPException(

--- a/backend/endpoints/roms/manual.py
+++ b/backend/endpoints/roms/manual.py
@@ -57,6 +57,7 @@ async def add_rom_manuals(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     if not _is_allowed_manual_file(filename):
@@ -147,6 +148,7 @@ async def redownload_rom_manual(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     if not rom.url_manual:
@@ -202,6 +204,7 @@ async def add_rom_manual_file(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     if rom.has_simple_single_file:
@@ -310,6 +313,7 @@ async def delete_rom_manual_file(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     rom_file = db_rom_handler.get_rom_file_by_id(file_id)
@@ -364,6 +368,7 @@ async def delete_rom_manuals(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     if not fs_resource_handler.manual_exists(rom):

--- a/backend/endpoints/roms/notes.py
+++ b/backend/endpoints/roms/notes.py
@@ -132,6 +132,7 @@ async def update_rom_note(
     note = db_rom_handler.update_rom_note(
         note_id=note_id,
         user_id=request.user.id,
+        rom_id=rom.id,
         **{
             k: v
             for k, v in note_data.items()
@@ -168,7 +169,9 @@ async def delete_rom_note(
         raise RomNotFoundInDatabaseException(id)
     assert_rom_visible(request, rom)
 
-    success = db_rom_handler.delete_rom_note(note_id=note_id, user_id=request.user.id)
+    success = db_rom_handler.delete_rom_note(
+        note_id=note_id, user_id=request.user.id, rom_id=rom.id
+    )
 
     if not success:
         raise HTTPException(

--- a/backend/endpoints/roms/notes.py
+++ b/backend/endpoints/roms/notes.py
@@ -37,6 +37,7 @@ async def get_rom_notes(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     if tags is None:
@@ -67,6 +68,7 @@ async def get_rom_note_identifiers(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     notes = db_rom_handler.get_rom_notes(
@@ -93,6 +95,7 @@ async def create_rom_note(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     note = db_rom_handler.create_rom_note(
@@ -127,6 +130,7 @@ async def update_rom_note(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     note = db_rom_handler.update_rom_note(
@@ -167,6 +171,7 @@ async def delete_rom_note(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     success = db_rom_handler.delete_rom_note(

--- a/backend/endpoints/roms/notes.py
+++ b/backend/endpoints/roms/notes.py
@@ -8,6 +8,7 @@ from decorators.auth import protected_route
 from endpoints.responses.rom import UserNoteSchema
 from exceptions.endpoint_exceptions import RomNotFoundInDatabaseException
 from handler.auth.constants import Scope
+from handler.auth.dependencies import assert_rom_visible
 from handler.database import db_rom_handler
 from models.rom import RomNote
 from utils.router import APIRouter
@@ -36,6 +37,7 @@ async def get_rom_notes(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
 
     if tags is None:
         tags = []
@@ -65,6 +67,7 @@ async def get_rom_note_identifiers(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
 
     notes = db_rom_handler.get_rom_notes(
         rom_id=id,
@@ -90,6 +93,7 @@ async def create_rom_note(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
 
     note = db_rom_handler.create_rom_note(
         rom_id=id,
@@ -120,6 +124,11 @@ async def update_rom_note(
     note_data: Annotated[dict, Body()],
 ) -> UserNoteSchema:
     """Update a ROM note."""
+    rom = db_rom_handler.get_rom(id)
+    if not rom:
+        raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
+
     note = db_rom_handler.update_rom_note(
         note_id=note_id,
         user_id=request.user.id,
@@ -154,6 +163,11 @@ async def delete_rom_note(
     note_id: Annotated[int, PathVar(description="Note id.", ge=1)],
 ) -> dict:
     """Delete a ROM note."""
+    rom = db_rom_handler.get_rom(id)
+    if not rom:
+        raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
+
     success = db_rom_handler.delete_rom_note(note_id=note_id, user_id=request.user.id)
 
     if not success:

--- a/backend/endpoints/roms/screenshot.py
+++ b/backend/endpoints/roms/screenshot.py
@@ -55,6 +55,7 @@ async def add_rom_screenshots(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     if rom.has_simple_single_file:
@@ -165,6 +166,7 @@ async def delete_rom_screenshot(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     rom_file = db_rom_handler.get_rom_file_by_id(file_id)

--- a/backend/endpoints/roms/screenshot.py
+++ b/backend/endpoints/roms/screenshot.py
@@ -13,6 +13,7 @@ from decorators.auth import protected_route
 from exceptions.endpoint_exceptions import RomNotFoundInDatabaseException
 from exceptions.fs_exceptions import RomAlreadyExistsException
 from handler.auth.constants import Scope
+from handler.auth.dependencies import assert_rom_visible
 from handler.database import db_rom_handler
 from handler.filesystem import fs_rom_handler
 from handler.rom_conversion import promote_single_file_to_folder
@@ -54,6 +55,7 @@ async def add_rom_screenshots(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
 
     if rom.has_simple_single_file:
         try:
@@ -163,6 +165,7 @@ async def delete_rom_screenshot(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
 
     rom_file = db_rom_handler.get_rom_file_by_id(file_id)
     if (

--- a/backend/endpoints/roms/soundtrack.py
+++ b/backend/endpoints/roms/soundtrack.py
@@ -52,6 +52,7 @@ async def get_rom_soundtrack_metadata(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     tracks = db_rom_handler.get_rom_files_by_category(
@@ -94,6 +95,7 @@ async def add_rom_soundtracks(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     if rom.has_simple_single_file:
@@ -231,6 +233,7 @@ async def delete_rom_soundtrack(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+
     assert_rom_visible(request, rom)
 
     rom_file = db_rom_handler.get_rom_file_by_id(file_id)

--- a/backend/endpoints/roms/soundtrack.py
+++ b/backend/endpoints/roms/soundtrack.py
@@ -14,6 +14,7 @@ from endpoints.responses.rom import SoundtrackTrackMetaSchema, TrackMetaSchema
 from exceptions.endpoint_exceptions import RomNotFoundInDatabaseException
 from exceptions.fs_exceptions import RomAlreadyExistsException
 from handler.auth.constants import Scope
+from handler.auth.dependencies import assert_rom_visible
 from handler.database import db_rom_handler
 from handler.filesystem import fs_rom_handler
 from handler.rom_conversion import promote_single_file_to_folder
@@ -51,6 +52,7 @@ async def get_rom_soundtrack_metadata(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
 
     tracks = db_rom_handler.get_rom_files_by_category(
         rom_id=rom.id, category=RomFileCategory.SOUNDTRACK
@@ -92,6 +94,7 @@ async def add_rom_soundtracks(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
 
     if rom.has_simple_single_file:
         try:
@@ -228,6 +231,7 @@ async def delete_rom_soundtrack(
     rom = db_rom_handler.get_rom(id)
     if not rom:
         raise RomNotFoundInDatabaseException(id)
+    assert_rom_visible(request, rom)
 
     rom_file = db_rom_handler.get_rom_file_by_id(file_id)
     if (

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -2377,12 +2377,17 @@ class DBRomsHandler(DBBaseHandler):
         self,
         note_id: int,
         user_id: int,
+        rom_id: int,
         session: Session = None,  # type: ignore
         **fields,
     ) -> dict | None:
         note = (
             session.query(RomNote)
-            .filter(RomNote.id == note_id, RomNote.user_id == user_id)
+            .filter(
+                RomNote.id == note_id,
+                RomNote.user_id == user_id,
+                RomNote.rom_id == rom_id,
+            )
             .first()
         )
 
@@ -2413,11 +2418,16 @@ class DBRomsHandler(DBBaseHandler):
         self,
         note_id: int,
         user_id: int,
+        rom_id: int,
         session: Session = None,  # type: ignore
     ) -> bool:
         result = session.execute(
             delete(RomNote).where(
-                and_(RomNote.id == note_id, RomNote.user_id == user_id)
+                and_(
+                    RomNote.id == note_id,
+                    RomNote.user_id == user_id,
+                    RomNote.rom_id == rom_id,
+                )
             )
         )
         return result.rowcount > 0

--- a/backend/tests/endpoints/test_permissions_visibility.py
+++ b/backend/tests/endpoints/test_permissions_visibility.py
@@ -23,7 +23,7 @@ from models.permission import (
     PermissionGroup,
     PermissionGroupGrant,
 )
-from models.rom import RomFile, RomFileCategory
+from models.rom import Rom, RomFile, RomFileCategory
 
 
 def _auth(user):
@@ -244,6 +244,41 @@ def test_hidden_rom_note_write_routes_are_404_masked(client, viewer_user, rom):
 
     delete = client.delete(f"/api/roms/{rom.id}/notes/1", headers=headers)
     assert delete.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_note_on_hidden_rom_not_reachable_via_visible_rom_path(
+    client, viewer_user, rom, platform
+):
+    # The path rom only authorizes itself: a note belonging to a hidden rom must
+    # not be reachable by pairing its id with a visible rom in the path.
+    hidden = db_rom_handler.add_rom(
+        Rom(
+            platform_id=platform.id,
+            name="hidden_rom",
+            slug="hidden_rom_slug",
+            fs_name="hidden_rom.zip",
+            fs_name_no_tags="hidden_rom",
+            fs_name_no_ext="hidden_rom",
+            fs_extension="zip",
+            fs_path=f"{platform.slug}/roms",
+        )
+    )
+    note = db_rom_handler.create_rom_note(
+        rom_id=hidden.id, user_id=viewer_user.id, title="secret"
+    )
+    _hide(PermEntity.ROMS, hidden.id, viewer_user.id)
+    headers = _auth(viewer_user)
+
+    update = client.put(
+        f"/api/roms/{rom.id}/notes/{note['id']}", headers=headers, json={"title": "x"}
+    )
+    assert update.status_code == status.HTTP_404_NOT_FOUND
+
+    delete = client.delete(f"/api/roms/{rom.id}/notes/{note['id']}", headers=headers)
+    assert delete.status_code == status.HTTP_404_NOT_FOUND
+
+    surviving = db_rom_handler.get_rom_notes(rom_id=hidden.id, user_id=viewer_user.id)
+    assert [n.title for n in surviving] == ["secret"]
 
 
 def test_visible_rom_child_route_is_not_masked(client, viewer_user, rom):

--- a/backend/tests/endpoints/test_permissions_visibility.py
+++ b/backend/tests/endpoints/test_permissions_visibility.py
@@ -13,8 +13,9 @@ from fastapi import status
 
 from config import OAUTH_ACCESS_TOKEN_EXPIRE_SECONDS
 from handler.auth import oauth_handler
-from handler.database import db_user_handler
+from handler.database import db_rom_handler, db_user_handler
 from handler.database.base_handler import sync_session
+from handler.filesystem import fs_resource_handler
 from models.permission import (
     HiddenEntity,
     PermAction,
@@ -22,6 +23,7 @@ from models.permission import (
     PermissionGroup,
     PermissionGroupGrant,
 )
+from models.rom import RomFile, RomFileCategory
 
 
 def _auth(user):
@@ -149,6 +151,105 @@ def test_hidden_rom_patch_is_404_masked(client, viewer_user, rom, rom_file):
         data={"patch_file_id": rom_file.id},
     )
     assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.parametrize(
+    ("path", "headers"),
+    [
+        ("/screenshots", {"x-upload-filename": "shot.png"}),
+        ("/soundtracks", {"x-upload-filename": "track.mp3"}),
+        ("/manuals", {"x-upload-filename": "manual.pdf"}),
+        ("/manuals/files", {"x-upload-filename": "manual.pdf"}),
+        ("/manuals/redownload", {}),
+    ],
+)
+def test_hidden_rom_child_upload_routes_are_404_masked(
+    client, editor_user, rom, path, headers
+):
+    # Editor holds library-wide roms write, so the coarse scope gate passes; the
+    # child media routes must still mask the hidden rom instead of writing to it.
+    _hide(PermEntity.ROMS, rom.id, editor_user.id)
+    resp = client.post(
+        f"/api/roms/{rom.id}{path}", headers={**_auth(editor_user), **headers}
+    )
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.parametrize(
+    ("path", "category"),
+    [
+        ("/screenshots/{file_id}", RomFileCategory.SCREENSHOT),
+        ("/soundtracks/{file_id}", RomFileCategory.SOUNDTRACK),
+        ("/manuals/files/{file_id}", RomFileCategory.MANUAL),
+    ],
+)
+def test_hidden_rom_child_delete_routes_are_404_masked(
+    client, editor_user, rom, path, category
+):
+    # The child file must match the route's category, otherwise the route 404s
+    # on the category check and the visibility gate is never exercised.
+    child = db_rom_handler.add_rom_file(
+        RomFile(
+            rom_id=rom.id,
+            file_name=f"child.{category}",
+            file_path=f"{rom.fs_path}/{category}",
+            file_size_bytes=10,
+            category=category,
+        )
+    )
+    _hide(PermEntity.ROMS, rom.id, editor_user.id)
+
+    resp = client.delete(
+        f"/api/roms/{rom.id}{path.format(file_id=child.id)}",
+        headers=_auth(editor_user),
+    )
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+    # The row must survive: masking is worthless if the sink already ran.
+    assert db_rom_handler.get_rom_file_by_id(child.id) is not None
+
+
+def test_hidden_rom_manual_delete_is_404_masked(client, editor_user, rom, monkeypatch):
+    # Without a manual on disk the route 404s before the visibility gate, so
+    # force the existence check to pass.
+    monkeypatch.setattr(fs_resource_handler, "manual_exists", lambda _rom: True)
+    _hide(PermEntity.ROMS, rom.id, editor_user.id)
+
+    resp = client.delete(f"/api/roms/{rom.id}/manuals", headers=_auth(editor_user))
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.parametrize(
+    "path", ["/soundtracks/metadata", "/notes", "/notes/identifiers"]
+)
+def test_hidden_rom_child_read_routes_are_404_masked(client, viewer_user, rom, path):
+    _hide(PermEntity.ROMS, rom.id, viewer_user.id)
+    resp = client.get(f"/api/roms/{rom.id}{path}", headers=_auth(viewer_user))
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_hidden_rom_note_write_routes_are_404_masked(client, viewer_user, rom):
+    # ROMS_USER_WRITE is self-service, so only the entity check can mask these.
+    _hide(PermEntity.ROMS, rom.id, viewer_user.id)
+    headers = _auth(viewer_user)
+
+    create = client.post(
+        f"/api/roms/{rom.id}/notes", headers=headers, json={"title": "x"}
+    )
+    assert create.status_code == status.HTTP_404_NOT_FOUND
+
+    update = client.put(
+        f"/api/roms/{rom.id}/notes/1", headers=headers, json={"title": "x"}
+    )
+    assert update.status_code == status.HTTP_404_NOT_FOUND
+
+    delete = client.delete(f"/api/roms/{rom.id}/notes/1", headers=headers)
+    assert delete.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_visible_rom_child_route_is_not_masked(client, viewer_user, rom):
+    # Control: the same route reaches its handler when the rom isn't hidden.
+    resp = client.get(f"/api/roms/{rom.id}/notes", headers=_auth(viewer_user))
+    assert resp.status_code == status.HTTP_200_OK
 
 
 def test_delete_requires_delete_grant_even_with_write_scope(


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The fine-grained permission layer lets an admin hide specific roms/platforms from a user. Core rom routes enforce that with `assert_rom_visible()` (`endpoints/roms/__init__.py`), and `endpoints/roms/files.py` and `endpoints/roms/patch.py` do the equivalent, but the rom *child* routes were never updated to match: they resolve the rom by path id and then proceed straight to their handler.

This makes the gate consistent across the remaining child routes:

| File | Routes |
| --- | --- |
| `roms/screenshot.py` | upload, delete |
| `roms/soundtrack.py` | metadata, upload, delete |
| `roms/manual.py` | upload, redownload, file upload, file delete, delete-all |
| `roms/notes.py` | list, identifiers, create, update, delete |

Each now calls `assert_rom_visible(request, rom)` immediately after the `get_rom(id)` lookup, so a hidden rom reads as not-found rather than resolving. `update_rom_note` / `delete_rom_note` accepted `{id}` in their path without resolving it at all, so they now load the rom first.

No schema or route-signature changes: every affected route already declared `404` in its `responses`, so no OpenAPI regeneration is needed.

**Testing**

`backend/tests/endpoints/test_permissions_visibility.py` gains 13 cases covering every route above, plus a control asserting a non-hidden rom still reaches its handler. Two of these needed care to be meaningful:

- The delete-by-`file_id` routes 404 on their category check when the child file's category doesn't match the route, which would mask the gate entirely. Each case now creates a `RomFile` of the matching category and asserts the row survives the call.
- `DELETE /manuals` returns early when no manual is on disk, so `manual_exists` is patched to let the request reach the gate.

Verified by stubbing `assert_rom_visible` to a no-op: all 13 new tests fail without the change and pass with it. Full backend suite: 2445 passed, 2 skipped. `trunk fmt && trunk check` clean.

**AI assistance disclosure**

Written with AI assistance (Claude Opus 5 via Claude Code). The AI located the inconsistent routes, wrote the endpoint changes and the tests, and ran the verification described above. Reviewed by me before submitting.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A - backend only.
