### PR TITLE
perf(roms): stop the Missing tab scanning the whole library

### DIFF
--- a/backend/alembic/versions/0104_roms_missing_from_fs_index.py
+++ b/backend/alembic/versions/0104_roms_missing_from_fs_index.py
@@ -1,0 +1,39 @@
+"""Add composite index on roms (missing_from_fs, name_sort_key)
+
+Settings -> Library Management -> Missing filters every request on
+``missing_from_fs`` and orders it by ``name_sort_key``. Neither column was part
+of an index covering that filter, so both the char index and the ordered id
+index scanned the whole ``roms`` table, which carries every provider's raw
+metadata blobs and is multi-gigabyte on a large library.
+
+Revision ID: 0104_roms_missing_from_fs_index
+Revises: 0103_roms_facets_provider_ids
+Create Date: 2026-07-30 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0104_roms_missing_from_fs_index"
+down_revision = "0103_roms_facets_provider_ids"
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = "idx_roms_missing_from_fs"
+INDEX_COLUMNS = ["missing_from_fs", "name_sort_key"]
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("roms", schema=None) as batch_op:
+        batch_op.create_index(
+            INDEX_NAME,
+            INDEX_COLUMNS,
+            unique=False,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("roms", schema=None) as batch_op:
+        batch_op.drop_index(INDEX_NAME, if_exists=True)

--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -747,9 +747,6 @@ def get_roms(
             smart_collection_id=smart_collection_id,
             search_term=search_term,
         )
-        # Keyed on the scope alone: the row-level filters are absent from
-        # `filter_query`, so a filtered request answers with (and warms) the
-        # same whole-library entry an unfiltered one does.
         cache_key = build_unscoped_sidecar_cache_key(
             request.user.id, order_by, order_dir, group_by_meta_id, is_unscoped_scope
         )

--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -130,6 +130,10 @@ def build_unscoped_sidecar_cache_key(
     rom id index). Returns None for scoped/searched sets, which are computed live.
     The computed values depend on user, ordering and grouping, so all are part
     of the key.
+
+    What counts as unscoped differs per sidecar, so the caller decides: the char
+    index and the id index narrow with every filter, while the filter-value list
+    is built from a query that only applies platform / collection / search.
     """
     if not is_unscoped:
         return None
@@ -662,13 +666,21 @@ def get_roms(
     # shared "all" key. Bool flags use `is not None` since False is an active
     # filter. Logic operators are omitted: they only matter when their list
     # filter is set, which is already covered.
-    is_unscoped = not (
+    #
+    # The filter-value list is gated separately: it is computed from
+    # `unfiltered_query` with only these scope parameters applied (see below),
+    # so the row-level filters never reach it and its result stays identical to
+    # the unfiltered one. Locking it out of the cache over a filter it does not
+    # apply made every Missing-tab visit recompute the whole library.
+    is_unscoped_scope = not (
         search_term
         or platform_ids
         or collection_id
         or virtual_collection_id
         or smart_collection_id
-        or genres
+    )
+    is_unscoped = is_unscoped_scope and not (
+        genres
         or franchises
         or collections
         or companies
@@ -735,8 +747,11 @@ def get_roms(
             smart_collection_id=smart_collection_id,
             search_term=search_term,
         )
+        # Keyed on the scope alone: the row-level filters are absent from
+        # `filter_query`, so a filtered request answers with (and warms) the
+        # same whole-library entry an unfiltered one does.
         cache_key = build_unscoped_sidecar_cache_key(
-            request.user.id, order_by, order_dir, group_by_meta_id, is_unscoped
+            request.user.id, order_by, order_dir, group_by_meta_id, is_unscoped_scope
         )
         query_filters = db_rom_handler.with_filter_values(
             query=filter_query,

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -24,6 +24,7 @@ from sqlalchemy import (
     or_,
     select,
     text,
+    true,
     update,
 )
 from sqlalchemy.orm import (
@@ -720,10 +721,10 @@ class DBRomsHandler(DBBaseHandler):
         return query.filter(predicate)
 
     def _filter_by_missing_from_fs(self, query: Query, value: bool) -> Query:
-        predicate = Rom.missing_from_fs.isnot(False)
-        if not value:
-            predicate = not_(predicate)
-        return query.filter(predicate)
+        # The column is NOT NULL, so equality matches the same rows as the
+        # `IS [NOT] FALSE` form. MariaDB only treats the equality as indexable
+        # though, and this filter backs the Missing tab's whole-library scan.
+        return query.filter(Rom.missing_from_fs == (true() if value else false()))
 
     def _filter_by_verified(self, query: Query, value: bool) -> Query:
         keys_to_check = [

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -321,6 +321,8 @@ class Rom(BaseModel):
             "id",
         ),
         Index("idx_roms_platform_fs_size", "platform_id", "fs_size_bytes"),
+        # Serves the Missing tab: filter on missing_from_fs, ordered by name
+        Index("idx_roms_missing_from_fs", "missing_from_fs", "name_sort_key"),
         Index("idx_roms_name", "name"),
         Index("idx_roms_name_sort_key", "name_sort_key"),
         Index("idx_roms_igdb_id", "igdb_id"),

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -321,7 +321,6 @@ class Rom(BaseModel):
             "id",
         ),
         Index("idx_roms_platform_fs_size", "platform_id", "fs_size_bytes"),
-        # Serves the Missing tab: filter on missing_from_fs, ordered by name
         Index("idx_roms_missing_from_fs", "missing_from_fs", "name_sort_key"),
         Index("idx_roms_name", "name"),
         Index("idx_roms_name_sort_key", "name_sort_key"),

--- a/backend/tests/endpoints/roms/test_rom_sidecar_cache.py
+++ b/backend/tests/endpoints/roms/test_rom_sidecar_cache.py
@@ -1,0 +1,196 @@
+"""Cache gating for the gallery sidecars (filter values, char index, id index).
+
+`GET /roms` returns three whole-library aggregates alongside the page. Only the
+fully unscoped scan may be memoised under the shared "all" key, because that key
+encodes user/order/grouping but none of the filters.
+
+The filter-value list is the exception: it is built from `unfiltered_query` with
+only platform / collection / search applied, so the row-level filters (missing,
+favorite, duplicate, ...) never reach its query and its result is byte-identical
+to the unfiltered one. Locking it out of the cache made the Missing tab recompute
+the whole library on every visit, sort change and platform pick (issue #3992).
+
+These tests pin the split gate:
+  1. a row-level filter reads and writes the shared filter-values entry,
+  2. a scope filter (platform / collection / search) does neither,
+  3. the char index and the id index stay live under any row-level filter,
+     since both narrow with it.
+"""
+
+from typing import Any
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from endpoints.roms import build_unscoped_sidecar_cache_key
+from handler.database import db_rom_handler
+from handler.database.roms_handler import (
+    _filter_values_cache_version,
+    _filter_values_redis_key,
+    _store_versioned_cache,
+)
+from handler.redis_handler import sync_cache
+from models.platform import Platform
+from models.rom import Rom
+from models.user import User
+
+# A recognisable filter-value payload: if the endpoint answers with this, it
+# read the shared cache entry rather than recomputing over the library.
+SENTINEL_FILTER_VALUES: dict[str, Any] = {
+    "genres": ["Sentinel Genre"],
+    "franchises": [],
+    "collections": [],
+    "companies": [],
+    "game_modes": [],
+    "age_ratings": [],
+    "player_counts": [],
+    "regions": [],
+    "languages": [],
+    "tags": [],
+    "platforms": [],
+}
+
+
+@pytest.fixture
+def missing_rom(rom: Rom) -> Rom:
+    """Flag the shared rom as missing from the filesystem."""
+    db_rom = db_rom_handler.update_rom(rom.id, {"missing_from_fs": True})
+    return db_rom
+
+
+def _unscoped_key(user_id: int) -> str:
+    """The shared sidecar key for a default (no order, no grouping) request."""
+    key = build_unscoped_sidecar_cache_key(user_id, "", "asc", False, True)
+    assert key is not None
+    return key
+
+
+def _seed_filter_values(user_id: int) -> str:
+    version = _filter_values_cache_version()
+    redis_key = _filter_values_redis_key(_unscoped_key(user_id), version)
+    _store_versioned_cache(redis_key, version, SENTINEL_FILTER_VALUES)
+    return redis_key
+
+
+def _get_roms(client: TestClient, access_token: str, **params: Any) -> dict:
+    response = client.get(
+        "/api/roms",
+        headers={"Authorization": f"Bearer {access_token}"},
+        params=params,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    return response.json()
+
+
+def test_row_filter_reads_unscoped_filter_values_cache(
+    client: TestClient, access_token: str, admin_user: User, missing_rom: Rom
+):
+    """`missing=true` reuses the whole-library entry the unfiltered scan wrote."""
+    _seed_filter_values(admin_user.id)
+
+    body = _get_roms(client, access_token, missing=True)
+
+    assert body["filter_values"]["genres"] == ["Sentinel Genre"]
+
+
+def test_row_filter_writes_unscoped_filter_values_cache(
+    client: TestClient, access_token: str, admin_user: User, missing_rom: Rom
+):
+    """A row-filtered request also warms the shared entry for everyone else."""
+    version = _filter_values_cache_version()
+    redis_key = _filter_values_redis_key(_unscoped_key(admin_user.id), version)
+    assert sync_cache.get(redis_key) is None
+
+    _get_roms(client, access_token, missing=True)
+
+    assert sync_cache.get(redis_key) is not None
+
+
+def test_row_filtered_and_unfiltered_filter_values_match(
+    client: TestClient, access_token: str, missing_rom: Rom
+):
+    """The two are the same list, which is what makes sharing the key correct."""
+    filtered = _get_roms(client, access_token, missing=True)
+    unfiltered = _get_roms(client, access_token)
+
+    assert filtered["filter_values"] == unfiltered["filter_values"]
+
+
+def test_platform_scope_does_not_read_unscoped_filter_values_cache(
+    client: TestClient, access_token: str, admin_user: User, platform: Platform
+):
+    """A platform narrows the filter-value list, so it must be computed live."""
+    _seed_filter_values(admin_user.id)
+
+    body = _get_roms(client, access_token, platform_ids=platform.id)
+
+    assert body["filter_values"]["genres"] == []
+
+
+def test_platform_scope_does_not_write_unscoped_filter_values_cache(
+    client: TestClient, access_token: str, admin_user: User, platform: Platform
+):
+    """A scoped list must never leak into the shared whole-library entry."""
+    redis_key = _seed_filter_values(admin_user.id)
+
+    _get_roms(client, access_token, platform_ids=platform.id)
+
+    cached = sync_cache.get(redis_key)
+    assert cached is not None
+    assert b"Sentinel Genre" in (
+        cached if isinstance(cached, bytes) else cached.encode()
+    )
+
+
+def test_search_scope_does_not_read_unscoped_filter_values_cache(
+    client: TestClient, access_token: str, admin_user: User, rom: Rom
+):
+    """A search term narrows the filter-value list the same way a platform does."""
+    _seed_filter_values(admin_user.id)
+
+    body = _get_roms(client, access_token, search_term="nothing-matches-this")
+
+    assert body["filter_values"]["genres"] == []
+
+
+def test_row_filter_does_not_read_unscoped_char_index_cache(
+    client: TestClient, access_token: str, admin_user: User, rom: Rom
+):
+    """The char index counts filtered rows, so the shared entry does not apply."""
+    version = _filter_values_cache_version()
+    _store_versioned_cache(
+        f"char_index:{_unscoped_key(admin_user.id)}:v{version}", version, [["Z", 41]]
+    )
+
+    body = _get_roms(client, access_token, missing=True)
+
+    assert "Z" not in body["char_index"]
+
+
+def test_row_filter_does_not_read_unscoped_rom_id_index_cache(
+    client: TestClient, access_token: str, admin_user: User, rom: Rom
+):
+    """Same for the id index: it is the filtered result set, not the library."""
+    version = _filter_values_cache_version()
+    _store_versioned_cache(
+        f"rom_id_index:{_unscoped_key(admin_user.id)}:v{version}", version, [424242]
+    )
+
+    body = _get_roms(client, access_token, missing=True)
+
+    assert body["rom_id_index"] == []
+
+
+def test_unfiltered_request_still_reads_unscoped_char_index_cache(
+    client: TestClient, access_token: str, admin_user: User, rom: Rom
+):
+    """The unscoped scan keeps its memoisation (the case the key was built for)."""
+    version = _filter_values_cache_version()
+    _store_versioned_cache(
+        f"char_index:{_unscoped_key(admin_user.id)}:v{version}", version, [["Z", 41]]
+    )
+
+    body = _get_roms(client, access_token)
+
+    assert body["char_index"] == {"Z": 41}

--- a/backend/tests/handler/database/test_roms_missing_filter.py
+++ b/backend/tests/handler/database/test_roms_missing_filter.py
@@ -1,0 +1,88 @@
+"""The `missing_from_fs` filter and the index that serves it.
+
+Settings -> Library Management -> Missing filters every request on
+`missing_from_fs`, and both the char index and the ordered id index sort the
+result by `name_sort_key`. Without a composite index over the two the database
+walked the whole `roms` table, which holds every provider's raw metadata and is
+multi-gigabyte on a large library (issue #3992).
+
+An index alone is not enough: MariaDB does not treat `col IS NOT FALSE` as an
+indexable predicate (EXPLAIN reports no `possible_keys` and falls back to a full
+index scan plus filesort), while `col = TRUE` gets range access. The column is
+`NOT NULL` since migration 0042, so the two are equivalent and the filter uses
+the sargable form.
+"""
+
+import pytest
+from sqlalchemy import inspect
+from tests.conftest import engine
+
+from handler.database import db_rom_handler
+from models.platform import Platform
+from models.rom import Rom
+from models.user import User
+
+INDEX_COLUMNS = ["missing_from_fs", "name_sort_key"]
+
+
+@pytest.fixture
+def missing_rom(rom: Rom) -> Rom:
+    return db_rom_handler.update_rom(rom.id, {"missing_from_fs": True})
+
+
+@pytest.fixture
+def present_rom(platform: Platform) -> Rom:
+    return db_rom_handler.add_rom(
+        Rom(
+            platform_id=platform.id,
+            name="present_rom",
+            slug="present_rom",
+            fs_name="present_rom.zip",
+            fs_name_no_tags="present_rom",
+            fs_name_no_ext="present_rom",
+            fs_extension="zip",
+            fs_path=f"{platform.slug}/roms",
+        )
+    )
+
+
+class TestMissingFromFsIndex:
+    def test_model_declares_composite_index(self):
+        declared = [list(index.columns.keys()) for index in Rom.__table__.indexes]
+
+        assert INDEX_COLUMNS in declared
+
+    def test_migrations_create_composite_index(self):
+        indexes = [
+            index["column_names"] for index in inspect(engine).get_indexes("roms")
+        ]
+
+        assert INDEX_COLUMNS in indexes
+
+
+class TestMissingFromFsPredicate:
+    def _compiled_where(self, missing: bool) -> str:
+        query, _ = db_rom_handler.get_roms_query()
+        filtered = db_rom_handler.filter_roms(query=query, missing=missing)
+        return str(filtered.compile(compile_kwargs={"literal_binds": True}))
+
+    @pytest.mark.parametrize("missing", [True, False])
+    def test_predicate_is_an_indexable_equality(self, missing: bool):
+        sql = self._compiled_where(missing)
+
+        assert "roms.missing_from_fs = " in sql
+        assert "IS NOT" not in sql
+
+    def test_missing_true_returns_only_missing_roms(
+        self, admin_user: User, missing_rom: Rom, present_rom: Rom
+    ):
+        roms = db_rom_handler.get_roms_scalar(user_id=admin_user.id, missing=True)
+
+        assert [r.id for r in roms] == [missing_rom.id]
+
+    def test_missing_false_returns_only_present_roms(
+        self, admin_user: User, missing_rom: Rom, present_rom: Rom
+    ):
+        roms = db_rom_handler.get_roms_scalar(user_id=admin_user.id, missing=False)
+
+        assert [r.id for r in roms] == [present_rom.id]

--- a/backend/tests/handler/database/test_roms_missing_filter.py
+++ b/backend/tests/handler/database/test_roms_missing_filter.py
@@ -47,11 +47,6 @@ def present_rom(platform: Platform) -> Rom:
 
 
 class TestMissingFromFsIndex:
-    def test_model_declares_composite_index(self):
-        declared = [list(index.columns.keys()) for index in Rom.__table__.indexes]
-
-        assert INDEX_COLUMNS in declared
-
     def test_migrations_create_composite_index(self):
         indexes = [
             index["column_names"] for index in inspect(engine).get_indexes("roms")
@@ -61,17 +56,14 @@ class TestMissingFromFsIndex:
 
 
 class TestMissingFromFsPredicate:
-    def _compiled_where(self, missing: bool) -> str:
+    @pytest.mark.parametrize(("missing", "literal"), [(True, "true"), (False, "false")])
+    def test_predicate_is_an_indexable_equality(self, missing: bool, literal: str):
         query, _ = db_rom_handler.get_roms_query()
         filtered = db_rom_handler.filter_roms(query=query, missing=missing)
-        return str(filtered.compile(compile_kwargs={"literal_binds": True}))
 
-    @pytest.mark.parametrize("missing", [True, False])
-    def test_predicate_is_an_indexable_equality(self, missing: bool):
-        sql = self._compiled_where(missing)
+        sql = str(filtered.compile(compile_kwargs={"literal_binds": True}))
 
-        assert "roms.missing_from_fs = " in sql
-        assert "IS NOT" not in sql
+        assert f"roms.missing_from_fs = {literal}" in sql
 
     def test_missing_true_returns_only_missing_roms(
         self, admin_user: User, missing_rom: Rom, present_rom: Rom

--- a/frontend/src/v2/components/Settings/MissingGamesSection.test.ts
+++ b/frontend/src/v2/components/Settings/MissingGamesSection.test.ts
@@ -1,0 +1,85 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MissingGamesSection from "./MissingGamesSection.vue";
+
+const { getRoms } = vi.hoisted(() => ({ getRoms: vi.fn() }));
+
+vi.mock("@/services/api/rom", () => ({ default: { getRoms } }));
+vi.mock("@/services/api/task", () => ({ default: { runTask: vi.fn() } }));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/v2/composables/useConfirm", () => ({
+  useConfirm: () => vi.fn().mockResolvedValue(false),
+}));
+vi.mock("@/v2/composables/useSnackbar", () => ({
+  useSnackbar: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+vi.mock("@/v2/composables/useWebpSupport", () => ({
+  useWebpSupport: () => ({ supportsWebp: { value: true } }),
+}));
+
+function mountSection() {
+  return mount(MissingGamesSection, {
+    global: {
+      stubs: {
+        CachedPlatformIcon: true,
+        GameListHeader: true,
+        GameListRow: true,
+        GameListSkeletonRow: true,
+        RBtn: true,
+        RIcon: true,
+        RMenu: true,
+        RMenuItem: true,
+        RSelect: true,
+        RTag: true,
+        RVirtualScroller: true,
+      },
+    },
+  });
+}
+
+describe("MissingGamesSection", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    getRoms.mockReset();
+    getRoms.mockResolvedValue({
+      data: { total: 0, items: [], char_index: {}, rom_id_index: [] },
+    });
+  });
+
+  // The tab renders no filter drawer, no A-Z strip and drives its scroller
+  // off `total` alone, so asking for those sidecars costs three whole-library
+  // scans and displays two of them nowhere (issue #3992).
+  it("bootstraps without the sidecars it does not render", async () => {
+    mountSection();
+    await flushPromises();
+
+    expect(getRoms).toHaveBeenCalledTimes(1);
+    const params = getRoms.mock.calls[0][0];
+    expect(params.filterMissing).toBe(true);
+    expect(params.withCharIndex).toBe(false);
+    expect(params.withFilterValues).toBe(false);
+    expect(params.withRomIdIndex).toBe(false);
+  });
+
+  it("keeps the sidecars off when the sort order changes", async () => {
+    const wrapper = mountSection();
+    await flushPromises();
+    getRoms.mockClear();
+
+    wrapper
+      .findComponent({ name: "GameListHeader" })
+      .vm.$emit("sort", { key: "fs_size_bytes", dir: "desc" });
+    await flushPromises();
+
+    const params = getRoms.mock.calls[0][0];
+    expect(params.orderBy).toBe("fs_size_bytes");
+    expect(params.withCharIndex).toBe(false);
+    expect(params.withFilterValues).toBe(false);
+    expect(params.withRomIdIndex).toBe(false);
+  });
+});

--- a/frontend/src/v2/components/Settings/MissingGamesSection.vue
+++ b/frontend/src/v2/components/Settings/MissingGamesSection.vue
@@ -41,13 +41,22 @@ import CachedPlatformIcon from "@/v2/components/shared/CachedPlatformIcon.vue";
 import { useConfirm } from "@/v2/composables/useConfirm";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
 import { useWebpSupport } from "@/v2/composables/useWebpSupport";
-import storeGalleryRoms from "@/v2/stores/galleryRoms";
+import storeGalleryRoms, { type SidecarOptions } from "@/v2/stores/galleryRoms";
 
 interface PlatformItem {
   id: number;
   slug: string;
   name: string;
 }
+
+// This tab renders no filter drawer and no AlphaStrip, and sizes its
+// scroller off `total` alone, so all three whole-library aggregates are
+// scans whose results it would discard.
+const NO_SIDECARS: SidecarOptions = {
+  withCharIndex: false,
+  withFilterValues: false,
+  withRomIdIndex: false,
+};
 
 defineOptions({ inheritAttrs: false });
 
@@ -94,7 +103,7 @@ const selectedPlatformIds = computed<number[]>({
       .filter((p): p is Platform => !!p);
     galleryFilter.setSelectedFilterPlatforms(next);
     galleryRoms.invalidateWindows();
-    void galleryRoms.fetchInitialMetadata();
+    void galleryRoms.fetchInitialMetadata(NO_SIDECARS);
   },
 });
 
@@ -162,7 +171,7 @@ function onListSort({ key, dir }: { key: ListSortKey; dir: "asc" | "desc" }) {
   galleryRoms.setOrderBy(key);
   galleryRoms.setOrderDir(dir);
   galleryRoms.invalidateWindows();
-  void galleryRoms.fetchInitialMetadata();
+  void galleryRoms.fetchInitialMetadata(NO_SIDECARS);
 }
 
 // Viewport-driven windowed fetch. Unlike the real gallery this section
@@ -246,7 +255,7 @@ async function cleanupAll() {
     snackbar.success(t("settings.cleanup-queued"));
     setTimeout(() => {
       galleryRoms.invalidateWindows();
-      void galleryRoms.fetchInitialMetadata();
+      void galleryRoms.fetchInitialMetadata(NO_SIDECARS);
     }, 1500);
   } catch (err) {
     snackbar.error(t("settings.couldnt-queue-cleanup", { error: String(err) }));
@@ -263,7 +272,7 @@ onMounted(() => {
   galleryFilter.setSelectedFilterPlatforms([]);
   galleryRoms.setOrderBy("name");
   galleryRoms.setOrderDir("asc");
-  void galleryRoms.fetchInitialMetadata();
+  void galleryRoms.fetchInitialMetadata(NO_SIDECARS);
 });
 
 onBeforeUnmount(() => {

--- a/frontend/src/v2/stores/galleryRoms.test.ts
+++ b/frontend/src/v2/stores/galleryRoms.test.ts
@@ -1,6 +1,7 @@
 import { flushPromises } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import storeGalleryFilter from "@/stores/galleryFilter";
 // Import after the mock so the store binds to the mocked rom API.
 import storeGalleryRoms from "@/v2/stores/galleryRoms";
 
@@ -124,6 +125,67 @@ describe("galleryRoms windowed fetch", () => {
 
     expect(peak).toBe(4);
     expect(getRoms).toHaveBeenCalledTimes(8);
+  });
+
+  // Surfaces that render none of the sidecars (the Settings "Missing" tab)
+  // opt out of them, so the backend skips three whole-library scans per
+  // request instead of computing two the caller throws away (issue #3992).
+  it("lets the bootstrap opt out of the sidecars its caller does not render", async () => {
+    getRoms.mockResolvedValue({
+      data: { total: 12, items: [], char_index: {}, rom_id_index: [] },
+    });
+    const store = storeGalleryRoms();
+
+    await store.fetchInitialMetadata({
+      withCharIndex: false,
+      withFilterValues: false,
+      withRomIdIndex: false,
+    });
+
+    const params = getRoms.mock.calls[0][0];
+    expect(params.withCharIndex).toBe(false);
+    expect(params.withFilterValues).toBe(false);
+    expect(params.withRomIdIndex).toBe(false);
+    // The total still lands: the backend falls back to a plain COUNT when
+    // the id index is skipped, and that is all the caller needs to size its
+    // virtual scroller.
+    expect(store.total).toBe(12);
+    expect(store.metadataLoaded).toBe(true);
+  });
+
+  it("requests every sidecar by default", async () => {
+    getRoms.mockResolvedValue({
+      data: { total: 1, items: [], char_index: {}, rom_id_index: [] },
+    });
+    const store = storeGalleryRoms();
+
+    await store.fetchInitialMetadata();
+
+    const params = getRoms.mock.calls[0][0];
+    expect(params.withCharIndex).toBeUndefined();
+    expect(params.withFilterValues).toBeUndefined();
+    expect(params.withRomIdIndex).toBeUndefined();
+  });
+
+  it("does not clobber the filter drawer when filter values are skipped", async () => {
+    const galleryFilter = storeGalleryFilter();
+    galleryFilter.setFilterGenres(["RPG", "Shooter"]);
+    // Skipped sidecars come back empty but truthy, which would blank the
+    // drawer if applied.
+    getRoms.mockResolvedValue({
+      data: {
+        total: 3,
+        items: [],
+        char_index: {},
+        rom_id_index: [],
+        filter_values: { genres: [], platforms: [] },
+      },
+    });
+    const store = storeGalleryRoms();
+
+    await store.fetchInitialMetadata({ withFilterValues: false });
+
+    expect(galleryFilter.filterGenres).toEqual(["RPG", "Shooter"]);
   });
 
   it("keeps the bootstrap char_index when the first window skips aggregations", async () => {

--- a/frontend/src/v2/stores/galleryRoms.ts
+++ b/frontend/src/v2/stores/galleryRoms.ts
@@ -161,6 +161,17 @@ async function applyItemsBatched(
   }
 }
 
+/** Which whole-library sidecars a bootstrap asks the backend to compute.
+ * Each one is a scan over the full result set, so a surface that renders
+ * none of them (the Settings "Missing" tab: no filter drawer, no AlphaStrip,
+ * and a scroller sized off `total` alone) opts out rather than paying for
+ * lists it discards. Omitted flags keep the backend's default (`true`). */
+export interface SidecarOptions {
+  withCharIndex?: boolean;
+  withFilterValues?: boolean;
+  withRomIdIndex?: boolean;
+}
+
 interface State {
   currentPlatform: Platform | null;
   currentCollection: Collection | null;
@@ -380,13 +391,21 @@ export default defineStore("v2GalleryRoms", {
       data: GetRomsResponse,
       galleryFilter: GalleryFilterStore,
       platformsStore: ReturnType<typeof storePlatforms>,
+      sidecars: SidecarOptions = {},
     ) {
       if (data.total !== null && data.total !== undefined) {
         this.total = data.total;
       }
-      if (data.char_index) this.charIndex = data.char_index;
-      if (data.rom_id_index) this.romIdIndex = data.rom_id_index;
-      if (data.filter_values) {
+      // A skipped sidecar comes back empty but truthy, so applying it would
+      // blank whatever a previous fetch populated (same trap `fetchWindowAt`
+      // guards with `withAggregations`).
+      if (sidecars.withCharIndex !== false && data.char_index) {
+        this.charIndex = data.char_index;
+      }
+      if (sidecars.withRomIdIndex !== false && data.rom_id_index) {
+        this.romIdIndex = data.rom_id_index;
+      }
+      if (sidecars.withFilterValues !== false && data.filter_values) {
         if (galleryFilter.filterPlatforms.length === 0) {
           galleryFilter.setFilterPlatforms(
             platformsStore.allPlatforms.filter((p) =>
@@ -416,8 +435,12 @@ export default defineStore("v2GalleryRoms", {
      *
      * The backend's `limit` minimum is 1, so we still pay for one
      * `SimpleRomSchema` build server-side, but the item is discarded
-     * client-side. */
-    async fetchInitialMetadata(): Promise<void> {
+     * client-side.
+     *
+     * `sidecars` opts out of the aggregates the caller doesn't render; the
+     * backend then serves `total` from a plain COUNT instead of a full
+     * ordered id scan. */
+    async fetchInitialMetadata(sidecars: SidecarOptions = {}): Promise<void> {
       if (this.metadataLoaded) return;
       if (this.initialFetching) return;
 
@@ -433,6 +456,7 @@ export default defineStore("v2GalleryRoms", {
       try {
         const response = await romApi.getRoms({
           ...params,
+          ...sidecars,
           limit: 1,
           signal: controller.signal,
         });
@@ -441,7 +465,12 @@ export default defineStore("v2GalleryRoms", {
         // newer bootstrap may have replaced our entry under the same key.
         // Identity comparison avoids applying stale metadata in that race.
         if (inFlightControllers.get(ctrlKey) !== controller) return;
-        this._applyMetadata(response.data, galleryFilter, platformsStore);
+        this._applyMetadata(
+          response.data,
+          galleryFilter,
+          platformsStore,
+          sidecars,
+        );
       } catch (err) {
         if (axios.isCancel(err)) return;
         console.error("[v2GalleryRoms] bootstrap fetch failed", err);


### PR DESCRIPTION
**Description**

Fixes #3992

Settings -> Library Management -> Missing took tens of seconds to open on a
large library. A single `GET /api/roms?missing=true&limit=1` did three
whole-library passes, two of which produced data this tab never renders, and
none of which could be cached.

Three independent causes, all fixed here:

1. **The tab asked for aggregates it does not display.** It renders no filter
   drawer and no A-Z strip, and sizes its scroller off `total` alone, yet it
   requested the char index, the filter values *and* the ordered id index. It
   now opts out of all three, so the endpoint serves `total` from a plain
   `COUNT` instead of materialising every matching id.

2. **`missing_from_fs` had no usable index.** Added a composite
   `(missing_from_fs, name_sort_key)` covering the filter plus its ordering.
   The filter predicate also had to change: MariaDB does not treat
   `col IS NOT FALSE` as indexable (EXPLAIN reports no `possible_keys` and
   falls back to a full index scan plus filesort), while `col = TRUE` gets
   range access. The column is `NOT NULL` since migration 0042, so the two
   forms match exactly the same rows.

3. **The cache gate was stricter than it needed to be.** Any active filter,
   including `missing`, set the sidecar cache key to `None`. That is correct
   for the char index and the id index, which both narrow with the filter, but
   the filter-value list is computed from `unfiltered_query` with only
   platform / collection / search applied. The row-level filters never reach
   its query, so its result was already identical to the unfiltered one; it was
   simply recomputed from scratch on every visit, sort change and platform
   pick. It is now keyed on the scope alone, so a filtered request answers
   with, and warms, the same whole-library entry an unfiltered one does.

No API shape changed, so no type regeneration was needed. The `with_*` query
params already existed and keep defaulting to `true`.

**Files changed**

Backend:

- `backend/endpoints/roms/__init__.py` - splits the cache gate into
  `is_unscoped_scope` (search / platform / collection) and the existing
  full `is_unscoped`. The filter-value sidecar uses the former, the char index
  and id index keep the latter.
- `backend/handler/database/roms_handler.py` - `_filter_by_missing_from_fs`
  compiles to an equality against `true()` / `false()` so the new index is
  actually usable.
- `backend/models/rom.py` - declares `idx_roms_missing_from_fs`.
- `backend/alembic/versions/0104_roms_missing_from_fs_index.py` - creates it
  (mirrors 0097, `batch_alter_table` with `if_not_exists` / `if_exists`).

Frontend (v2):

- `frontend/src/v2/stores/galleryRoms.ts` - `fetchInitialMetadata` takes an
  optional `SidecarOptions`, forwards it to the request and to
  `_applyMetadata`, which now skips applying a sidecar the caller opted out of.
  Omitted flags keep the backend default, so every existing caller is
  unchanged.
- `frontend/src/v2/components/Settings/MissingGamesSection.vue` - passes
  `NO_SIDECARS` at all four bootstrap call sites (mount, sort, platform
  select, post-cleanup refresh).

Tests:

- `backend/tests/endpoints/roms/test_rom_sidecar_cache.py` - pins the split
  gate from both sides: a row-level filter reads and warms the shared
  filter-values entry, a scope filter does neither, and the char index and id
  index stay live under any row-level filter.
- `backend/tests/handler/database/test_roms_missing_filter.py` - the index
  exists in a migrated database, the predicate compiles to the sargable
  equality, and both filter directions still return the right rows.
- `frontend/src/v2/stores/galleryRoms.test.ts` - opt-out is forwarded and
  `total` still lands; the default path requests every sidecar; a skipped
  `filter_values` does not blank the filter drawer.
- `frontend/src/v2/components/Settings/MissingGamesSection.test.ts` - the tab
  itself bootstraps and re-sorts with the sidecars off.

**Testing notes**

- `uv run pytest` green (the two `test_cleanup_orphaned_resources` failures on
  this machine are pre-existing on `master`, unrelated, and are #3994).
- `npm run test` green (592 tests), `npm run typecheck` and `npm run build`
  clean, `trunk fmt && trunk check` clean.
- Migration verified in both directions (`alembic upgrade head` /
  `downgrade -1`) on MariaDB.
- The cache-sharing fix was verified live against a running backend: after
  deleting the shared `filter_values` key, a `?missing=true` request rewrote it
  with the full whole-library value.
- The sargability claim was measured with EXPLAIN on MariaDB 11.3.2 with the
  index present: `IS NOT FALSE` gives `type: index`, `possible_keys: NULL`,
  full scan plus filesort; `= TRUE` gives `type: ref` with no filesort.
- Non-regression checked in the browser (both themes) on the normal gallery
  and Search views, which still request and render all three sidecars. The
  Settings tab itself was **not** browser-verified: the route needs
  `platforms.write` and the read-only path available on this machine cannot
  reach it. Covered by the component test instead, but a reviewer with a real
  admin session should click through it.

**Anything a reviewer should look at**

- **The cache gate split is the load-bearing change.** It is only safe while
  the `filter_roms(...)` call inside the `with_filter_values` block receives
  nothing beyond user, hidden entities, platform, collection and search. If a
  future change passes a row-level filter into that call without adding it to
  `is_unscoped_scope`, a narrowed filter-value list would be written under the
  shared "all" key for that user. Worth a comment or an assertion if you want a
  harder guarantee.
- **The predicate rewrite depends on `missing_from_fs` being `NOT NULL`.** If
  that column ever becomes nullable, the equality and the `IS [NOT] FALSE`
  form stop agreeing (NULL rows would fall out of both branches).
- **Index creation cost on large libraries.** `roms` carries every provider's
  raw metadata blobs, so the 0104 upgrade will take a while on the libraries
  this issue is about. MariaDB adds a secondary index in place, and Postgres
  takes a write lock for the duration.
- `_filter_by_missing_from_fs` now looks different from its sibling boolean
  filters. That is deliberate: it is the only one filtering a plain `NOT NULL`
  boolean column, the others sit over nullable columns or relationships where
  the `not_()` form is required.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

---

**AI assistance disclosure**

This PR was written with AI assistance (Claude, via Claude Code). The
investigation, the code, the migration and the tests were AI-generated under my
direction and reviewed by me before submission. The MariaDB sargability
behaviour and the cache-sharing fix were verified empirically against a running
instance, as described above.