### PR TITLE
fix(backend): tolerate calendar-invalid gamelist dates on PostgreSQL

### DIFF
--- a/backend/alembic/versions/0098_generated_metadata_columns.py
+++ b/backend/alembic/versions/0098_generated_metadata_columns.py
@@ -399,13 +399,24 @@ def _thin_view_sql(is_pg: bool) -> str:
 # make_timestamp is IMMUTABLE and the components are interpreted as UTC, so the
 # stored value is deterministic regardless of the writer's session time zone
 # (to_timestamp() is only STABLE and would freeze a session-local value).
+#
+# The caller's regex only proves the value is 8+6 digits, so calendar-invalid
+# dates still reach make_timestamp, which raises on them. EmulationStation,
+# ES-DE and Skyscraper all write "00000000T000000" for an unknown release date,
+# and one such row is enough to abort the whole ALTER TABLE (or any later
+# INSERT). plpgsql traps that and yields NULL, matching the range guard the
+# MariaDB branch applies before its own conversion.
 _GAMELIST_EPOCH_FN = """
 CREATE OR REPLACE FUNCTION romm_gamelist_epoch_ms(s text) RETURNS bigint
-    LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
-    SELECT (extract(epoch FROM make_timestamp(
+    LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE AS $$
+BEGIN
+    RETURN (extract(epoch FROM make_timestamp(
         substr(s, 1, 4)::int, substr(s, 5, 2)::int, substr(s, 7, 2)::int,
         substr(s, 10, 2)::int, substr(s, 12, 2)::int, substr(s, 14, 2)::int
-    ) AT TIME ZONE 'UTC') * 1000)::bigint
+    ) AT TIME ZONE 'UTC') * 1000)::bigint;
+EXCEPTION WHEN others THEN
+    RETURN NULL;
+END
 $$
 """
 

--- a/backend/alembic/versions/0105_fix_gamelist_epoch_ms.py
+++ b/backend/alembic/versions/0105_fix_gamelist_epoch_ms.py
@@ -1,0 +1,65 @@
+"""Make romm_gamelist_epoch_ms tolerate calendar-invalid gamelist dates
+
+``generated_first_release_date`` (migration 0098) gates the gamelist branch on
+``'^[0-9]{8}T[0-9]{6}$'``, which proves the value is 8+6 digits but not that
+those digits form a real date. EmulationStation, ES-DE and Skyscraper all write
+``00000000T000000`` when a game has no known release date, and ``make_timestamp``
+raises on it. Since the column is STORED, that error aborts the statement: the
+0098 ``ALTER TABLE`` for anyone still on 5.0, and every later ``INSERT`` of such
+a ROM for anyone who upgraded before a gamelist scan brought one in.
+
+0098 now defines the function defensively, but that only helps installs that
+have yet to run it. This replaces the function in place for the rest. Existing
+generated values are untouched and need no backfill: they are valid by
+construction, or 0098 would not have completed.
+
+MariaDB is unaffected. Its branch of 0098 range-checks the components in SQL
+before converting.
+
+Revision ID: 0105_fix_gamelist_epoch_ms
+Revises: 0104_roms_missing_from_fs_index
+Create Date: 2026-07-30 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op  # type: ignore[attr-defined]
+
+from utils.database import is_postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0105_fix_gamelist_epoch_ms"
+down_revision = "0104_roms_missing_from_fs_index"
+branch_labels = None
+depends_on = None
+
+# Kept in sync with _GAMELIST_EPOCH_FN in 0098. CREATE OR REPLACE is accepted
+# while a STORED generated column depends on the function: the signature is
+# unchanged, so no table rewrite happens and only subsequent writes see the new
+# body.
+_GAMELIST_EPOCH_FN = """
+CREATE OR REPLACE FUNCTION romm_gamelist_epoch_ms(s text) RETURNS bigint
+    LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE AS $$
+BEGIN
+    RETURN (extract(epoch FROM make_timestamp(
+        substr(s, 1, 4)::int, substr(s, 5, 2)::int, substr(s, 7, 2)::int,
+        substr(s, 10, 2)::int, substr(s, 12, 2)::int, substr(s, 14, 2)::int
+    ) AT TIME ZONE 'UTC') * 1000)::bigint;
+EXCEPTION WHEN others THEN
+    RETURN NULL;
+END
+$$
+"""
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    if is_postgresql(connection):
+        connection.execute(sa.text(_GAMELIST_EPOCH_FN))
+
+
+def downgrade() -> None:
+    # Restoring the raising definition would only re-break writes, and 0098 (now
+    # carrying the same body) drops the function on its own downgrade.
+    pass

--- a/backend/tests/handler/database/test_generated_metadata.py
+++ b/backend/tests/handler/database/test_generated_metadata.py
@@ -7,6 +7,8 @@ columns, the rating average, the gamelist date wrapper, and the quoted-string
 date that the old view silently truncated to ``0``.
 """
 
+import pytest
+
 from handler.database import db_rom_handler
 from models.rom import Rom
 
@@ -66,6 +68,37 @@ class TestGeneratedMetadata:
 
         meta = _reload(rom).metadatum
         assert meta.first_release_date == 1577836800000  # 2020-01-01T00:00:00Z
+
+    def test_gamelist_leap_day_is_accepted(self, rom: Rom):
+        db_rom_handler.update_rom(
+            rom.id,
+            {"gamelist_metadata": {"first_release_date": "20240229T000000"}},
+        )
+
+        meta = _reload(rom).metadatum
+        assert meta.first_release_date == 1709164800000  # 2024-02-29T00:00:00Z
+
+    @pytest.mark.parametrize(
+        "release_date",
+        [
+            "00000000T000000",  # what ES/ES-DE/Skyscraper write for "unknown"
+            "19700000T000000",
+            "20201301T000000",
+            "20200230T000000",
+        ],
+    )
+    def test_calendar_invalid_gamelist_date_yields_null(
+        self, rom: Rom, release_date: str
+    ):
+        # These pass the 8+6 digit regex but are not real dates. The write must
+        # succeed rather than raise out of the generated-column expression.
+        db_rom_handler.update_rom(
+            rom.id,
+            {"gamelist_metadata": {"first_release_date": release_date}},
+        )
+
+        meta = _reload(rom).metadatum
+        assert meta.first_release_date is None
 
     def test_empty_metadata_yields_defaults(self, rom: Rom):
         meta = _reload(rom).metadatum


### PR DESCRIPTION
**Description**

Fixes #4016

Upgrading to 5.1 on PostgreSQL fails during `0098_generated_metadata_columns` with:

```
psycopg.errors.DatetimeFieldOverflow: date field value out of range: 0-00-00
CONTEXT:  SQL function "romm_gamelist_epoch_ms" statement 1
```

**Root cause**

The gamelist branch of `generated_first_release_date` gates on `'^[0-9]{8}T[0-9]{6}$'`, which proves the value is 8 digits + `T` + 6 digits but not that those digits form a real calendar date. EmulationStation, ES-DE and Skyscraper all write `<releasedate>00000000T000000</releasedate>` when a game has no known release date, and `gamelist_handler.py` stores that verbatim. `make_timestamp()` raises on it, and because the column is `STORED` the error aborts the entire statement.

This is not only an upgrade-time failure. On an install that already ran 0098 cleanly, the first `INSERT` of a ROM carrying such a value fails the same way, so a later gamelist scan can break writes for users who are not currently blocked.

The MariaDB branch of the same migration already handles this with an explicit `calendar_valid` range and leap-year guard. That guard was never mirrored into the PostgreSQL branch.

**Changes**

1. `0098_generated_metadata_columns.py`: `romm_gamelist_epoch_ms` becomes `plpgsql` with `EXCEPTION WHEN others THEN RETURN NULL`, so calendar-invalid values fall through to `NULL` exactly as they do on MariaDB. This unblocks anyone still on 5.0 who has not run 0098 yet.
2. `0105_fix_gamelist_epoch_ms.py` (new): `CREATE OR REPLACE`s the function for installs already past 0098. No backfill is needed, since existing generated values are valid by construction (0098 would not have completed otherwise). No-op on MariaDB.
3. Tests covering the calendar-invalid values and a leap day, so an over-broad guard would fail too.

Trapping the error was preferred over porting MariaDB's explicit range SQL: it is shorter, and it covers malformed inputs nobody thought to enumerate.

**Testing**

- Reproduced the reported error verbatim (including the `CONTEXT:` line) against postgres:16, then confirmed `CREATE OR REPLACE` succeeds while a `STORED` generated column depends on the function, with no table rewrite and valid values preserved.
- Seeded a scratch database at revision 0097 with both `00000000T000000` and `20240229T000000`, then ran `alembic upgrade head`: previously the failure point, now completes, leaving `NULL` and `1709164800000` respectively.
- `tests/handler/database`: 176 passed on PostgreSQL; the generated-metadata tests pass on both PostgreSQL and MariaDB (the CI matrix covers both).
- `trunk fmt && trunk check` clean.

**Notes for reviewers**

- `gamelist_handler.py` still stores `00000000T000000` verbatim. The database fix makes that harmless, but filtering placeholder dates at ingestion would keep the blob cleaner. Left out as separate scope.
- Small pre-existing cross-engine divergence remains: `make_timestamp` accepts hour `24` and rolls it to the next day, while the MariaDB guard rejects it as `NULL`. Unrelated to this bug and only affects sort ordering.
- Anyone blocked right now can use the SQL workaround in the issue thread before this ships.

**AI assistance disclosure**

This PR was written with AI assistance (Claude Code). The root-cause analysis and proposed approach come from the investigation in #4016 by @Spinnich. AI was used to implement the migrations and tests and to run the verification described above; all changes were reviewed by a human before submission.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
