### PR TITLE
Serve each PKG file as its own FPKGi entry

### DIFF
--- a/backend/endpoints/feeds.py
+++ b/backend/endpoints/feeds.py
@@ -1,5 +1,6 @@
 import csv
 import io
+import re
 from collections.abc import Sequence
 from datetime import datetime
 from typing import Annotated
@@ -577,6 +578,10 @@ FPKGI_CATEGORY_LABELS: dict[RomFileCategory, str] = {
 }
 
 
+# PS4/PS5 title ids as they appear in package file names, e.g. CUSA12345
+FPKGI_TITLE_ID_REGEX = re.compile(r"(?:CUSA|PPSA)\d{5}", re.IGNORECASE)
+
+
 def fpkgi_item_name(rom: Rom, file: RomFile, *, is_single_file: bool) -> str:
     """Name shown in FPKGi, disambiguated when a rom holds several packages."""
     rom_name = rom.name or rom.fs_name
@@ -585,6 +590,20 @@ def fpkgi_item_name(rom: Rom, file: RomFile, *, is_single_file: bool) -> str:
 
     label = FPKGI_CATEGORY_LABELS.get(file.category) if file.category else None
     return f"{rom_name} - {label or file.file_name_no_ext}"
+
+
+def fpkgi_title_id(rom: Rom, files: list[RomFile]) -> str:
+    """The game's real title id when a file name carries one, else a RomM one.
+
+    Resolved per rom so a base game and its updates/DLC stay grouped, the way
+    FPKGi searches and sorts content.
+    """
+    for name in (rom.fs_name, *(file.file_name for file in files)):
+        match = FPKGI_TITLE_ID_REGEX.search(name)
+        if match:
+            return match.group(0).upper()
+
+    return f"ROMM{str(rom.id)[-5:].zfill(5)}"
 
 
 @protected_route(
@@ -631,7 +650,12 @@ def fpkgi_feed(
 
     for rom in roms:
         # FPKGi installs one package per entry, so each .pkg is listed on its own
-        pkg_files = [f for f in rom.files if f.file_extension.lower() == "pkg"]
+        pkg_files = [
+            f
+            for f in rom.files
+            if f.file_extension.lower() == "pkg" and not f.missing_from_fs
+        ]
+        title_id = fpkgi_title_id(rom, pkg_files)
         cover_url = (
             str(URLPath(rom.path_cover_large).make_absolute_url(request.base_url))
             if rom.path_cover_large
@@ -648,7 +672,7 @@ def fpkgi_feed(
             response_data[download_url] = FPKGiFeedItemSchema(
                 name=fpkgi_item_name(rom, file, is_single_file=len(pkg_files) == 1),
                 size=file.file_size_bytes,
-                title_id=f"ROMM{str(rom.id)[-5:].zfill(5)}",
+                title_id=title_id,
                 region=rom.regions[0] if rom.regions else None,
                 version=rom.revision or None,
                 release=format_release_date(rom.metadatum.first_release_date),

--- a/backend/endpoints/feeds.py
+++ b/backend/endpoints/feeds.py
@@ -7,7 +7,7 @@ from urllib.parse import quote
 
 from fastapi import HTTPException
 from fastapi import Path as PathVar
-from fastapi import Request
+from fastapi import Query, Request
 from fastapi.responses import JSONResponse, Response
 from starlette.datastructures import URLPath
 
@@ -568,18 +568,47 @@ def format_release_date(timestamp: int | None) -> str | None:
     return datetime.fromtimestamp(timestamp / 1000).strftime("%m-%d-%Y")
 
 
+FPKGI_CATEGORY_LABELS: dict[RomFileCategory, str] = {
+    RomFileCategory.GAME: "Game",
+    RomFileCategory.DLC: "DLC",
+    RomFileCategory.UPDATE: "Update",
+    RomFileCategory.PATCH: "Patch",
+    RomFileCategory.DEMO: "Demo",
+}
+
+
+def fpkgi_item_name(rom: Rom, file: RomFile, *, is_single_file: bool) -> str:
+    """Name shown in FPKGi, disambiguated when a rom holds several packages."""
+    rom_name = rom.name or rom.fs_name
+    if is_single_file:
+        return rom_name
+
+    label = FPKGI_CATEGORY_LABELS.get(file.category) if file.category else None
+    return f"{rom_name} - {label or file.file_name_no_ext}"
+
+
 @protected_route(
     router.get,
     "/fpkgi/{platform_slug}",
     [] if DISABLE_DOWNLOAD_ENDPOINT_AUTH else [Scope.ROMS_READ],
 )
-def fpkgi_feed(request: Request, platform_slug: str) -> Response:
+def fpkgi_feed(
+    request: Request,
+    platform_slug: str,
+    content_type: Annotated[
+        str | None,
+        Query(
+            description="Only list packages of this category (game, dlc, update, patch, demo)"
+        ),
+    ] = None,
+) -> Response:
     """
     https://github.com/ItsJokerZz/FPKGi
 
     Args:
         request (Request): Fastapi Request object
         platform_slug (str): Platform slug (ps4, ps5)
+        content_type (str | None): Optional rom file category filter
 
     Returns:
         Response: JSON file in FPKGi format
@@ -590,23 +619,42 @@ def fpkgi_feed(request: Request, platform_slug: str) -> Response:
             status_code=404, detail=f"Platform {platform_slug} not found"
         )
 
-    roms = _platform_roms(request, platform.id)
+    try:
+        category_filter = RomFileCategory(content_type) if content_type else None
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid content type: {content_type}"
+        ) from e
+
+    roms = _platform_roms(request, platform.id, include_files=True)
     response_data = {}
 
     for rom in roms:
-        download_url = generate_rom_download_url(request, rom)
-        response_data[download_url] = FPKGiFeedItemSchema(
-            name=rom.name or rom.fs_name,
-            size=rom.fs_size_bytes,
-            title_id=f"ROMM{str(rom.id)[-5:].zfill(5)}",
-            region=rom.regions[0] if rom.regions else None,
-            version=rom.revision or None,
-            release=format_release_date(rom.metadatum.first_release_date),
-            min_fw=None,
-            cover_url=str(
-                URLPath(rom.path_cover_large).make_absolute_url(request.base_url)
-            ),
-        ).model_dump()
+        # FPKGi installs one package per entry, so each .pkg is listed on its own
+        pkg_files = [f for f in rom.files if f.file_extension.lower() == "pkg"]
+        cover_url = (
+            str(URLPath(rom.path_cover_large).make_absolute_url(request.base_url))
+            if rom.path_cover_large
+            else None
+        )
+
+        for file in pkg_files:
+            # Files without a category folder are treated as the base game
+            category = file.category or RomFileCategory.GAME
+            if category_filter and category != category_filter:
+                continue
+
+            download_url = generate_romfile_download_url(request, file)
+            response_data[download_url] = FPKGiFeedItemSchema(
+                name=fpkgi_item_name(rom, file, is_single_file=len(pkg_files) == 1),
+                size=file.file_size_bytes,
+                title_id=f"ROMM{str(rom.id)[-5:].zfill(5)}",
+                region=rom.regions[0] if rom.regions else None,
+                version=rom.revision or None,
+                release=format_release_date(rom.metadatum.first_release_date),
+                min_fw=None,
+                cover_url=cover_url,
+            ).model_dump()
 
     return JSONResponse(
         content={"DATA": response_data},

--- a/backend/tests/endpoints/feeds.py
+++ b/backend/tests/endpoints/feeds.py
@@ -230,7 +230,7 @@ def test_fpkgi_feed(
     db_rom_handler.add_rom_file(
         RomFile(
             rom_id=rom.id,
-            file_name="Test PS4.pkg",
+            file_name="Test PS4 [CUSA12345].pkg",
             file_path=rom.fs_path,
             file_size_bytes=456,
             sha1_hash="beadfeed",
@@ -250,6 +250,7 @@ def test_fpkgi_feed(
     entry = next(iter(body["DATA"].values()))
     assert entry["name"] == "Test PS4"
     assert entry["size"] == 456
+    assert entry["title_id"] == "CUSA12345"
 
 
 def test_fpkgi_feed_multi_file_rom(
@@ -272,11 +273,12 @@ def test_fpkgi_feed_multi_file_rom(
             "regions": ["US"],
         },
     )
-    for file_name, category in (
-        ("Test PS4 base.pkg", None),
-        ("Test PS4 update.pkg", RomFileCategory.UPDATE),
-        ("Test PS4 dlc.pkg", RomFileCategory.DLC),
-        ("Test PS4 cover.png", None),
+    for file_name, category, missing_from_fs in (
+        ("Test PS4 base.pkg", None, False),
+        ("Test PS4 update.pkg", RomFileCategory.UPDATE, False),
+        ("Test PS4 dlc.pkg", RomFileCategory.DLC, False),
+        ("Test PS4 cover.png", None, False),
+        ("Test PS4 deleted.pkg", None, True),
     ):
         db_rom_handler.add_rom_file(
             RomFile(
@@ -285,6 +287,7 @@ def test_fpkgi_feed_multi_file_rom(
                 file_path=f"{rom.fs_path}/{rom.fs_name}",
                 file_size_bytes=123,
                 category=category,
+                missing_from_fs=missing_from_fs,
             )
         )
 
@@ -297,12 +300,15 @@ def test_fpkgi_feed_multi_file_rom(
     data = response.json()["DATA"]
     assert len(data) == 3
     assert all(url.endswith(".pkg") for url in data)
+    assert not any("deleted" in url for url in data)
     assert all(entry["size"] == 123 for entry in data.values())
     assert sorted(entry["name"] for entry in data.values()) == [
         "Test PS4 - DLC",
         "Test PS4 - Test PS4 base",
         "Test PS4 - Update",
     ]
+    # Packages of the same game stay grouped under one title id
+    assert len({entry["title_id"] for entry in data.values()}) == 1
 
     response = client.get(
         "/api/feeds/fpkgi/ps4?content_type=update",

--- a/backend/tests/endpoints/feeds.py
+++ b/backend/tests/endpoints/feeds.py
@@ -227,6 +227,15 @@ def test_fpkgi_feed(
             "regions": ["US"],
         },
     )
+    db_rom_handler.add_rom_file(
+        RomFile(
+            rom_id=rom.id,
+            file_name="Test PS4.pkg",
+            file_path=rom.fs_path,
+            file_size_bytes=456,
+            sha1_hash="beadfeed",
+        )
+    )
 
     response = client.get(
         "/api/feeds/fpkgi/ps4",
@@ -237,6 +246,79 @@ def test_fpkgi_feed(
     body = response.json()
     assert "DATA" in body
     assert len(body["DATA"]) == 1
+
+    entry = next(iter(body["DATA"].values()))
+    assert entry["name"] == "Test PS4"
+    assert entry["size"] == 456
+
+
+def test_fpkgi_feed_multi_file_rom(
+    client: TestClient, access_token: str, platform: Platform, rom: Rom
+):
+    platform = db_platform_handler.update_platform(
+        platform.id, {"name": "PlayStation 4", "slug": UPS.PS4, "fs_slug": UPS.PS4}
+    )
+    rom = db_rom_handler.update_rom(
+        rom.id,
+        {
+            "platform_id": platform.id,
+            "name": "Test PS4",
+            "fs_name": "Test PS4",
+            "fs_name_no_tags": "Test PS4",
+            "fs_name_no_ext": "Test PS4",
+            "fs_extension": "",
+            "fs_path": f"{platform.slug}/roms",
+            "fs_size_bytes": 369,
+            "regions": ["US"],
+        },
+    )
+    for file_name, category in (
+        ("Test PS4 base.pkg", None),
+        ("Test PS4 update.pkg", RomFileCategory.UPDATE),
+        ("Test PS4 dlc.pkg", RomFileCategory.DLC),
+        ("Test PS4 cover.png", None),
+    ):
+        db_rom_handler.add_rom_file(
+            RomFile(
+                rom_id=rom.id,
+                file_name=file_name,
+                file_path=f"{rom.fs_path}/{rom.fs_name}",
+                file_size_bytes=123,
+                category=category,
+            )
+        )
+
+    response = client.get(
+        "/api/feeds/fpkgi/ps4",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.json()["DATA"]
+    assert len(data) == 3
+    assert all(url.endswith(".pkg") for url in data)
+    assert all(entry["size"] == 123 for entry in data.values())
+    assert sorted(entry["name"] for entry in data.values()) == [
+        "Test PS4 - DLC",
+        "Test PS4 - Test PS4 base",
+        "Test PS4 - Update",
+    ]
+
+    response = client.get(
+        "/api/feeds/fpkgi/ps4?content_type=update",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.json()["DATA"]
+    assert len(data) == 1
+    assert next(iter(data.values()))["name"] == "Test PS4 - Update"
+
+    response = client.get(
+        "/api/feeds/fpkgi/ps4?content_type=not-a-category",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 def test_kekatsu_feed(

--- a/docs/BACKEND_ARCHITECTURE.md
+++ b/docs/BACKEND_ARCHITECTURE.md
@@ -965,20 +965,20 @@ Facet endpoints (`/artists`, `/albums`, `/genres`, `/years`) return `{value, cou
 
 ### 6.13 Feeds (`/api/feeds`)
 
-| Method | Path                  | Description                                                                         |
-| ------ | --------------------- | ----------------------------------------------------------------------------------- |
-| GET    | `/webrcade`           | WebRcade feed format                                                                |
-| GET    | `/tinfoil`            | Tinfoil custom index (Switch)                                                       |
-| GET    | `/pkgi/ps3/{type}`    | PKGi PS3 database                                                                   |
-| GET    | `/pkgi/psvita/{type}` | PKGi PS Vita database                                                               |
-| GET    | `/pkgi/psp/{type}`    | PKGi PSP database                                                                   |
-| GET    | `/fpkgi/{platform}`   | FPKGi (PS4/PS5) format, one entry per `.pkg` file; optional `?content_type=` filter |
-| GET    | `/kekatsu/{platform}` | Kekatsu DS format                                                                   |
-| GET    | `/pkgj/psp/games`     | PKGj PSP games                                                                      |
-| GET    | `/pkgj/psp/dlc`       | PKGj PSP DLC                                                                        |
-| GET    | `/pkgj/psvita/games`  | PKGj PS Vita games                                                                  |
-| GET    | `/pkgj/psvita/dlc`    | PKGj PS Vita DLC                                                                    |
-| GET    | `/pkgj/psx/games`     | PKGj PSX games                                                                      |
+| Method | Path                  | Description                   |
+| ------ | --------------------- | ----------------------------- |
+| GET    | `/webrcade`           | WebRcade feed format          |
+| GET    | `/tinfoil`            | Tinfoil custom index (Switch) |
+| GET    | `/pkgi/ps3/{type}`    | PKGi PS3 database             |
+| GET    | `/pkgi/psvita/{type}` | PKGi PS Vita database         |
+| GET    | `/pkgi/psp/{type}`    | PKGi PSP database             |
+| GET    | `/fpkgi/{platform}`   | FPKGi (PS4/PS5) format        |
+| GET    | `/kekatsu/{platform}` | Kekatsu DS format             |
+| GET    | `/pkgj/psp/games`     | PKGj PSP games                |
+| GET    | `/pkgj/psp/dlc`       | PKGj PSP DLC                  |
+| GET    | `/pkgj/psvita/games`  | PKGj PS Vita games            |
+| GET    | `/pkgj/psvita/dlc`    | PKGj PS Vita DLC              |
+| GET    | `/pkgj/psx/games`     | PKGj PSX games                |
 
 ### 6.14 Configuration (`/api/config`)
 
@@ -1541,17 +1541,17 @@ Falls back to `FakeRedis` in test mode.
 
 #### Authentication
 
-| Variable                             | Default   | Description                           |
-| ------------------------------------ | --------- | ------------------------------------- |
-| `ROMM_AUTH_SECRET_KEY`               |           | **Required.** JWT/session signing key |
-| `OAUTH_ACCESS_TOKEN_EXPIRE_SECONDS`  | `1800`    | 30 minutes                            |
-| `OAUTH_REFRESH_TOKEN_EXPIRE_SECONDS` | `604800`  | 7 days                                |
-| `SESSION_MAX_AGE_SECONDS`            | `1209600` | 14 days                               |
-| `DISABLE_CSRF_PROTECTION`            | `false`   | Disable CSRF                          |
-| `DISABLE_DOWNLOAD_ENDPOINT_AUTH`     | `false`   | Allow unauthenticated downloads       |
-| `DISABLE_USERPASS_LOGIN`             | `false`   | Disable password login                |
-| `DISABLE_LOGS_VIEWER`                | `false`   | Disable backend log viewer + endpoint |
-| `KIOSK_MODE`                         | `false`   | Read-only anonymous access            |
+| Variable                             | Default   | Description                               |
+| ------------------------------------ | --------- | ----------------------------------------- |
+| `ROMM_AUTH_SECRET_KEY`               |           | JWT/session signing key (random if unset) |
+| `OAUTH_ACCESS_TOKEN_EXPIRE_SECONDS`  | `1800`    | 30 minutes                                |
+| `OAUTH_REFRESH_TOKEN_EXPIRE_SECONDS` | `604800`  | 7 days                                    |
+| `SESSION_MAX_AGE_SECONDS`            | `1209600` | 14 days                                   |
+| `DISABLE_CSRF_PROTECTION`            | `false`   | Disable CSRF                              |
+| `DISABLE_DOWNLOAD_ENDPOINT_AUTH`     | `false`   | Allow unauthenticated downloads           |
+| `DISABLE_USERPASS_LOGIN`             | `false`   | Disable password login                    |
+| `DISABLE_LOGS_VIEWER`                | `false`   | Disable backend log viewer + endpoint     |
+| `KIOSK_MODE`                         | `false`   | Read-only anonymous access                |
 
 #### OIDC
 

--- a/docs/BACKEND_ARCHITECTURE.md
+++ b/docs/BACKEND_ARCHITECTURE.md
@@ -965,20 +965,20 @@ Facet endpoints (`/artists`, `/albums`, `/genres`, `/years`) return `{value, cou
 
 ### 6.13 Feeds (`/api/feeds`)
 
-| Method | Path                  | Description                   |
-| ------ | --------------------- | ----------------------------- |
-| GET    | `/webrcade`           | WebRcade feed format          |
-| GET    | `/tinfoil`            | Tinfoil custom index (Switch) |
-| GET    | `/pkgi/ps3/{type}`    | PKGi PS3 database             |
-| GET    | `/pkgi/psvita/{type}` | PKGi PS Vita database         |
-| GET    | `/pkgi/psp/{type}`    | PKGi PSP database             |
-| GET    | `/fpkgi/{platform}`   | FPKGi (PS4/PS5) format        |
-| GET    | `/kekatsu/{platform}` | Kekatsu DS format             |
-| GET    | `/pkgj/psp/games`     | PKGj PSP games                |
-| GET    | `/pkgj/psp/dlc`       | PKGj PSP DLC                  |
-| GET    | `/pkgj/psvita/games`  | PKGj PS Vita games            |
-| GET    | `/pkgj/psvita/dlc`    | PKGj PS Vita DLC              |
-| GET    | `/pkgj/psx/games`     | PKGj PSX games                |
+| Method | Path                  | Description                                                                         |
+| ------ | --------------------- | ----------------------------------------------------------------------------------- |
+| GET    | `/webrcade`           | WebRcade feed format                                                                |
+| GET    | `/tinfoil`            | Tinfoil custom index (Switch)                                                       |
+| GET    | `/pkgi/ps3/{type}`    | PKGi PS3 database                                                                   |
+| GET    | `/pkgi/psvita/{type}` | PKGi PS Vita database                                                               |
+| GET    | `/pkgi/psp/{type}`    | PKGi PSP database                                                                   |
+| GET    | `/fpkgi/{platform}`   | FPKGi (PS4/PS5) format, one entry per `.pkg` file; optional `?content_type=` filter |
+| GET    | `/kekatsu/{platform}` | Kekatsu DS format                                                                   |
+| GET    | `/pkgj/psp/games`     | PKGj PSP games                                                                      |
+| GET    | `/pkgj/psp/dlc`       | PKGj PSP DLC                                                                        |
+| GET    | `/pkgj/psvita/games`  | PKGj PS Vita games                                                                  |
+| GET    | `/pkgj/psvita/dlc`    | PKGj PS Vita DLC                                                                    |
+| GET    | `/pkgj/psx/games`     | PKGj PSX games                                                                      |
 
 ### 6.14 Configuration (`/api/config`)
 


### PR DESCRIPTION
**Description**

The FPKGi feed emitted one entry per rom, keyed by the rom download URL (`/roms/{id}/content/...`). That endpoint zips multi-file roms, so a PS4 game stored as a folder (base + update + DLC) was served to FPKGi as a single zip and installation failed on the console. Single-`.pkg` games worked because the same endpoint serves those directly.

The feed now walks each rom's `.pkg` files and emits one entry per file, keyed by the per-file download URL (`/roms/{id}/files/content/...`), with that file's own `size` (FPKGi warns that an inaccurate size breaks downloads).

- Entry names are disambiguated only when a rom holds several packages: `"<Game> - Update"` / `"- DLC"` when the file has a scanned category (from a `dlc`/`update`/… subfolder), otherwise `"<Game> - <file name>"`. Single-package roms keep their plain name, so existing libraries look unchanged.
- New optional `?content_type=` query param (`game`, `dlc`, `update`, `patch`, `demo`), so each of FPKGi's `CONTENT_URLS` slots (`games`, `updates`, `DLC`, …) can point at its own RomM URL. Files without a category folder count as `game`. Invalid values return 400, matching the existing pkgi endpoints.
- Packages marked `missing_from_fs` are skipped, so the feed no longer advertises a download that can't resolve.
- `title_id` is taken from a `CUSA`/`PPSA` id in the rom or package file names when present, falling back to the generated `ROMM#####` id. It is resolved once per rom, so a base game and its updates/DLC stay grouped the way FPKGi searches and sorts content (and the way real PS4 dumps are numbered).
- Drive-by: `cover_url` is now `null` when a rom has no cover, instead of a URL pointing at the site root.

Behavior note: a rom with no `.pkg` files (e.g. a zipped package) is no longer listed. It was listed before, but FPKGi cannot install it.

No frontend regeneration needed: the feed endpoints return a raw `Response`, so nothing FPKGi-related exists in `frontend/src/__generated__/`.

Fixes #3962

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

`uv run pytest tests/endpoints/feeds.py` → 13 passed. Added `test_fpkgi_feed_multi_file_rom` (base + update + DLC, a non-pkg file, a `missing_from_fs` package, shared title id, the `content_type` filter, and the 400 case) and extended `test_fpkgi_feed` to assert the per-file name, size and extracted title id.

**AI assistance**

This PR was written primarily by Claude Code (code, tests and description), reviewed by me before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
