### PR TITLE
fix(v2): pivot to a filtered search from the overview info grid

### DIFF
--- a/frontend/src/v2/components/GameDetails/InfoGrid.vue
+++ b/frontend/src/v2/components/GameDetails/InfoGrid.vue
@@ -7,7 +7,15 @@
 // hover affordance so they read as candidates for click-to-filter.
 // Sections with no items are omitted so the grid doesn't show empty
 // columns.
+//
+// A section carrying a `filter` renders its chips as links into the
+// global search scoped to that value (`/search?genres=Adventure`), the
+// pivot-to-search v1 offered from the same rows. Links (not click
+// handlers) so middle-click / open-in-new-tab work and the chips join
+// keyboard + spatial navigation as `a[href]`.
 import { RIcon } from "@v2/lib";
+import { ROUTES } from "@/plugins/router";
+import type { FilterType } from "@/stores/galleryFilter";
 
 defineOptions({ inheritAttrs: false });
 
@@ -17,11 +25,19 @@ export type InfoGridSection = {
   /** Leading icon for the section header — gives each category a
    *  semantic cue (e.g. tags for genres, building for companies). */
   icon?: string;
+  /** Gallery filter these items map to. Set it to make the chips
+   *  clickable pivots into a filtered search. */
+  filter?: FilterType;
 };
 
 const props = defineProps<{ sections: InfoGridSection[] }>();
 
 const visible = () => props.sections.filter((s) => s.items.length > 0);
+
+const searchLocation = (filter: FilterType, item: string) => ({
+  name: ROUTES.SEARCH,
+  query: { [filter]: item },
+});
 </script>
 
 <template>
@@ -41,13 +57,16 @@ const visible = () => props.sections.filter((s) => s.items.length > 0);
         <span>{{ section.label }}</span>
       </div>
       <div class="r-v2-det-infogrid__chips">
-        <span
-          v-for="item in section.items"
-          :key="item"
-          class="r-v2-det-infogrid__chip"
-        >
-          {{ item }}
-        </span>
+        <template v-for="item in section.items" :key="item">
+          <router-link
+            v-if="section.filter"
+            :to="searchLocation(section.filter, item)"
+            class="r-v2-det-infogrid__chip r-v2-det-infogrid__chip--link"
+          >
+            {{ item }}
+          </router-link>
+          <span v-else class="r-v2-det-infogrid__chip">{{ item }}</span>
+        </template>
       </div>
     </div>
   </div>
@@ -105,5 +124,10 @@ const visible = () => props.sections.filter((s) => s.items.length > 0);
   color: var(--r-color-fg);
   border-color: var(--r-color-brand-primary);
   background: var(--r-color-surface-hover);
+}
+
+.r-v2-det-infogrid__chip--link {
+  cursor: pointer;
+  text-decoration: none;
 }
 </style>

--- a/frontend/src/v2/views/GameDetails.vue
+++ b/frontend/src/v2/views/GameDetails.vue
@@ -167,10 +167,14 @@ const lastPlayed = computed(() => {
 // would be a lie. "Franchises" mirrors the singular→plural consistency
 // of the surrounding rows.
 const overviewSections = computed<InfoGridSection[]>(() => [
-  { label: t("rom.genres"), items: genres.value },
-  { label: t("rom.companies"), items: companies.value },
-  { label: t("rom.franchises"), items: franchises.value },
-  { label: t("rom.collections"), items: collections.value },
+  { label: t("rom.genres"), items: genres.value, filter: "genres" },
+  { label: t("rom.companies"), items: companies.value, filter: "companies" },
+  { label: t("rom.franchises"), items: franchises.value, filter: "franchises" },
+  {
+    label: t("rom.collections"),
+    items: collections.value,
+    filter: "collections",
+  },
 ]);
 
 const playerCount = computed<string | null>(() => {


### PR DESCRIPTION
**Description**

The v2 game details overview rendered its genre / company / franchise / collection chips as plain `<span>`s with a hover affordance but no behavior, so the pivot-to-search that v1's `GameInfo.vue` offered from the same rows was lost: hovering highlighted a chip, clicking did nothing.

`InfoGridSection` now carries an optional `filter` (the `FilterType` its items map to), and sections that set one render their chips as `<router-link>`s into the search view scoped to that value (`/search?genres=Adventure`). `GameDetails.vue` wires genres, companies, franchises and collections to their filter keys.

Notes:

- Links rather than click handlers, so middle-click / open-in-new-tab work and the chips become `a[href]`, which puts them in keyboard and spatial (gamepad) navigation with the standard modality-gated focus ring.
- The query schema is the one `useGalleryFilterUrl` already round-trips, so the search view hydrates the filter store from the URL and fetches filtered results. No store or search-view changes needed, and the resulting links are bookmarkable.
- Chips in a section without a `filter` stay non-interactive spans; the visual styling is unchanged.

Regions, languages, tags, player count and age ratings were also clickable in v1. In v2 they live in `GameHeader` and the overview fact rows and are still non-pivoting; happy to extend the same treatment to them in a follow-up if wanted.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

Verified against a local backend by building the branch and driving it with Playwright: chips render as `/search?genres=Arcade`, `?companies=Nintendo+EPD+...`, `?collections=1-2-Switch`; clicking lands on the search view with the filter active and results returned; Enter activates the focused chip and the focus ring paints in dark mode; layout is unchanged at desktop and `xs` widths. `npm run typecheck`, `npm run test`, `npm run build` and `trunk check` are clean.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code): the diff, the browser verification and this description were produced by the agent and reviewed by me before submitting.

Fixes #4011