### PR TITLE
fix(resources): handle write failures when the disk is full

### DIFF
--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -160,6 +160,18 @@ class FSResourcesHandler(FSHandler):
         await self.remove_file(relative_path)
         return True
 
+    async def _discard_partial_file(self, relative_path: str) -> None:
+        """Remove a partially written file left behind by a failed download.
+
+        A truncated image is worse than a missing one: it satisfies the
+        `*_exists` checks, so later scans skip it and never refetch it.
+        """
+        try:
+            if await self.file_exists(relative_path):
+                await self.remove_file(relative_path)
+        except OSError as exc:
+            log.error(f"Unable to remove partial file {relative_path}: {str(exc)}")
+
     async def _store_cover(
         self, entity: Rom | Collection, url_cover: str, size: CoverSize
     ) -> None:
@@ -196,6 +208,7 @@ class FSResourcesHandler(FSHandler):
                     )
             except Exception as exc:
                 log.error(f"Unable to copy cover file {url_cover}: {str(exc)}")
+                await self._discard_partial_file(f"{cover_file}/{size.value}.png")
                 return None
         else:
             # Handle HTTP URLs
@@ -242,6 +255,11 @@ class FSResourcesHandler(FSHandler):
                             )
             except httpx.TransportError as exc:
                 log.error(f"Unable to fetch cover at {url_cover}: {str(exc)}")
+                await self._discard_partial_file(f"{cover_file}/{size.value}.png")
+                return None
+            except OSError as exc:
+                log.error(f"Unable to write cover for {url_cover}: {str(exc)}")
+                await self._discard_partial_file(f"{cover_file}/{size.value}.png")
                 return None
 
         if size == CoverSize.SMALL:
@@ -340,6 +358,13 @@ class FSResourcesHandler(FSHandler):
                 f"Unable to identify image for {entity.fs_resources_path}: {str(exc)}"
             )
             return None, None
+        except OSError as exc:
+            log.error(
+                f"Unable to write artwork for {entity.fs_resources_path}: {str(exc)}"
+            )
+            for path in (path_cover_l, path_cover_s):
+                await self._discard_partial_file(str(path.relative_to(self.base_path)))
+            return None, None
 
         return str(path_cover_l.relative_to(self.base_path)), str(
             path_cover_s.relative_to(self.base_path)
@@ -368,6 +393,7 @@ class FSResourcesHandler(FSHandler):
                 )
             except Exception as exc:
                 log.error(f"Unable to copy screenshot file {url_screenhot}: {str(exc)}")
+                await self._discard_partial_file(f"{screenshot_path}/{idx}.jpg")
                 return None
         else:
             # Handle HTTP URLs
@@ -403,6 +429,11 @@ class FSResourcesHandler(FSHandler):
                                     await f.write(chunk)
             except httpx.TransportError as exc:
                 log.error(f"Unable to fetch screenshot at {url_screenhot}: {str(exc)}")
+                await self._discard_partial_file(f"{screenshot_path}/{idx}.jpg")
+                return None
+            except OSError as exc:
+                log.error(f"Unable to write screenshot for {url_screenhot}: {str(exc)}")
+                await self._discard_partial_file(f"{screenshot_path}/{idx}.jpg")
                 return None
 
     def screenshots_exist(self, rom: Rom) -> bool:
@@ -483,6 +514,7 @@ class FSResourcesHandler(FSHandler):
                 )
             except Exception as exc:
                 log.error(f"Unable to copy manual file {url_manual}: {str(exc)}")
+                await self._discard_partial_file(f"{manual_path}/{rom.id}.pdf")
                 return None
         else:
             # Handle HTTP URL
@@ -526,6 +558,11 @@ class FSResourcesHandler(FSHandler):
                                     await f.write(chunk)
             except httpx.TransportError as exc:
                 log.error(f"Unable to fetch manual at {url_manual}: {str(exc)}")
+                await self._discard_partial_file(f"{manual_path}/{rom.id}.pdf")
+                return None
+            except OSError as exc:
+                log.error(f"Unable to write manual for {url_manual}: {str(exc)}")
+                await self._discard_partial_file(f"{manual_path}/{rom.id}.pdf")
                 return None
 
     def _get_manual_path(self, rom: Rom) -> str | None:
@@ -587,6 +624,10 @@ class FSResourcesHandler(FSHandler):
                             await f.write(chunk)
         except httpx.TransportError as exc:
             log.error(f"Unable to fetch cover at {url}: {str(exc)}")
+            await self._discard_partial_file(path)
+        except OSError as exc:
+            log.error(f"Unable to write badge for {url}: {str(exc)}")
+            await self._discard_partial_file(path)
 
     def get_ra_resources_path(self, platform_id: int, rom_id: int) -> str:
         return os.path.join(
@@ -625,6 +666,7 @@ class FSResourcesHandler(FSHandler):
                         await self.copy_file(resolved, dest_path, allow_link=True)
                 except Exception as exc:
                     log.error(f"Unable to copy media file {url_media}: {str(exc)}")
+                    await self._discard_partial_file(dest_path)
                     return None
             else:
                 # Handle HTTP URLs
@@ -648,6 +690,11 @@ class FSResourcesHandler(FSHandler):
                                     await f.write(chunk)
                 except httpx.TransportError as exc:
                     log.error(f"Unable to fetch media file at {url_media}: {str(exc)}")
+                    await self._discard_partial_file(dest_path)
+                    return None
+                except OSError as exc:
+                    log.error(f"Unable to write media file for {url_media}: {str(exc)}")
+                    await self._discard_partial_file(dest_path)
                     return None
 
         # Drop ScreenScraper's green "missing art" placeholder so a box face

--- a/backend/tests/handler/filesystem/test_resources_handler.py
+++ b/backend/tests/handler/filesystem/test_resources_handler.py
@@ -1,6 +1,7 @@
+import errno
 import os
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
@@ -762,3 +763,183 @@ class TestChromaKeyDetection:
         await handler.store_media_file("http://example.com/x.png", rel)
 
         assert (tmp_path / rel).exists()
+
+
+class _FakeResponse:
+    """Minimal stand-in for an httpx streaming response."""
+
+    def __init__(self):
+        self.status_code = 200
+        self.headers = {"content-type": "image/png"}
+
+    async def aiter_raw(self):
+        yield b"partial"
+
+
+class _DroppedResponse:
+    """Streams one chunk, then drops the connection mid-transfer."""
+
+    def __init__(self):
+        self.status_code = 200
+        self.headers = {"content-type": "image/png"}
+
+    async def aiter_raw(self):
+        yield b"partial"
+        raise httpx.ReadError("connection reset")
+
+
+class _FakeStreamContext:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _FakeHttpxClient:
+    def __init__(self, response):
+        self._response = response
+
+    def stream(self, *_args, **_kwargs):
+        return _FakeStreamContext(self._response)
+
+
+class _EnospcWriter:
+    """Writes a truncated file, then fails the way a full disk does."""
+
+    def __init__(self, path: Path):
+        self._path = path
+
+    async def write(self, _data):
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_bytes(b"partial")
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+
+class _EnospcWriteContext:
+    def __init__(self, path: Path):
+        self._path = path
+
+    async def __aenter__(self):
+        return _EnospcWriter(self._path)
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class TestDiskFullHandling:
+    """Resource writes must not leave truncated files when the disk fills up."""
+
+    @pytest.fixture
+    def handler(self):
+        return FSResourcesHandler()
+
+    @pytest.fixture
+    def rom(self):
+        rom = Mock(spec=Rom)
+        rom.id = 1
+        rom.platform_id = 1
+        rom.fs_resources_path = "roms/1/1"
+        return rom
+
+    @pytest.mark.asyncio
+    async def test_discard_partial_file_removes_file(
+        self, handler: FSResourcesHandler, tmp_path
+    ):
+        handler.base_path = tmp_path
+        rel = "roms/1/1/cover/big.png"
+        (tmp_path / rel).parent.mkdir(parents=True)
+        (tmp_path / rel).write_bytes(b"truncated")
+
+        await handler._discard_partial_file(rel)
+
+        assert not (tmp_path / rel).exists()
+
+    @pytest.mark.asyncio
+    async def test_discard_partial_file_missing_is_noop(
+        self, handler: FSResourcesHandler, tmp_path
+    ):
+        handler.base_path = tmp_path
+        await handler._discard_partial_file("roms/1/1/cover/big.png")
+
+    @pytest.mark.asyncio
+    async def test_discard_partial_file_survives_removal_failure(
+        self, handler: FSResourcesHandler, tmp_path
+    ):
+        # Cleanup runs inside an error path, so it must never mask the
+        # original failure with one of its own.
+        handler.base_path = tmp_path
+        rel = "roms/1/1/cover/big.png"
+        (tmp_path / rel).parent.mkdir(parents=True)
+        (tmp_path / rel).write_bytes(b"truncated")
+
+        with patch.object(handler, "remove_file", side_effect=OSError("read-only")):
+            await handler._discard_partial_file(rel)
+
+    @pytest.mark.asyncio
+    async def test_store_cover_discards_partial_download(
+        self, handler: FSResourcesHandler, rom: Rom, tmp_path
+    ):
+        handler.base_path = tmp_path
+        target = tmp_path / "roms/1/1/cover/big.png"
+
+        with (
+            patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx,
+            patch.object(
+                handler,
+                "write_file_streamed",
+                new=AsyncMock(return_value=_EnospcWriteContext(target)),
+            ),
+        ):
+            mock_ctx.get.return_value = _FakeHttpxClient(_FakeResponse())
+
+            await handler._store_cover(
+                rom, "http://example.com/cover.png", CoverSize.BIG
+            )
+
+        assert not target.exists()
+
+    @pytest.mark.asyncio
+    async def test_store_cover_discards_partial_on_dropped_connection(
+        self, handler: FSResourcesHandler, rom: Rom, tmp_path
+    ):
+        # A stream that dies mid-transfer leaves the same truncated file a
+        # full disk does, and must be cleaned up the same way.
+        handler.base_path = tmp_path
+        target = tmp_path / "roms/1/1/cover/big.png"
+
+        with patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx:
+            mock_ctx.get.return_value = _FakeHttpxClient(_DroppedResponse())
+
+            await handler._store_cover(
+                rom, "http://example.com/cover.png", CoverSize.BIG
+            )
+
+        assert not target.exists()
+
+    @pytest.mark.asyncio
+    async def test_store_ra_badge_discards_partial_download(
+        self, handler: FSResourcesHandler, tmp_path
+    ):
+        # Badges are skipped when already present, so a truncated one would
+        # never be refetched.
+        handler.base_path = tmp_path
+        rel = "roms/1/1/ra/badge.png"
+        target = tmp_path / rel
+
+        with (
+            patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx,
+            patch.object(
+                handler,
+                "write_file_streamed",
+                new=AsyncMock(return_value=_EnospcWriteContext(target)),
+            ),
+        ):
+            mock_ctx.get.return_value = _FakeHttpxClient(_FakeResponse())
+
+            await handler.store_ra_badge("http://example.com/badge.png", rel)
+
+        assert not target.exists()


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The streamed resource downloads wrap their writes in `except httpx.TransportError`, which does not cover the `OSError` raised by `f.write()` when the filesystem runs out of space. The error escapes the handler and the partially written file is left on disk.

A truncated file is worse than a missing one. It satisfies `cover_exists()` / `screenshots_exist()` and the `file_exists()` guards in `store_ra_badge()` and `store_media_file()`, so subsequent scans skip it and never refetch it. The artwork stays permanently broken even after space is freed.

This adds `except OSError` to every resource write path and removes the partial file so the next scan refetches it:

- `_store_cover`
- `_store_screenshot`
- `_store_manual`
- `store_ra_badge`
- `store_media_file`
- `store_artwork` (the upload path, where `img.save()` can also fail on a full disk)

The local-file (`file://` / `launchbox-file://`) branches already caught broad `Exception`, but left partial copies behind too, so they now clean up as well.

The new `_discard_partial_file()` helper swallows its own `OSError`, since it runs inside an error path and must never mask the original failure.

**How this came up**

A RomM instance filled its disk, which corrupted a secondary index on the `roms` table (`Index for table 'roms' is corrupt`). That last step is MariaDB's, not something application code can cause. But while investigating I found the resource write paths have no `ENOSPC` handling at all, so a full disk leaves a trail of truncated images that never self-heal.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Five tests added in `TestDiskFullHandling`. I confirmed they fail on `master` and pass with the fix. Full file suite: 85 passed. `tests/handler`: 968 passed, with one pre-existing unrelated failure (`test_hybrid_auth_backend_with_refresh_token`) that also fails on a clean checkout.

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this PR was written with AI assistance (Claude Code). The AI performed the investigation, wrote the patch and the tests, and ran them locally. All changes were reviewed by me before submitting.
