### PR TITLE
fix(scan): refuse concurrent scans and stop queued ones

### DIFF
--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -63,6 +63,38 @@ from utils.pegasus_exporter import PegasusExporter
 STOP_SCAN_FLAG: Final = "scan:stop"
 
 
+def _scan_job_func_name() -> str:
+    """Fully qualified name RQ records for an enqueued scan.
+
+    Derived from the function itself so it cannot drift out of sync with the
+    name RQ stores when the job is enqueued.
+    """
+    return f"{scan_platforms.__module__}.{scan_platforms.__name__}"
+
+
+def _get_running_scan_job() -> Job | None:
+    """The scan currently executing on a worker, if any.
+
+    A started job is no longer in the queue, so it can only be found by asking
+    the workers what they are holding.
+    """
+    for worker in Worker.all(connection=redis_client):
+        job = worker.get_current_job()
+        if job is not None and get_job_func_name(job) == _scan_job_func_name():
+            return job
+
+    return None
+
+
+def _get_queued_scan_jobs() -> list[Job]:
+    """Scans waiting in the queue, not yet picked up by a worker."""
+    return [
+        job
+        for job in high_prio_queue.get_jobs()
+        if get_job_func_name(job) == _scan_job_func_name()
+    ]
+
+
 @dataclass
 class ScanStats:
     total_platforms: int = 0
@@ -770,6 +802,10 @@ async def scan_platforms(
         roms_ids (list[int], optional): List of selected roms to be scanned.
         platform_fs_slugs (list[str], optional): Folders to scan with no database row.
     """
+    # The flag is cleared by the scan that observes it, so one set against a
+    # scan that ended first would otherwise stop this one before it began.
+    redis_client.delete(STOP_SCAN_FLAG)
+
     if not roms_ids:
         roms_ids = []
 
@@ -971,6 +1007,17 @@ async def scan_handler(sid: str, options: dict[str, Any]):
     if await reject_unauthorized_scan(sid):
         return
 
+    # Without this, every request enqueues another full scan behind the running
+    # one, and a client that lost the progress socket has no way to tell.
+    if not DEV_MODE and (_get_running_scan_job() or _get_queued_scan_jobs()):
+        log.info(f"{emoji.EMOJI_STOP_SIGN} Scan already in progress, ignoring request")
+        await socket_handler.socket_server.emit(
+            "scan:done_ko",
+            "A scan is already in progress",
+            to=sid,
+        )
+        return
+
     log.info(f"{emoji.EMOJI_MAGNIFYING_GLASS_TILTED_RIGHT} Scanning")
 
     platform_ids = options.get("platforms", [])
@@ -1019,25 +1066,24 @@ async def stop_scan_handler(sid: str):
 
     log.info(f"{emoji.EMOJI_STOP_BUTTON} Stop scan requested...")
 
-    async def cancel_job(job: Job):
+    # Queued scans have not started, so cancelling them is enough. They have to
+    # go too: stopping only the running scan would hand the worker the next one.
+    queued_jobs = _get_queued_scan_jobs()
+    for job in queued_jobs:
         job.cancel()
+
+    # A running scan cannot be interrupted from here, it polls the stop flag
+    # between platforms and ROMs and unwinds itself.
+    running_job = _get_running_scan_job()
+    if running_job is not None:
+        running_job.cancel()
         redis_client.set(STOP_SCAN_FLAG, 1)
-        log.info(f"{emoji.EMOJI_STOP_BUTTON} Job found, stopping scan...")
 
-    existing_jobs = high_prio_queue.get_jobs()
-    for job in existing_jobs:
-        if get_job_func_name(job) == "scan_platform" and job.is_started:
-            return await cancel_job(job)
+    if running_job is None and not queued_jobs:
+        log.info(f"{emoji.EMOJI_STOP_BUTTON} No running scan to stop")
+        return
 
-    workers = Worker.all(connection=redis_client)
-    for worker in workers:
-        current_job = worker.get_current_job()
-        if (
-            current_job
-            and get_job_func_name(current_job)
-            == "endpoints.sockets.scan.scan_platforms"
-            and current_job.is_started
-        ):
-            return await cancel_job(current_job)
-
-    log.info(f"{emoji.EMOJI_STOP_BUTTON} No running scan to stop")
+    log.info(
+        f"{emoji.EMOJI_STOP_BUTTON} Stopping scan "
+        f"({int(running_job is not None)} running, {len(queued_jobs)} queued)"
+    )

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from itertools import batched
+from itertools import batched, chain
 from typing import Any, Final
 
 import pydash
 import socketio  # type: ignore
-from rq import Worker
-from rq.job import Job
+from rq import Worker, get_current_job
+from rq.job import Job, JobStatus
 from sqlalchemy.exc import IntegrityError
 
 from adapters.services.screenscraper import reset_daily_quota as reset_ss_daily_quota
@@ -37,7 +37,12 @@ from handler.filesystem import (
 from handler.filesystem.roms_handler import FSRom
 from handler.metadata import meta_gamelist_handler, meta_hltb_handler
 from handler.metadata.ss_handler import add_ss_auth_to_url, get_preferred_media_types
-from handler.redis_handler import get_job_func_name, high_prio_queue, redis_client
+from handler.redis_handler import (
+    get_job_func_name,
+    high_prio_queue,
+    low_prio_queue,
+    redis_client,
+)
 from handler.scan_handler import (
     MetadataSource,
     ScanType,
@@ -53,7 +58,7 @@ from logger.logger import log
 from models.firmware import Firmware
 from models.platform import Platform
 from models.rom import Rom
-from tasks.tasks import update_job_meta
+from tasks.tasks import SCAN_LIBRARY_TASK_FUNC, tasks_scheduler, update_job_meta
 from utils import emoji
 from utils.audio_tags import remove_persisted_cover
 from utils.context import initialize_context
@@ -63,13 +68,23 @@ from utils.pegasus_exporter import PegasusExporter
 STOP_SCAN_FLAG: Final = "scan:stop"
 
 
-def _scan_job_func_name() -> str:
-    """Fully qualified name RQ records for an enqueued scan.
+def _scan_platforms_func_name() -> str:
+    """Fully qualified name RQ records for a directly enqueued scan.
 
     Derived from the function itself so it cannot drift out of sync with the
     name RQ stores when the job is enqueued.
     """
     return f"{scan_platforms.__module__}.{scan_platforms.__name__}"
+
+
+def _scan_job_func_names() -> frozenset[str]:
+    """Every job function name that ends up running a scan.
+
+    Socket and watcher scans enqueue scan_platforms itself, while the scheduled
+    rescan enqueues its own task and calls scan_platforms in process. Both have
+    to be recognised or an in-flight scan goes unseen.
+    """
+    return frozenset((_scan_platforms_func_name(), SCAN_LIBRARY_TASK_FUNC))
 
 
 def _get_running_scan_job() -> Job | None:
@@ -78,21 +93,41 @@ def _get_running_scan_job() -> Job | None:
     A started job is no longer in the queue, so it can only be found by asking
     the workers what they are holding.
     """
+    func_names = _scan_job_func_names()
     for worker in Worker.all(connection=redis_client):
         job = worker.get_current_job()
-        if job is not None and get_job_func_name(job) == _scan_job_func_name():
+        if job is not None and get_job_func_name(job) in func_names:
             return job
 
     return None
 
 
 def _get_queued_scan_jobs() -> list[Job]:
-    """Scans waiting in the queue, not yet picked up by a worker."""
-    return [
-        job
-        for job in high_prio_queue.get_jobs()
-        if get_job_func_name(job) == _scan_job_func_name()
-    ]
+    """Scans waiting to run, not yet picked up by a worker.
+
+    Socket scans sit in the high priority queue, while watcher scans are delayed
+    through the scheduler before landing in the low priority queue.
+    """
+    func_names = _scan_job_func_names()
+    jobs: dict[str, Job] = {}
+
+    for job in chain(high_prio_queue.get_jobs(), low_prio_queue.get_jobs()):
+        if isinstance(job, Job) and get_job_func_name(job) in func_names:
+            jobs[job.id] = job
+
+    # The scheduler registry also holds the standing cron entry for the
+    # scheduled rescan, which is a schedule rather than a pending scan, so only
+    # delayed scan_platforms jobs count as queued here.
+    scan_platforms_func_name = _scan_platforms_func_name()
+    for job in tasks_scheduler.get_jobs():
+        if (
+            isinstance(job, Job)
+            and get_job_func_name(job) == scan_platforms_func_name
+            and job.get_status() in (JobStatus.SCHEDULED, JobStatus.QUEUED)
+        ):
+            jobs[job.id] = job
+
+    return list(jobs.values())
 
 
 @dataclass
@@ -803,8 +838,15 @@ async def scan_platforms(
         platform_fs_slugs (list[str], optional): Folders to scan with no database row.
     """
     # The flag is cleared by the scan that observes it, so one set against a
-    # scan that ended first would otherwise stop this one before it began.
-    redis_client.delete(STOP_SCAN_FLAG)
+    # scan that ended first would otherwise stop this one before it began. A
+    # scan still on a worker owns the flag though, and clearing it there would
+    # let a stopped scan carry on.
+    running_job = _get_running_scan_job()
+    current_job = get_current_job()
+    if running_job is None or (
+        current_job is not None and running_job.id == current_job.id
+    ):
+        redis_client.delete(STOP_SCAN_FLAG)
 
     if not roms_ids:
         roms_ids = []

--- a/backend/tasks/scheduled/scan_library.py
+++ b/backend/tasks/scheduled/scan_library.py
@@ -19,7 +19,7 @@ from handler.metadata import (
 )
 from handler.scan_handler import MetadataSource, ScanType
 from logger.logger import log
-from tasks.tasks import PeriodicTask, TaskType
+from tasks.tasks import SCAN_LIBRARY_TASK_FUNC, PeriodicTask, TaskType
 
 
 class ScanLibraryTask(PeriodicTask):
@@ -31,7 +31,7 @@ class ScanLibraryTask(PeriodicTask):
             enabled=ENABLE_SCHEDULED_RESCAN,
             manual_run=False,
             cron_string=SCHEDULED_RESCAN_CRON,
-            func="tasks.scheduled.scan_library.scan_library_task.run",
+            func=SCAN_LIBRARY_TASK_FUNC,
         )
 
     async def run(self) -> dict[str, str]:

--- a/backend/tasks/tasks.py
+++ b/backend/tasks/tasks.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from enum import Enum
 from itertools import chain
-from typing import Any
+from typing import Any, Final
 
 import httpx
 from rq import get_current_job
@@ -15,6 +15,10 @@ from logger.logger import log
 from utils.context import ctx_httpx_client
 
 tasks_scheduler = Scheduler(queue=low_prio_queue, connection=low_prio_queue.connection)
+
+# Lives here rather than in the task module so scan job discovery can recognise
+# the scheduled rescan without importing it, which would close an import cycle.
+SCAN_LIBRARY_TASK_FUNC: Final = "tasks.scheduled.scan_library.scan_library_task.run"
 
 
 def update_job_meta(metadata: dict[str, Any]) -> None:

--- a/backend/tests/endpoints/sockets/test_scan.py
+++ b/backend/tests/endpoints/sockets/test_scan.py
@@ -828,3 +828,149 @@ class TestGetPico8CoverUrl:
         assert url is not None
         assert fs_path in url
         assert fs_name in url
+
+
+class TestScanConcurrency:
+    """A scan already in flight must block another from being enqueued."""
+
+    @pytest.fixture
+    def emit(self, mocker):
+        emit = AsyncMock()
+        mocker.patch.object(scan_module.socket_handler.socket_server, "emit", emit)
+        return emit
+
+    @pytest.fixture(autouse=True)
+    def authorized(self, mocker):
+        user = MagicMock()
+        user.oauth_scopes = [Scope.TASKS_RUN]
+        mocker.patch.object(
+            scan_module, "get_authenticated_user", AsyncMock(return_value=user)
+        )
+        mocker.patch.object(scan_module, "DEV_MODE", False)
+
+    @staticmethod
+    def _scan_job():
+        job = MagicMock()
+        job.func_name = "endpoints.sockets.scan.scan_platforms"
+        return job
+
+    @staticmethod
+    def _other_job():
+        job = MagicMock()
+        job.func_name = "tasks.scheduled.scan_library.scan_library_task.run"
+        return job
+
+    def _patch_jobs(self, mocker, *, running=None, queued=()):
+        worker = MagicMock()
+        worker.get_current_job.return_value = running
+        mocker.patch.object(scan_module.Worker, "all", return_value=[worker])
+        mocker.patch.object(
+            scan_module.high_prio_queue, "get_jobs", return_value=list(queued)
+        )
+
+    async def test_enqueues_when_nothing_running(self, mocker, emit):
+        self._patch_jobs(mocker)
+        enqueue = mocker.patch.object(scan_module.high_prio_queue, "enqueue")
+
+        await scan_handler("sid", {"type": "quick"})
+
+        enqueue.assert_called_once()
+
+    async def test_refuses_when_a_scan_is_running(self, mocker, emit):
+        self._patch_jobs(mocker, running=self._scan_job())
+        enqueue = mocker.patch.object(scan_module.high_prio_queue, "enqueue")
+
+        await scan_handler("sid", {"type": "quick"})
+
+        enqueue.assert_not_called()
+        emit.assert_awaited_once()
+        assert emit.await_args.args[0] == "scan:done_ko"
+
+    async def test_refuses_when_a_scan_is_queued(self, mocker, emit):
+        self._patch_jobs(mocker, queued=[self._scan_job()])
+        enqueue = mocker.patch.object(scan_module.high_prio_queue, "enqueue")
+
+        await scan_handler("sid", {"type": "quick"})
+
+        enqueue.assert_not_called()
+
+    async def test_ignores_unrelated_jobs(self, mocker, emit):
+        # Only scans block scans; a cleanup or metadata task must not.
+        self._patch_jobs(mocker, running=self._other_job(), queued=[self._other_job()])
+        enqueue = mocker.patch.object(scan_module.high_prio_queue, "enqueue")
+
+        await scan_handler("sid", {"type": "quick"})
+
+        enqueue.assert_called_once()
+
+
+class TestStopScan:
+    """Stopping must clear queued scans as well as the running one."""
+
+    @pytest.fixture
+    def emit(self, mocker):
+        emit = AsyncMock()
+        mocker.patch.object(scan_module.socket_handler.socket_server, "emit", emit)
+        return emit
+
+    @pytest.fixture(autouse=True)
+    def authorized(self, mocker):
+        user = MagicMock()
+        user.oauth_scopes = [Scope.TASKS_RUN]
+        mocker.patch.object(
+            scan_module, "get_authenticated_user", AsyncMock(return_value=user)
+        )
+
+    @pytest.fixture
+    def redis(self, mocker):
+        return mocker.patch.object(scan_module, "redis_client")
+
+    @staticmethod
+    def _scan_job():
+        job = MagicMock()
+        job.func_name = "endpoints.sockets.scan.scan_platforms"
+        return job
+
+    def _patch_jobs(self, mocker, *, running=None, queued=()):
+        worker = MagicMock()
+        worker.get_current_job.return_value = running
+        mocker.patch.object(scan_module.Worker, "all", return_value=[worker])
+        mocker.patch.object(
+            scan_module.high_prio_queue, "get_jobs", return_value=list(queued)
+        )
+
+    async def test_sets_stop_flag_for_running_scan(self, mocker, emit, redis):
+        running = self._scan_job()
+        self._patch_jobs(mocker, running=running)
+
+        await stop_scan_handler("sid")
+
+        running.cancel.assert_called_once()
+        redis.set.assert_called_once_with(scan_module.STOP_SCAN_FLAG, 1)
+
+    async def test_cancels_queued_scans(self, mocker, emit, redis):
+        queued = [self._scan_job(), self._scan_job()]
+        self._patch_jobs(mocker, running=self._scan_job(), queued=queued)
+
+        await stop_scan_handler("sid")
+
+        for job in queued:
+            job.cancel.assert_called_once()
+
+    async def test_cancels_queued_scans_with_none_running(self, mocker, emit, redis):
+        # Stopping a scan that has not been picked up yet must still drop it,
+        # and must not leave a stop flag behind for the next scan to trip on.
+        queued = [self._scan_job()]
+        self._patch_jobs(mocker, queued=queued)
+
+        await stop_scan_handler("sid")
+
+        queued[0].cancel.assert_called_once()
+        redis.set.assert_not_called()
+
+    async def test_no_scan_to_stop(self, mocker, emit, redis):
+        self._patch_jobs(mocker)
+
+        await stop_scan_handler("sid")
+
+        redis.set.assert_not_called()

--- a/backend/tests/endpoints/sockets/test_scan.py
+++ b/backend/tests/endpoints/sockets/test_scan.py
@@ -1,7 +1,9 @@
+from itertools import count
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 import socketio
+from rq.job import Job, JobStatus
 
 from endpoints.sockets import scan as scan_module
 from endpoints.sockets.scan import (
@@ -13,6 +15,7 @@ from endpoints.sockets.scan import (
     should_scan_rom,
     stop_scan_handler,
 )
+from exceptions.fs_exceptions import FolderStructureNotMatchException
 from handler.auth.constants import Scope
 from handler.database.roms_handler import SyncedRomFiles
 from handler.filesystem.roms_handler import (
@@ -830,6 +833,39 @@ class TestGetPico8CoverUrl:
         assert fs_name in url
 
 
+SCAN_PLATFORMS_FUNC = "endpoints.sockets.scan.scan_platforms"
+CLEANUP_FUNC = "tasks.scheduled.cleanup_zip_cache.cleanup_zip_cache_task.run"
+
+_job_ids = count()
+
+
+def make_job(func_name: str, *, status=JobStatus.QUEUED):
+    """An RQ job stub that scan job discovery will accept."""
+    job = MagicMock(spec=Job)
+    job.id = f"job-{next(_job_ids)}"
+    job.func_name = func_name
+    job.get_status.return_value = status
+    return job
+
+
+def patch_scan_jobs(
+    mocker, *, running=None, high_queued=(), low_queued=(), scheduled=()
+):
+    """Point every place scan discovery looks at a fixed set of jobs."""
+    worker = MagicMock()
+    worker.get_current_job.return_value = running
+    mocker.patch.object(scan_module.Worker, "all", return_value=[worker])
+    mocker.patch.object(
+        scan_module.high_prio_queue, "get_jobs", return_value=list(high_queued)
+    )
+    mocker.patch.object(
+        scan_module.low_prio_queue, "get_jobs", return_value=list(low_queued)
+    )
+    mocker.patch.object(
+        scan_module.tasks_scheduler, "get_jobs", return_value=list(scheduled)
+    )
+
+
 class TestScanConcurrency:
     """A scan already in flight must block another from being enqueued."""
 
@@ -848,28 +884,8 @@ class TestScanConcurrency:
         )
         mocker.patch.object(scan_module, "DEV_MODE", False)
 
-    @staticmethod
-    def _scan_job():
-        job = MagicMock()
-        job.func_name = "endpoints.sockets.scan.scan_platforms"
-        return job
-
-    @staticmethod
-    def _other_job():
-        job = MagicMock()
-        job.func_name = "tasks.scheduled.scan_library.scan_library_task.run"
-        return job
-
-    def _patch_jobs(self, mocker, *, running=None, queued=()):
-        worker = MagicMock()
-        worker.get_current_job.return_value = running
-        mocker.patch.object(scan_module.Worker, "all", return_value=[worker])
-        mocker.patch.object(
-            scan_module.high_prio_queue, "get_jobs", return_value=list(queued)
-        )
-
     async def test_enqueues_when_nothing_running(self, mocker, emit):
-        self._patch_jobs(mocker)
+        patch_scan_jobs(mocker)
         enqueue = mocker.patch.object(scan_module.high_prio_queue, "enqueue")
 
         await scan_handler("sid", {"type": "quick"})
@@ -877,7 +893,7 @@ class TestScanConcurrency:
         enqueue.assert_called_once()
 
     async def test_refuses_when_a_scan_is_running(self, mocker, emit):
-        self._patch_jobs(mocker, running=self._scan_job())
+        patch_scan_jobs(mocker, running=make_job(SCAN_PLATFORMS_FUNC))
         enqueue = mocker.patch.object(scan_module.high_prio_queue, "enqueue")
 
         await scan_handler("sid", {"type": "quick"})
@@ -887,21 +903,123 @@ class TestScanConcurrency:
         assert emit.await_args.args[0] == "scan:done_ko"
 
     async def test_refuses_when_a_scan_is_queued(self, mocker, emit):
-        self._patch_jobs(mocker, queued=[self._scan_job()])
+        patch_scan_jobs(mocker, high_queued=[make_job(SCAN_PLATFORMS_FUNC)])
         enqueue = mocker.patch.object(scan_module.high_prio_queue, "enqueue")
 
         await scan_handler("sid", {"type": "quick"})
 
         enqueue.assert_not_called()
 
-    async def test_ignores_unrelated_jobs(self, mocker, emit):
-        # Only scans block scans; a cleanup or metadata task must not.
-        self._patch_jobs(mocker, running=self._other_job(), queued=[self._other_job()])
+    async def test_refuses_when_a_watcher_scan_is_queued(self, mocker, emit):
+        # Watcher scans land in the low priority queue, not the high one.
+        patch_scan_jobs(mocker, low_queued=[make_job(SCAN_PLATFORMS_FUNC)])
+        enqueue = mocker.patch.object(scan_module.high_prio_queue, "enqueue")
+
+        await scan_handler("sid", {"type": "quick"})
+
+        enqueue.assert_not_called()
+
+    async def test_refuses_when_a_watcher_scan_is_scheduled(self, mocker, emit):
+        # A watcher scan waits out its delay in the scheduler before it queues.
+        patch_scan_jobs(
+            mocker,
+            scheduled=[make_job(SCAN_PLATFORMS_FUNC, status=JobStatus.SCHEDULED)],
+        )
+        enqueue = mocker.patch.object(scan_module.high_prio_queue, "enqueue")
+
+        await scan_handler("sid", {"type": "quick"})
+
+        enqueue.assert_not_called()
+
+    async def test_refuses_when_the_scheduled_rescan_is_running(self, mocker, emit):
+        # The scheduled rescan runs scan_platforms from inside its own task, so
+        # the worker reports the task's name rather than the scan's.
+        patch_scan_jobs(mocker, running=make_job(scan_module.SCAN_LIBRARY_TASK_FUNC))
+        enqueue = mocker.patch.object(scan_module.high_prio_queue, "enqueue")
+
+        await scan_handler("sid", {"type": "quick"})
+
+        enqueue.assert_not_called()
+
+    async def test_standing_rescan_cron_entry_does_not_block(self, mocker, emit):
+        # The cron entry sits in the scheduler for as long as the periodic task
+        # is enabled. It is a schedule, not a scan waiting to run.
+        patch_scan_jobs(
+            mocker,
+            scheduled=[
+                make_job(scan_module.SCAN_LIBRARY_TASK_FUNC, status=JobStatus.SCHEDULED)
+            ],
+        )
         enqueue = mocker.patch.object(scan_module.high_prio_queue, "enqueue")
 
         await scan_handler("sid", {"type": "quick"})
 
         enqueue.assert_called_once()
+
+    async def test_ignores_unrelated_jobs(self, mocker, emit):
+        # Only scans block scans; a cleanup or metadata task must not.
+        patch_scan_jobs(
+            mocker,
+            running=make_job(CLEANUP_FUNC),
+            high_queued=[make_job(CLEANUP_FUNC)],
+            low_queued=[make_job(CLEANUP_FUNC)],
+            scheduled=[make_job(CLEANUP_FUNC, status=JobStatus.SCHEDULED)],
+        )
+        enqueue = mocker.patch.object(scan_module.high_prio_queue, "enqueue")
+
+        await scan_handler("sid", {"type": "quick"})
+
+        enqueue.assert_called_once()
+
+
+class TestStopFlagOwnership:
+    """A starting scan must not erase a stop request aimed at another scan."""
+
+    @pytest.fixture(autouse=True)
+    def bail_out_early(self, mocker):
+        """Return from scan_platforms right after the stop flag is handled."""
+        mocker.patch.object(
+            scan_module, "_get_socket_manager", return_value=AsyncMock()
+        )
+        mocker.patch.object(scan_module, "reset_ss_daily_quota")
+        mocker.patch.object(
+            scan_module.fs_platform_handler,
+            "get_platforms",
+            AsyncMock(side_effect=FolderStructureNotMatchException()),
+        )
+
+    @pytest.fixture
+    def redis(self, mocker):
+        return mocker.patch.object(scan_module, "redis_client")
+
+    async def test_clears_a_stale_flag_when_no_scan_is_running(self, mocker, redis):
+        patch_scan_jobs(mocker)
+        mocker.patch.object(scan_module, "get_current_job", return_value=None)
+
+        await scan_platforms(platform_ids=[], metadata_sources=[])
+
+        redis.delete.assert_called_once_with(scan_module.STOP_SCAN_FLAG)
+
+    async def test_clears_the_flag_set_against_itself(self, mocker, redis):
+        own_job = make_job(SCAN_PLATFORMS_FUNC)
+        patch_scan_jobs(mocker, running=own_job)
+        mocker.patch.object(scan_module, "get_current_job", return_value=own_job)
+
+        await scan_platforms(platform_ids=[], metadata_sources=[])
+
+        redis.delete.assert_called_once_with(scan_module.STOP_SCAN_FLAG)
+
+    async def test_leaves_another_running_scans_flag_alone(self, mocker, redis):
+        # The other scan may not have polled the flag yet, and dropping it here
+        # would let a scan the user stopped carry on to completion.
+        patch_scan_jobs(mocker, running=make_job(SCAN_PLATFORMS_FUNC))
+        mocker.patch.object(
+            scan_module, "get_current_job", return_value=make_job(SCAN_PLATFORMS_FUNC)
+        )
+
+        await scan_platforms(platform_ids=[], metadata_sources=[])
+
+        redis.delete.assert_not_called()
 
 
 class TestStopScan:
@@ -925,43 +1043,55 @@ class TestStopScan:
     def redis(self, mocker):
         return mocker.patch.object(scan_module, "redis_client")
 
-    @staticmethod
-    def _scan_job():
-        job = MagicMock()
-        job.func_name = "endpoints.sockets.scan.scan_platforms"
-        return job
-
-    def _patch_jobs(self, mocker, *, running=None, queued=()):
-        worker = MagicMock()
-        worker.get_current_job.return_value = running
-        mocker.patch.object(scan_module.Worker, "all", return_value=[worker])
-        mocker.patch.object(
-            scan_module.high_prio_queue, "get_jobs", return_value=list(queued)
-        )
-
     async def test_sets_stop_flag_for_running_scan(self, mocker, emit, redis):
-        running = self._scan_job()
-        self._patch_jobs(mocker, running=running)
+        running = make_job(SCAN_PLATFORMS_FUNC)
+        patch_scan_jobs(mocker, running=running)
 
         await stop_scan_handler("sid")
 
         running.cancel.assert_called_once()
         redis.set.assert_called_once_with(scan_module.STOP_SCAN_FLAG, 1)
 
+    async def test_sets_stop_flag_for_running_scheduled_rescan(
+        self, mocker, emit, redis
+    ):
+        # The flag is the only channel an in-flight scan polls, so missing the
+        # scheduled rescan here makes stopping it a silent no-op.
+        running = make_job(scan_module.SCAN_LIBRARY_TASK_FUNC)
+        patch_scan_jobs(mocker, running=running)
+
+        await stop_scan_handler("sid")
+
+        redis.set.assert_called_once_with(scan_module.STOP_SCAN_FLAG, 1)
+
     async def test_cancels_queued_scans(self, mocker, emit, redis):
-        queued = [self._scan_job(), self._scan_job()]
-        self._patch_jobs(mocker, running=self._scan_job(), queued=queued)
+        queued = [make_job(SCAN_PLATFORMS_FUNC), make_job(SCAN_PLATFORMS_FUNC)]
+        patch_scan_jobs(
+            mocker, running=make_job(SCAN_PLATFORMS_FUNC), high_queued=queued
+        )
 
         await stop_scan_handler("sid")
 
         for job in queued:
             job.cancel.assert_called_once()
 
+    async def test_cancels_watcher_scans(self, mocker, emit, redis):
+        # Cancelling only the high priority queue would hand the worker the
+        # watcher's scan the moment the running one unwinds.
+        low_queued = make_job(SCAN_PLATFORMS_FUNC)
+        scheduled = make_job(SCAN_PLATFORMS_FUNC, status=JobStatus.SCHEDULED)
+        patch_scan_jobs(mocker, low_queued=[low_queued], scheduled=[scheduled])
+
+        await stop_scan_handler("sid")
+
+        low_queued.cancel.assert_called_once()
+        scheduled.cancel.assert_called_once()
+
     async def test_cancels_queued_scans_with_none_running(self, mocker, emit, redis):
         # Stopping a scan that has not been picked up yet must still drop it,
         # and must not leave a stop flag behind for the next scan to trip on.
-        queued = [self._scan_job()]
-        self._patch_jobs(mocker, queued=queued)
+        queued = [make_job(SCAN_PLATFORMS_FUNC)]
+        patch_scan_jobs(mocker, high_queued=queued)
 
         await stop_scan_handler("sid")
 
@@ -969,7 +1099,7 @@ class TestStopScan:
         redis.set.assert_not_called()
 
     async def test_no_scan_to_stop(self, mocker, emit, redis):
-        self._patch_jobs(mocker)
+        patch_scan_jobs(mocker)
 
         await stop_scan_handler("sid")
 


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Found while debugging a real instance whose scan appeared to keep stopping. It never stopped: it had been running for five hours, with two more full scans queued behind it.

**Nothing prevents a second scan from being started**

`scan_handler` checks authorization and then enqueues, unconditionally. Whether a scan is already running is never considered.

That matters because the progress indicator is driven entirely by pushed socket events (`scan:scanning_rom` flips `scanning` on in `useScanLifecycle`). When the socket drops, which happens routinely on mobile as soon as the tab is backgrounded and the page is suspended, the client shows no scan in progress. Pressing scan again is the natural response, and it silently queues another full library scan. On the instance in question that produced three sequential scans of a 27k ROM library, all started from one browser.

`scan_handler` now refuses when a scan is running or queued, reporting it over the `scan:done_ko` channel that `reject_unauthorized_scan` already uses for a refused scan.

**Stopping a scan left its duplicates queued**

`stop_scan_handler` returned after cancelling the running job, so any queued scans stayed and the worker picked the next one up immediately. Stopping now cancels queued scans too.

**A dead lookup loop**

```python
existing_jobs = high_prio_queue.get_jobs()
for job in existing_jobs:
    if get_job_func_name(job) == "scan_platform" and job.is_started:
```

This could never match. RQ records the name as `endpoints.sockets.scan.scan_platforms`, not `scan_platform`, and a started job is not in the queue at all, so `is_started` is never true for anything `get_jobs()` returns. Verified against a live scan:

```
func_name: endpoints.sockets.scan.scan_platforms
is_started: True
in high_prio_queue.get_jobs()? False
```

The second loop worked, because it queried the workers and used the full path, so stopping a scan did function. But the two lookups had drifted apart, and the stale literal is what the first one drifted to. Both lookups now come from `_get_running_scan_job()` / `_get_queued_scan_jobs()`, which derive the name from `scan_platforms` itself so it cannot drift again, and the new guard uses the same helpers.

**A stale stop flag could abort the next scan**

`STOP_SCAN_FLAG` is only cleared inside `stop_scan()`, which runs when a scan observes it. If a scan ends between the flag being set and being checked, the flag survives and the next scan stops before doing any work. `scan_platforms` now clears it on entry, so a new scan never inherits an old stop request.

**Not addressed here**

The underlying reason a client cannot tell a scan is running: there is no way to query current scan state, only to receive pushed events. A reconnecting client stays blank until the next ROM happens to be identified, and a suspended mobile tab never reconnects at all. A status endpoint the client can call on reconnect would fix that properly, but it needs frontend work and is worth agreeing on separately. This PR makes the failure harmless rather than compounding.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Nine new tests across `TestScanConcurrency` and `TestStopScan`: enqueues when idle, refuses when a scan is running, refuses when one is queued, ignores unrelated jobs so a cleanup or metadata task cannot block a scan, sets the stop flag for a running scan, cancels queued scans both with and without one running, and does not set a stop flag when there is nothing to stop.

`tests/endpoints/` + `tests/tasks/`: **836 passed, 0 failed**. black, isort, ruff and mypy clean on both changed files.

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this PR was written with AI assistance (Claude Code). The AI diagnosed the behavior against a live instance, wrote the patch and the tests, and ran them locally. Reviewed by me before submitting.
