### PR TITLE
fix(docker): stop valkey rewriting its whole RDB every few minutes

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import Final, overload
 
 import yarl
@@ -38,6 +39,13 @@ RESOURCES_BASE_PATH: Final[str] = f"{ROMM_BASE_PATH}/resources"
 ASSETS_BASE_PATH: Final[str] = f"{ROMM_BASE_PATH}/assets"
 ZIP_CACHE_PATH: Final[str] = f"{ROMM_BASE_PATH}/cache/zips"
 FRONTEND_RESOURCES_PATH: Final[str] = "/assets/romm/resources"
+
+# ROM UPLOADS
+# Chunked upload parts are staged on disk, under RESOURCES_BASE_PATH by default.
+ROM_UPLOAD_TMP_BASE: Final[Path] = (
+    Path(ROMM_TMP_PATH) if ROMM_TMP_PATH else Path(RESOURCES_BASE_PATH)
+) / "tmp/uploads"
+ROM_UPLOAD_TTL: Final[int] = 86400  # 24 hours
 
 # SEVEN ZIP
 SEVEN_ZIP_TIMEOUT: Final[int] = safe_int(_get_env("SEVEN_ZIP_TIMEOUT"), 60)

--- a/backend/endpoints/roms/upload.py
+++ b/backend/endpoints/roms/upload.py
@@ -1,6 +1,5 @@
 import json
 import shutil
-from pathlib import Path
 from typing import Annotated
 from uuid import UUID, uuid4
 
@@ -8,7 +7,7 @@ from anyio import open_file
 from fastapi import Header, HTTPException, Request, status
 from starlette.responses import Response
 
-from config import RESOURCES_BASE_PATH, ROMM_TMP_PATH
+from config import ROM_UPLOAD_TMP_BASE, ROM_UPLOAD_TTL
 from decorators.auth import protected_route
 from handler.auth.constants import Scope
 from handler.database import db_platform_handler
@@ -22,10 +21,6 @@ router = APIRouter(
     tags=["upload"],
 )
 
-# Store upload chunks under RESOURCES_BASE_PATH (disk-backed) by default.
-_tmp_root = Path(ROMM_TMP_PATH) if ROMM_TMP_PATH else Path(RESOURCES_BASE_PATH)
-ROM_UPLOAD_TMP_BASE = _tmp_root / "tmp" / "uploads"
-ROM_UPLOAD_TTL = 86400  # 24 hours
 ROM_ASSEMBLY_CHUNK_SIZE = 8192  # 8KB read buffer during assembly
 ROM_UPLOAD_MAX_CHUNK_SIZE = 64 * 1024 * 1024  # 64MB hard cap per chunk
 

--- a/backend/tasks/scheduled/cleanup_upload_tmp.py
+++ b/backend/tasks/scheduled/cleanup_upload_tmp.py
@@ -1,7 +1,7 @@
 import shutil
 import time
 
-from endpoints.roms.upload import ROM_UPLOAD_TMP_BASE, ROM_UPLOAD_TTL
+from config import ROM_UPLOAD_TMP_BASE, ROM_UPLOAD_TTL
 from logger.logger import log
 from tasks.tasks import PeriodicTask, TaskType
 

--- a/backend/tests/tasks/test_task_func_paths.py
+++ b/backend/tests/tasks/test_task_func_paths.py
@@ -1,0 +1,47 @@
+import os
+import pkgutil
+import subprocess
+import sys
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+import tasks
+from tasks.tasks import PeriodicTask
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _periodic_task_funcs() -> list[str]:
+    funcs = set()
+    for module_info in pkgutil.walk_packages(tasks.__path__, prefix="tasks."):
+        module = import_module(module_info.name)
+        for value in vars(module).values():
+            if isinstance(value, PeriodicTask):
+                funcs.add(value.func)
+    return sorted(funcs)
+
+
+@pytest.mark.parametrize("func", _periodic_task_funcs())
+def test_task_func_resolves_in_a_fresh_interpreter(func):
+    """The RQ worker resolves a job by importing its func path into a process
+    where the task module is the first application module imported. An import
+    cycle that stays hidden in the web process breaks the job there, so resolve
+    each func the way the worker does, in a clean interpreter."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys\n"
+            "from rq.utils import import_attribute\n"
+            "assert callable(import_attribute(sys.argv[1]))\n",
+            func,
+        ],
+        cwd=BACKEND_ROOT,
+        env={**os.environ, "PYTHONPATH": str(BACKEND_ROOT)},
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, f"{func} is not importable by RQ:\n{result.stderr}"

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -21,7 +21,7 @@ REDIS_HOST="${REDIS_HOST:=""}"
 # snapshot policy of the internal valkey, as "<seconds> <changes>" pairs. Saving
 # hourly keeps a graceful shutdown lossless while a hard crash can only lose an
 # hour of sessions and cached metadata. Set to an empty value to never snapshot.
-REDIS_SAVE_POLICY="${REDIS_SAVE_POLICY:="3600 1"}"
+REDIS_SAVE_POLICY="${REDIS_SAVE_POLICY="3600 1"}"
 
 # logger colors
 RED='\033[0;31m'

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -18,6 +18,11 @@ ENABLE_SYNC_FOLDER_WATCHER="${ENABLE_SYNC_FOLDER_WATCHER:="false"}"
 # if REDIS_HOST is set, we assume that an external redis is used
 REDIS_HOST="${REDIS_HOST:=""}"
 
+# snapshot policy of the internal valkey, as "<seconds> <changes>" pairs. Saving
+# hourly keeps a graceful shutdown lossless while a hard crash can only lose an
+# hour of sessions and cached metadata. Set to an empty value to never snapshot.
+REDIS_SAVE_POLICY="${REDIS_SAVE_POLICY:="3600 1"}"
+
 # logger colors
 RED='\033[0;31m'
 LIGHTMAGENTA='\033[0;95m'
@@ -164,6 +169,16 @@ start_bin_nginx() {
 start_bin_valkey-server() {
 	info_log "Starting internal valkey"
 
+	# Most of the keyspace is bulky, rebuildable metadata (Switch TitleDB,
+	# LaunchBox), so every snapshot rewrites hundreds of MB of dump.rdb. Valkey's
+	# stock policy does that every few minutes even on an idle instance, which
+	# adds up to gigabytes of disk writes per hour.
+	local -a save_flags=(--save "")
+	if [[ -n ${REDIS_SAVE_POLICY} ]]; then
+		# shellcheck disable=SC2206 # each "<seconds> <changes>" token is its own argument
+		save_flags=(--save ${REDIS_SAVE_POLICY})
+	fi
+
 	if [[ -f /usr/local/etc/valkey/valkey.conf ]]; then
 		if [[ ${LOGLEVEL} == "DEBUG" ]]; then
 			valkey-server /usr/local/etc/valkey/valkey.conf &
@@ -172,9 +187,9 @@ start_bin_valkey-server() {
 		fi
 	else
 		if [[ ${LOGLEVEL} == "DEBUG" ]]; then
-			valkey-server --dir /redis-data &
+			valkey-server --dir /redis-data "${save_flags[@]}" &
 		else
-			valkey-server --dir /redis-data >/dev/null 2>&1 &
+			valkey-server --dir /redis-data "${save_flags[@]}" >/dev/null 2>&1 &
 		fi
 	fi
 

--- a/docs/BACKEND_ARCHITECTURE.md
+++ b/docs/BACKEND_ARCHITECTURE.md
@@ -1537,29 +1537,29 @@ Falls back to `FakeRedis` in test mode.
 
 #### Redis
 
-| Variable            | Default     | Description                                                                 |
-| ------------------- | ----------- | --------------------------------------------------------------------------- |
-| `REDIS_HOST`        | `127.0.0.1` | Redis host                                                                  |
-| `REDIS_PORT`        | `6379`      | Redis port                                                                  |
-| `REDIS_USERNAME`    |             | Redis username (ACL)                                                        |
-| `REDIS_PASSWORD`    |             | Redis password                                                              |
-| `REDIS_DB`          | `0`         | Redis database number                                                       |
-| `REDIS_SSL`         | `false`     | Enable SSL                                                                  |
-| `REDIS_SAVE_POLICY` | `3600 1`    | Internal Valkey snapshot policy, `"<seconds> <changes>"` pairs (empty: off) |
+| Variable            | Default     | Description            |
+| ------------------- | ----------- | ---------------------- |
+| `REDIS_HOST`        | `127.0.0.1` | Redis host             |
+| `REDIS_PORT`        | `6379`      | Redis port             |
+| `REDIS_USERNAME`    |             | Redis username (ACL)   |
+| `REDIS_PASSWORD`    |             | Redis password         |
+| `REDIS_DB`          | `0`         | Redis database number  |
+| `REDIS_SSL`         | `false`     | Enable SSL             |
+| `REDIS_SAVE_POLICY` | `3600 1`    | Valkey snapshot policy |
 
 #### Authentication
 
-| Variable                             | Default   | Description                               |
-| ------------------------------------ | --------- | ----------------------------------------- |
-| `ROMM_AUTH_SECRET_KEY`               |           | JWT/session signing key (random if unset) |
-| `OAUTH_ACCESS_TOKEN_EXPIRE_SECONDS`  | `1800`    | 30 minutes                                |
-| `OAUTH_REFRESH_TOKEN_EXPIRE_SECONDS` | `604800`  | 7 days                                    |
-| `SESSION_MAX_AGE_SECONDS`            | `1209600` | 14 days                                   |
-| `DISABLE_CSRF_PROTECTION`            | `false`   | Disable CSRF                              |
-| `DISABLE_DOWNLOAD_ENDPOINT_AUTH`     | `false`   | Allow unauthenticated downloads           |
-| `DISABLE_USERPASS_LOGIN`             | `false`   | Disable password login                    |
-| `DISABLE_LOGS_VIEWER`                | `false`   | Disable backend log viewer + endpoint     |
-| `KIOSK_MODE`                         | `false`   | Read-only anonymous access                |
+| Variable                             | Default   | Description                           |
+| ------------------------------------ | --------- | ------------------------------------- |
+| `ROMM_AUTH_SECRET_KEY`               |           | Session signing key (random if unset) |
+| `OAUTH_ACCESS_TOKEN_EXPIRE_SECONDS`  | `1800`    | 30 minutes                            |
+| `OAUTH_REFRESH_TOKEN_EXPIRE_SECONDS` | `604800`  | 7 days                                |
+| `SESSION_MAX_AGE_SECONDS`            | `1209600` | 14 days                               |
+| `DISABLE_CSRF_PROTECTION`            | `false`   | Disable CSRF                          |
+| `DISABLE_DOWNLOAD_ENDPOINT_AUTH`     | `false`   | Allow unauthenticated downloads       |
+| `DISABLE_USERPASS_LOGIN`             | `false`   | Disable password login                |
+| `DISABLE_LOGS_VIEWER`                | `false`   | Disable backend log viewer + endpoint |
+| `KIOSK_MODE`                         | `false`   | Read-only anonymous access            |
 
 #### OIDC
 

--- a/docs/BACKEND_ARCHITECTURE.md
+++ b/docs/BACKEND_ARCHITECTURE.md
@@ -1537,14 +1537,15 @@ Falls back to `FakeRedis` in test mode.
 
 #### Redis
 
-| Variable         | Default     | Description           |
-| ---------------- | ----------- | --------------------- |
-| `REDIS_HOST`     | `127.0.0.1` | Redis host            |
-| `REDIS_PORT`     | `6379`      | Redis port            |
-| `REDIS_USERNAME` |             | Redis username (ACL)  |
-| `REDIS_PASSWORD` |             | Redis password        |
-| `REDIS_DB`       | `0`         | Redis database number |
-| `REDIS_SSL`      | `false`     | Enable SSL            |
+| Variable            | Default     | Description                                                                 |
+| ------------------- | ----------- | --------------------------------------------------------------------------- |
+| `REDIS_HOST`        | `127.0.0.1` | Redis host                                                                  |
+| `REDIS_PORT`        | `6379`      | Redis port                                                                  |
+| `REDIS_USERNAME`    |             | Redis username (ACL)                                                        |
+| `REDIS_PASSWORD`    |             | Redis password                                                              |
+| `REDIS_DB`          | `0`         | Redis database number                                                       |
+| `REDIS_SSL`         | `false`     | Enable SSL                                                                  |
+| `REDIS_SAVE_POLICY` | `3600 1`    | Internal Valkey snapshot policy, `"<seconds> <changes>"` pairs (empty: off) |
 
 #### Authentication
 

--- a/env.template
+++ b/env.template
@@ -22,6 +22,7 @@ REDIS_USERNAME=  # Username for the Redis/Valkey instance
 REDIS_PASSWORD=  # Password for the Redis/Valkey instance
 REDIS_DB=0  # Database number for the Redis/Valkey instance
 REDIS_SSL=false  # Enable SSL (rediss://) for the Redis/Valkey connection
+REDIS_SAVE_POLICY=3600 1  # Snapshot policy of the internal Valkey, as "<seconds> <changes>" pairs (empty to never snapshot)
 
 # Authentication
 ROMM_AUTH_SECRET_KEY=  # App secret, generate with `openssl rand -hex 32` [REQUIRED]


### PR DESCRIPTION
**Description**

Fixes #3980, the unexplained gigabytes/hour of writes, plus the failing scheduled task in the same report's logs.

**The writes are valkey snapshots, not a RomM task.** RomM keeps its bulky metadata caches (Switch TitleDB, LaunchBox) in the internal valkey, and we started it with valkey's stock save policy (`3600 1 300 100 60 10000`). That rewrites the *entire* `dump.rdb` every ~5 minutes as soon as 100 keys change, which idle RQ worker/job bookkeeping alone is enough to trigger.

Measured on a dev instance with both caches enabled:

- `used_memory` 675MB, `dump.rdb` **424MB**
- x ~10 snapshots/hour = **4-5GB/hour** written to `/redis-data`, matching the reported volume and 6-10 minute cadence

The internal valkey now starts with `--save`, defaulting to `3600 1` (at most one snapshot an hour), overridable through a new `REDIS_SAVE_POLICY` env var; set it empty to never snapshot. Shutdown still saves, so a graceful restart is lossless and only a hard crash can lose up to an hour of sessions and cached metadata. A user-supplied `/usr/local/etc/valkey/valkey.conf` still wins, unchanged.

**Second, unrelated bug from the same logs.** `cleanup_upload_tmp_task` died every hour with `ValueError: Invalid attribute name: run`. It imported its constants from `endpoints.roms.upload`, and when the RQ worker makes that task module the first application module imported, it closes an import cycle (`endpoints.roms` -> `handler.auth.dependencies` -> `decorators.database` -> `handler.database` -> `decorators.database`). RQ swallows the `ImportError` and reports that misleading attribute error. The task never ran, so orphaned chunked-upload temp directories were never cleaned up. `ROM_UPLOAD_TMP_BASE` / `ROM_UPLOAD_TTL` now live in `config`, which both the endpoint and the task import.

The new test discovers every `PeriodicTask.func` and resolves it with `rq.utils.import_attribute` in a fresh interpreter, the only place this class of failure surfaces. It fails on the old code and covers the other 9 task funcs.

One caveat: an hourly snapshot of a 424MB RDB is still ~10GB/day on an idle instance. Going further (AOF, or keeping the metadata caches out of the persisted keyspace) is a bigger change than this issue warrants, hence the `REDIS_SAVE_POLICY=""` escape hatch.

Verified: full backend suite (`2495 passed, 2 skipped`), `trunk fmt && trunk check` clean, `bash -n` on the init script, and all three `--save` forms (`3600 1`, empty, multi-pair) parsed against the real valkey binary.

<sub>AI assistance disclosure: written with Claude Code. It did the diagnosis, the code and test changes, and the verification runs; I reviewed everything before opening this PR.</sub>

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

n/a
