### PR TITLE
Always allow changing the virtual collection type in v2 settings

### DIFF
--- a/frontend/src/v2/views/Settings/UserInterface.vue
+++ b/frontend/src/v2/views/Settings/UserInterface.vue
@@ -8,7 +8,7 @@
 //   4. Gallery           (toggle grid + boxart RSelect prefix-label +
 //                         advanced per-page boxart overrides)
 //   5. Gameplay          (launch-confirmation toggle)
-//   6. Virtual collections (single toggle + RSelect prefix-label)
+//   6. Virtual collections (RSelect prefix-label)
 //   7. UI version        (v2-only, beta — kept last)
 //
 // The v1 "Platforms drawer" section was removed (no equivalent in v2).
@@ -448,7 +448,6 @@ function onVirtualCollectionTypeChange(value: unknown) {
         <RSelect
           :model-value="virtualCollectionType"
           :items="virtualCollectionTypeItems"
-          :disabled="!showVirtualCollections"
           prefix-label="stacked"
           hide-details
           @update:model-value="onVirtualCollectionTypeChange"


### PR DESCRIPTION
**Description**

In v2 UI settings, the "Virtual collection type (ROM grouping method)" selector was permanently disabled for most users, with no indication why.

The `RSelect` was bound to `:disabled="!showVirtualCollections"`. That flag is the *Show autogenerated collections* home-page toggle, which defaults to `false` (`useUISettings.ts`) and lives in a different section far above the selector, so out of the box the control was greyed out and the dependency was invisible.

The gate is also incorrect on the merits. The grouping type is not home-only:

- `v2/views/CollectionsIndex.vue` reads `settings.virtualCollectionType` and calls `fetchVirtualCollections(type)` unconditionally.
- `v2/views/Gallery/Collection.vue` does the same when resolving a virtual collection.

So the collections page always rendered autogenerated collections using the stored grouping, while the only control for that grouping stayed locked behind an unrelated toggle.

This removes the `:disabled` binding. The *Show autogenerated collections* toggle keeps its actual job (showing/hiding the home-page section); it no longer blocks configuring how those collections are grouped.

v1's identical gate (`components/Settings/UserInterface/Interface.vue`) is left untouched, since v1 is frozen.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

Verified with `npm run typecheck` and `trunk check` (both clean). No unit test added: the change removes a prop binding in a settings view with no existing test coverage.

---

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The AI diagnosed the disabled selector, traced the `virtualCollectionType` consumers to establish that the gate was incorrect, made the one-line fix, and drafted this description. All of it was reviewed by me before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)