### PR TITLE
fix(tasks): honor ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES

### DIFF
--- a/backend/endpoints/tasks.py
+++ b/backend/endpoints/tasks.py
@@ -138,6 +138,10 @@ manual_tasks: list[ManualTask] = [
 
 def _build_task_info(name: str, task: Task) -> TaskInfo:
     """Builds a TaskInfo object from task details."""
+    # A task holding a cron expression it never runs on reads as scheduled in
+    # the UI, so only report the expression the task is actually scheduled with.
+    cron_string = task.cron_string if task.is_scheduled else None
+
     return TaskInfo(
         name=name,
         type=task.task_type,
@@ -145,7 +149,7 @@ def _build_task_info(name: str, task: Task) -> TaskInfo:
         description=task.description,
         enabled=task.enabled,
         manual_run=task.can_run_manually,
-        cron_string=task.cron_string or "",
+        cron_string=cron_string or "",
     )
 
 

--- a/backend/tasks/scheduled/cleanup_orphaned_resources.py
+++ b/backend/tasks/scheduled/cleanup_orphaned_resources.py
@@ -4,7 +4,6 @@ import shutil
 from dataclasses import dataclass
 
 from anyio import Path as AnyioPath
-from rq.job import Job
 
 from config import (
     ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES,
@@ -86,14 +85,12 @@ class CleanupOrphanedResourcesTask(PeriodicTask):
             func="tasks.scheduled.cleanup_orphaned_resources.cleanup_orphaned_resources_task.run",
         )
 
-    def init(self) -> Job | None:
-        # `enabled` stays True for manual runs, so the absence of a cron string
-        # is what drives unscheduling when the schedule is turned off.
-        if not self.cron_string:
-            self.unschedule()
-            return None
-
-        return super().init()
+    @property
+    def is_scheduled(self) -> bool:
+        # `enabled` stays True so an admin can always run this by hand, and the
+        # cron string stays populated either way. This flag alone decides
+        # whether the task also runs on its own.
+        return ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES
 
     @initialize_context()
     async def run(self, force: bool = False) -> dict[str, int]:

--- a/backend/tasks/tasks.py
+++ b/backend/tasks/tasks.py
@@ -79,6 +79,15 @@ class Task(ABC):
         """Whether an admin can trigger this task on demand."""
         return self.manual_run and self.enabled
 
+    @property
+    def is_scheduled(self) -> bool:
+        """Whether the task runs itself on a schedule.
+
+        Separate from `enabled` so a task can stay manually runnable while its
+        schedule is off. Subclasses override this to gate on their own setting.
+        """
+        return self.enabled and bool(self.cron_string)
+
     @abstractmethod
     async def run(self, *args: Any, **kwargs: Any) -> Any: ...
 
@@ -106,9 +115,9 @@ class PeriodicTask(Task, ABC):
         """
         job = self._get_existing_job()
 
-        if self.enabled and not job:
+        if self.is_scheduled and not job:
             return self.schedule()
-        elif job and not self.enabled:
+        elif job and not self.is_scheduled:
             self.unschedule()
             return None
         return None

--- a/backend/tests/endpoints/test_tasks.py
+++ b/backend/tests/endpoints/test_tasks.py
@@ -165,6 +165,45 @@ class TestListTasks:
         assert watcher_task["cron_string"] == ""
 
     @patch("endpoints.tasks.ENABLE_RESCAN_ON_FILESYSTEM_CHANGE", False)
+    @patch("endpoints.tasks.manual_tasks", [])
+    @patch(
+        "endpoints.tasks.scheduled_tasks",
+        [
+            {
+                "name": "test_unscheduled",
+                "type": TaskType.CLEANUP,
+                "task": Mock(
+                    spec=Task,
+                    task_type=TaskType.CLEANUP,
+                    title="Unscheduled Task",
+                    description="Manually runnable, but not on a schedule",
+                    enabled=True,
+                    manual_run=True,
+                    can_run_manually=True,
+                    is_scheduled=False,
+                    timeout=300,
+                    cron_string="0 5 * * *",
+                ),
+            }
+        ],
+    )
+    def test_list_tasks_omits_cron_for_unscheduled_task(self, client, access_token):
+        """A task that carries a cron expression it never runs on reports none.
+
+        Reporting the expression anyway makes the Tasks page show a schedule
+        that will not fire.
+        """
+        response = client.get(
+            "/api/tasks", headers={"Authorization": f"Bearer {access_token}"}
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        task = response.json()["scheduled"][0]
+
+        assert task["cron_string"] == ""
+        assert task["manual_run"] is True
+
+    @patch("endpoints.tasks.ENABLE_RESCAN_ON_FILESYSTEM_CHANGE", False)
     @patch("endpoints.tasks.RESCAN_ON_FILESYSTEM_CHANGE_DELAY", 10)
     @patch("endpoints.tasks.manual_tasks", [])
     @patch("endpoints.tasks.scheduled_tasks", [])

--- a/backend/tests/tasks/test_cleanup_orphaned_resources.py
+++ b/backend/tests/tasks/test_cleanup_orphaned_resources.py
@@ -1,8 +1,9 @@
 import os
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from rq.job import Job
 
 import tasks.scheduled.cleanup_orphaned_resources as mod
 from tasks.scheduled.cleanup_orphaned_resources import CleanupOrphanedResourcesTask
@@ -25,28 +26,37 @@ class TestCleanupOrphanedResourcesTask:
         assert task.enabled is True
         assert task.manual_run is True
 
-    def test_no_cron_string_by_default(self, task):
-        assert task.cron_string is None
+    def test_cron_string_always_populated(self, task):
+        # Turning the schedule off is expressed through `is_scheduled`, not by
+        # dropping the expression.
+        assert task.cron_string == mod.SCHEDULED_CLEANUP_ORPHANED_RESOURCES_CRON
+        assert task.cron_string
 
-    def test_cron_string_set_when_schedule_enabled(self):
+    def test_not_scheduled_by_default(self, task):
+        assert task.is_scheduled is False
+
+    def test_scheduled_when_flag_enabled(self, task):
         with patch.object(mod, "ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES", True):
-            with patch.object(
-                mod, "SCHEDULED_CLEANUP_ORPHANED_RESOURCES_CRON", "0 5 * * *"
-            ):
-                assert CleanupOrphanedResourcesTask().cron_string == "0 5 * * *"
+            assert task.is_scheduled is True
 
-    def test_init_unschedules_when_no_cron(self, task):
-        with patch.object(task, "unschedule") as mock_unschedule:
-            assert task.init() is None
-            mock_unschedule.assert_called_once()
-
-    def test_init_schedules_when_cron_set(self, task):
-        task.cron_string = "0 5 * * *"
-
+    def test_init_does_not_schedule_when_flag_disabled(self, task):
         with patch.object(task, "_get_existing_job", return_value=None):
             with patch.object(task, "schedule") as mock_schedule:
-                task.init()
-                mock_schedule.assert_called_once()
+                assert task.init() is None
+                mock_schedule.assert_not_called()
+
+    def test_init_unschedules_when_flag_disabled(self, task):
+        with patch.object(task, "_get_existing_job", return_value=MagicMock(spec=Job)):
+            with patch.object(task, "unschedule") as mock_unschedule:
+                assert task.init() is None
+                mock_unschedule.assert_called_once()
+
+    def test_init_schedules_when_flag_enabled(self, task):
+        with patch.object(mod, "ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES", True):
+            with patch.object(task, "_get_existing_job", return_value=None):
+                with patch.object(task, "schedule") as mock_schedule:
+                    task.init()
+                    mock_schedule.assert_called_once()
 
 
 class TestCleanupOrphanedResourcesRun:

--- a/backend/tests/tasks/test_tasks.py
+++ b/backend/tests/tasks/test_tasks.py
@@ -46,6 +46,22 @@ class TestPeriodicTask:
         assert task.enabled is True
         assert task.cron_string == "0 0 * * *"
 
+    def test_is_scheduled_requires_enabled_and_cron(self, task, disabled_task):
+        assert task.is_scheduled is True
+        assert disabled_task.is_scheduled is False
+
+    def test_is_scheduled_false_without_cron_string(self):
+        task = ConcretePeriodicTask(
+            func="test.function",
+            title="Test Task",
+            description="test task",
+            task_type=TaskType.GENERIC,
+            enabled=True,
+            cron_string=None,
+        )
+
+        assert task.is_scheduled is False
+
     @patch.object(tasks_scheduler, "get_jobs")
     def test_get_existing_job_found(self, mock_get_jobs, task):
         """Test finding an existing job"""
@@ -103,6 +119,29 @@ class TestPeriodicTask:
         mock_unschedule.return_value = None
 
         result = disabled_task.init()
+
+        mock_unschedule.assert_called_once()
+        mock_schedule.assert_not_called()
+        assert result is None
+
+    @patch.object(ConcretePeriodicTask, "_get_existing_job")
+    @patch.object(ConcretePeriodicTask, "schedule")
+    @patch.object(ConcretePeriodicTask, "unschedule")
+    def test_init_unschedules_enabled_task_without_cron(
+        self, mock_unschedule, mock_schedule, mock_get_existing_job
+    ):
+        """An enabled task with no cron expression must not keep a stale job."""
+        task = ConcretePeriodicTask(
+            func="test.function",
+            title="Test Task",
+            description="test task",
+            task_type=TaskType.GENERIC,
+            enabled=True,
+            cron_string=None,
+        )
+        mock_get_existing_job.return_value = MagicMock(spec=Job)
+
+        result = task.init()
 
         mock_unschedule.assert_called_once()
         mock_schedule.assert_not_called()

--- a/frontend/src/utils/index.test.ts
+++ b/frontend/src/utils/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { SimpleRom } from "@/stores/roms";
-import { getDownloadPath } from "./index";
+import { convertCronExperssion, getDownloadPath } from "./index";
 
 function makeRom(overrides: Partial<SimpleRom>): SimpleRom {
   return {
@@ -55,5 +55,21 @@ describe("getDownloadPath", () => {
     expect(getDownloadPath({ rom, fileIDs: [999] })).toBe(
       "/api/roms/24/content/B.A.T.?file_ids=999",
     );
+  });
+});
+
+describe("convertCronExperssion", () => {
+  it("describes a cron expression in lower case", () => {
+    expect(convertCronExperssion("0 5 * * *")).toBe("at 05:00 AM, every day");
+  });
+
+  it("returns an empty string for an empty expression", () => {
+    // A task with no schedule must not break the Tasks page: cronstrue throws
+    // on "", and the throw happens inside a computed the template renders.
+    expect(convertCronExperssion("")).toBe("");
+  });
+
+  it("returns an empty string for an unparseable expression", () => {
+    expect(convertCronExperssion("not a cron expression")).toBe("");
   });
 });

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -96,11 +96,24 @@ export function normalizeString(s: string) {
 /**
  * Convert a cron expression to a human-readable string.
  *
+ * Callers use this inside computed properties that templates read, and cronstrue
+ * throws on an empty or malformed expression. A throw there costs the whole
+ * surrounding component, so an undescribable schedule yields no description.
+ *
  * @param expression The cron expression to convert.
- * @returns The human-readable string.
+ * @returns The human-readable string, or an empty string if there is none.
  */
 export function convertCronExperssion(expression: string) {
-  let convertedExpression = cronstrue.toString(expression, { verbose: true });
+  if (!expression) return "";
+
+  let convertedExpression: string;
+  try {
+    convertedExpression = cronstrue.toString(expression, { verbose: true });
+  } catch (error) {
+    console.error(`Unable to describe cron expression "${expression}":`, error);
+    return "";
+  }
+
   convertedExpression =
     convertedExpression.charAt(0).toLocaleLowerCase() +
     convertedExpression.substr(1);

--- a/frontend/src/v2/components/Settings/TasksSection.test.ts
+++ b/frontend/src/v2/components/Settings/TasksSection.test.ts
@@ -1,0 +1,110 @@
+/* eslint-disable vue/one-component-per-file */
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent } from "vue";
+import type { TaskInfo } from "@/__generated__/models/TaskInfo";
+import storeTasks from "@/stores/tasks";
+import TasksSection from "./TasksSection.vue";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key, locale: "en_US" }),
+}));
+
+vi.mock("@v2/lib", () => ({
+  RBtn: defineComponent({ template: "<button><slot /></button>" }),
+  RIcon: defineComponent({
+    props: { icon: { type: String, default: "" } },
+    template: '<i class="r-icon" :data-icon="icon" />',
+  }),
+  RSpinner: defineComponent({ template: "<div />" }),
+}));
+
+vi.mock("@/v2/components/Settings/SettingsSection.vue", () => ({
+  default: defineComponent({ template: "<section><slot /></section>" }),
+}));
+
+vi.mock("@/v2/composables/useSnackbar", () => ({
+  useSnackbar: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock("@/services/api/task", () => ({
+  default: {
+    getTasks: vi.fn(),
+    getTaskStatus: vi.fn(),
+    runTask: vi.fn(),
+  },
+}));
+
+function makeTask(overrides: Partial<TaskInfo>): TaskInfo {
+  return {
+    name: "cleanup_orphaned_resources",
+    type: "cleanup",
+    title: "Cleanup orphaned resources",
+    description: "Clean up orphaned resources in the ROMs directory",
+    enabled: true,
+    manual_run: true,
+    cron_string: "",
+    ...overrides,
+  } as TaskInfo;
+}
+
+function mountWithScheduledTasks(tasks: TaskInfo[]) {
+  setActivePinia(createPinia());
+  const store = storeTasks();
+  vi.spyOn(store, "fetchTasks").mockResolvedValue({
+    watcherTasks: [],
+    scheduledTasks: tasks,
+    manualTasks: [],
+  });
+  vi.spyOn(store, "fetchTaskStatus").mockResolvedValue([]);
+  store.scheduledTasks = tasks;
+
+  return mount(TasksSection);
+}
+
+describe("TasksSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a task whose schedule is off without blanking the panel", () => {
+    // A throw inside the cron computed costs the whole component, so a task
+    // with no describable schedule must still render alongside the others.
+    const wrapper = mountWithScheduledTasks([makeTask({ cron_string: "" })]);
+
+    expect(wrapper.find("section").exists()).toBe(true);
+    expect(wrapper.text()).toContain("Cleanup orphaned resources");
+  });
+
+  it("shows no schedule and an off clock when the schedule is off", () => {
+    const wrapper = mountWithScheduledTasks([makeTask({ cron_string: "" })]);
+
+    expect(wrapper.text()).not.toContain("every day");
+    expect(wrapper.find(".r-v2-tasks__schedule").exists()).toBe(false);
+    expect(wrapper.find(".r-icon").attributes("data-icon")).toBe(
+      "mdi-clock-remove-outline",
+    );
+  });
+
+  it("keeps the run button for a manually runnable task with no schedule", () => {
+    const wrapper = mountWithScheduledTasks([
+      makeTask({ cron_string: "", manual_run: true }),
+    ]);
+
+    expect(wrapper.find(".r-v2-tasks__run-btn").exists()).toBe(true);
+  });
+
+  it("describes the schedule and shows an on clock when it is on", () => {
+    const wrapper = mountWithScheduledTasks([
+      makeTask({ cron_string: "0 5 * * *" }),
+    ]);
+
+    expect(wrapper.find(".r-v2-tasks__schedule").text()).toContain(
+      "at 05:00 AM, every day",
+    );
+    expect(wrapper.find(".r-icon").attributes("data-icon")).toBe(
+      "mdi-clock-check-outline",
+    );
+  });
+});

--- a/frontend/src/v2/components/Settings/TasksSection.vue
+++ b/frontend/src/v2/components/Settings/TasksSection.vue
@@ -37,7 +37,11 @@ const watcherTasksUI = computed(() =>
 const scheduledTasksUI = computed(() =>
   scheduledTasks.value.map((task) => ({
     ...task,
-    icon: task.enabled ? "mdi-clock-check-outline" : "mdi-clock-remove-outline",
+    // A task can be enabled for manual runs with its schedule turned off, so
+    // the clock reflects the schedule rather than the task being enabled.
+    icon: task.cron_string
+      ? "mdi-clock-check-outline"
+      : "mdi-clock-remove-outline",
     cron_string: convertCronExperssion(task.cron_string),
   })),
 );


### PR DESCRIPTION
**Description**

Fixes #3994

`ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES` had no effect in 5.1.0. The
"Cleanup orphaned resources" task was scheduled at 05:00 on every install
regardless of the setting. Because the task `shutil.rmtree`s resource
directories for platforms and ROMs the database does not report, a library
share that is temporarily unmounted or a database that is mid-migration could
cost users their custom covers and screenshots, with no undo.

The flag was wired up by expressing "schedule off" as "no cron string". A
later fix for the resulting blank Tasks page made the task always pass its
cron expression, which left the `if not self.cron_string` guard in `init()`
unreachable and silently removed the flag's only effect.

The underlying problem is that `enabled` carried two meanings: "the feature is
available and can be run by hand" (`can_run_manually = manual_run and
enabled`) and "the schedule is on" (what `PeriodicTask.init()` read). This
task needs those to differ, since it should stay manually runnable with its
schedule off.

This splits them. A new `Task.is_scheduled` property defaults to
`enabled and bool(cron_string)`, and `init()` now drives off it.
`CleanupOrphanedResourcesTask` overrides it to return the flag, so the cron
expression stays populated and the flag alone decides whether the task also
runs on its own. Reading the flag inside the property rather than at
construction keeps it re-evaluated on every `init()`.

The API side follows: `_build_task_info` reports a cron expression only when
the task is actually scheduled with it, so the Tasks page no longer shows a
schedule that will never fire.

**Files modified**

Backend

- `backend/tasks/tasks.py` — adds the `Task.is_scheduled` property and makes
  `PeriodicTask.init()` schedule/unschedule from it instead of from `enabled`.
  Side benefit: an enabled task with no cron expression now has a stale job
  cleaned up instead of left in the scheduler.
- `backend/tasks/scheduled/cleanup_orphaned_resources.py` — replaces the
  unreachable `init()` override with an `is_scheduled` override returning
  `ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES`. `enabled` and `manual_run`
  stay `True` so admins can still run it on demand.
- `backend/endpoints/tasks.py` — `_build_task_info` reports `cron_string` only
  when the task is scheduled.

Frontend

- `frontend/src/utils/index.ts` — `convertCronExperssion` returns `""` instead
  of throwing on an empty or malformed expression. Callers use it inside
  computed properties that templates read, and a throw there costs the whole
  surrounding component (Vue substitutes a comment node, blanking the panel).
- `frontend/src/v2/components/Settings/TasksSection.vue` — the clock icon is
  derived from the schedule rather than from `enabled`, so a task that is
  runnable but unscheduled shows `mdi-clock-remove-outline`.

Tests

- `backend/tests/tasks/test_tasks.py` — `is_scheduled` truth table and the new
  unschedule-on-missing-cron path.
- `backend/tests/tasks/test_cleanup_orphaned_resources.py` — replaces the two
  tests that asserted the "no cron string" contract with coverage of the flag:
  not scheduled by default, scheduled when the flag is on, `init()` neither
  schedules nor leaves a stale job when it is off, and the cron expression
  stays populated either way.
- `backend/tests/endpoints/test_tasks.py` — `/api/tasks` reports an empty
  `cron_string` for an unscheduled task while keeping `manual_run` true.
- `frontend/src/utils/index.test.ts` — empty and unparseable expressions
  describe as `""`.
- `frontend/src/v2/components/Settings/TasksSection.test.ts` (new) — renders
  the section at the layer the blank-panel bug lived at: an unscheduled task
  still renders with its run button and an off clock, and a scheduled one
  still shows its description and on clock.

No migration, no schema change, no new setting. `env.template` and
`docs/BACKEND_ARCHITECTURE.md` already document the flag as the gate, so they
needed no edit.

**Testing notes**

- Backend suite: `2519 passed, 2 skipped`. For reference, the 5.1.0 release
  commit was `2 failed, 2511 passed, 2 skipped`, the two failures being the
  tests referenced in the issue.
- Frontend: `594 passed` across 43 files, `npm run typecheck` clean for
  `src/`, `npm run build` succeeds, i18n parity check clean.
- `trunk fmt && trunk check` clean on every changed file.
- Every new test was confirmed to fail against the unfixed code before the fix
  was written.
- Verified in-process against a real RQ scheduler in both directions: with the
  flag off `init()` schedules no job and `/api/tasks` reports `cron_string:
  ""`; with it on a real cron job is created and the endpoint reports
  `"0 5 * * *"`; flipping it back off removes the existing job, which is the
  upgrade path for installs that already have the 5.1.0 job in Redis.
- `/api/tasks` checked live against a running backend, not only through the
  test client.

**Things worth a reviewer's attention**

1. *Disabled scheduled tasks also stop advertising a cron.* Because
   `_build_task_info` now gates on `is_scheduled`, a scheduled task that is
   disabled reports `cron_string: ""` where it previously reported its
   inactive expression. For example `scan_library` with
   `ENABLE_SCHEDULED_RESCAN=false` reported `"0 3 * * *"` before and reports
   `""` now. This is consistent with only reporting a schedule that fires, and
   it touches the API output of five other tasks, so it is worth a deliberate
   yes or no. Reverting just that line keeps the core fix intact.
2. *`schedule()` still checks `enabled`, not `is_scheduled`.* Left alone on
   purpose: `init()` is its only production caller, and switching it would
   turn the documented "return `None` when there is no cron expression"
   behaviour into a raise. Policy lives in `init()`, the primitive stays dumb.
3. *No runtime re-check inside `run()`.* Sibling tasks such as
   `cleanup_zip_cache` and `scan_library` re-read their flag in `run()` and
   self-unschedule. Copying that here would break manual runs, which is the
   entire point of this task, so it is intentionally absent. Stale jobs are
   handled at startup by `init()` instead.
4. *The cron helper fix lives in shared `src/utils/`.* That means v1's
   `Tasks.vue` is hardened too without editing a frozen v1 file, so
   `check-v1-frozen` stays green.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**AI assistance disclosure**

This change was written with AI assistance (Claude Code), used extensively:
for investigating the regression, designing the `is_scheduled` split, writing
the implementation and all tests, and running the verification described
above. Every change was reviewed and tested by me before submitting, including
the empirical scheduler and endpoint checks in both flag states.
