### PR TITLE
fix(launchbox): stop the cloud provider from silently matching nothing

### DIFF
--- a/backend/endpoints/tasks.py
+++ b/backend/endpoints/tasks.py
@@ -11,7 +11,6 @@ from config import (
     ENABLE_RESCAN_ON_FILESYSTEM_CHANGE,
     RESCAN_ON_FILESYSTEM_CHANGE_DELAY,
     TASK_RESULT_TTL,
-    TASK_TIMEOUT,
 )
 from decorators.auth import protected_route
 from endpoints.responses import (
@@ -145,7 +144,7 @@ def _build_task_info(name: str, task: Task) -> TaskInfo:
         title=task.title,
         description=task.description,
         enabled=task.enabled,
-        manual_run=task.manual_run,
+        manual_run=task.can_run_manually,
         cron_string=task.cron_string or "",
     )
 
@@ -385,7 +384,7 @@ async def run_single_task(
         )
 
     task_instance = all_tasks[task_name]
-    if not task_instance.enabled or not task_instance.manual_run:
+    if not task_instance.can_run_manually:
         raise HTTPException(
             status_code=400,
             detail=f"Task '{task_name}' cannot be run",
@@ -394,7 +393,7 @@ async def run_single_task(
     job = low_prio_queue.enqueue(
         task_instance.run,
         kwargs=task_kwargs or {},
-        job_timeout=TASK_TIMEOUT,
+        job_timeout=task_instance.timeout,
         result_ttl=TASK_RESULT_TTL,
         meta={
             "task_name": task_instance.title,

--- a/backend/handler/metadata/launchbox_handler/handler.py
+++ b/backend/handler/metadata/launchbox_handler/handler.py
@@ -39,8 +39,18 @@ class LaunchboxHandler(MetadataHandler):
     def is_enabled(cls) -> bool:
         return cls.is_cloud_enabled() or cls.is_local_enabled()
 
+    @staticmethod
+    async def is_remote_store_populated() -> bool:
+        return bool(await async_cache.exists(LAUNCHBOX_METADATA_NAME_KEY))
+
     async def heartbeat(self) -> bool:
-        return self.is_enabled()
+        if self.is_local_enabled():
+            return True
+
+        # Cloud lookups read from a cache the metadata update task fills. Until
+        # it has run, every lookup returns nothing, so reporting healthy here
+        # would be a lie.
+        return self.is_cloud_enabled() and await self.is_remote_store_populated()
 
     def get_platform(self, slug: str) -> LaunchboxPlatform:
         return get_platform(slug)
@@ -60,9 +70,7 @@ class LaunchboxHandler(MetadataHandler):
 
         local = await self._local.get_rom(fs_name, platform_slug)
 
-        remote_available = remote_enabled and bool(
-            await async_cache.exists(LAUNCHBOX_METADATA_NAME_KEY)
-        )
+        remote_available = remote_enabled and await self.is_remote_store_populated()
 
         if local is not None:
             launchbox_id_local = safe_int(local.get("DatabaseID"))
@@ -237,6 +245,13 @@ class LaunchboxHandler(MetadataHandler):
     ) -> list[LaunchboxRom]:
         if not self.is_enabled():
             return []
+
+        if self.is_cloud_enabled() and not await self.is_remote_store_populated():
+            log.warning(
+                "LaunchBox metadata store is empty, so no cloud results can be "
+                "returned. Set ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA=true and "
+                "run the LaunchBox metadata update task to populate it."
+            )
 
         rom = await self.get_rom(search_term, platform_slug, keep_tags=True)
         return [rom]

--- a/backend/handler/metadata/launchbox_handler/handler.py
+++ b/backend/handler/metadata/launchbox_handler/handler.py
@@ -14,6 +14,7 @@ from .platforms import get_platform
 from .remote_source import RemoteSource
 from .types import (
     DASH_COLON_REGEX,
+    LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY,
     LAUNCHBOX_METADATA_NAME_KEY,
     LAUNCHBOX_PLATFORMS_DIR,
     LAUNCHBOX_TAG_REGEX,
@@ -43,14 +44,27 @@ class LaunchboxHandler(MetadataHandler):
     async def is_remote_store_populated() -> bool:
         return bool(await async_cache.exists(LAUNCHBOX_METADATA_NAME_KEY))
 
+    @staticmethod
+    async def is_remote_store_importing() -> bool:
+        return bool(await async_cache.exists(LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY))
+
     async def heartbeat(self) -> bool:
         if self.is_local_enabled():
             return True
 
+        if not self.is_cloud_enabled():
+            return False
+
+        # A first import commits in batches, so the store starts answering for a
+        # handful of names long before it holds the whole dump. Until that run
+        # finishes, most lookups still miss.
+        if await self.is_remote_store_importing():
+            return False
+
         # Cloud lookups read from a cache the metadata update task fills. Until
         # it has run, every lookup returns nothing, so reporting healthy here
         # would be a lie.
-        return self.is_cloud_enabled() and await self.is_remote_store_populated()
+        return await self.is_remote_store_populated()
 
     def get_platform(self, slug: str) -> LaunchboxPlatform:
         return get_platform(slug)

--- a/backend/handler/metadata/launchbox_handler/platforms.py
+++ b/backend/handler/metadata/launchbox_handler/platforms.py
@@ -52,7 +52,7 @@ LAUNCHBOX_PLATFORM_LIST: dict[UPS, SlugToLaunchboxId] = {
     UPS.CAMPUTERS_LYNX: {"id": 61, "name": "Camputers Lynx"},
     UPS.CASIO_LOOPY: {"id": 114, "name": "Casio Loopy"},
     UPS.CASIO_PV_1000: {"id": 115, "name": "Casio PV-1000"},
-    UPS.COLECOADAM: {"id": 117, "name": "Coleco Adam"},
+    UPS.COLECOADAM: {"id": 117, "name": "Coleco ADAM"},
     UPS.COLECOVISION: {"id": 13, "name": "ColecoVision"},
     UPS.COLOUR_GENIE: {"id": 73, "name": "EACA EG2000 Colour Genie"},
     UPS.COMMODORE_CDTV: {"id": 120, "name": "Commodore CDTV"},
@@ -76,7 +76,9 @@ LAUNCHBOX_PLATFORM_LIST: dict[UPS, SlugToLaunchboxId] = {
         "id": 58,
         "name": "Fairchild Channel F",
     },
-    UPS.FAMICOM: {"id": 27, "name": "Nintendo Famicom"},
+    # LaunchBox files Famicom and Super Famicom titles under their western
+    # platform names, so both slugs share the NES/SNES entries.
+    UPS.FAMICOM: {"id": 27, "name": "Nintendo Entertainment System"},
     UPS.FDS: {"id": 157, "name": "Nintendo Famicom Disk System"},
     UPS.FM_7: {"id": 186, "name": "Fujitsu FM-7"},
     UPS.FM_TOWNS: {"id": 124, "name": "Fujitsu FM Towns Marty"},
@@ -161,7 +163,7 @@ LAUNCHBOX_PLATFORM_LIST: dict[UPS, SlugToLaunchboxId] = {
     UPS.SEGACD: {"id": 39, "name": "Sega CD"},
     UPS.SEGACD32: {"id": 173, "name": "Sega CD 32X"},
     UPS.SERIES_X_S: {"id": 222, "name": "Microsoft Xbox Series X/S"},
-    UPS.SFAM: {"id": 53, "name": "Super Famicom"},
+    UPS.SFAM: {"id": 53, "name": "Super Nintendo Entertainment System"},
     UPS.SG1000: {"id": 80, "name": "Sega SG-1000"},
     UPS.SHARP_MZ_80B20002500: {"id": 205, "name": "Sharp MZ-2500"},
     UPS.SHARP_X68000: {"id": 128, "name": "Sharp X68000"},

--- a/backend/handler/metadata/launchbox_handler/platforms.py
+++ b/backend/handler/metadata/launchbox_handler/platforms.py
@@ -76,8 +76,6 @@ LAUNCHBOX_PLATFORM_LIST: dict[UPS, SlugToLaunchboxId] = {
         "id": 58,
         "name": "Fairchild Channel F",
     },
-    # LaunchBox files Famicom and Super Famicom titles under their western
-    # platform names, so both slugs share the NES/SNES entries.
     UPS.FAMICOM: {"id": 27, "name": "Nintendo Entertainment System"},
     UPS.FDS: {"id": 157, "name": "Nintendo Famicom Disk System"},
     UPS.FM_7: {"id": 186, "name": "Fujitsu FM-7"},

--- a/backend/handler/metadata/launchbox_handler/remote_source.py
+++ b/backend/handler/metadata/launchbox_handler/remote_source.py
@@ -70,8 +70,14 @@ class RemoteSource:
             metadata_database_index_entry = await async_cache.hget(
                 LAUNCHBOX_METADATA_DATABASE_ID_KEY, database_id
             )
-            if metadata_database_index_entry:
-                return json.loads(metadata_database_index_entry)
+            if not metadata_database_index_entry:
+                continue
+
+            # The alternate name index is not keyed by platform, so a hit can
+            # point at a same-titled game on a completely different system.
+            entry = json.loads(metadata_database_index_entry)
+            if entry.get("Platform") == platform_name:
+                return entry
 
         return None
 

--- a/backend/handler/metadata/launchbox_handler/types.py
+++ b/backend/handler/metadata/launchbox_handler/types.py
@@ -16,9 +16,7 @@ LAUNCHBOX_METADATA_ALTERNATE_NAME_KEY: Final[str] = (
 LAUNCHBOX_METADATA_IMAGE_KEY: Final[str] = "romm:launchbox_metadata_image"
 LAUNCHBOX_MAME_KEY: Final[str] = "romm:launchbox_mame"
 LAUNCHBOX_FILES_KEY: Final[str] = "romm:launchbox_files"
-# Set while the store is being filled for the first time, and cleared once a run
-# completes. The dump is written in batches, so a partial store answers for only
-# a fraction of the entries.
+# Set while the store is being filled for the first time
 LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY: Final[str] = (
     "romm:launchbox_metadata_initial_import"
 )

--- a/backend/handler/metadata/launchbox_handler/types.py
+++ b/backend/handler/metadata/launchbox_handler/types.py
@@ -16,6 +16,12 @@ LAUNCHBOX_METADATA_ALTERNATE_NAME_KEY: Final[str] = (
 LAUNCHBOX_METADATA_IMAGE_KEY: Final[str] = "romm:launchbox_metadata_image"
 LAUNCHBOX_MAME_KEY: Final[str] = "romm:launchbox_mame"
 LAUNCHBOX_FILES_KEY: Final[str] = "romm:launchbox_files"
+# Set while the store is being filled for the first time, and cleared once a run
+# completes. The dump is written in batches, so a partial store answers for only
+# a fraction of the entries.
+LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY: Final[str] = (
+    "romm:launchbox_metadata_initial_import"
+)
 
 LAUNCHBOX_LOCAL_DIR: Final[Path] = Path(ROMM_BASE_PATH) / "launchbox"
 LAUNCHBOX_PLATFORMS_DIR: Final[Path] = LAUNCHBOX_LOCAL_DIR / "Data" / "Platforms"

--- a/backend/tasks/scheduled/update_launchbox_metadata.py
+++ b/backend/tasks/scheduled/update_launchbox_metadata.py
@@ -1,13 +1,17 @@
 import json
 import zipfile
+from collections.abc import Iterator
 from io import BytesIO
-from typing import Any
+from typing import Any, Final
 
 from defusedxml import ElementTree as ET
+from redis.asyncio.client import Pipeline
 
 from config import (
     ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA,
+    LAUNCHBOX_API_ENABLED,
     SCHEDULED_UPDATE_LAUNCHBOX_METADATA_CRON,
+    TASK_TIMEOUT,
 )
 from handler.metadata import meta_launchbox_handler
 from handler.metadata.launchbox_handler.types import (
@@ -26,6 +30,65 @@ from utils.context import initialize_context
 
 from . import UpdateStats
 
+# The dump is ~500MB across 600k+ entries. Buffering it into one pipeline peaks
+# well over a gigabyte of memory and discards everything if the job dies, so
+# writes go out in batches instead.
+CACHE_WRITE_BATCH_SIZE: Final[int] = 2000
+
+# Downloading ~100MB and parsing it takes far longer than an ordinary task.
+LAUNCHBOX_TASK_TIMEOUT: Final[int] = max(TASK_TIMEOUT, 30 * 60)
+
+
+class BatchedCacheWriter:
+    """Queues cache writes on a pipeline, flushing every `batch_size` entries."""
+
+    def __init__(self, pipe: Pipeline, batch_size: int | None = None):
+        self._pipe = pipe
+        self._batch_size = batch_size or CACHE_WRITE_BATCH_SIZE
+        self._queued = 0
+
+    async def hset(self, key: str, field: str, value: Any) -> None:
+        await self._pipe.hset(key, mapping={field: json.dumps(value)})
+        self._queued += 1
+        if self._queued >= self._batch_size:
+            await self.flush()
+
+    async def flush(self) -> None:
+        if self._queued:
+            await self._pipe.execute()
+            self._queued = 0
+
+
+def _element_to_dict(elem: Any) -> dict[str, Any]:
+    return {child.tag: child.text for child in elem}
+
+
+def _iter_elements(source: Any) -> Iterator[Any]:
+    """Yield each top-level record, discarding it once the caller moves on.
+
+    `iterparse` keeps every element it has parsed attached to the root, so
+    without dropping them the whole document ends up in memory.
+    """
+    ctx = ET.iterparse(source, events=("start", "end"))
+
+    try:
+        _, root = next(iter(ctx))
+    except StopIteration:
+        return
+
+    depth = 0
+    for event, elem in ctx:
+        if event == "start":
+            depth += 1
+            continue
+
+        depth -= 1
+        if depth > 0:
+            continue
+
+        yield elem
+        root.clear()
+
 
 class UpdateLaunchboxMetadataTask(RemoteFilePullTask):
     def __init__(self):
@@ -38,7 +101,15 @@ class UpdateLaunchboxMetadataTask(RemoteFilePullTask):
             manual_run=True,
             func="tasks.scheduled.update_launchbox_metadata.update_launchbox_metadata_task.run",
             url="https://gamesdb.launchbox-app.com/Metadata.zip",
+            timeout=LAUNCHBOX_TASK_TIMEOUT,
         )
+
+    @property
+    def can_run_manually(self) -> bool:
+        # The store lives only in the cache, so admins need a way to fill it
+        # even when the scheduled update is off. Otherwise turning LaunchBox on
+        # leaves a provider that silently matches nothing.
+        return self.manual_run and (self.enabled or LAUNCHBOX_API_ENABLED)
 
     @initialize_context()
     async def run(self, force: bool = False) -> dict[str, Any]:
@@ -48,7 +119,9 @@ class UpdateLaunchboxMetadataTask(RemoteFilePullTask):
             log.warning("Launchbox API is not enabled, skipping metadata update")
             return update_stats.to_dict()
 
-        content = await super().run(force)
+        # Reaching here means either the cron fired or an admin asked for it, so
+        # the pull goes ahead regardless of the scheduled-update setting.
+        content = await super().run(True)
         if content is None:
             log.warning("No content received from launchbox metadata update")
             return update_stats.to_dict()
@@ -67,51 +140,38 @@ class UpdateLaunchboxMetadataTask(RemoteFilePullTask):
                     if file == "Platforms.xml":
                         with z.open(file, "r") as f:
                             async with async_cache.pipeline() as pipe:
-                                ctx = ET.iterparse(f, events=("end",))
+                                writer = BatchedCacheWriter(pipe)
 
-                                for _, elem in ctx:
+                                for elem in _iter_elements(f):
                                     if elem.tag == "Platform":
                                         name_elem = elem.find("Name")
                                         if name_elem is not None and name_elem.text:
-                                            await pipe.hset(
+                                            await writer.hset(
                                                 LAUNCHBOX_PLATFORMS_KEY,
-                                                mapping={
-                                                    name_elem.text: json.dumps(
-                                                        {
-                                                            child.tag: child.text
-                                                            for child in elem
-                                                        }
-                                                    )
-                                                },
+                                                name_elem.text,
+                                                _element_to_dict(elem),
                                             )
 
-                                        elem.clear()
-                                await pipe.execute()
+                                await writer.flush()
                                 processed_files += 1
                                 update_stats.update(processed=processed_files)
 
                     elif file == "Metadata.xml":
                         with z.open(file, "r") as f:
                             async with async_cache.pipeline() as pipe:
-                                ctx = ET.iterparse(f, events=("end",))
+                                writer = BatchedCacheWriter(pipe)
 
                                 current_game_image_db_id = None
                                 current_game_images: list[dict[str, Any]] = []
 
-                                for _, elem in ctx:
+                                for elem in _iter_elements(f):
                                     if elem.tag == "Game":
                                         id_elem = elem.find("DatabaseID")
                                         if id_elem is not None and id_elem.text:
-                                            await pipe.hset(
+                                            await writer.hset(
                                                 LAUNCHBOX_METADATA_DATABASE_ID_KEY,
-                                                mapping={
-                                                    id_elem.text: json.dumps(
-                                                        {
-                                                            child.tag: child.text
-                                                            for child in elem
-                                                        }
-                                                    )
-                                                },
+                                                id_elem.text,
+                                                _element_to_dict(elem),
                                             )
 
                                         name_elem = elem.find("Name")
@@ -123,18 +183,11 @@ class UpdateLaunchboxMetadataTask(RemoteFilePullTask):
                                             and platform_elem.text
                                         ):
                                             # Use a unique combination of name and platform as the key
-                                            await pipe.hset(
+                                            await writer.hset(
                                                 LAUNCHBOX_METADATA_NAME_KEY,
-                                                mapping={
-                                                    f"{name_elem.text.lower()}:{platform_elem.text}": json.dumps(
-                                                        {
-                                                            child.tag: child.text
-                                                            for child in elem
-                                                        }
-                                                    )
-                                                },
+                                                f"{name_elem.text.lower()}:{platform_elem.text}",
+                                                _element_to_dict(elem),
                                             )
-                                        elem.clear()
 
                                     elif elem.tag == "GameAlternateName":
                                         alternate_name_elem = elem.find("AlternateName")
@@ -142,19 +195,11 @@ class UpdateLaunchboxMetadataTask(RemoteFilePullTask):
                                             alternate_name_elem is not None
                                             and alternate_name_elem.text
                                         ):
-                                            await pipe.hset(
+                                            await writer.hset(
                                                 LAUNCHBOX_METADATA_ALTERNATE_NAME_KEY,
-                                                mapping={
-                                                    alternate_name_elem.text.lower(): json.dumps(
-                                                        {
-                                                            child.tag: child.text
-                                                            for child in elem
-                                                        }
-                                                    )
-                                                },
+                                                alternate_name_elem.text.lower(),
+                                                _element_to_dict(elem),
                                             )
-
-                                        elem.clear()
 
                                     elif elem.tag == "GameImage":
                                         id_elem = elem.find("DatabaseID")
@@ -166,94 +211,70 @@ class UpdateLaunchboxMetadataTask(RemoteFilePullTask):
                                                 and image_id != current_game_image_db_id
                                             ):
                                                 # Store the previous game's images
-                                                await pipe.hset(
+                                                await writer.hset(
                                                     LAUNCHBOX_METADATA_IMAGE_KEY,
-                                                    mapping={
-                                                        current_game_image_db_id: json.dumps(
-                                                            current_game_images
-                                                        )
-                                                    },
+                                                    current_game_image_db_id,
+                                                    current_game_images,
                                                 )
                                                 current_game_images = []
 
                                             current_game_image_db_id = image_id
                                             current_game_images.append(
-                                                {
-                                                    child.tag: child.text
-                                                    for child in elem
-                                                }
+                                                _element_to_dict(elem)
                                             )
-                                        elem.clear()
 
                                 # Store the last game's images
                                 if current_game_image_db_id is not None:
-                                    await pipe.hset(
+                                    await writer.hset(
                                         LAUNCHBOX_METADATA_IMAGE_KEY,
-                                        mapping={
-                                            current_game_image_db_id: json.dumps(
-                                                current_game_images
-                                            )
-                                        },
+                                        current_game_image_db_id,
+                                        current_game_images,
                                     )
-                                await pipe.execute()
+                                await writer.flush()
                                 processed_files += 1
                                 update_stats.update(processed=processed_files)
 
                     elif file == "Mame.xml":
                         with z.open(file, "r") as f:
                             async with async_cache.pipeline() as pipe:
-                                ctx = ET.iterparse(f, events=("end",))
+                                writer = BatchedCacheWriter(pipe)
 
-                                for _, elem in ctx:
+                                for elem in _iter_elements(f):
                                     if elem.tag == "MameFile":
                                         filename_elem = elem.find("FileName")
                                         if (
                                             filename_elem is not None
                                             and filename_elem.text
                                         ):
-                                            await pipe.hset(
+                                            await writer.hset(
                                                 LAUNCHBOX_MAME_KEY,
-                                                mapping={
-                                                    filename_elem.text: json.dumps(
-                                                        {
-                                                            child.tag: child.text
-                                                            for child in elem
-                                                        }
-                                                    )
-                                                },
+                                                filename_elem.text,
+                                                _element_to_dict(elem),
                                             )
 
-                                        elem.clear()
-                                await pipe.execute()
+                                await writer.flush()
                                 processed_files += 1
                                 update_stats.update(processed=processed_files)
 
                     elif file == "Files.xml":
                         with z.open(file, "r") as f:
                             async with async_cache.pipeline() as pipe:
-                                ctx = ET.iterparse(f, events=("end",))
+                                writer = BatchedCacheWriter(pipe)
 
-                                for _, elem in ctx:
+                                for elem in _iter_elements(f):
                                     if elem.tag == "File":
                                         filename_elem = elem.find("FileName")
                                         if (
                                             filename_elem is not None
                                             and filename_elem.text
                                         ):
-                                            await pipe.hset(
+                                            await writer.hset(
                                                 LAUNCHBOX_FILES_KEY,
-                                                mapping={
-                                                    filename_elem.text: json.dumps(
-                                                        {
-                                                            child.tag: child.text
-                                                            for child in elem
-                                                        }
-                                                    )
-                                                },
+                                                filename_elem.text,
+                                                _element_to_dict(elem),
                                             )
 
-                                        elem.clear()
-                                await pipe.execute()
+                                await writer.flush()
                                 processed_files += 1
                                 update_stats.update(processed=processed_files)
 

--- a/backend/tasks/scheduled/update_launchbox_metadata.py
+++ b/backend/tasks/scheduled/update_launchbox_metadata.py
@@ -20,6 +20,7 @@ from handler.metadata.launchbox_handler.types import (
     LAUNCHBOX_METADATA_ALTERNATE_NAME_KEY,
     LAUNCHBOX_METADATA_DATABASE_ID_KEY,
     LAUNCHBOX_METADATA_IMAGE_KEY,
+    LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY,
     LAUNCHBOX_METADATA_NAME_KEY,
     LAUNCHBOX_PLATFORMS_KEY,
 )
@@ -125,6 +126,12 @@ class UpdateLaunchboxMetadataTask(RemoteFilePullTask):
         if content is None:
             log.warning("No content received from launchbox metadata update")
             return update_stats.to_dict()
+
+        # A refresh keeps serving the previous dump, but a first import only
+        # holds the batches committed so far, so flag it to keep the provider
+        # from reporting healthy off a fraction of the entries.
+        if not await meta_launchbox_handler.is_remote_store_populated():
+            await async_cache.set(LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY, "1")
 
         try:
             zip_file_bytes = BytesIO(content)
@@ -281,6 +288,9 @@ class UpdateLaunchboxMetadataTask(RemoteFilePullTask):
         except (zipfile.BadZipFile, RuntimeError, OSError):
             log.error("Bad zip file in launchbox metadata update")
             return update_stats.to_dict()
+
+        # Also clears a flag left behind by an earlier run that died partway.
+        await async_cache.delete(LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY)
 
         log.info("Scheduled launchbox metadata update completed!")
 

--- a/backend/tasks/tasks.py
+++ b/backend/tasks/tasks.py
@@ -54,6 +54,7 @@ class Task(ABC):
     manual_run: bool
     cron_string: str | None = None
     task_type: TaskType
+    timeout: int
 
     def __init__(
         self,
@@ -63,6 +64,7 @@ class Task(ABC):
         enabled: bool = False,
         manual_run: bool = False,
         cron_string: str | None = None,
+        timeout: int = TASK_TIMEOUT,
     ):
         self.title = title
         self.description = description or title
@@ -70,6 +72,12 @@ class Task(ABC):
         self.enabled = enabled
         self.manual_run = manual_run
         self.cron_string = cron_string
+        self.timeout = timeout
+
+    @property
+    def can_run_manually(self) -> bool:
+        """Whether an admin can trigger this task on demand."""
+        return self.manual_run and self.enabled
 
     @abstractmethod
     async def run(self, *args: Any, **kwargs: Any) -> Any: ...
@@ -122,7 +130,7 @@ class PeriodicTask(Task, ABC):
                 self.cron_string,
                 func=self.func,
                 repeat=None,
-                timeout=TASK_TIMEOUT,
+                timeout=self.timeout,
                 meta={
                     "task_name": self.title,
                     "task_type": self.task_type.value,

--- a/backend/tests/endpoints/test_heartbeat.py
+++ b/backend/tests/endpoints/test_heartbeat.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi import status
 
 from exceptions.fs_exceptions import PlatformAlreadyExistsException
+from handler.metadata.launchbox_handler.handler import LaunchboxHandler
 from utils import get_version
 
 
@@ -63,11 +64,19 @@ def test_heartbeat_with_malformed_authorization_header(
 
 
 def test_heartbeat_metadata(client):
+    """LaunchBox is only healthy once its metadata store has been populated."""
     response = client.get("/api/heartbeat/metadata/launchbox")
     assert response.status_code == status.HTTP_200_OK
+    assert response.json() is False
 
-    heartbeat = response.json()
-    assert heartbeat
+    with patch.object(
+        LaunchboxHandler, "is_remote_store_populated", new_callable=AsyncMock
+    ) as mock_populated:
+        mock_populated.return_value = True
+        response = client.get("/api/heartbeat/metadata/launchbox")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() is True
 
 
 def test_heartbeat_metadata_unknown_source(client):

--- a/backend/tests/endpoints/test_tasks.py
+++ b/backend/tests/endpoints/test_tasks.py
@@ -16,7 +16,9 @@ def mock_task():
     task.task_type = TaskType.CLEANUP
     task.enabled = True
     task.manual_run = True
+    task.can_run_manually = True
     task.cron_string = "0 0 * * *"
+    task.timeout = 300
     task.run = Mock()
     return task
 
@@ -30,7 +32,9 @@ def mock_disabled_task():
     task.task_type = TaskType.CLEANUP
     task.enabled = False
     task.manual_run = True
+    task.can_run_manually = False
     task.cron_string = None
+    task.timeout = 300
     task.run = Mock()
     return task
 
@@ -44,7 +48,9 @@ def mock_non_manual_task():
     task.task_type = TaskType.CLEANUP
     task.enabled = True
     task.manual_run = False
+    task.can_run_manually = False
     task.cron_string = "0 0 * * *"
+    task.timeout = 300
     task.run = Mock()
     return task
 
@@ -87,6 +93,8 @@ class TestListTasks:
                     description="Manual task",
                     enabled=True,
                     manual_run=True,
+                    can_run_manually=True,
+                    timeout=300,
                     cron_string=None,
                 ),
             }
@@ -105,6 +113,8 @@ class TestListTasks:
                     description="Scheduled task",
                     enabled=True,
                     manual_run=False,
+                    can_run_manually=False,
+                    timeout=300,
                     cron_string="0 0 * * *",
                 ),
             }
@@ -218,6 +228,8 @@ class TestRunSingleTask:
                     description="Test Description",
                     enabled=True,
                     manual_run=True,
+                    can_run_manually=True,
+                    timeout=300,
                     run=Mock(),
                 ),
             }
@@ -269,6 +281,8 @@ class TestRunSingleTask:
                     description="Disabled Description",
                     enabled=False,
                     manual_run=True,
+                    can_run_manually=False,
+                    timeout=300,
                     run=Mock(),
                 ),
             }
@@ -300,6 +314,8 @@ class TestRunSingleTask:
                     description="Non-Manual Description",
                     enabled=True,
                     manual_run=False,
+                    can_run_manually=False,
+                    timeout=300,
                     run=Mock(),
                 ),
             }
@@ -510,6 +526,8 @@ class TestTaskInfoBuilding:
                         description="Test Description",
                         enabled=True,
                         manual_run=True,
+                        can_run_manually=True,
+                        timeout=300,
                         cron_string="0 0 * * *",
                     ),
                 }
@@ -555,6 +573,8 @@ class TestIntegration:
                         description="Workflow Description",
                         enabled=True,
                         manual_run=True,
+                        can_run_manually=True,
+                        timeout=300,
                         run=Mock(),
                     ),
                 }

--- a/backend/tests/handler/metadata/test_launchbox_handler.py
+++ b/backend/tests/handler/metadata/test_launchbox_handler.py
@@ -36,6 +36,7 @@ from handler.metadata.launchbox_handler.types import (
     LAUNCHBOX_METADATA_ALTERNATE_NAME_KEY,
     LAUNCHBOX_METADATA_DATABASE_ID_KEY,
     LAUNCHBOX_METADATA_IMAGE_KEY,
+    LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY,
     LAUNCHBOX_METADATA_NAME_KEY,
     LaunchboxImage,
     LaunchboxMetadata,
@@ -1135,12 +1136,19 @@ class TestLaunchboxHandlerEnabled:
 
 
 class TestLaunchboxHandlerHeartbeat:
+    @staticmethod
+    def _cache_exists(*present: str) -> AsyncMock:
+        async def exists(key: str) -> int:
+            return 1 if key in present else 0
+
+        return AsyncMock(side_effect=exists)
+
     async def test_unhealthy_when_cloud_store_is_empty(self):
         handler = LaunchboxHandler()
         with (
             patch.object(LaunchboxHandler, "is_cloud_enabled", return_value=True),
             patch.object(LaunchboxHandler, "is_local_enabled", return_value=False),
-            patch.object(async_cache, "exists", new_callable=AsyncMock, return_value=0),
+            patch.object(async_cache, "exists", self._cache_exists()),
         ):
             assert await handler.heartbeat() is False
 
@@ -1149,16 +1157,34 @@ class TestLaunchboxHandlerHeartbeat:
         with (
             patch.object(LaunchboxHandler, "is_cloud_enabled", return_value=True),
             patch.object(LaunchboxHandler, "is_local_enabled", return_value=False),
-            patch.object(async_cache, "exists", new_callable=AsyncMock, return_value=1),
+            patch.object(
+                async_cache, "exists", self._cache_exists(LAUNCHBOX_METADATA_NAME_KEY)
+            ),
         ):
             assert await handler.heartbeat() is True
+
+    async def test_unhealthy_while_the_first_import_is_still_running(self):
+        """The store answers only for the batches committed so far."""
+        handler = LaunchboxHandler()
+        with (
+            patch.object(LaunchboxHandler, "is_cloud_enabled", return_value=True),
+            patch.object(LaunchboxHandler, "is_local_enabled", return_value=False),
+            patch.object(
+                async_cache,
+                "exists",
+                self._cache_exists(
+                    LAUNCHBOX_METADATA_NAME_KEY, LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY
+                ),
+            ),
+        ):
+            assert await handler.heartbeat() is False
 
     async def test_healthy_from_local_install_without_cloud_store(self):
         handler = LaunchboxHandler()
         with (
             patch.object(LaunchboxHandler, "is_cloud_enabled", return_value=False),
             patch.object(LaunchboxHandler, "is_local_enabled", return_value=True),
-            patch.object(async_cache, "exists", new_callable=AsyncMock, return_value=0),
+            patch.object(async_cache, "exists", self._cache_exists()),
         ):
             assert await handler.heartbeat() is True
 

--- a/backend/tests/handler/metadata/test_launchbox_handler.py
+++ b/backend/tests/handler/metadata/test_launchbox_handler.py
@@ -86,6 +86,7 @@ SAMPLE_NES_XML = """\
 REMOTE_ENTRY = {
     "DatabaseID": "1234",
     "Name": "Super Mario Bros.",
+    "Platform": "Nintendo Entertainment System",
     "Overview": "Jump and run platformer by Nintendo.",
     "MaxPlayers": "2",
     "ReleaseDate": "1985-09-13T00:00:00",
@@ -518,6 +519,30 @@ class TestRemoteSourceGetRom:
             )
         assert result is not None
         assert result.get("Name", None) == "Super Mario Bros."
+
+    async def test_alternate_name_on_other_platform_is_rejected(
+        self, source: RemoteSource
+    ):
+        """The alternate name index is not keyed by platform, so a hit pointing
+        at a same-titled game on another system must not be returned."""
+        alt_entry = {"DatabaseID": "1234"}
+
+        async def side_effect(key, _field):
+            if key == LAUNCHBOX_METADATA_NAME_KEY:
+                return None
+            if key == LAUNCHBOX_METADATA_ALTERNATE_NAME_KEY:
+                return json.dumps(alt_entry)
+            if key == LAUNCHBOX_METADATA_DATABASE_ID_KEY:
+                return json.dumps(REMOTE_ENTRY)
+            return None
+
+        with patch.object(
+            async_cache, "hget", new_callable=AsyncMock, side_effect=side_effect
+        ):
+            result = await source.get_rom(
+                "super mario bros.", "psx", assume_cache_present=True
+            )
+        assert result is None
 
     async def test_no_match_returns_none(self, source: RemoteSource):
         with patch.object(
@@ -1107,6 +1132,35 @@ class TestLaunchboxHandlerEnabled:
         with patch.object(LaunchboxHandler, "is_cloud_enabled", return_value=False):
             with patch.object(LaunchboxHandler, "is_local_enabled", return_value=False):
                 assert LaunchboxHandler.is_enabled() is False
+
+
+class TestLaunchboxHandlerHeartbeat:
+    async def test_unhealthy_when_cloud_store_is_empty(self):
+        handler = LaunchboxHandler()
+        with (
+            patch.object(LaunchboxHandler, "is_cloud_enabled", return_value=True),
+            patch.object(LaunchboxHandler, "is_local_enabled", return_value=False),
+            patch.object(async_cache, "exists", new_callable=AsyncMock, return_value=0),
+        ):
+            assert await handler.heartbeat() is False
+
+    async def test_healthy_when_cloud_store_is_populated(self):
+        handler = LaunchboxHandler()
+        with (
+            patch.object(LaunchboxHandler, "is_cloud_enabled", return_value=True),
+            patch.object(LaunchboxHandler, "is_local_enabled", return_value=False),
+            patch.object(async_cache, "exists", new_callable=AsyncMock, return_value=1),
+        ):
+            assert await handler.heartbeat() is True
+
+    async def test_healthy_from_local_install_without_cloud_store(self):
+        handler = LaunchboxHandler()
+        with (
+            patch.object(LaunchboxHandler, "is_cloud_enabled", return_value=False),
+            patch.object(LaunchboxHandler, "is_local_enabled", return_value=True),
+            patch.object(async_cache, "exists", new_callable=AsyncMock, return_value=0),
+        ):
+            assert await handler.heartbeat() is True
 
 
 class TestLaunchboxHandlerGetPlatform:

--- a/backend/tests/tasks/test_update_launchbox_metadata.py
+++ b/backend/tests/tasks/test_update_launchbox_metadata.py
@@ -12,9 +12,11 @@ from handler.metadata.launchbox_handler.types import (
     LAUNCHBOX_METADATA_ALTERNATE_NAME_KEY,
     LAUNCHBOX_METADATA_DATABASE_ID_KEY,
     LAUNCHBOX_METADATA_IMAGE_KEY,
+    LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY,
     LAUNCHBOX_METADATA_NAME_KEY,
     LAUNCHBOX_PLATFORMS_KEY,
 )
+from handler.redis_handler import async_cache
 from tasks.scheduled.update_launchbox_metadata import (
     BatchedCacheWriter,
     UpdateLaunchboxMetadataTask,
@@ -390,6 +392,64 @@ class TestBatchedCacheWriter:
 
         # One execute per queued write rather than one for the whole file.
         assert mock_pipe.execute.call_count == mock_pipe.hset.call_count
+
+
+class TestInitialImportFlag:
+    """The store is written in batches, so a half-filled one must not read as
+    ready to the provider heartbeat."""
+
+    @patch.object(RemoteFilePullTask, "run")
+    @patch("tasks.scheduled.update_launchbox_metadata.async_cache.pipeline")
+    async def test_first_import_flags_and_clears_on_completion(
+        self, mock_pipeline, mock_super_run, task, sample_zip_content
+    ):
+        mock_super_run.return_value = sample_zip_content
+        mock_pipeline.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_pipeline.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch.object(async_cache, "exists", AsyncMock(return_value=0)),
+            patch.object(async_cache, "set", AsyncMock()) as mock_set,
+            patch.object(async_cache, "delete", AsyncMock()) as mock_delete,
+        ):
+            await task.run(force=True)
+
+        mock_set.assert_awaited_once_with(LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY, "1")
+        mock_delete.assert_awaited_once_with(LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY)
+
+    @patch.object(RemoteFilePullTask, "run")
+    @patch("tasks.scheduled.update_launchbox_metadata.async_cache.pipeline")
+    async def test_refresh_of_a_filled_store_is_not_flagged(
+        self, mock_pipeline, mock_super_run, task, sample_zip_content
+    ):
+        """An existing store keeps answering while it is refreshed in place."""
+        mock_super_run.return_value = sample_zip_content
+        mock_pipeline.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_pipeline.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch.object(async_cache, "exists", AsyncMock(return_value=1)),
+            patch.object(async_cache, "set", AsyncMock()) as mock_set,
+            patch.object(async_cache, "delete", AsyncMock()),
+        ):
+            await task.run(force=True)
+
+        mock_set.assert_not_awaited()
+
+    @patch.object(RemoteFilePullTask, "run")
+    async def test_flag_survives_a_failed_run(
+        self, mock_super_run, task, corrupt_zip_content
+    ):
+        mock_super_run.return_value = corrupt_zip_content
+
+        with (
+            patch.object(async_cache, "exists", AsyncMock(return_value=0)),
+            patch.object(async_cache, "set", AsyncMock()),
+            patch.object(async_cache, "delete", AsyncMock()) as mock_delete,
+        ):
+            await task.run(force=True)
+
+        mock_delete.assert_not_awaited()
 
 
 class TestManualRunGate:

--- a/backend/tests/tasks/test_update_launchbox_metadata.py
+++ b/backend/tests/tasks/test_update_launchbox_metadata.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 import anyio
 import pytest
 
+from config import TASK_TIMEOUT
 from handler.metadata.launchbox_handler.handler import LaunchboxHandler
 from handler.metadata.launchbox_handler.types import (
     LAUNCHBOX_FILES_KEY,
@@ -15,6 +16,7 @@ from handler.metadata.launchbox_handler.types import (
     LAUNCHBOX_PLATFORMS_KEY,
 )
 from tasks.scheduled.update_launchbox_metadata import (
+    BatchedCacheWriter,
     UpdateLaunchboxMetadataTask,
     update_launchbox_metadata_task,
 )
@@ -319,3 +321,102 @@ class TestUpdateLaunchboxMetadataTaskIntegration:
             assert (
                 expected_key in redis_keys_used
             ), f"Expected key {expected_key} not found in Redis operations"
+
+
+class TestBatchedCacheWriter:
+    """The dump is far too large to buffer into a single pipeline."""
+
+    async def test_flushes_once_the_batch_is_full(self):
+        pipe = AsyncMock()
+        writer = BatchedCacheWriter(pipe, batch_size=3)
+
+        for i in range(3):
+            await writer.hset("key", f"field-{i}", {"i": i})
+
+        assert pipe.execute.call_count == 1
+
+    async def test_does_not_flush_a_partial_batch_early(self):
+        pipe = AsyncMock()
+        writer = BatchedCacheWriter(pipe, batch_size=3)
+
+        await writer.hset("key", "field", {"a": 1})
+
+        assert pipe.execute.call_count == 0
+
+    async def test_final_flush_writes_the_remainder(self):
+        pipe = AsyncMock()
+        writer = BatchedCacheWriter(pipe, batch_size=3)
+
+        await writer.hset("key", "field", {"a": 1})
+        await writer.flush()
+
+        assert pipe.execute.call_count == 1
+
+    async def test_flush_is_a_noop_with_nothing_queued(self):
+        pipe = AsyncMock()
+        writer = BatchedCacheWriter(pipe, batch_size=3)
+
+        await writer.flush()
+
+        assert pipe.execute.call_count == 0
+
+    async def test_values_are_json_encoded(self):
+        pipe = AsyncMock()
+        writer = BatchedCacheWriter(pipe, batch_size=10)
+
+        await writer.hset("key", "field", {"Name": "Super Mario Bros."})
+
+        pipe.hset.assert_called_once_with(
+            "key", mapping={"field": '{"Name": "Super Mario Bros."}'}
+        )
+
+    async def test_large_input_flushes_repeatedly(self, task, sample_zip_content):
+        """A real dump must not end up in one pipeline execute."""
+        mock_pipe = AsyncMock()
+
+        with (
+            patch.object(RemoteFilePullTask, "run", return_value=sample_zip_content),
+            patch(
+                "tasks.scheduled.update_launchbox_metadata.CACHE_WRITE_BATCH_SIZE", 1
+            ),
+            patch(
+                "tasks.scheduled.update_launchbox_metadata.async_cache.pipeline"
+            ) as mock_pipeline,
+        ):
+            mock_pipeline.return_value.__aenter__ = AsyncMock(return_value=mock_pipe)
+            mock_pipeline.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            await task.run(force=True)
+
+        # One execute per queued write rather than one for the whole file.
+        assert mock_pipe.execute.call_count == mock_pipe.hset.call_count
+
+
+class TestManualRunGate:
+    def test_runnable_when_only_the_provider_is_enabled(self, task):
+        """Enabling LaunchBox without the cron must still leave a way to fill
+        the store, otherwise the provider silently matches nothing."""
+        task.enabled = False
+        with patch(
+            "tasks.scheduled.update_launchbox_metadata.LAUNCHBOX_API_ENABLED", True
+        ):
+            assert task.can_run_manually is True
+
+    def test_runnable_when_scheduled(self, task):
+        task.enabled = True
+        with patch(
+            "tasks.scheduled.update_launchbox_metadata.LAUNCHBOX_API_ENABLED", False
+        ):
+            assert task.can_run_manually is True
+
+    def test_not_runnable_when_launchbox_is_off(self, task):
+        task.enabled = False
+        with patch(
+            "tasks.scheduled.update_launchbox_metadata.LAUNCHBOX_API_ENABLED", False
+        ):
+            assert task.can_run_manually is False
+
+    def test_timeout_is_generous(self, task):
+        """Downloading ~100MB and parsing ~500MB overruns the default timeout."""
+        assert task.timeout >= 30 * 60
+        assert task.timeout >= TASK_TIMEOUT

--- a/frontend/src/components/Settings/Administration/Tasks.vue
+++ b/frontend/src/components/Settings/Administration/Tasks.vue
@@ -49,6 +49,9 @@ const fetchTaskStatus = async () => {
 let refreshInterval: number | null = null;
 
 onMounted(() => {
+  // /tasks needs the `tasks.run` scope, so a session established after app
+  // boot (any login without a reload) would leave the lists empty for good.
+  tasksStore.fetchTasks();
   fetchTaskStatus();
   refreshInterval = window.setInterval(() => {
     fetchTaskStatus().catch((error) => {

--- a/frontend/src/components/Settings/Administration/Tasks.vue
+++ b/frontend/src/components/Settings/Administration/Tasks.vue
@@ -49,8 +49,6 @@ const fetchTaskStatus = async () => {
 let refreshInterval: number | null = null;
 
 onMounted(() => {
-  // /tasks needs the `tasks.run` scope, so a session established after app
-  // boot (any login without a reload) would leave the lists empty for good.
   tasksStore.fetchTasks();
   fetchTaskStatus();
   refreshInterval = window.setInterval(() => {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -6,7 +6,6 @@ import router from "@/plugins/router";
 import storeAuth from "@/stores/auth";
 import storeConfig from "@/stores/config";
 import storeHeartbeat from "@/stores/heartbeat";
-import storeTasks from "@/stores/tasks";
 import "@/styles/common.css";
 import "@/styles/fonts.css";
 import "@/styles/scrollbar.css";
@@ -16,14 +15,12 @@ async function initializeData() {
   const heartbeatStore = storeHeartbeat();
   const authStore = storeAuth();
   const configStore = storeConfig();
-  const tasksStore = storeTasks();
 
   // Load initial data (config + heartbeat + user)
   await Promise.all([
     heartbeatStore.fetchHeartbeat(),
     authStore.fetchCurrentUser(),
     configStore.fetchConfig(),
-    tasksStore.fetchTasks(),
   ]);
 }
 

--- a/frontend/src/v2/components/Settings/TasksSection.vue
+++ b/frontend/src/v2/components/Settings/TasksSection.vue
@@ -8,6 +8,10 @@
 // Polls `tasksStore.fetchTaskStatus` every 5s while mounted so the
 // history feed updates in real time. Manual + scheduled tasks expose a
 // run button that posts to /tasks/{name}/run.
+//
+// The task list is fetched on mount rather than at app boot: /tasks needs
+// the `tasks.run` scope, so a session established after boot (any login
+// without a reload) would otherwise leave the lists empty for good.
 import { RBtn, RIcon, RSpinner } from "@v2/lib";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, onUnmounted } from "vue";
@@ -90,6 +94,7 @@ async function fetchTaskStatus() {
 let refreshInterval: number | null = null;
 
 onMounted(() => {
+  void tasksStore.fetchTasks();
   void fetchTaskStatus();
   refreshInterval = window.setInterval(() => {
     void fetchTaskStatus();

--- a/frontend/src/v2/components/Settings/TasksSection.vue
+++ b/frontend/src/v2/components/Settings/TasksSection.vue
@@ -8,10 +8,6 @@
 // Polls `tasksStore.fetchTaskStatus` every 5s while mounted so the
 // history feed updates in real time. Manual + scheduled tasks expose a
 // run button that posts to /tasks/{name}/run.
-//
-// The task list is fetched on mount rather than at app boot: /tasks needs
-// the `tasks.run` scope, so a session established after boot (any login
-// without a reload) would otherwise leave the lists empty for good.
 import { RBtn, RIcon, RSpinner } from "@v2/lib";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, onUnmounted } from "vue";

--- a/frontend/src/v2/components/Settings/TasksSection.vue
+++ b/frontend/src/v2/components/Settings/TasksSection.vue
@@ -165,7 +165,7 @@ function statusInfo(task: TaskStatusResponse) {
             </span>
           </div>
           <button
-            v-if="task.manual_run && task.enabled"
+            v-if="task.manual_run"
             type="button"
             class="r-v2-tasks__run-btn"
             :disabled="isTaskRunning(task.name)"


### PR DESCRIPTION
**Description**

LaunchBox cloud lookups read from a Redis store that only the metadata update task fills. When that store is empty nothing says so: the provider reports healthy, `search.py` drops the `launchbox_id=None` fallback rom, and the user gets "No results" with a clean log. That is what #3981 hit.

The matching code itself was fine. I pulled the live `Metadata.zip`, indexed it, and ran the reporter's exact search:

```
'3Xtreme' [psx] -> id=8293 name='3Xtreme'
```

So this PR is about making the empty-store case impossible to miss, and making the task that fills it survive.

**Empty store is now visible**

- `heartbeat()` returned the env flag and never looked at the store. It now reports unhealthy until the store is populated (a local LaunchBox install still counts as healthy on its own).
- A name search against an empty store logs a warning naming the env var to set, instead of silently returning nothing.

**The update task can actually be run**

`run_single_task` required `task.enabled`, which is `ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA`. So setting `LAUNCHBOX_API_ENABLED=true` alone left a provider with no way at all to populate its store. Added `Task.can_run_manually`, which LaunchBox overrides to also accept `LAUNCHBOX_API_ENABLED`.

**The ingest no longer throws everything away**

The whole dump was queued into one `async_cache.pipeline()` and executed once at the end. Measured against the real file (503MB of XML, 618k writes): peak **1.69GB RSS**, and any timeout, OOM, or Redis error meant **nothing at all** was written. All-or-nothing, on a job whose default timeout was 5 minutes.

Now writes flush in batches of 2000 and `_iter_elements` drops parsed records as they are consumed rather than letting `iterparse` accumulate the document under the root. Same file, same output:

| | before | after |
|---|---|---|
| peak RSS | 1.69 GB | 257 MB |
| redis executes | 1 | ~310 |

The task also gets its own timeout (30 min), since 5 minutes does not cover a 100MB download plus a 500MB parse.

**Two matching bugs found while in there**

- The alternate-name index is keyed by name only, so a hit could point at a same-titled game on another system. Verified before the fix: `Super Mario World` returned `(156904, Super Mario Bros.)` on psx, gb, and c64. Now platform-checked.
- `Coleco Adam` should be `Coleco ADAM` (case-sensitive key, 80 games), and `Nintendo Famicom` / `Super Famicom` are not LaunchBox platform names at all, so those two slugs could never match anything.

**Verification**

Against a throwaway valkey loaded with the live dump:

```
3Xtreme [psx]                            -> id=8293, cover + 16 images
Super Mario World [snes/sfam/nes]        -> correct per platform
Super Mario World [psx/gb/c64]           -> no match (was Super Mario Bros.)
Alcazar... [colecoadam]                  -> id=117455
Super Mario Bros. [famicom]              -> id=140
heartbeat, empty store / populated store -> False / True
```

Backend suite: 2499 passed, 2 skipped. `trunk fmt && trunk check` clean.

One frontend change: `TasksSection.vue` gated the run button on `task.manual_run && task.enabled`; it now uses `manual_run` alone, which the backend fills from `can_run_manually`. I did not get a browser or `npm run typecheck` run on it, so that one line is worth a look.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**AI assistance disclosure**

Written with Claude Code (Opus 5). The investigation, the fixes, the tests, and the measurements above were all produced by the agent and reviewed by me before opening.

Fixes #3981