### PR TITLE
perf(scan): stop hashing single-file ROMs twice

### DIFF
--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -414,9 +414,6 @@ class FSRomsHandler(FSHandler):
                             crc_c, _, md5_h, _, sha1_h, _ = await asyncio.to_thread(
                                 self._calculate_rom_hashes,
                                 Path(f_path, file_name),
-                                0,
-                                hashlib.md5(usedforsecurity=False),
-                                hashlib.sha1(usedforsecurity=False),
                             )
                     except zlib.error:
                         crc_c = 0
@@ -545,19 +542,18 @@ class FSRomsHandler(FSHandler):
                 )
         elif hashable_platform:
             try:
-                crc_c, rom_crc_c, md5_h, rom_md5_h, sha1_h, rom_sha1_h = (
-                    await asyncio.to_thread(
-                        self._calculate_rom_hashes,
-                        Path(abs_fs_path, rom.fs_name),
-                        rom_crc_c,
-                        rom_md5_h,
-                        rom_sha1_h,
-                    )
+                crc_c, _, md5_h, _, sha1_h, _ = await asyncio.to_thread(
+                    self._calculate_rom_hashes,
+                    Path(abs_fs_path, rom.fs_name),
                 )
             except zlib.error:
                 crc_c = 0
                 md5_h = hashlib.md5(usedforsecurity=False)
                 sha1_h = hashlib.sha1(usedforsecurity=False)
+
+            # A single-file ROM spans exactly one file, so its ROM-level hashes
+            # are that file's hashes.
+            rom_crc_c, rom_md5_h, rom_sha1_h = crc_c, md5_h, sha1_h
 
             # Calculate the RA hash if the platform has a slug that matches a known RA slug
             if calculate_hashes:
@@ -619,10 +615,17 @@ class FSRomsHandler(FSHandler):
     def _calculate_rom_hashes(
         self,
         file_path: Path,
-        rom_crc_c: int,
-        rom_md5_h: Any,
-        rom_sha1_h: Any,
+        rom_crc_c: int = 0,
+        rom_md5_h: Any = None,
+        rom_sha1_h: Any = None,
     ) -> tuple[int, int, Any, Any, Any, Any]:
+        """Hash one file, optionally folding its bytes into ROM-level accumulators.
+
+        A ROM-level hash spans every top-level file of a multi-file ROM, so it
+        can only be built by feeding each file through a second set of hashers.
+        Callers that don't need one pass no accumulators, because a second pass
+        over a chunk costs as much as the first.
+        """
         extension = Path(file_path).suffix.lower()
         try:
             file_type = detect_mime_type(file_path)
@@ -630,18 +633,19 @@ class FSRomsHandler(FSHandler):
             crc_c = 0
             md5_h = hashlib.md5(usedforsecurity=False)
             sha1_h = hashlib.sha1(usedforsecurity=False)
+            accumulate = rom_md5_h is not None and rom_sha1_h is not None
 
             def update_hashes(chunk: bytes | bytearray):
+                nonlocal crc_c, rom_crc_c
+
                 md5_h.update(chunk)
-                rom_md5_h.update(chunk)
-
                 sha1_h.update(chunk)
-                rom_sha1_h.update(chunk)
-
-                nonlocal crc_c
                 crc_c = binascii.crc32(chunk, crc_c)
-                nonlocal rom_crc_c
-                rom_crc_c = binascii.crc32(chunk, rom_crc_c)
+
+                if accumulate:
+                    rom_md5_h.update(chunk)
+                    rom_sha1_h.update(chunk)
+                    rom_crc_c = binascii.crc32(chunk, rom_crc_c)
 
             if extension == ".zip" or file_type == "application/zip":
                 for chunk in read_zip_file(file_path):

--- a/backend/tests/handler/filesystem/test_roms_handler.py
+++ b/backend/tests/handler/filesystem/test_roms_handler.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import shutil
 import tempfile
@@ -479,6 +480,54 @@ class TestFSRomsHandler:
                 assert isinstance(rom_file, RomFile)
                 assert rom_file.file_size_bytes > 0
                 assert rom_file.last_modified is not None
+
+    @pytest.mark.asyncio
+    async def test_get_rom_files_single_rom_hashes_match_its_only_file(
+        self, handler: FSRomsHandler, rom_single, config
+    ):
+        """A single-file ROM's hashes are its one file's hashes.
+
+        The ROM-level values reuse that file's hashers instead of streaming the
+        same bytes through a second set, so pin the identity that allows it.
+        """
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr("handler.filesystem.roms_handler.cm.get_config", lambda: config)
+            m.setattr("os.path.exists", lambda x: False)
+
+            parsed_rom_files = await handler.get_rom_files(rom_single)
+
+        assert len(parsed_rom_files.rom_files) == 1
+        only_file = parsed_rom_files.rom_files[0]
+        assert parsed_rom_files.crc_hash == only_file.crc_hash
+        assert parsed_rom_files.md5_hash == only_file.md5_hash
+        assert parsed_rom_files.sha1_hash == only_file.sha1_hash
+
+    @pytest.mark.asyncio
+    async def test_get_rom_files_multi_rom_hash_spans_every_part(
+        self, handler: FSRomsHandler, rom_multi, config
+    ):
+        """A multi-file ROM hashes the concatenation of its top-level files.
+
+        That composite cannot be derived from the per-file digests, so the parts
+        are streamed through a second set of hashers. Pin that it still covers
+        every part rather than collapsing to a single file's hash.
+        """
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr("handler.filesystem.roms_handler.cm.get_config", lambda: config)
+            m.setattr("os.path.exists", lambda x: False)
+
+            parsed_rom_files = await handler.get_rom_files(rom_multi)
+
+        rom_dir = Path(LIBRARY_BASE_PATH, "n64", "roms", rom_multi.fs_name)
+        expected_md5 = hashlib.md5(usedforsecurity=False)
+        for rom_file in parsed_rom_files.rom_files:
+            expected_md5.update((rom_dir / rom_file.file_name).read_bytes())
+
+        assert len(parsed_rom_files.rom_files) >= 2
+        assert parsed_rom_files.md5_hash == expected_md5.hexdigest()
+        assert parsed_rom_files.md5_hash not in {
+            rom_file.md5_hash for rom_file in parsed_rom_files.rom_files
+        }
 
     @pytest.mark.asyncio
     async def test_get_rom_files_multi_rom_multi_dot_exclusion(


### PR DESCRIPTION
**Description**

<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

`_calculate_rom_hashes` streams every chunk through **two** independent sets of hashers:

```python
def update_hashes(chunk: bytes | bytearray):
    md5_h.update(chunk)
    rom_md5_h.update(chunk)

    sha1_h.update(chunk)
    rom_sha1_h.update(chunk)

    nonlocal crc_c
    crc_c = binascii.crc32(chunk, crc_c)
    nonlocal rom_crc_c
    rom_crc_c = binascii.crc32(chunk, rom_crc_c)
```

The second set accumulates the ROM-level hash. That is genuinely required for a multi-file ROM, whose hash spans the concatenation of its top-level files and therefore cannot be derived from the per-file digests. But two callers pay for it without needing it:

- **Single-file ROMs** (the `elif hashable_platform:` branch). The ROM spans one file, so both sets see identical bytes and produce identical digests. The ROM-level pass is pure duplicate work.
- **Nested files inside a multi-file ROM.** These were handed throwaway accumulators whose results were then discarded at the call site with `_`:

```python
crc_c, _, md5_h, _, sha1_h, _ = await asyncio.to_thread(
    self._calculate_rom_hashes,
    Path(f_path, file_name),
    0,
    hashlib.md5(usedforsecurity=False),   # hashed into...
    hashlib.sha1(usedforsecurity=False),  # ...then thrown away
)
```

Since hashing is CPU-bound, a second pass over a chunk costs about as much as the first, so this roughly doubles hashing cost for the common case. Most libraries are predominantly single-file, so this is the default path rather than an edge case.

**Changes**

- The ROM-level accumulators on `_calculate_rom_hashes` become optional. When they are not supplied, only the per-file hashers run.
- Single-file ROMs reuse the file's own hashers as the ROM-level values instead of recomputing them.
- Nested files in multi-file ROMs stop requesting accumulators they discard.
- Top-level files in multi-file ROMs are unchanged: they still stream through the second set, because theirs is the case that needs it.

The signature stays backward compatible (the accumulators just gained defaults), so existing callers and tests are unaffected.

**Measurements**

Raspberry Pi 4, a 134 MB Nintendo 3DS ROM, page cache warmed first, best of three. Compared on **CPU time** rather than wall clock, because the machine was concurrently running a library scan:

| | CPU time | throughput |
| --- | --- | --- |
| before | 3.68s | 36.5 MB/s |
| after | 2.23s | **60.3 MB/s** |

**1.65x** on a real ROM (1.42x wall clock under that load). An isolated in-memory benchmark of just the hasher calls shows 2.4x; the difference is the `read()` syscalls and page-cache copies that the optimization cannot remove.

Digests are byte-identical before and after, at both the file and ROM level:

```
crc      7603056f       rom_crc  7603056f (before) == 7603056f (after)
md5      083c286178ed0ab28c941596429b86f3
sha1     51d121e366abe00ff3f90d8a1e7ad43e9f721d6a
```

**Testing**

Two tests added to `tests/handler/filesystem/test_roms_handler.py`, pinning the invariants on each side of the change:

- `test_get_rom_files_single_rom_hashes_match_its_only_file` — a single-file ROM's ROM-level hashes equal its one file's hashes. This is the identity that makes the reuse valid.
- `test_get_rom_files_multi_rom_hash_spans_every_part` — a multi-file ROM's hash still equals the hash of its top-level files concatenated, and is not merely one part's hash.

The second was mutation-tested: dropping the accumulators from the multi-file top-level branch (the change this PR deliberately does *not* make) makes it fail, so it is not vacuous.

Also verified:

- `tests/handler/filesystem/test_roms_handler.py`: 76 passed, including the pre-existing `test_get_rom_files_single_rom`, which already asserted exact ROM-level CRC/MD5/SHA1 for a single-file ROM and continues to pass unchanged.
- `ruff 0.15.22` and `black 26.5.1` (the versions pinned in `.trunk/trunk.yaml`) clean on both changed files.
- `mypy` reports zero errors in `handler/filesystem/roms_handler.py`. It surfaces pre-existing errors in transitively imported modules such as `handler/scan_handler.py`, none of them touched here.

<sub>Full disclosure on what I could not complete: a full `tests/handler tests/endpoints` run was killed by my own timeout while the host was saturated (load ~25 on 4 cores) by an unrelated library scan running concurrently. An earlier partial run of that same selection gave 355 passed / 3 failed, and those 3 (`TestScanTotals`) fail identically on unmodified `master` because they require a Redis on `127.0.0.1:6379`. I have no reason to think anything outside the hashing path is affected, but I would rather flag the gap than imply coverage I did not get.</sub>

**Checklist**

<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this change was written with AI assistance (Claude Code). The bottleneck was found by profiling a real scan on my own hardware; the AI wrote the patch, the tests and the benchmarks, and I reviewed the result.
