### PR TITLE
fix(v2): use full document navigation for EmulatorJS player

### DIFF
--- a/frontend/src/v2/composables/useGameActions/index.test.ts
+++ b/frontend/src/v2/composables/useGameActions/index.test.ts
@@ -1,12 +1,25 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import type { ActionKey } from "@/__generated__";
 import type { SimpleRom } from "@/stores/roms";
 import { useGameActions } from "./index";
 
 // Controllable stubs shared with the mocked modules below.
 const push = vi.fn();
+const locationAssign = vi.fn();
 const confirmFn = vi.fn();
 const confirmProtectedLaunch = { value: true };
+const canPlayEJS = { value: true };
+const canPlayRuffle = { value: false };
+const streamContainer = { value: null as object | null };
+let originalLocation: Location;
 // Granted action keys — `null` means "everything" (the default).
 const grantedActions: { value: Set<ActionKey> | null } = { value: null };
 
@@ -35,7 +48,9 @@ vi.mock("@/stores/roms", () => ({
   default: () => ({ update: vi.fn(), removeFromContinuePlaying: vi.fn() }),
 }));
 vi.mock("@/stores/streaming", () => ({
-  useStreamingStore: () => ({ containerForPlatform: () => null }),
+  useStreamingStore: () => ({
+    containerForPlatform: () => streamContainer.value,
+  }),
 }));
 vi.mock("@/utils", () => ({
   getDownloadLink: vi.fn(),
@@ -49,12 +64,8 @@ vi.mock("@/v2/composables/useCan", () => ({
     },
   }),
 }));
-// EJS is the only playable core in these tests, so play() routes to /ejs.
 vi.mock("@/v2/composables/useCanPlay", () => ({
-  useCanPlay: () => ({
-    canPlayEJS: { value: true },
-    canPlayRuffle: { value: false },
-  }),
+  useCanPlay: () => ({ canPlayEJS, canPlayRuffle }),
 }));
 vi.mock("@/v2/composables/useClipboard", () => ({
   useClipboard: () => ({ copy: vi.fn() }),
@@ -81,10 +92,29 @@ function makeRom(status: SimpleRom["rom_user"]["status"] = null): SimpleRom {
   } as unknown as SimpleRom;
 }
 
+beforeAll(() => {
+  originalLocation = window.location;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...originalLocation, assign: locationAssign },
+  });
+});
+
+afterAll(() => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: originalLocation,
+  });
+});
+
 beforeEach(() => {
   push.mockClear();
+  locationAssign.mockClear();
   confirmFn.mockClear();
   confirmProtectedLaunch.value = true;
+  canPlayEJS.value = true;
+  canPlayRuffle.value = false;
+  streamContainer.value = null;
   grantedActions.value = null;
 });
 
@@ -93,7 +123,8 @@ describe("useGameActions.play — launch confirmation", () => {
     const actions = useGameActions(() => makeRom(null));
     await actions.play();
     expect(confirmFn).not.toHaveBeenCalled();
-    expect(push).toHaveBeenCalledWith("/rom/1/ejs");
+    expect(locationAssign).toHaveBeenCalledWith("/rom/1/ejs");
+    expect(push).not.toHaveBeenCalled();
   });
 
   it.each(["retired", "never_playing"] as const)(
@@ -103,6 +134,7 @@ describe("useGameActions.play — launch confirmation", () => {
       const actions = useGameActions(() => makeRom(status));
       await actions.play();
       expect(confirmFn).toHaveBeenCalledTimes(1);
+      expect(locationAssign).not.toHaveBeenCalled();
       expect(push).not.toHaveBeenCalled();
     },
   );
@@ -112,7 +144,8 @@ describe("useGameActions.play — launch confirmation", () => {
     const actions = useGameActions(() => makeRom("retired"));
     await actions.play();
     expect(confirmFn).toHaveBeenCalledTimes(1);
-    expect(push).toHaveBeenCalledWith("/rom/1/ejs");
+    expect(locationAssign).toHaveBeenCalledWith("/rom/1/ejs");
+    expect(push).not.toHaveBeenCalled();
   });
 
   it("skips the prompt when the preference is disabled", async () => {
@@ -120,7 +153,29 @@ describe("useGameActions.play — launch confirmation", () => {
     const actions = useGameActions(() => makeRom("never_playing"));
     await actions.play();
     expect(confirmFn).not.toHaveBeenCalled();
-    expect(push).toHaveBeenCalledWith("/rom/1/ejs");
+    expect(locationAssign).toHaveBeenCalledWith("/rom/1/ejs");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("prefers streaming over EmulatorJS", async () => {
+    streamContainer.value = {};
+    const actions = useGameActions(() => makeRom());
+
+    await actions.play();
+
+    expect(push).toHaveBeenCalledWith("/rom/1/stream");
+    expect(locationAssign).not.toHaveBeenCalled();
+  });
+
+  it("keeps SPA navigation for Ruffle", async () => {
+    canPlayEJS.value = false;
+    canPlayRuffle.value = true;
+    const actions = useGameActions(() => makeRom());
+
+    await actions.play();
+
+    expect(push).toHaveBeenCalledWith("/rom/1/ruffle");
+    expect(locationAssign).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/v2/composables/useGameActions/index.ts
+++ b/frontend/src/v2/composables/useGameActions/index.ts
@@ -243,12 +243,19 @@ export function useGameActions(
       if (!ok) return;
     }
 
+    // EmulatorJS cores can require SharedArrayBuffer. Nginx only attaches the
+    // necessary COOP/COEP headers to the player document, so an SPA navigation
+    // cannot enable cross-origin isolation. Load the document directly instead.
+    if (!canPlayStream.value && canPlayEJS.value) {
+      window.location.assign(`/rom/${rom.id}/ejs`);
+      return;
+    }
+
     // The launch "load" flourish (disc/cartridge insert) lives on the
     // player view itself — see EmulatorJS's onPlay — so navigation is
     // immediate here.
     let path: string | null = null;
     if (canPlayStream.value) path = `/rom/${rom.id}/stream`;
-    else if (canPlayEJS.value) path = `/rom/${rom.id}/ejs`;
     else if (canPlayRuffle.value) path = `/rom/${rom.id}/ruffle`;
     if (!path) return;
     const target = path;


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

The v2 Play action currently opens EmulatorJS with `router.push()`. Because RomM only serves the EmulatorJS route with COOP/COEP headers, SPA navigation keeps the existing non-isolated document and threaded cores cannot access `SharedArrayBuffer`.

Use a full document navigation for EmulatorJS so the browser loads `/rom/:id/ejs` with its route-specific isolation headers. Streaming remains preferred when configured, and streaming/Ruffle retain their existing SPA navigation and view transitions.

This restores the behavior introduced for the legacy UI in #2376 and complements the route-specific headers from #2356.

**Testing**

- `npm test -- --run src/v2/composables/useGameActions/index.test.ts` — 12 tests passed
- `npm run typecheck` — passed
- Prettier check — passed
- Full `npm test` executed locally: 489 tests passed, but 16 suites could not load because the local macOS process hit `EMFILE: too many open files`; no test assertions failed
- Verified against a production RomM deployment using DOSBox Pure

**AI assistance disclosure**

This PR was prepared with substantial AI assistance, including root-cause analysis, code and test changes, review, and the PR description. The changes were validated locally and in a production RomM deployment before submission.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
