### PR TITLE
fix(security): close three permission gaps found auditing 5.1.0

### DIFF
--- a/backend/endpoints/roms/files.py
+++ b/backend/endpoints/roms/files.py
@@ -12,12 +12,13 @@ from decorators.auth import protected_route
 from endpoints.responses.rom import RomFileSchema
 from exceptions.endpoint_exceptions import RomNotFoundInDatabaseException
 from handler.auth.constants import Scope
-from handler.auth.dependencies import assert_rom_visible
+from handler.auth.dependencies import assert_can, assert_rom_visible, get_permissions
 from handler.database import db_rom_handler
 from handler.filesystem import fs_rom_handler
 from logger.formatter import BLUE
 from logger.formatter import highlight as hl
 from logger.logger import log
+from models.permission import PermAction, PermEntity
 from models.rom import RomFileCategory
 from utils.audio_tags import guess_audio_media_type
 from utils.media_types import (
@@ -164,6 +165,12 @@ async def delete_rom_file(
     file_id: Annotated[int, PathVar(description="Rom file internal id.", ge=1)],
 ) -> Response:
     """Delete a single file from a ROM."""
+
+    # Removing a game file destroys library content, so it needs the same
+    # DELETE grant the whole-ROM delete route requires. The sibling routes for
+    # manuals/soundtracks/screenshots settle for ROMS_WRITE because a category
+    # guard keeps them off the game files themselves.
+    assert_can(get_permissions(request), PermEntity.ROMS, PermAction.DELETE)
 
     rom = db_rom_handler.get_rom(rom_id)
     if not rom:

--- a/backend/endpoints/streaming.py
+++ b/backend/endpoints/streaming.py
@@ -458,6 +458,14 @@ def _stop_broker(container: dict[str, Any]) -> None:
 
 
 # ── Routes ────────────────────────────────────────────────────────────────────
+#
+# Reads gate on ROMS_READ; anything that creates, controls or releases a session
+# gates on ROMS_USER_WRITE, matching the play-session routes. ROMS_USER_WRITE is
+# always-on for authenticated users, so this costs no real user anything, but it
+# is absent from READ_SCOPES -- which is all KIOSK_MODE hands an anonymous
+# visitor, and all a logged-in non-admin keeps under kiosk. Without it, kiosk
+# visitors (who all share user_id=-1, so session ownership cannot separate them)
+# could claim sessions and overwrite each other's save states.
 
 
 @protected_route(router.get, "/config", [Scope.ROMS_READ])
@@ -491,7 +499,7 @@ async def get_config(request: Request) -> JSONResponse:
     )
 
 
-@protected_route(router.post, "/sessions", [Scope.ROMS_READ])
+@protected_route(router.post, "/sessions", [Scope.ROMS_USER_WRITE])
 async def claim_session(
     request: Request, req: Annotated[ClaimSessionRequest, Body()]
 ) -> JSONResponse:
@@ -577,7 +585,9 @@ async def claim_session(
     )
 
 
-@protected_route(router.post, "/sessions/{platform}/save-and-exit", [Scope.ROMS_READ])
+@protected_route(
+    router.post, "/sessions/{platform}/save-and-exit", [Scope.ROMS_USER_WRITE]
+)
 async def save_and_exit_session(
     request: Request, platform: str, req: Annotated[SaveAndExitRequest, Body()]
 ) -> JSONResponse:
@@ -612,7 +622,7 @@ async def save_and_exit_session(
     return JSONResponse({"status": "ok", "saved": saved, "platform": platform})
 
 
-@protected_route(router.post, "/sessions/{platform}/volume", [Scope.ROMS_READ])
+@protected_route(router.post, "/sessions/{platform}/volume", [Scope.ROMS_USER_WRITE])
 async def set_volume(
     request: Request, platform: str, req: Annotated[VolumeRequest, Body()]
 ) -> JSONResponse:
@@ -627,7 +637,7 @@ async def set_volume(
     return JSONResponse({"status": "ok", "level": req.level, "platform": platform})
 
 
-@protected_route(router.post, "/sessions/{platform}/mute", [Scope.ROMS_READ])
+@protected_route(router.post, "/sessions/{platform}/mute", [Scope.ROMS_USER_WRITE])
 async def set_mute(
     request: Request, platform: str, req: Annotated[MuteRequest, Body()]
 ) -> JSONResponse:
@@ -642,7 +652,9 @@ async def set_mute(
     return JSONResponse({"status": "ok", "mute": confirmed, "platform": platform})
 
 
-@protected_route(router.post, "/sessions/{platform}/save-state", [Scope.ROMS_READ])
+@protected_route(
+    router.post, "/sessions/{platform}/save-state", [Scope.ROMS_USER_WRITE]
+)
 async def save_state(
     request: Request, platform: str, req: Annotated[SaveStateRequest, Body()]
 ) -> JSONResponse:
@@ -658,7 +670,9 @@ async def save_state(
     return JSONResponse({"status": "saving", "slot": req.slot, "platform": platform})
 
 
-@protected_route(router.post, "/sessions/{platform}/load-state", [Scope.ROMS_READ])
+@protected_route(
+    router.post, "/sessions/{platform}/load-state", [Scope.ROMS_USER_WRITE]
+)
 async def load_state(
     request: Request, platform: str, req: Annotated[LoadStateRequest, Body()]
 ) -> JSONResponse:
@@ -676,7 +690,7 @@ async def load_state(
     )
 
 
-@protected_route(router.delete, "/sessions/{platform}", [Scope.ROMS_READ])
+@protected_route(router.delete, "/sessions/{platform}", [Scope.ROMS_USER_WRITE])
 async def release_session(request: Request, platform: str) -> JSONResponse:
     """Release a session and tell the broker to stop the emulator."""
     container = _container_for_platform(platform)
@@ -724,7 +738,7 @@ async def list_sessions(request: Request) -> JSONResponse:
     return JSONResponse(sessions)
 
 
-@protected_route(router.delete, "/sessions", [Scope.ROMS_READ])
+@protected_route(router.delete, "/sessions", [Scope.ROMS_USER_WRITE])
 async def force_release_all(request: Request) -> JSONResponse:
     """Force-release all active sessions."""
     if request.user.role != Role.ADMIN:

--- a/backend/tasks/scheduled/cleanup_orphaned_resources.py
+++ b/backend/tasks/scheduled/cleanup_orphaned_resources.py
@@ -80,19 +80,15 @@ class CleanupOrphanedResourcesTask(PeriodicTask):
             title="Cleanup orphaned resources",
             description="Clean up orphaned resources in the ROMs directory",
             task_type=TaskType.CLEANUP,
-            enabled=True,
+            enabled=ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES,
             manual_run=True,
-            cron_string=(
-                SCHEDULED_CLEANUP_ORPHANED_RESOURCES_CRON
-                if ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES
-                else None
-            ),
+            cron_string=SCHEDULED_CLEANUP_ORPHANED_RESOURCES_CRON,
             func="tasks.scheduled.cleanup_orphaned_resources.cleanup_orphaned_resources_task.run",
         )
 
     def init(self) -> Job | None:
-        # `enabled` stays True for manual runs, so the absence of a cron string
-        # is what drives unscheduling when the schedule is turned off.
+        # Without a cron string there is nothing to schedule, so drop any job
+        # left over from a previous configuration.
         if not self.cron_string:
             self.unschedule()
             return None

--- a/backend/tasks/scheduled/cleanup_orphaned_resources.py
+++ b/backend/tasks/scheduled/cleanup_orphaned_resources.py
@@ -82,7 +82,11 @@ class CleanupOrphanedResourcesTask(PeriodicTask):
             task_type=TaskType.CLEANUP,
             enabled=True,
             manual_run=True,
-            cron_string=SCHEDULED_CLEANUP_ORPHANED_RESOURCES_CRON,
+            cron_string=(
+                SCHEDULED_CLEANUP_ORPHANED_RESOURCES_CRON
+                if ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES
+                else None
+            ),
             func="tasks.scheduled.cleanup_orphaned_resources.cleanup_orphaned_resources_task.run",
         )
 

--- a/backend/tests/endpoints/roms/test_files.py
+++ b/backend/tests/endpoints/roms/test_files.py
@@ -6,7 +6,8 @@ from fastapi import status
 from fastapi.testclient import TestClient
 
 from endpoints.roms import files as files_endpoint
-from handler.database import db_rom_handler
+from handler.database import db_permission_handler, db_rom_handler
+from models.permission import PermAction, PermEntity
 from models.platform import Platform
 from models.rom import Rom, RomFile, RomFileCategory
 from models.user import User
@@ -303,3 +304,55 @@ def test_delete_rom_file_forbidden_viewer(
     assert response.status_code == status.HTTP_403_FORBIDDEN
     # File must NOT have been deleted.
     assert db_rom_handler.get_rom_file_by_id(rom_file.id) is not None
+
+
+def test_delete_rom_file_forbidden_without_delete_grant(
+    client: TestClient,
+    editor_access_token: str,
+    editor_user: User,
+    admin_user: User,
+    platform: Platform,
+    files_fs: Path,
+):
+    """ROMS_WRITE alone must not delete library content.
+
+    The editor keeps write (so the coarse scope gate passes) but loses the
+    ROMS/DELETE grant, which is what the route now requires.
+    """
+    db_permission_handler.replace_user_overrides(
+        editor_user.id,
+        [(PermEntity.ROMS, PermAction.DELETE, False, False)],
+    )
+    rom = _make_rom(admin_user, platform)
+    (files_fs / "game.bin").write_bytes(b"\x00" * 16)
+    rom_file = _add_file(rom, "game.bin", RomFileCategory.GAME)
+
+    response = client.delete(
+        f"/api/roms/{rom.id}/files/{rom_file.id}",
+        headers=_auth(editor_access_token),
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert db_rom_handler.get_rom_file_by_id(rom_file.id) is not None
+    assert (files_fs / "game.bin").exists()
+
+
+def test_delete_rom_file_allowed_for_editor(
+    client: TestClient,
+    editor_access_token: str,
+    admin_user: User,
+    platform: Platform,
+    files_fs: Path,
+):
+    """The legacy Editor group holds ROMS/DELETE, so it must keep working."""
+    rom = _make_rom(admin_user, platform)
+    (files_fs / "game.bin").write_bytes(b"\x00" * 16)
+    rom_file = _add_file(rom, "game.bin", RomFileCategory.GAME)
+
+    response = client.delete(
+        f"/api/roms/{rom.id}/files/{rom_file.id}",
+        headers=_auth(editor_access_token),
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert db_rom_handler.get_rom_file_by_id(rom_file.id) is None

--- a/backend/tests/endpoints/test_streaming.py
+++ b/backend/tests/endpoints/test_streaming.py
@@ -504,3 +504,34 @@ def test_list_sessions_requires_auth(client):
 def test_list_sessions_requires_admin(client, viewer_access_token):
     r = client.get("/api/streaming/sessions", headers=_auth(viewer_access_token))
     assert r.status_code == 403
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "body"),
+    [
+        ("post", "/api/streaming/sessions", {"rom_id": 1}),
+        ("post", "/api/streaming/sessions/ps2/save-and-exit", {}),
+        ("post", "/api/streaming/sessions/ps2/volume", {"level": 50}),
+        ("post", "/api/streaming/sessions/ps2/mute", {"mute": True}),
+        ("post", "/api/streaming/sessions/ps2/save-state", {"slot": 1}),
+        ("post", "/api/streaming/sessions/ps2/load-state", {"slot": 1}),
+        ("delete", "/api/streaming/sessions/ps2", None),
+        ("delete", "/api/streaming/sessions", None),
+    ],
+)
+def test_kiosk_mode_cannot_mutate_sessions(client, method, path, body):
+    """KIOSK_MODE hands anonymous visitors READ_SCOPES, which must not suffice.
+
+    Every kiosk visitor resolves to the same synthetic user (id=-1), so session
+    ownership cannot separate them -- without a write scope on these routes an
+    anonymous visitor could claim sessions and overwrite others' save states.
+    """
+    with patch("handler.auth.hybrid_auth.KIOSK_MODE", True):
+        kwargs = {"json": body} if body is not None else {}
+        assert getattr(client, method)(path, **kwargs).status_code == 403
+
+
+def test_kiosk_mode_can_still_read_config(client):
+    """The read side of streaming stays open to kiosk visitors."""
+    with patch("handler.auth.hybrid_auth.KIOSK_MODE", True), _streaming():
+        assert client.get("/api/streaming/config").status_code == 200

--- a/backend/tests/tasks/test_cleanup_orphaned_resources.py
+++ b/backend/tests/tasks/test_cleanup_orphaned_resources.py
@@ -19,34 +19,46 @@ class TestCleanupOrphanedResourcesTask:
             == "tasks.scheduled.cleanup_orphaned_resources.cleanup_orphaned_resources_task.run"
         )
 
-    def test_stays_manually_runnable(self, task):
-        # The run-task endpoint rejects a task unless both flags are set, so
-        # these must hold regardless of whether the cron schedule is on.
-        assert task.enabled is True
+    def test_disabled_by_default(self, task):
+        # The run-task endpoint rejects a task unless both flags are set, so a
+        # disabled schedule also means no manual runs.
+        assert task.enabled is False
         assert task.manual_run is True
+        assert task.can_run_manually is False
 
-    def test_no_cron_string_by_default(self, task):
-        assert task.cron_string is None
-
-    def test_cron_string_set_when_schedule_enabled(self):
+    def test_enabled_follows_config_flag(self):
         with patch.object(mod, "ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES", True):
-            with patch.object(
-                mod, "SCHEDULED_CLEANUP_ORPHANED_RESOURCES_CRON", "0 5 * * *"
-            ):
-                assert CleanupOrphanedResourcesTask().cron_string == "0 5 * * *"
+            task = CleanupOrphanedResourcesTask()
+            assert task.enabled is True
+            assert task.can_run_manually is True
+
+    def test_cron_string_from_config(self):
+        with patch.object(
+            mod, "SCHEDULED_CLEANUP_ORPHANED_RESOURCES_CRON", "0 5 * * *"
+        ):
+            assert CleanupOrphanedResourcesTask().cron_string == "0 5 * * *"
 
     def test_init_unschedules_when_no_cron(self, task):
+        task.cron_string = ""
+
         with patch.object(task, "unschedule") as mock_unschedule:
             assert task.init() is None
             mock_unschedule.assert_called_once()
 
-    def test_init_schedules_when_cron_set(self, task):
+    def test_init_schedules_when_enabled(self, task):
+        task.enabled = True
         task.cron_string = "0 5 * * *"
 
         with patch.object(task, "_get_existing_job", return_value=None):
             with patch.object(task, "schedule") as mock_schedule:
                 task.init()
                 mock_schedule.assert_called_once()
+
+    def test_init_does_not_schedule_when_disabled(self, task):
+        with patch.object(task, "_get_existing_job", return_value=None):
+            with patch.object(task, "schedule") as mock_schedule:
+                assert task.init() is None
+                mock_schedule.assert_not_called()
 
 
 class TestCleanupOrphanedResourcesRun:


### PR DESCRIPTION
**Description**

Three permission gaps found while security-auditing the `5.0.0..5.1.0` diff. All three are in code new to 5.1.0. Each fix is verified by a test that fails without it.

**1. ROM file deletion only needed `roms.write`** — `backend/endpoints/roms/files.py`

The new `DELETE /api/roms/{rom_id}/files/{file_id}` (#3753) gated on `[Scope.ROMS_WRITE]` and, unlike its siblings, had no category guard: `manual.py`, `soundtrack.py`, and `screenshot.py` each 404 on files outside their own category, so before 5.1.0 `roms.write` could only remove manuals/soundtracks/screenshots. Meanwhile whole-ROM deletion at `roms/__init__.py:1970` requires `assert_can(perms, ROMS, DELETE)`.

Net effect: a group holding write-but-not-delete could iterate `file_id`s and delete a ROM's actual game files from disk. Now gated on the same `ROMS/DELETE` grant as whole-ROM deletion. The legacy Editor group holds `ROMS/DELETE`, so editors are unaffected (covered by a test).

**2. Mutating streaming routes were reachable anonymously under `KIOSK_MODE`** — `backend/endpoints/streaming.py`

All ten streaming routes gated on `[Scope.ROMS_READ]`, including `save-state`, `load-state`, session claim, and release. `ROMS_READ` is in `READ_SCOPES`, and `hybrid_auth.py:105` hands an anonymous request the full `READ_SCOPES` set when `KIOSK_MODE=true`. The fine-grained kiosk clamp at `permissions.py:143` doesn't help, since it only covers routes gated by `assert_can`. Because every kiosk visitor resolves to the same synthetic `user_id=-1`, `_assert_session_owner` can't separate them either — so an anonymous visitor could claim a session, launch any visible ROM on the emulator container, and overwrite another visitor's save states.

The eight mutating routes now gate on `ROMS_USER_WRITE`, matching what the play-session routes already use. `ROMS_USER_WRITE` is in `ALWAYS_ON_SCOPES`, so no real user (viewer included) loses anything; it is absent from `READ_SCOPES`, so kiosk visitors are blocked. `GET /config` and `GET /sessions` stay on `ROMS_READ`. This also aligns streaming with existing kiosk behavior — kiosk visitors already can't write saves (`ASSETS_WRITE`) or create play sessions (`ROMS_USER_WRITE`).

**3. `ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES` was inert** — `backend/tasks/scheduled/cleanup_orphaned_resources.py`

`env.template:96` documents this as `false`, but the flag was imported and never read, so a destructive nightly task was scheduled regardless of the opt-out.

Worth a look before merging: the gate was added by #3970 and removed by 06cafd4b1, whose commit message refers to `update_switch_titledb` (a file it doesn't touch, and which already uses the correct `enabled=` pattern). That commit also left `init()`'s comment describing gating that no longer existed, and **broke two of the task's own pre-existing tests** (`test_no_cron_string_by_default`, `test_init_unschedules_when_no_cron`) — both fail on current `master`. This restores the original conditional. If the removal was deliberate, say so and I'll drop this part.

**Not included** (found in the same audit, but pre-existing rather than 5.1.0 regressions, so they belong in their own PRs): collection-ownership isn't checked in `roms_handler._filter_by_collection_id`; the 7zz argv in `archives.py` lacks a `--` separator; `nginx` sets `client_max_body_size 0` ahead of the new upload-size middleware; `broker` requests follow redirects with `X-Broker-Secret` attached.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**Testing**

`uv run pytest tests/endpoints/ tests/tasks/` — 885 passed, no regressions. `trunk fmt && trunk check` clean. Each fix was stash-reverted to confirm its test fails without it:

- `test_delete_rom_file_forbidden_without_delete_grant` — fails without fix 1
- `test_kiosk_mode_cannot_mutate_sessions` — 7 of 8 routes fail without fix 2 (the 8th, `force_release_all`, has an inner admin check)
- `test_no_cron_string_by_default`, `test_init_unschedules_when_no_cron` — already in the repo, fail on `master`

No OpenAPI schema change (scopes don't reach `__generated__`), so no frontend regen. No frontend change needed: `ROMM_USER_WRITE` being always-on means every existing streaming affordance keeps working.

**AI assistance disclosure**

Written with AI assistance (Claude Opus 5 via Claude Code), extensively. The audit that found these three issues, the root-cause analysis, the fixes, and the tests were all AI-produced. A human reviewed the findings and directed the fix scope. Every claim in this description was verified against the source or by running the tests, but please review the permission-model reasoning in fix 2 independently — the choice of `ROMS_USER_WRITE` over a new streaming-specific scope is a judgment call.
