### PR TITLE
fix(docker): bound the shutdown wait so a stuck process cannot strand PID 1

### DIFF
--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -23,6 +23,9 @@ REDIS_HOST="${REDIS_HOST:=""}"
 # hour of sessions and cached metadata. Set to an empty value to never snapshot.
 REDIS_SAVE_POLICY="${REDIS_SAVE_POLICY="3600 1"}"
 
+# how long to wait for a signalled process to exit before escalating to SIGKILL
+STOP_TIMEOUT="${STOP_TIMEOUT:="10"}"
+
 # logger colors
 RED='\033[0;31m'
 LIGHTMAGENTA='\033[0;95m'
@@ -305,6 +308,20 @@ watchdog_process_pid() {
 	fi
 }
 
+# Wait for PID $1 to disappear, polling every 100ms for at most $2 polls.
+# Returns non-zero if it is still alive when the budget runs out.
+wait_for_pid_exit() {
+	local pid=$1 max_polls=$2 polls=0
+	while [[ -e "/proc/${pid}" ]]; do
+		if ((polls >= max_polls)); then
+			return 1
+		fi
+		sleep 0.1
+		polls=$((polls + 1))
+	done
+	return 0
+}
+
 stop_process_pid() {
 	PROCESS=$1
 	if [[ -f "/tmp/${PROCESS}.pid" ]]; then
@@ -312,8 +329,18 @@ stop_process_pid() {
 		if [[ -d "/proc/${PID}" ]]; then
 			info_log "Stopping ${PROCESS}"
 			kill "${PID}" || true
-			# wait for process exit
-			while [[ -e "/proc/${PID}" ]]; do sleep 0.1; done
+
+			# A process that will not exit must never strand PID 1. Valkey aborts
+			# its own shutdown when the snapshot it writes on exit fails, so on a
+			# read-only /redis-data an unbounded wait here leaves the container up
+			# and serving nothing, which no restart policy can detect.
+			if ! wait_for_pid_exit "${PID}" $((STOP_TIMEOUT * 10)); then
+				warn_log "${PROCESS} did not exit within ${STOP_TIMEOUT}s, sending SIGKILL"
+				kill -9 "${PID}" || true
+				if ! wait_for_pid_exit "${PID}" $((STOP_TIMEOUT * 10)); then
+					warn_log "${PROCESS} survived SIGKILL, continuing shutdown without it"
+				fi
+			fi
 		fi
 	fi
 }

--- a/docs/BACKEND_ARCHITECTURE.md
+++ b/docs/BACKEND_ARCHITECTURE.md
@@ -1516,13 +1516,14 @@ Falls back to `FakeRedis` in test mode.
 
 #### Core
 
-| Variable         | Default          | Description          |
-| ---------------- | ---------------- | -------------------- |
-| `ROMM_BASE_PATH` | `/romm`          | Base data directory  |
-| `ROMM_BASE_URL`  | `http://0.0.0.0` | Application base URL |
-| `ROMM_PORT`      | `8080`           | Server port          |
-| `DEV_MODE`       | `false`          | Development mode     |
-| `LOGLEVEL`       | `INFO`           | Log level            |
+| Variable         | Default          | Description                        |
+| ---------------- | ---------------- | ---------------------------------- |
+| `ROMM_BASE_PATH` | `/romm`          | Base data directory                |
+| `ROMM_BASE_URL`  | `http://0.0.0.0` | Application base URL               |
+| `ROMM_PORT`      | `8080`           | Server port                        |
+| `DEV_MODE`       | `false`          | Development mode                   |
+| `LOGLEVEL`       | `INFO`           | Log level                          |
+| `STOP_TIMEOUT`   | `10`             | Seconds before SIGKILL on shutdown |
 
 #### Database
 

--- a/env.template
+++ b/env.template
@@ -4,6 +4,7 @@ ROMM_TMP_PATH=  # Custom temporary directory path
 ROMM_BASE_URL=http://0.0.0.0  # Public URL of this instance
 ROMM_PORT=8080  # Port on which the application listens
 KIOSK_MODE=false  # Read-only mode for public displays or kiosks
+STOP_TIMEOUT=10  # Seconds to wait for a service to exit on shutdown before sending SIGKILL
 
 # Database
 ROMM_DB_DRIVER=mariadb  # Database driver to use (mariadb, mysql, postgresql)

--- a/examples/docker-compose.example.yml
+++ b/examples/docker-compose.example.yml
@@ -27,6 +27,18 @@ services:
       - /path/to/config:/romm/config # (Optional) Path where config.yml is stored
     ports:
       - 80:8080
+    healthcheck:
+      # $$ defers expansion to the container, so a custom ROMM_PORT still works
+      test:
+        [
+          "CMD-SHELL",
+          "curl -fsS http://localhost:$${ROMM_PORT:-8080}/api/heartbeat",
+        ]
+      start_period: 60s
+      start_interval: 10s
+      interval: 30s
+      timeout: 5s
+      retries: 3
     depends_on:
       romm-db:
         condition: service_healthy


### PR DESCRIPTION
**Description**

<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

`stop_process_pid` signals each managed process and then waits on it forever:

```bash
kill "${PID}" || true
# wait for process exit
while [[ -e "/proc/${PID}" ]]; do sleep 0.1; done
```

A process that refuses to exit wedges PID 1. The container then sits `Up` serving nothing, and **no restart policy can detect it, because policies only react to exits.**

Valkey reaches exactly that state. It aborts its own shutdown when the snapshot it writes on exit cannot be written, so on a read-only `/redis-data` it catches SIGTERM, fails the save, and keeps running.

Getting there is routine, because `trap 'exited=1 && shutdown' SIGINT SIGTERM EXIT` means every fatal error path runs `shutdown()`, exactly when the environment is most likely to be broken. The path I hit is a failed startup migration: the daemon's restart policy starts every container at once at host boot and **does not honour compose's `depends_on`** (that is applied by `docker compose up`), so RomM regularly comes up before its database, `alembic upgrade head` fails, and `error_log` ends in `exit 1`.

Observed three times on a host whose storage layer briefly remounts read-only during boot:

```
t=34.6s   EXT4-fs (sdb): mounted ... r/w
t=83.6s   EXT4-fs (sdb): re-mounted ... ro
t=84s     romm container starts            <- 0.4s into the read-only window
t=175.6s  EXT4-fs (sdb): re-mounted ... r/w
t=199s    romm-db container starts         <- two minutes after romm
```

```
sqlalchemy.exc.OperationalError: (mariadb.OperationalError) Can't connect to server on 'romm-db' (115)
ERROR: Failed to run database migrations
INFO:  Stopping valkey-server
<hangs forever>
```

`ps` inside the wedged container showed only `bash /init`, `valkey-server`, and a live `sleep 0.1`. Every reboot needed a manual `docker restart`.

**Changes**

- `stop_process_pid` waits `STOP_TIMEOUT` (default 10s), then escalates to `SIGKILL`, with a second bounded wait and a warning if even that fails. A process that will not exit can no longer strand PID 1.
- A healthcheck on the `romm` service in the compose example, hitting the existing unauthenticated `/api/heartbeat`.
- `STOP_TIMEOUT` documented in `env.template` and `docs/BACKEND_ARCHITECTURE.md`.

**Why this is the whole fix**

Bounding the wait is enough on its own. Once PID 1 can exit, the failure becomes self-healing: migrations fail, `exit 1`, shutdown completes, the container exits, and `restart: unless-stopped` brings it back and retries until the database is up.

An earlier revision of this PR also retried the migrations in-process, but per review that only saves a few container restarts, which the restart policy already handles. It is a startup-time optimization riding along in a hang fix, and it cost two tunables the project would have to support, so I dropped it. Worth revisiting separately if the restart churn bothers anyone in practice.

One clarification, since it came up in review and is easy to get backwards: **a healthcheck cannot recover this by itself.** Docker healthchecks take no action, they only set status; nothing restarts an unhealthy container in plain Compose without an external agent (autoheal) or an orchestrator. The healthcheck here exists to make a hung PID 1 observable, not to fix it. Note also that the mechanism that failed in the trace above was `romm-db`'s healthcheck combined with `depends_on: condition: service_healthy`, which the daemon skips at host boot.

**Note on `REDIS_SAVE_POLICY`**

48259b3a9 (after 5.0.0) added `REDIS_SAVE_POLICY`, and setting it empty sidesteps the valkey hang, since valkey skips the shutdown snapshot when no save point is configured. But the default is `3600 1`, which configures one, so the hang is reachable on current master. That is a workaround at the cost of persistence, not a fix, and it only addresses valkey, whereas the unbounded wait is a hazard for every managed process.

**Testing**

`stop_process_pid` is exercised by a test script that extracts the function verbatim from the init script and runs it under the same `errexit`/`nounset`/`pipefail`/`inherit_errexit` options. An untested error path is the reason this bug exists, so I did not want to eyeball it.

- Normal process: stops in 0s, no escalation, no spurious `SIGKILL`.
- Process with `trap "" TERM` (valkey's exact behaviour): killed after `STOP_TIMEOUT` with the expected warning, instead of hanging.

Also verified:

- `bash -n`, `shellcheck`, `shfmt 3.6.0`, `prettier 3.9.5`, `yamllint 1.38.0` all clean. The compose example produces no new yamllint findings versus `master` (23 pre-existing on both).
- The compose example parses under `docker compose config`, and the healthcheck command runs successfully inside a live container. `$$` defers expansion to the container so a custom `ROMM_PORT` still works; without that, anyone setting `ROMM_PORT` would get a permanently unhealthy container.
- Separately, the valkey mechanism was reproduced directly in a throwaway container with a read-only bind mount: with `--save "3600 1"` it survives SIGTERM, with `--save ""` it exits cleanly.

**Checklist**

<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

<sub>The init script has no test harness in-repo, so the coverage above lives in a standalone script that sources the function rather than in a committed suite. Happy to add a `bats` (or similar) target if the project wants shell tests committed.</sub>

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this change was written with AI assistance (Claude Code). The root-cause diagnosis came from a real reproduction on my own hardware; the AI wrote the patch and the test script, and I reviewed the result. No `Fixes #`: I searched open issues and did not find one covering this.
