### PR TITLE
fix(frontend): only treat top-level game folder files as media assets

### DIFF
--- a/frontend/src/v2/utils/romArtwork.test.ts
+++ b/frontend/src/v2/utils/romArtwork.test.ts
@@ -77,6 +77,24 @@ describe("resolveRomArtwork — library media files", () => {
     expect(entries[0].label).toBe("keep");
   });
 
+  it("ignores media nested inside the game's own data", () => {
+    const rom = makeRom([
+      makeFile({
+        id: 1,
+        file_name: "Demo101_0.mp4",
+        file_path: "platform/roms/game/content/Movie",
+        full_path: "platform/roms/game/content/Movie/Demo101_0.mp4",
+        is_top_level: false,
+        category: null,
+      }),
+      makeFile({ id: 2, file_name: "trailer.mp4" }),
+    ]);
+    const entries = resolveRomArtwork(rom);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].label).toBe("trailer");
+  });
+
   it("orders image files before video files", () => {
     const rom = makeRom([
       makeFile({ id: 1, file_name: "clip.mp4" }),

--- a/frontend/src/v2/utils/romArtwork.ts
+++ b/frontend/src/v2/utils/romArtwork.ts
@@ -6,9 +6,9 @@
 //   1. Scraped resources — ScreenScraper is the richest and wins; gamelist
 //      fills in for the few types it also scrapes (mirrors v1's MediaCarousel
 //      fallbacks).
-//   2. Library media files — images/videos that live in the game folder on
-//      disk (rom.files), so a trailer or artwork dropped next to the ROM shows
-//      up here too.
+//   2. Library media files — images/videos sitting at the top level of the
+//      game folder on disk (rom.files), so a trailer or artwork dropped next
+//      to the ROM shows up here too.
 //
 // Covers, screenshots, the manual and the soundtrack are intentionally left
 // out: they each have their own surface elsewhere in the details view.
@@ -121,7 +121,15 @@ export function resolveRomArtwork(rom: DetailedRom): RomArtworkEntry[] {
     ];
 
   const libraryMedia = rom.files
-    .filter((file) => !file.category || !SURFACED_ELSEWHERE.has(file.category))
+    // Only top-level files count as media assets. Anything nested lives inside
+    // the game's own data (a Wii U dump ships cutscenes as content/Movie/*.mp4)
+    // and would otherwise flood the page with video elements. Nested media that
+    // is genuinely an asset has its own surface via its category.
+    .filter(
+      (file) =>
+        file.is_top_level &&
+        (!file.category || !SURFACED_ELSEWHERE.has(file.category)),
+    )
     .map((file) => {
       const ext = file.file_name.split(".").pop()?.toLowerCase() ?? "";
       const isVideo = LIBRARY_VIDEO_EXTENSIONS.has(ext);


### PR DESCRIPTION
**Description**

Fixes #3975

The v2 details view scooped **every** uncategorized image/video inside a multi-file ROM folder into the artwork resolver (`resolveRomArtwork`). `OverviewTab` and the Media tab's `ArtworkSubtab` then render one `<video preload="metadata">` per entry.

A Wii U dump ships its cutscenes as game data at `content/Movie/Demo*.mp4`, so opening the game's detail view rendered dozens of video elements at once. The resulting burst of `Range: bytes=0-` requests against `/api/roms/{id}/files/content/…` saturated the backend's request workers, hanging the page for minutes with requests stuck at status 0.

Excluding `mp4` via `exclude.roms.multi_file.parts.extensions` doesn't help, since that only stops files from being *scanned* on already-indexed data, and it also throws away files the user may legitimately want indexed.

**The fix**

Library media now has to sit at the **top level** of the game folder, which is what "a trailer or artwork dropped next to the ROM" meant all along. Anything nested belongs to the game's own data. Nested files that genuinely are assets (`screenshots/`, `soundtrack/`, `manual/`) are unaffected: the scanner categorizes them and they already have their own surfaces.

`RomFile.is_top_level` is a computed model property rather than a column, so existing libraries are fixed without a rescan or a migration.

**Not addressed here** (flagging as possible follow-ups)

- A game folder with many *top-level* videos would still fire a wall of preloads. Capping the eager set or dropping to `preload="none"` would harden that, but it costs the first-frame poster in the common one-trailer case, so it felt like a separate call.
- A Wii U ROM carries thousands of `RomFile` rows in the detail payload, which is likely the residual slowness the reporter still saw after excluding `.mp4`. That's a separate backend/pagination concern.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The AI diagnosed the issue, wrote the fix and the regression test, and ran the verification below. I reviewed the diff and the reasoning before opening this PR.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Verification: new regression test in `romArtwork.test.ts`, full `src/v2/utils` + `src/v2/components/GameDetails` suites pass (59 tests), `npm run typecheck` clean, `trunk fmt && trunk check` clean. Not manually browser-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
