### PR TITLE
fix(tasks): skip orphaned resource cleanup when the database looks empty

### DIFF
--- a/backend/tasks/scheduled/cleanup_orphaned_resources.py
+++ b/backend/tasks/scheduled/cleanup_orphaned_resources.py
@@ -71,8 +71,12 @@ class CleanupOrphanedResourcesTask(PeriodicTask):
         return super().init()
 
     @initialize_context()
-    async def run(self) -> dict[str, int]:
-        """Clean up orphaned resources."""
+    async def run(self, force: bool = False) -> dict[str, int]:
+        """Clean up orphaned resources.
+
+        Args:
+            force: Clean up even when the database reports an empty library.
+        """
         log.info(f"Starting {self.title} task...")
 
         cleanup_stats = CleanupStats()
@@ -108,6 +112,18 @@ class CleanupOrphanedResourcesTask(PeriodicTask):
             async for entry in roms_resources_dir.iterdir()
             if entry.name.isdigit() and await entry.is_dir()
         }
+
+        # An empty library alongside artwork on disk is far more likely to be a
+        # database that is unavailable or mid-migration than one that was really
+        # emptied, and every platform directory would be removed in one pass.
+        if platform_dirs and not existing_platforms and not force:
+            cleanup_stats.update(platforms_in_fs=len(platform_dirs))
+            log.warning(
+                f"Database reports no platforms while {len(platform_dirs)} platform "
+                "resource directories exist on disk, skipping cleanup. Run the task "
+                "manually with `force` to clean them up anyway."
+            )
+            return cleanup_stats.to_dict()
 
         rom_dirs_by_platform: dict[int, set[int]] = {}
         for platform_dir in platform_dirs:

--- a/backend/tests/tasks/test_cleanup_orphaned_resources.py
+++ b/backend/tests/tasks/test_cleanup_orphaned_resources.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -45,3 +46,83 @@ class TestCleanupOrphanedResourcesTask:
             with patch.object(task, "schedule") as mock_schedule:
                 task.init()
                 mock_schedule.assert_called_once()
+
+
+class TestCleanupOrphanedResourcesRun:
+    @pytest.fixture
+    def resources_path(self, tmp_path, mocker):
+        mocker.patch.object(mod, "RESOURCES_BASE_PATH", str(tmp_path))
+        (tmp_path / "roms").mkdir()
+        return tmp_path
+
+    @staticmethod
+    def _make_dirs(resources_path, platform_id: int, rom_ids: list[int]) -> None:
+        for rom_id in rom_ids:
+            (resources_path / "roms" / str(platform_id) / str(rom_id)).mkdir(
+                parents=True
+            )
+
+    @staticmethod
+    def _mock_db(mocker, library: dict[int, list[int]]) -> None:
+        """Make the database report `library`, a mapping of platform id to ROM ids."""
+        mocker.patch.object(
+            mod.db_platform_handler,
+            "get_platforms",
+            return_value=[SimpleNamespace(id=pid) for pid in library],
+        )
+        mocker.patch.object(
+            mod.db_rom_handler,
+            "get_roms_scalar",
+            side_effect=lambda platform_ids: [
+                SimpleNamespace(id=rom_id) for rom_id in library[platform_ids[0]]
+            ],
+        )
+
+    async def test_skips_when_db_empty_and_filesystem_populated(
+        self, resources_path, mocker
+    ):
+        self._make_dirs(resources_path, 1, [10])
+        self._make_dirs(resources_path, 2, [20])
+        self._mock_db(mocker, {})
+
+        stats = await CleanupOrphanedResourcesTask().run()
+
+        assert stats["platforms_in_fs"] == 2
+        assert stats["removed_fs_platforms"] == 0
+        assert stats["removed_fs_roms"] == 0
+        assert (resources_path / "roms" / "1" / "10").exists()
+        assert (resources_path / "roms" / "2" / "20").exists()
+
+    async def test_force_cleans_up_when_db_empty(self, resources_path, mocker):
+        self._make_dirs(resources_path, 1, [10])
+        self._mock_db(mocker, {})
+
+        stats = await CleanupOrphanedResourcesTask().run(force=True)
+
+        assert stats["removed_fs_platforms"] == 1
+        assert not (resources_path / "roms" / "1").exists()
+
+    async def test_removes_orphans_when_db_reports_platforms(
+        self, resources_path, mocker
+    ):
+        self._make_dirs(resources_path, 1, [10, 11])
+        self._make_dirs(resources_path, 2, [20])
+        self._mock_db(mocker, {1: [10]})
+
+        stats = await CleanupOrphanedResourcesTask().run()
+
+        assert stats["removed_fs_platforms"] == 1
+        assert stats["removed_fs_roms"] == 2
+        assert (resources_path / "roms" / "1" / "10").exists()
+        assert not (resources_path / "roms" / "1" / "11").exists()
+        assert not (resources_path / "roms" / "2").exists()
+
+    async def test_empty_db_and_empty_filesystem_is_not_skipped(
+        self, resources_path, mocker
+    ):
+        self._mock_db(mocker, {})
+
+        stats = await CleanupOrphanedResourcesTask().run()
+
+        assert stats["platforms_in_fs"] == 0
+        assert stats["removed_fs_platforms"] == 0

--- a/docs/BACKEND_ARCHITECTURE.md
+++ b/docs/BACKEND_ARCHITECTURE.md
@@ -1403,7 +1403,11 @@ Triggered via `POST /api/tasks/run/{task_name}`:
 | `sync_folder_scan`     | Scan sync folder for new device saves         |
 
 `cleanup_orphaned_resources` is also runnable this way; it is listed under
-Scheduled Tasks because it additionally supports an opt-in cron schedule.
+Scheduled Tasks because it additionally supports an opt-in cron schedule. It
+skips the cleanup when the database reports no platforms at all while artwork
+is still on disk, since that usually means the database is unavailable rather
+than the library being empty. Pass `{"force": true}` as the request body to
+clean up a genuinely emptied library.
 
 ### Filesystem Watcher
 


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Follow-up to #3970, which made `cleanup_orphaned_resources` runnable on a cron schedule.

The task decides what to delete purely by asking whether a resource directory's id is absent from the database, with no sanity floor. If `db_platform_handler.get_platforms()` ever comes back empty while artwork is still on disk (database unavailable, mid-migration, half-restored backup), every platform directory under `resources/roms/` is treated as orphaned and `shutil.rmtree`'d in a single pass. The per-directory `except` only logs, so the loop keeps going.

That was tolerable when the only trigger was an admin clicking the button. Now that the task can run unattended at 5 AM via `ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES`, nobody is watching when it happens, and the artwork is gone before anyone notices the database was down.

This adds one guard: if the database reports zero platforms *and* platform directories exist on disk, log a warning and return without deleting anything. The stats still report `platforms_in_fs` so the skip is visible in the task result.

**Escape hatch**

A library that was genuinely emptied should still be cleanable. `run()` gains `force: bool = False`, matching the existing convention in `update_launchbox_metadata` and `update_switch_titledb`. `POST /api/tasks/run/cleanup_orphaned_resources` with a body of `{"force": true}` bypasses the guard, using the `task_kwargs` forwarding the endpoint already supports, so no endpoint change is needed.

The guard is deliberately narrow: it only trips on *zero* platforms in the database. A library that still reports a single platform cleans up normally, including orphans of every other platform.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Four new tests in `TestCleanupOrphanedResourcesRun` cover the skip, the `force` bypass, that normal orphan removal is unaffected when the database does report platforms, and that an empty database plus an empty filesystem is not treated as a skip. `tests/tasks/` + `tests/endpoints/test_tasks.py`: 118 passed. `trunk fmt && trunk check` clean.

`docs/BACKEND_ARCHITECTURE.md` updated with the guard and the `force` body.

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this PR was written with AI assistance (Claude Code). The issue was found while security-auditing #3970; the AI wrote the patch, the tests, and the docs update, and ran them locally. Reviewed by me before submitting.