### PR TITLE
fix(v2): keep RSelect menus inside the viewport and tidy the selection text

### DIFF
--- a/frontend/src/locales/bg_BG/settings.json
+++ b/frontend/src/locales/bg_BG/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "Обложка (2D)",
   "media-box2d-back": "Задна корица",
   "media-box2d-side": "Гръб на кутията",
-  "media-box3d": "3D обложка",
+  "media-box3d": "Обложка (3D)",
   "media-fanart": "Фен арт",
   "media-logo": "Лого",
   "media-manual": "Ръководство",

--- a/frontend/src/locales/cs_CZ/settings.json
+++ b/frontend/src/locales/cs_CZ/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "Obal (2D)",
   "media-box2d-back": "Zadní strana obalu",
   "media-box2d-side": "Hřbet obalu",
-  "media-box3d": "3D obal",
+  "media-box3d": "Obal (3D)",
   "media-fanart": "Fanouškovská grafika",
   "media-logo": "Logo",
   "media-manual": "Manuál",

--- a/frontend/src/locales/de_DE/settings.json
+++ b/frontend/src/locales/de_DE/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "Boxart (2D)",
   "media-box2d-back": "Rückseite",
   "media-box2d-side": "Box-Seitenteil",
-  "media-box3d": "3D-Boxart",
+  "media-box3d": "Boxart (3D)",
   "media-fanart": "Fan-Art",
   "media-logo": "Logo",
   "media-manual": "Handbuch",

--- a/frontend/src/locales/en_GB/settings.json
+++ b/frontend/src/locales/en_GB/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "Box art (2D)",
   "media-box2d-back": "Back cover",
   "media-box2d-side": "Box spine",
-  "media-box3d": "3D box art",
+  "media-box3d": "Box art (3D)",
   "media-fanart": "Fan art",
   "media-logo": "Logo",
   "media-manual": "Manual",

--- a/frontend/src/locales/en_US/settings.json
+++ b/frontend/src/locales/en_US/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "Box art (2D)",
   "media-box2d-back": "Back cover",
   "media-box2d-side": "Box spine",
-  "media-box3d": "3D box art",
+  "media-box3d": "Box art (3D)",
   "media-fanart": "Fan art",
   "media-logo": "Logo",
   "media-manual": "Manual",

--- a/frontend/src/locales/es_ES/settings.json
+++ b/frontend/src/locales/es_ES/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "Carátula (2D)",
   "media-box2d-back": "Contraportada",
   "media-box2d-side": "Lomo de la caja",
-  "media-box3d": "Carátula 3D",
+  "media-box3d": "Carátula (3D)",
   "media-fanart": "Fan art",
   "media-logo": "Logo",
   "media-manual": "Manual",

--- a/frontend/src/locales/fr_FR/settings.json
+++ b/frontend/src/locales/fr_FR/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "Jaquette (2D)",
   "media-box2d-back": "Dos de la jaquette",
   "media-box2d-side": "Tranche de la boîte",
-  "media-box3d": "Jaquette 3D",
+  "media-box3d": "Jaquette (3D)",
   "media-fanart": "Fan art",
   "media-logo": "Logo",
   "media-manual": "Manuel",

--- a/frontend/src/locales/hu_HU/settings.json
+++ b/frontend/src/locales/hu_HU/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "Dobozkép (2D)",
   "media-box2d-back": "Hátsó borító",
   "media-box2d-side": "Doboz gerinc",
-  "media-box3d": "3D dobozkép",
+  "media-box3d": "Dobozkép (3D)",
   "media-fanart": "Rajongói grafika",
   "media-logo": "Logó",
   "media-manual": "Kézikönyv",

--- a/frontend/src/locales/it_IT/settings.json
+++ b/frontend/src/locales/it_IT/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "Copertina (2D)",
   "media-box2d-back": "Retro della copertina",
   "media-box2d-side": "Dorso della scatola",
-  "media-box3d": "Copertina 3D",
+  "media-box3d": "Copertina (3D)",
   "media-fanart": "Fan art",
   "media-logo": "Logo",
   "media-manual": "Manuale",

--- a/frontend/src/locales/ja_JP/settings.json
+++ b/frontend/src/locales/ja_JP/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "ボックスアート（2D）",
   "media-box2d-back": "背面カバー",
   "media-box2d-side": "背表紙",
-  "media-box3d": "3Dボックスアート",
+  "media-box3d": "ボックスアート（3D）",
   "media-fanart": "ファンアート",
   "media-logo": "ロゴ",
   "media-manual": "マニュアル",

--- a/frontend/src/locales/ko_KR/settings.json
+++ b/frontend/src/locales/ko_KR/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "박스아트 (2D)",
   "media-box2d-back": "뒷면 커버",
   "media-box2d-side": "박스 측면",
-  "media-box3d": "3D 박스아트",
+  "media-box3d": "박스아트 (3D)",
   "media-fanart": "팬아트",
   "media-logo": "로고",
   "media-manual": "매뉴얼",

--- a/frontend/src/locales/pl_PL/settings.json
+++ b/frontend/src/locales/pl_PL/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "Okładka (2D)",
   "media-box2d-back": "Tylna okładka",
   "media-box2d-side": "Grzbiet pudełka",
-  "media-box3d": "Okładka 3D",
+  "media-box3d": "Okładka (3D)",
   "media-fanart": "Fan art",
   "media-logo": "Logo",
   "media-manual": "Instrukcja",

--- a/frontend/src/locales/pt_BR/settings.json
+++ b/frontend/src/locales/pt_BR/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "Capa (2D)",
   "media-box2d-back": "Contracapa",
   "media-box2d-side": "Lombada da caixa",
-  "media-box3d": "Capa 3D",
+  "media-box3d": "Capa (3D)",
   "media-fanart": "Fan art",
   "media-logo": "Logo",
   "media-manual": "Manual",

--- a/frontend/src/locales/ro_RO/settings.json
+++ b/frontend/src/locales/ro_RO/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "Copertă (2D)",
   "media-box2d-back": "Copertă spate",
   "media-box2d-side": "Cotor cutie",
-  "media-box3d": "Copertă 3D",
+  "media-box3d": "Copertă (3D)",
   "media-fanart": "Artă de fani",
   "media-logo": "Logo",
   "media-manual": "Manual",

--- a/frontend/src/locales/ru_RU/settings.json
+++ b/frontend/src/locales/ru_RU/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "Обложка (2D)",
   "media-box2d-back": "Задняя обложка",
   "media-box2d-side": "Корешок коробки",
-  "media-box3d": "3D-обложка",
+  "media-box3d": "Обложка (3D)",
   "media-fanart": "Фан-арт",
   "media-logo": "Логотип",
   "media-manual": "Руководство",

--- a/frontend/src/locales/tr_TR/settings.json
+++ b/frontend/src/locales/tr_TR/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "Kutu görseli (2D)",
   "media-box2d-back": "Arka kapak",
   "media-box2d-side": "Kutu sırtı",
-  "media-box3d": "3D kutu görseli",
+  "media-box3d": "Kutu görseli (3D)",
   "media-fanart": "Hayran sanatı",
   "media-logo": "Logo",
   "media-manual": "Kılavuz",

--- a/frontend/src/locales/zh_CN/settings.json
+++ b/frontend/src/locales/zh_CN/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "封面（2D）",
   "media-box2d-back": "封底",
   "media-box2d-side": "侧封",
-  "media-box3d": "3D封面",
+  "media-box3d": "封面（3D）",
   "media-fanart": "同人插画",
   "media-logo": "徽标",
   "media-manual": "说明书",

--- a/frontend/src/locales/zh_TW/settings.json
+++ b/frontend/src/locales/zh_TW/settings.json
@@ -214,7 +214,7 @@
   "media-box2d": "封面（2D）",
   "media-box2d-back": "封底",
   "media-box2d-side": "側封",
-  "media-box3d": "3D封面",
+  "media-box3d": "封面（3D）",
   "media-fanart": "同人插畫",
   "media-logo": "標誌",
   "media-manual": "說明書",

--- a/frontend/src/v2/lib/forms/RSelect/RSelect.stories.ts
+++ b/frontend/src/v2/lib/forms/RSelect/RSelect.stories.ts
@@ -233,6 +233,18 @@ export const Multiple: Story = {
   }),
 };
 
+// Without `chips` the selections render as one run of text. The comma
+// separator must read "A, B" — a space on both sides means the separator
+// picked up the value row's flex gap.
+export const MultipleText: Story = {
+  name: "Multiple (no chips)",
+  render: () => ({
+    components: { RSelect },
+    setup: () => ({ value: ref(["psx", "snes"]), items: PLATFORMS }),
+    template: `<div style="width:480px"><RSelect v-model="value" :items="items" multiple placeholder="Pick platforms" /></div>`,
+  }),
+};
+
 export const MultipleOverflow: Story = {
   name: "Multiple · dynamic overflow",
   render: () => ({

--- a/frontend/src/v2/lib/forms/RSelect/RSelect.test.ts
+++ b/frontend/src/v2/lib/forms/RSelect/RSelect.test.ts
@@ -1,0 +1,31 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import RSelect from "./RSelect.vue";
+
+// Regression guard: `.r-select__value` is a flex row with a 6px gap (it
+// spaces chips apart). A multi-select without chips renders its titles and
+// the "," separator as plain spans, so hoisting them into that row put the
+// gap on both sides of the comma and the activator read "A , B".
+describe("RSelect multi-select without chips", () => {
+  const items = [
+    { title: "Screenshot", value: "screenshot" },
+    { title: "Manual", value: "manual" },
+  ];
+
+  it("keeps the titles and separator in one box inside the value row", () => {
+    const wrapper = mount(RSelect, {
+      props: { items, multiple: true, modelValue: ["screenshot", "manual"] },
+    });
+
+    const value = wrapper.get(".r-select__value");
+    expect(value.element.children).toHaveLength(1);
+
+    const selection = wrapper.get(".r-select__selection");
+    expect(selection.findAll(".r-select__title").map((n) => n.text())).toEqual([
+      "Screenshot",
+      "Manual",
+    ]);
+    expect(selection.findAll(".r-select__sep")).toHaveLength(1);
+    expect(selection.text()).toBe("Screenshot, Manual");
+  });
+});

--- a/frontend/src/v2/lib/forms/RSelect/RSelect.vue
+++ b/frontend/src/v2/lib/forms/RSelect/RSelect.vue
@@ -653,6 +653,9 @@ const isOpen = ref(false);
 const activatorRef = ref<HTMLElement | null>(null);
 const panelRef = ref<HTMLElement | null>(null);
 
+// Ceiling for the panel; the viewport remainder can shrink it further.
+const MAX_PANEL_HEIGHT = 360;
+
 const PLACEMENT_MAP: Record<string, Placement> = {
   top: "top",
   bottom: "bottom",
@@ -676,14 +679,15 @@ const { floatingStyles } = useFloating(activatorRef, panelRef, {
     flip({ padding: 8 }),
     shift({ padding: 8 }),
     sizeMiddleware({
-      apply({ rects, elements }) {
+      apply({ availableHeight, rects, elements }) {
         // Pin the menu's min-width to the activator so single-line
         // labels and short option lists don't render as a thin chip.
-        // Max height is bounded by the viewport remainder so long
-        // lists scroll inside the panel.
+        // `availableHeight` is the room left between the activator and
+        // the viewport edge on the placement `flip` settled on, so the
+        // panel always fits on screen and long lists scroll inside it.
         Object.assign(elements.floating.style, {
           minWidth: `${rects.reference.width}px`,
-          maxHeight: `min(360px, var(--available-height, 360px))`,
+          maxHeight: `${Math.min(MAX_PANEL_HEIGHT, availableHeight)}px`,
         });
       },
       padding: 8,
@@ -1035,8 +1039,10 @@ const hasPrependInner = computed(
           />
         </template>
         <!-- Single selection or multi-without-chips — defer to the
-             `#selection` slot for custom rendering. Default: title. -->
-        <template v-else>
+             `#selection` slot for custom rendering. Default: title.
+             Wrapped in one box so the comma separator doesn't inherit
+             `.r-select__value`'s flex gap and read as " , ". -->
+        <span v-else class="r-select__selection">
           <template v-for="(item, i) in selectedItems" :key="i">
             <slot
               name="selection"
@@ -1047,7 +1053,7 @@ const hasPrependInner = computed(
               <span class="r-select__title">{{ item.title }}</span>
             </slot>
           </template>
-        </template>
+        </span>
       </span>
 
       <span
@@ -1378,11 +1384,25 @@ const hasPrependInner = computed(
   gap: 6px;
   white-space: nowrap;
 }
+.r-select__selection {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  overflow: hidden;
+}
+.r-select__sep {
+  flex: 0 0 auto;
+}
 .r-select__title,
 .r-select__placeholder {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+/* Flex items default to `min-width: auto` — without this the title
+   refuses to shrink and a long selection clips instead of ellipsizing. */
+.r-select__title {
+  min-width: 0;
 }
 .r-select__placeholder {
   color: var(--r-color-fg-faint);

--- a/frontend/src/v2/lib/forms/RTextField/RTextField.vue
+++ b/frontend/src/v2/lib/forms/RTextField/RTextField.vue
@@ -300,7 +300,10 @@ function clear() {
 }
 
 onMounted(() => {
-  if (props.autofocus) inputRef.value?.focus();
+  // `preventScroll` because an autofocused field often lives in a panel
+  // that a positioner (floating-ui) only places after mount — letting the
+  // UA scroll to its pre-placement box would yank the page.
+  if (props.autofocus) inputRef.value?.focus({ preventScroll: true });
 });
 
 // Slot shape helpers — drives whether to render the prepend / append


### PR DESCRIPTION
**Description**

Fixes #4000.

**1. Menus could open outside the viewport.** `RSelect`'s `size` middleware capped the panel with `maxHeight: min(360px, var(--available-height, 360px))` — but `--available-height` is never defined anywhere, so the cap was always a flat 360px regardless of the room around the activator. `flip` then placed a 360px panel into a smaller gap and it spilled past the screen edge. Measured on the current build at a 500px-tall viewport:

| activator y | before | after |
| --- | --- | --- |
| 300 | panel top **−66px** (the search field sat above the viewport) | top 8px, height 286px |
| 200 | panel bottom **606px**, i.e. 106px past the viewport | bottom 492px, height 246px |

Now it uses floating-ui's real `availableHeight` for the placement `flip` settled on, which is what `RMenu` already does. Roomy viewports are unaffected (still capped at 360px).

**2. The activator read `A , B`.** A multi-select without chips rendered each title and each `,&nbsp;` separator as a *direct child* of `.r-select__value`, which is a flex row with `gap: 6px` — so the gap landed on both sides of the comma. The run now gets its own box.

Before / after on the Scan settings "Media to download" field:

```
Capture d'écran , Manuel , Jaquette (2D)
Capture d'écran, Manuel, Jaquette (2D)
```

**3. `preventScroll` on `RTextField`'s autofocus.** The searchable panel's search field autofocuses on mount, which is *before* floating-ui places the panel — instrumenting the live app confirms it still reads `position: fixed; left: 0px; top: 0px` at that moment. Letting the UA scroll to that pre-placement box is a page-jump waiting to happen.

**4. `Cover (2D)` vs `Cover 3D`.** The 2D/3D media labels disagreed in *every* locale (`Box art (2D)` / `3D box art`, `Jaquette (2D)` / `Jaquette 3D`, …). `media-box3d` now uses the parenthesised form in all 18 locales, translated per language.

**On the reported scroll jump:** I could not reproduce it. I drove a build of this branch with Playwright in Chromium and Firefox, headless and headed, at viewport heights 500/700/950 and across every activator position — the scroll delta was 0 in all cases, including when the panel's search field was entirely above the viewport. Items 1 and 3 remove the two plausible mechanisms (a panel placed outside the viewport, and a focus on an element that has not been positioned yet), but this needs a retest by the reporter to confirm.

**AI assistance disclosure:** this PR was written with Claude Code (Opus 5). The diagnosis, the browser-driven measurements above, the code changes, the locale updates and the new unit test were all produced with AI assistance and reviewed by me.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

`npm run typecheck`, `npm run test` (589 pass, including a new `RSelect.test.ts` guard verified to fail without the fix), `npm run build`, `trunk fmt && trunk check`, and both `check_i18n_*.py` scripts pass. Browser measurements ran against a `vite preview` of the built branch.

#### Screenshots (if applicable)

Selection text after the fix, rendered from a build of this branch (comma spacing, and `Box art (3D)` now matching `Box art (2D)`):

```
Box art (2D), Back cover, Box spine, Box art (3D), Screenshot, Mixed image, Mixed image (v2), Physical media, ...
```
