### PR TITLE
perf(tasks): walk resource directories with os.scandir

### DIFF
--- a/backend/tasks/scheduled/cleanup_orphaned_resources.py
+++ b/backend/tasks/scheduled/cleanup_orphaned_resources.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import shutil
 from dataclasses import dataclass
@@ -14,6 +15,34 @@ from handler.database import db_platform_handler, db_rom_handler
 from logger.logger import log
 from tasks.tasks import PeriodicTask, TaskType, update_job_meta
 from utils.context import initialize_context
+
+
+def _numeric_subdirs(path: str) -> set[int]:
+    """Numeric-named subdirectories of `path`, as ints."""
+    try:
+        with os.scandir(path) as entries:
+            return {
+                int(entry.name)
+                for entry in entries
+                if entry.name.isdigit() and entry.is_dir()
+            }
+    except OSError as exc:
+        log.error(f"Unable to list resource directory {path}: {str(exc)}")
+        return set()
+
+
+def _scan_resource_dirs(roms_resources_path: str) -> dict[int, set[int]]:
+    """Map each platform id on disk to the ROM ids that have a resource directory.
+
+    `os.scandir` reports the entry type from the directory read itself, so this
+    walks tens of thousands of entries without a stat call per entry.
+    """
+    return {
+        platform_id: _numeric_subdirs(
+            os.path.join(roms_resources_path, str(platform_id))
+        )
+        for platform_id in _numeric_subdirs(roms_resources_path)
+    }
 
 
 @dataclass
@@ -107,11 +136,10 @@ class CleanupOrphanedResourcesTask(PeriodicTask):
         )
 
         # Count total platforms and ROMs for progress tracking
-        platform_dirs: set[int] = {
-            int(entry.name)
-            async for entry in roms_resources_dir.iterdir()
-            if entry.name.isdigit() and await entry.is_dir()
-        }
+        rom_dirs_by_platform: dict[int, set[int]] = await asyncio.to_thread(
+            _scan_resource_dirs, roms_resources_path
+        )
+        platform_dirs = set(rom_dirs_by_platform)
 
         # An empty library alongside artwork on disk is far more likely to be a
         # database that is unavailable or mid-migration than one that was really
@@ -124,16 +152,6 @@ class CleanupOrphanedResourcesTask(PeriodicTask):
                 "manually with `force` to clean them up anyway."
             )
             return cleanup_stats.to_dict()
-
-        rom_dirs_by_platform: dict[int, set[int]] = {}
-        for platform_dir in platform_dirs:
-            platform_path = os.path.join(roms_resources_path, str(platform_dir))
-            platform_dir_path = AnyioPath(platform_path)
-            rom_dirs_by_platform[platform_dir] = {
-                int(entry.name)
-                async for entry in platform_dir_path.iterdir()
-                if entry.name.isdigit() and await entry.is_dir()
-            }
 
         cleanup_stats.update(
             platforms_in_fs=len(platform_dirs),

--- a/backend/tests/tasks/test_cleanup_orphaned_resources.py
+++ b/backend/tests/tasks/test_cleanup_orphaned_resources.py
@@ -1,3 +1,4 @@
+import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -126,3 +127,55 @@ class TestCleanupOrphanedResourcesRun:
 
         assert stats["platforms_in_fs"] == 0
         assert stats["removed_fs_platforms"] == 0
+
+
+class TestScanResourceDirs:
+    """The resource tree walk backing the cleanup task."""
+
+    @staticmethod
+    def _make_tree(root, layout: dict[int, list[int]]) -> None:
+        for platform_id, rom_ids in layout.items():
+            for rom_id in rom_ids:
+                (root / str(platform_id) / str(rom_id)).mkdir(parents=True)
+
+    def test_maps_platforms_to_rom_dirs(self, tmp_path):
+        self._make_tree(tmp_path, {1: [10, 11], 2: [20]})
+
+        assert mod._scan_resource_dirs(str(tmp_path)) == {1: {10, 11}, 2: {20}}
+
+    def test_ignores_non_numeric_names(self, tmp_path):
+        self._make_tree(tmp_path, {1: [10]})
+        (tmp_path / "not-a-platform").mkdir()
+        (tmp_path / "1" / "not-a-rom").mkdir()
+
+        assert mod._scan_resource_dirs(str(tmp_path)) == {1: {10}}
+
+    def test_ignores_files(self, tmp_path):
+        self._make_tree(tmp_path, {1: [10]})
+        (tmp_path / "2").write_text("stray file named like a platform")
+        (tmp_path / "1" / "20").write_text("stray file named like a rom")
+
+        assert mod._scan_resource_dirs(str(tmp_path)) == {1: {10}}
+
+    def test_empty_tree(self, tmp_path):
+        assert mod._scan_resource_dirs(str(tmp_path)) == {}
+
+    def test_platform_with_no_rom_dirs(self, tmp_path):
+        (tmp_path / "1").mkdir()
+
+        assert mod._scan_resource_dirs(str(tmp_path)) == {1: set()}
+
+    def test_unreadable_directory_yields_empty_set(self, tmp_path):
+        # A directory that disappears or denies access must not abort the walk,
+        # otherwise one bad platform would strand every other platform's orphans.
+        self._make_tree(tmp_path, {1: [10]})
+
+        real_scandir = os.scandir
+
+        def flaky_scandir(path):
+            if path.endswith(os.sep + "1"):
+                raise PermissionError(13, "Permission denied")
+            return real_scandir(path)
+
+        with patch.object(mod.os, "scandir", side_effect=flaky_scandir):
+            assert mod._scan_resource_dirs(str(tmp_path)) == {1: set()}


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Follow-up to #3970 and #3971. Now that `cleanup_orphaned_resources` runs on a schedule, its cost is worth looking at.

The task walks the resource tree through `anyio.Path`, which dispatches to a worker thread for every entry `iterdir()` yields and again for every `await entry.is_dir()`. On a library with ~30k ROM resource directories that is roughly 60k thread round trips, all to read information the directory listing already contains.

`os.scandir` returns `DirEntry` objects that carry the entry type from the directory read itself, so `is_dir()` needs no extra syscall. The walk moves into `_scan_resource_dirs()` and runs once via `asyncio.to_thread`, so the event loop stays free while the whole traversal happens in a single thread hop instead of tens of thousands.

**Measurements**

Real library, 28 platform directories / 30,262 ROM resource directories, Raspberry Pi 4, ext4 on a spinning disk:

| Implementation | Time |
| --- | --- |
| `anyio` `iterdir()` + `is_dir()` (current) | **50.3s** |
| `anyio` `iterdir()` alone, no `is_dir()` | 25.6s |
| `os.scandir` (this PR) | **0.15s** |

Cold and warm runs of the current code came out within 1% of each other (49.9s vs 50.3s), which is what identified this as thread-dispatch overhead rather than disk I/O. For reference the database half of the task, all 94 per-platform ROM queries, takes 0.83s, so the directory walk was ~98% of the runtime.

**Behavior notes**

- The ROM directories are now scanned before the empty-database guard from #3971 rather than after. The guard still short-circuits before any deletion; it just has the full map in hand when it does. At 0.15s for the whole tree this is strictly cheaper than the old code was for the platform level alone.
- `_numeric_subdirs()` logs and returns an empty set when a directory cannot be listed. Previously an unreadable platform directory raised and aborted the entire walk, so one bad directory stranded every other platform's orphans.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Six new tests in `TestScanResourceDirs` cover the platform-to-ROM mapping, non-numeric names ignored, files ignored, an empty tree, a platform with no ROM directories, and an unreadable directory yielding an empty set instead of aborting. The four `TestCleanupOrphanedResourcesRun` tests from #3971 pass unchanged, which is the main assurance that behavior is identical. `tests/tasks/` + `tests/endpoints/test_tasks.py`: 121 passed. The three `TestPeriodicTask::test_get_existing_job_*` failures in my environment are pre-existing and need a live Redis; they fail identically on a clean checkout of `master`.

black, isort, ruff and mypy are clean on both changed files.

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this PR was written with AI assistance (Claude Code). The AI profiled the existing walk, wrote the patch and the tests, and ran the benchmarks and test suites locally. Reviewed by me before submitting.
