### PR TITLE
fix(gallery): pack placeholder covers at the active boxart ratio

### DIFF
--- a/frontend/src/v2/components/Gallery/GalleryShell.vue
+++ b/frontend/src/v2/components/Gallery/GalleryShell.vue
@@ -302,6 +302,9 @@ const { columns, usableWidth } = useResponsiveColumns(sectionEl, {
 
 // Fallback cover ratio (boxart style) — the per-card `--r-cover-ratio` seed
 // before GameCover measures the real image, plus the bootstrap skeletons.
+// The flow-packer takes it too (`fallbackRatio`): a card with no artwork
+// paints its placeholder at this ratio and never reports a measured one, so
+// packing it as box art would under-reserve its width and overflow the row.
 const { boxartStyle } = useUISettings();
 const coverAspectRatio = computed(() =>
   coverRatio(
@@ -378,6 +381,7 @@ const { virtualItems, letterToIndex, availableLetters, getItemHeight } =
     gap: CARD_GAP_PX,
     ratioAt,
     ratioVersion,
+    fallbackRatio: coverAspectRatio,
   });
 
 const scrollerRef = ref<InstanceType<typeof RVirtualScroller> | null>(null);

--- a/frontend/src/v2/composables/useGalleryVirtualItems/fallbackRatio.test.ts
+++ b/frontend/src/v2/composables/useGalleryVirtualItems/fallbackRatio.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { computed, ref } from "vue";
+import { useGalleryVirtualItems, type GalleryItem } from "./index";
+
+// A 240px-tall card is 160px wide at box art (2/3) and 240px wide at square
+// (miximage / physical). In an 800px row that is 4 per row vs 3 per row —
+// pack a square-painted card as box art and the row overflows.
+const CARD_HEIGHT = 240;
+const ROW_WIDTH = 800;
+
+function packedRows(fallbackRatio?: number): Array<[number, number]> {
+  const { virtualItems } = useGalleryVirtualItems({
+    layout: ref("grid"),
+    groupBy: ref("none"),
+    total: ref(6),
+    charIndex: ref({ a: 0 }),
+    columns: ref(6),
+    loadingInitial: computed(() => false),
+    emptyMessage: ref(""),
+    cardHeight: CARD_HEIGHT,
+    rowWidth: ROW_WIDTH,
+    gap: 12,
+    fallbackRatio,
+  });
+  return virtualItems.value
+    .filter((i): i is Extract<GalleryItem, { kind: "row" }> => i.kind === "row")
+    .map((r) => [r.startPosition, r.endPosition]);
+}
+
+describe("useGalleryVirtualItems — unmeasured cover ratio", () => {
+  it("packs unmeasured positions as box art by default", () => {
+    expect(packedRows()).toEqual([
+      [0, 4],
+      [4, 6],
+    ]);
+  });
+
+  it("packs unmeasured positions at the active style's ratio", () => {
+    // Square style (miximage / physical): a card with no artwork paints its
+    // placeholder square and never measures, so it must reserve 240px.
+    expect(packedRows(1)).toEqual([
+      [0, 3],
+      [3, 6],
+    ]);
+  });
+
+  it("ignores a non-positive fallback ratio", () => {
+    expect(packedRows(0)).toEqual([
+      [0, 4],
+      [4, 6],
+    ]);
+  });
+});

--- a/frontend/src/v2/composables/useGalleryVirtualItems/index.ts
+++ b/frontend/src/v2/composables/useGalleryVirtualItems/index.ts
@@ -141,8 +141,15 @@ interface Options {
   /** Horizontal gap between cards in px (default 12). */
   gap?: MaybeRefOrGetter<number>;
   /** Natural cover ratio (w / h) for a position (card width =
-   *  `cardHeight * ratioAt(p)`). Defaults to 2/3 until the image is measured. */
+   *  `cardHeight * ratioAt(p)`). Falls back to `fallbackRatio` until the
+   *  image is measured. */
   ratioAt?: (position: number) => number;
+  /** Ratio to pack an unmeasured position at — must be the ratio its card
+   *  actually paints, which is the active boxart style's box ratio: a card
+   *  with no artwork paints its placeholder at that ratio and never
+   *  measures, and one waiting on its image paints there until it loads.
+   *  Defaults to box art (2/3). */
+  fallbackRatio?: MaybeRefOrGetter<number>;
   /** Bump to force a re-pack when measured ratios change (Vue tracks it). */
   ratioVersion?: Ref<number> | ComputedRef<number>;
 }
@@ -225,9 +232,19 @@ export function useGalleryVirtualItems(opts: Options) {
   // exact-offset regardless of how many variable-width cards a row holds.
   const rowHeightPx = computed(() => cardHeightPx() + ROW_CHROME_PX);
 
-  const ratioAt = (position: number): number => {
-    const r = opts.ratioAt?.(position);
-    return r != null && r > 0 ? r : DEFAULT_COVER_RATIO;
+  const fallbackRatio = () => {
+    const r = opts.fallbackRatio != null ? toValue(opts.fallbackRatio) : 0;
+    return r > 0 ? r : DEFAULT_COVER_RATIO;
+  };
+
+  /** Per-build ratio lookup — resolves the fallback once so the packer's
+   *  hot path (one call per position) stays a single map read. */
+  const makeRatioAt = () => {
+    const fallback = fallbackRatio();
+    return (position: number): number => {
+      const r = opts.ratioAt?.(position);
+      return r != null && r > 0 ? r : fallback;
+    };
   };
 
   // `unknown` matches RVirtualScroller's generic prop. Row / skeleton-row
@@ -379,6 +396,7 @@ export function useGalleryVirtualItems(opts: Options) {
     );
     // Track the version so a measured-ratio change re-runs the pack.
     void (opts.ratioVersion ? opts.ratioVersion.value : 0);
+    const ratioAt = makeRatioAt();
 
     if (opts.groupBy.value === "letter") {
       // Header + own flow-packed rows per letter (rows restart per letter).


### PR DESCRIPTION
**Description**

Fixes #3984 — game rows overflowed the viewport when they contained games without cover art.

The v2 gallery doesn't use a CSS grid: it flow-packs each row in JS (`packFlowRows`) from each card's real width (`cardHeight * coverRatio`), and rows render `flex-wrap: nowrap` with `flex-shrink: 0`. So when the packer underestimates a card's width, the row silently runs off-screen instead of wrapping.

Card ratios are measured from the cover image on load (`useGalleryCoverRatios`), and `useGalleryVirtualItems` fell back to a hardcoded 2/3 for any position it hadn't measured. A rom with no cover never measures anything — `GameCover` renders `CoverPlaceholder`, and the box paints at the active boxart style's ratio. Under a square style (miximage / physical) a placeholder card therefore painted 237px wide while the packer reserved 158px; a few of them per row freed enough phantom space for one extra card, and the row overflowed (visible in the issue's screenshots, where the affected rows are the ones full of placeholder covers).

The same mismatch also applied transiently to every card in a non-2/3 gallery before its image loaded.

Fix: the packer takes a `fallbackRatio` for positions without a measured cover, and `GalleryShell` passes the boxart style's ratio it already uses to seed `--r-cover-ratio` and the skeletons — so the packed width matches what the card actually paints, before and after measurement. `cover_path` galleries are unaffected (the fallback stays 2/3). It's a computed, so switching boxart style re-packs.

Related but out of scope, left alone: `GameCardSkeleton` sizes its art as `width = --r-card-art-w`, `height = width / ratio`, whereas `GameCard` uses a fixed height with a ratio-driven width. Under non-2/3 styles an un-fetched slot therefore paints smaller than the space reserved for it (a small jump when the window resolves, no overflow).

**AI assistance disclosure**

This change was written with AI assistance (Claude Code): the diagnosis, the patch, and the unit tests were AI-authored, then reviewed by me before submitting.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Verification: new `fallbackRatio.test.ts` covers the default, style-ratio, and non-positive-value cases (18 tests pass in that directory; 111 across `src/v2/composables` + `src/v2/components/Gallery`), `vue-tsc` clean, `trunk fmt` / `trunk check` clean. No browser check — this was verified statically.

#### Screenshots (if applicable)

N/A — no visual change to a correctly-packed gallery; the fix removes the row overflow shown in #3984.
