### PR TITLE
fix(backend): re-run the Hasheous hash lookup on a hashes scan

### DIFF
--- a/backend/handler/metadata/hasheous_handler.py
+++ b/backend/handler/metadata/hasheous_handler.py
@@ -231,19 +231,26 @@ class HasheousHandler(MetadataHandler):
             ra_id=platform["ra_id"],
         )
 
-    async def lookup_rom(self, platform_slug: str, files: list[RomFile]) -> HasheousRom:
+    async def lookup_rom(
+        self, platform_slug: str, files: list[RomFile]
+    ) -> tuple[HasheousRom, bool]:
         """Identify a ROM by its file hashes.
 
         Returns a HasheousRom with the matched IDs, or an empty match if the
         lookup fails. The lookup is best-effort and never raises to the caller,
         so an unreachable Hasheous can't abort a scan.
+
+        The second value tells the two empty matches apart: True means Hasheous
+        answered and knows nothing about these hashes, False means we never got
+        an answer (disabled, no hashes to send, or the request failed). Only the
+        former is safe to treat as "this ROM is not in any database".
         """
         fallback_rom = HasheousRom(
             hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None
         )
 
         if not self.is_enabled():
-            return fallback_rom
+            return fallback_rom, False
 
         filtered_files = [
             file
@@ -284,7 +291,7 @@ class HasheousHandler(MetadataHandler):
                 "No hashes provided for Hasheous lookup. "
                 "At least one of md5, sha1, or crc is required."
             )
-            return fallback_rom
+            return fallback_rom, False
 
         try:
             hasheous_game = await self._request(
@@ -297,10 +304,10 @@ class HasheousHandler(MetadataHandler):
             )
         except Exception as exc:
             log.error("Hasheous hash lookup failed, skipping: %s", exc)
-            return fallback_rom
+            return fallback_rom, False
 
         if not hasheous_game:
-            return fallback_rom
+            return fallback_rom, True
 
         metadata = hasheous_game.get("metadata", [])
         attributes = hasheous_game.get("attributes", [])
@@ -331,24 +338,27 @@ class HasheousHandler(MetadataHandler):
                 url_cover = f"https://hasheous.org{attr['link']}"
                 break
 
-        return HasheousRom(
-            hasheous_id=hasheous_game["id"],
-            name=hasheous_game.get("name", ""),
-            igdb_id=int(igdb_id) if igdb_id else None,
-            tgdb_id=int(tgdb_id) if tgdb_id else None,
-            ra_id=int(ra_id) if ra_id else None,
-            url_cover=url_cover,
-            hasheous_metadata=HasheousMetadata(
-                tosec_match="TOSEC" in signatures,
-                mame_arcade_match="MAMEArcade" in signatures,
-                mame_mess_match="MAMEMess" in signatures,
-                nointro_match="NoIntros" in signatures,
-                redump_match="Redump" in signatures,
-                whdload_match="WHDLoad" in signatures,
-                ra_match="RetroAchievements" in signatures,
-                fbneo_match="FBNeo" in signatures,
-                puredos_match="PureDOS" in signatures,
+        return (
+            HasheousRom(
+                hasheous_id=hasheous_game["id"],
+                name=hasheous_game.get("name", ""),
+                igdb_id=int(igdb_id) if igdb_id else None,
+                tgdb_id=int(tgdb_id) if tgdb_id else None,
+                ra_id=int(ra_id) if ra_id else None,
+                url_cover=url_cover,
+                hasheous_metadata=HasheousMetadata(
+                    tosec_match="TOSEC" in signatures,
+                    mame_arcade_match="MAMEArcade" in signatures,
+                    mame_mess_match="MAMEMess" in signatures,
+                    nointro_match="NoIntros" in signatures,
+                    redump_match="Redump" in signatures,
+                    whdload_match="WHDLoad" in signatures,
+                    ra_match="RetroAchievements" in signatures,
+                    fbneo_match="FBNeo" in signatures,
+                    puredos_match="PureDOS" in signatures,
+                ),
             ),
+            True,
         )
 
     async def get_igdb_game(self, hasheous_rom: HasheousRom) -> HasheousRom:

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -446,6 +446,9 @@ async def scan_rom(
             and (
                 newly_added
                 or scan_type == ScanType.COMPLETE
+                # New hashes mean a new signature match, so re-run the lookup
+                # even for a ROM that never matched Hasheous before
+                or scan_type == ScanType.HASHES
                 or (scan_type == ScanType.UPDATE and rom.hasheous_id)
                 or (
                     scan_type == ScanType.UNMATCHED
@@ -803,6 +806,7 @@ async def scan_rom(
             and (
                 newly_added
                 or scan_type == ScanType.COMPLETE
+                or scan_type == ScanType.HASHES
                 or (scan_type == ScanType.UPDATE and rom.hasheous_id)
                 or (
                     scan_type == ScanType.UNMATCHED
@@ -1000,9 +1004,11 @@ async def scan_rom(
             if field_value:
                 rom_attrs[field] = field_value
 
-    # Don't overwrite existing base fields on update and unmatched scans
-    if not newly_added and (
-        scan_type == ScanType.UNMATCHED or scan_type == ScanType.UPDATE
+    # Don't overwrite existing base fields on update, unmatched and hashes scans
+    if not newly_added and scan_type in (
+        ScanType.UNMATCHED,
+        ScanType.UPDATE,
+        ScanType.HASHES,
     ):
         # A ROM's name defaults to a filename-derived placeholder when first
         # created. Treat that placeholder as "no name" so a freshly matched provider

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -439,7 +439,7 @@ async def scan_rom(
             gamelist_id=None,
         )
 
-    async def fetch_hasheous_hash_match() -> HasheousRom:
+    async def fetch_hasheous_hash_match() -> tuple[HasheousRom, bool]:
         if (
             MetadataSource.HASHEOUS in metadata_sources
             and platform.hasheous_id
@@ -461,7 +461,10 @@ async def scan_rom(
                 platform.slug, get_match_files()
             )
 
-        return HasheousRom(hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None)
+        return (
+            HasheousRom(hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None),
+            False,
+        )
 
     _added_rom = db_rom_handler.add_rom(Rom(**rom_attrs))
     _added_rom.is_identifying = True
@@ -486,7 +489,7 @@ async def scan_rom(
     # Run hash fetches concurrently
     (
         playmatch_hash_match,
-        hasheous_hash_match,
+        (hasheous_hash_match, hasheous_lookup_conclusive),
     ) = await asyncio.gather(
         fetch_playmatch_hash_match(),
         fetch_hasheous_hash_match(),
@@ -1039,6 +1042,18 @@ async def scan_rom(
                 or [],
             }
         )
+
+    # A rehash that no longer matches must drop the previous Hasheous match, or
+    # the ROM keeps showing verification flags earned by hashes it no longer has.
+    # Only a conclusive lookup clears them, so an unreachable Hasheous can't
+    # silently de-verify a library.
+    if (
+        scan_type == ScanType.HASHES
+        and hasheous_lookup_conclusive
+        and not hasheous_hash_match.get("hasheous_id")
+    ):
+        rom_attrs["hasheous_id"] = None
+        rom_attrs["hasheous_metadata"] = {}
 
     # Use PICO-8 cartridge PNG as cover art if no cover is set.
     # PICO-8 .p8.png files are valid PNG images whose visual content is the

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -446,8 +446,6 @@ async def scan_rom(
             and (
                 newly_added
                 or scan_type == ScanType.COMPLETE
-                # New hashes mean a new signature match, so re-run the lookup
-                # even for a ROM that never matched Hasheous before
                 or scan_type == ScanType.HASHES
                 or (scan_type == ScanType.UPDATE and rom.hasheous_id)
                 or (

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -13,7 +13,7 @@ from handler.metadata import (
     meta_sgdb_handler,
     meta_ss_handler,
 )
-from handler.metadata.hasheous_handler import HasheousRom
+from handler.metadata.hasheous_handler import HasheousMetadata, HasheousRom
 from handler.metadata.ra_handler import RAGameRom
 from handler.metadata.ss_handler import SSRom
 from handler.scan_handler import (
@@ -505,6 +505,86 @@ async def test_scan_rom_unmatched_no_match_uses_parsed_name(
     assert result.hasheous_id is None
     # The raw filename placeholder must be replaced by the parsed name.
     assert result.name == "Snow Brothers"
+
+
+@patch.object(meta_playmatch_handler, "is_enabled", return_value=False)
+@patch.object(meta_hasheous_handler, "get_ra_game", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "get_igdb_game", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "lookup_rom", new_callable=AsyncMock)
+async def test_scan_rom_hashes_rematches_hasheous(
+    mock_lookup, mock_get_igdb, mock_get_ra, mock_playmatch_enabled
+):
+    """A HASHES rescan must re-run the Hasheous hash lookup, so a ROM whose
+    hashes were wrong picks up its signature matches (the verified flags)
+    without needing a complete rescan."""
+    hasheous_result = HasheousRom(
+        hasheous_id=999,
+        igdb_id=None,
+        tgdb_id=None,
+        ra_id=None,
+        name="Snow Bros.",
+        hasheous_metadata=HasheousMetadata(
+            tosec_match=False,
+            mame_arcade_match=False,
+            mame_mess_match=False,
+            nointro_match=True,
+            redump_match=False,
+            whdload_match=False,
+            ra_match=True,
+            fbneo_match=False,
+            puredos_match=False,
+        ),
+    )
+    mock_lookup.return_value = hasheous_result
+    mock_get_igdb.return_value = hasheous_result
+    mock_get_ra.return_value = hasheous_result
+
+    platform = Platform(
+        id=1, slug="n64", fs_slug="n64", name="Nintendo 64", igdb_id=4, hasheous_id=64
+    )
+    platform = db_platform_handler.add_platform(platform)
+
+    # ROM that never matched Hasheous because its hashes were wrong.
+    rom = Rom(
+        platform_id=platform.id,
+        fs_name="Snow Brothers (USA).7z",
+        fs_name_no_tags="Snow Brothers",
+        fs_name_no_ext="Snow Brothers (USA)",
+        fs_extension="7z",
+        fs_path="n64/Snow Brothers (USA)",
+        name="My Custom Title",
+        hasheous_id=None,
+        hasheous_metadata={},
+        fs_size_bytes=1024,
+        tags=[],
+    )
+    rom = db_rom_handler.add_rom(rom)
+
+    async with initialize_context():
+        result = await scan_rom(
+            platform=platform,
+            scan_type=ScanType.HASHES,
+            rom=rom,
+            fs_rom={
+                "fs_name": "Snow Brothers (USA).7z",
+                "flat": True,
+                "nested": False,
+                "files": [],
+                "crc_hash": "newcrc",
+                "md5_hash": "newmd5",
+                "sha1_hash": "newsha1",
+                "ra_hash": "newrahash",
+            },
+            metadata_sources=[MetadataSource.HASHEOUS],
+            newly_added=False,
+        )
+
+    mock_lookup.assert_called_once()
+    assert result.hasheous_id == 999
+    assert result.hasheous_metadata["nointro_match"] is True
+    assert result.hasheous_metadata["ra_match"] is True
+    # A rehash must not rewrite user-visible fields.
+    assert result.name == "My Custom Title"
 
 
 def _top_level_rom_file(**kwargs) -> RomFile:

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -131,7 +131,7 @@ async def test_scan_rom_complete_clears_unselected_metadata(
         ra_id=None,
         name="Mock Hasheous Game",
     )
-    mock_lookup.return_value = hasheous_result
+    mock_lookup.return_value = (hasheous_result, True)
     mock_get_igdb.return_value = hasheous_result
     mock_get_ra.return_value = hasheous_result
 
@@ -339,7 +339,7 @@ async def test_scan_rom_unmatched_replaces_placeholder_name(
         ra_id=None,
         name="Snow Bros.",
     )
-    mock_lookup.return_value = hasheous_result
+    mock_lookup.return_value = (hasheous_result, True)
     mock_get_igdb.return_value = hasheous_result
     mock_get_ra.return_value = hasheous_result
 
@@ -402,7 +402,7 @@ async def test_scan_rom_unmatched_preserves_custom_name(
         ra_id=None,
         name="Snow Bros.",
     )
-    mock_lookup.return_value = hasheous_result
+    mock_lookup.return_value = (hasheous_result, True)
     mock_get_igdb.return_value = hasheous_result
     mock_get_ra.return_value = hasheous_result
 
@@ -460,7 +460,7 @@ async def test_scan_rom_unmatched_no_match_uses_parsed_name(
     placeholder into the parsed name (tags and extension stripped), so the title
     is clean and a follow-up search uses the parsed name."""
     no_match = HasheousRom(hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None)
-    mock_lookup.return_value = no_match
+    mock_lookup.return_value = (no_match, True)
     mock_get_igdb.return_value = no_match
     mock_get_ra.return_value = no_match
 
@@ -535,7 +535,7 @@ async def test_scan_rom_hashes_rematches_hasheous(
             puredos_match=False,
         ),
     )
-    mock_lookup.return_value = hasheous_result
+    mock_lookup.return_value = (hasheous_result, True)
     mock_get_igdb.return_value = hasheous_result
     mock_get_ra.return_value = hasheous_result
 
@@ -587,6 +587,127 @@ async def test_scan_rom_hashes_rematches_hasheous(
     assert result.name == "My Custom Title"
 
 
+def _stale_hasheous_rom(platform: Platform) -> Rom:
+    """A ROM carrying a Hasheous match (and its verification flags) earned by
+    hashes it is about to lose."""
+    return db_rom_handler.add_rom(
+        Rom(
+            platform_id=platform.id,
+            fs_name="Snow Brothers (USA).7z",
+            fs_name_no_tags="Snow Brothers",
+            fs_name_no_ext="Snow Brothers (USA)",
+            fs_extension="7z",
+            fs_path="n64/Snow Brothers (USA)",
+            name="Snow Bros.",
+            hasheous_id=999,
+            hasheous_metadata={"nointro_match": True, "ra_match": True},
+            fs_size_bytes=1024,
+            tags=[],
+        )
+    )
+
+
+@patch.object(meta_playmatch_handler, "is_enabled", return_value=False)
+@patch.object(meta_hasheous_handler, "get_ra_game", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "get_igdb_game", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "lookup_rom", new_callable=AsyncMock)
+async def test_scan_rom_hashes_clears_stale_hasheous_match(
+    mock_lookup, mock_get_igdb, mock_get_ra, mock_playmatch_enabled
+):
+    """A HASHES rescan whose new hashes no longer match must drop the previous
+    Hasheous match, so the ROM stops reporting verification flags it earned with
+    hashes it no longer has."""
+    no_match = HasheousRom(hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None)
+    # Hasheous answered and knows nothing about the new hashes.
+    mock_lookup.return_value = (no_match, True)
+    mock_get_igdb.return_value = no_match
+    mock_get_ra.return_value = no_match
+
+    platform = db_platform_handler.add_platform(
+        Platform(
+            id=1,
+            slug="n64",
+            fs_slug="n64",
+            name="Nintendo 64",
+            igdb_id=4,
+            hasheous_id=64,
+        )
+    )
+    rom = _stale_hasheous_rom(platform)
+
+    async with initialize_context():
+        result = await scan_rom(
+            platform=platform,
+            scan_type=ScanType.HASHES,
+            rom=rom,
+            fs_rom={
+                "fs_name": "Snow Brothers (USA).7z",
+                "flat": True,
+                "nested": False,
+                "files": [],
+                "crc_hash": "changedcrc",
+                "md5_hash": "changedmd5",
+                "sha1_hash": "changedsha1",
+                "ra_hash": "",
+            },
+            metadata_sources=[MetadataSource.HASHEOUS],
+            newly_added=False,
+        )
+
+    assert result.hasheous_id is None
+    assert result.hasheous_metadata == {}
+
+
+@patch.object(meta_playmatch_handler, "is_enabled", return_value=False)
+@patch.object(meta_hasheous_handler, "get_ra_game", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "get_igdb_game", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "lookup_rom", new_callable=AsyncMock)
+async def test_scan_rom_hashes_keeps_match_when_hasheous_unreachable(
+    mock_lookup, mock_get_igdb, mock_get_ra, mock_playmatch_enabled
+):
+    """An inconclusive lookup (Hasheous down, no hashes to send) must leave the
+    existing match alone, so an outage can't silently de-verify a library."""
+    no_match = HasheousRom(hasheous_id=None, igdb_id=None, tgdb_id=None, ra_id=None)
+    # Same empty match, but we never got an answer.
+    mock_lookup.return_value = (no_match, False)
+    mock_get_igdb.return_value = no_match
+    mock_get_ra.return_value = no_match
+
+    platform = db_platform_handler.add_platform(
+        Platform(
+            id=1,
+            slug="n64",
+            fs_slug="n64",
+            name="Nintendo 64",
+            igdb_id=4,
+            hasheous_id=64,
+        )
+    )
+    rom = _stale_hasheous_rom(platform)
+
+    async with initialize_context():
+        result = await scan_rom(
+            platform=platform,
+            scan_type=ScanType.HASHES,
+            rom=rom,
+            fs_rom={
+                "fs_name": "Snow Brothers (USA).7z",
+                "flat": True,
+                "nested": False,
+                "files": [],
+                "crc_hash": "changedcrc",
+                "md5_hash": "changedmd5",
+                "sha1_hash": "changedsha1",
+                "ra_hash": "",
+            },
+            metadata_sources=[MetadataSource.HASHEOUS],
+            newly_added=False,
+        )
+
+    assert result.hasheous_id == 999
+    assert result.hasheous_metadata == {"nointro_match": True, "ra_match": True}
+
+
 def _top_level_rom_file(**kwargs) -> RomFile:
     """Build a RomFile whose `is_top_level` cached_property is pre-seeded to
     True, so it passes lookup_rom's filtering without a persisted rom."""
@@ -631,9 +752,11 @@ async def test_lookup_rom_sends_all_top_level_file_hashes(
         _top_level_rom_file(file_name="nohash.bin", file_size_bytes=50),
     ]
 
-    result = await meta_hasheous_handler.lookup_rom("n64", files)
+    result, conclusive = await meta_hasheous_handler.lookup_rom("n64", files)
 
     assert result["hasheous_id"] is None
+    # Hasheous answered, it just knows nothing about these hashes.
+    assert conclusive is True
     mock_request.assert_called_once()
     sent_data = mock_request.call_args.kwargs["data"]
     assert sent_data == [
@@ -648,9 +771,11 @@ async def test_lookup_rom_skips_request_when_no_hashes(mock_is_enabled, mock_req
     """lookup_rom must not hit the API when no file has any usable hash."""
     files = [_top_level_rom_file(file_name="nohash.bin", file_size_bytes=50)]
 
-    result = await meta_hasheous_handler.lookup_rom("n64", files)
+    result, conclusive = await meta_hasheous_handler.lookup_rom("n64", files)
 
     assert result["hasheous_id"] is None
+    # Nothing was asked, so the empty match says nothing about the ROM.
+    assert conclusive is False
     mock_request.assert_not_called()
 
 


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

Fixes #4001 (follow-up to #3806).

A ROM's "verified" state comes entirely from the Hasheous signature-match flags stored in `hasheous_metadata` (`nointro_match`, `ra_match`, ...). That's what the backend's `_filter_by_verified` and the v2 `romVerification` util both read.

But `ScanType.HASHES` was missing from **both** Hasheous gates in `scan_rom`:

- `fetch_hasheous_hash_match` - the hash lookup that produces the match flags
- `fetch_hasheous_rom` - the fetch whose result actually gets written to `hasheous_id` / `hasheous_metadata`

So a rehash recomputed the file hashes and then never re-asked Hasheous about them. RetroAchievements *was* already in the HASHES gate (`fetch_ra_rom`), which is exactly why the reporter saw the RA provider icon appear while every verification chip stayed dark.

The follow-up "Update metadata" scan didn't help either, because the UPDATE branch is gated on `rom.hasheous_id` already being set - and it never was, since the ROM had never matched.

**The fix**, three parts:

1. `ScanType.HASHES` added to `fetch_hasheous_hash_match` - new hashes mean a potentially new signature match, so the lookup re-runs even for a ROM that never matched before.
2. `ScanType.HASHES` added to `fetch_hasheous_rom` - without this the match would be computed but never persisted.
3. `HASHES` added to the "don't overwrite existing base fields" branch. Now that Hasheous runs on a rehash it returns a name/cover/summary too, and a rehash shouldn't rewrite those. This matters concretely for covers: `_identify_rom` short-circuits on HASHES *before* the cover-download step, so a changed `url_cover` would point at an image that is never fetched. This also reins in the same pre-existing behavior coming from the RA fetch.

`fetch_playmatch_hash_match` was deliberately left out of the HASHES gate. Playmatch is also hash-based, but its consumers (IGDB/Moby/SS/LaunchBox/SGDB fetches) don't run on HASHES scans, so including it would only add a wasted network call per ROM.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The root-cause analysis, the code change, and the regression test were AI-generated and human-reviewed.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Verification: new regression test `test_scan_rom_hashes_rematches_hasheous` asserts a HASHES scan on a never-matched ROM calls `lookup_rom`, persists `hasheous_id` plus the match flags, and leaves a user-set name alone. `tests/handler/test_fastapi.py` (14) plus `test_scan.py` / `test_scan_priority.py` / `test_scan_library.py` (77) all pass, and `trunk fmt` / `trunk check` are clean. Note this was verified via tests and static checks only - I did not exercise a live Hasheous lookup end to end.

#### Screenshots (if applicable)

N/A - backend only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)