### PR TITLE
fix(backend): scope ScreenScraper French fallback to taxonomy fields

### DIFF
--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -508,7 +508,7 @@ class ConfigManager:
             SCAN_LANGUAGE_PRIORITY=pydash.get(
                 self._raw_config,
                 "scan.priority.language",
-                ["en", "fr"],
+                ["en"],
             ),
             SCAN_MEDIA=pydash.get(
                 self._raw_config,

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -196,10 +196,16 @@ def get_preferred_regions(
 def get_preferred_languages() -> list[str]:
     """Get preferred languages from config.
 
-    Returns language priority list with default fallbacks.
+    Falls back to English when the list is empty, so clearing the setting does
+    not blank out every description.
     """
     config = cm.get_config()
-    return list(dict.fromkeys(config.SCAN_LANGUAGE_PRIORITY + ["en", "fr"]))
+    return list(dict.fromkeys(config.SCAN_LANGUAGE_PRIORITY)) or ["en"]
+
+
+def get_taxonomy_languages() -> list[str]:
+    """Preferred languages, extended with ScreenScraper's taxonomy fallbacks."""
+    return list(dict.fromkeys(get_preferred_languages() + ["en", "fr"]))
 
 
 def get_preferred_media_types() -> list[MetadataMediaType]:
@@ -512,7 +518,7 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
 
 
 def extract_metadata_from_ss_rom(rom: Rom, game: SSGame) -> SSMetadata:
-    preferred_languages = get_preferred_languages()
+    taxonomy_languages = get_taxonomy_languages()
 
     def _normalize_score(score: str) -> str:
         """Normalize the score to be between 0 and 10 because for some reason Screenscraper likes to rate over 20."""
@@ -564,7 +570,7 @@ def extract_metadata_from_ss_rom(rom: Rom, game: SSGame) -> SSMetadata:
         ]
 
     def _get_franchises(game: SSGame) -> list[str]:
-        for lang in preferred_languages:
+        for lang in taxonomy_languages:
             franchises = [
                 franchise_name["text"]
                 for franchise in game.get("familles", [])
@@ -576,7 +582,7 @@ def extract_metadata_from_ss_rom(rom: Rom, game: SSGame) -> SSMetadata:
         return []
 
     def _get_game_modes(game: SSGame) -> list[str]:
-        for lang in preferred_languages:
+        for lang in taxonomy_languages:
             modes = [
                 mode_name["text"]
                 for mode in game.get("modes", [])

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -26,8 +26,10 @@ from handler.metadata.ss_handler import (
     build_ss_game,
     extract_media_from_ss_game,
     extract_metadata_from_ss_rom,
+    get_preferred_languages,
     get_preferred_regions,
     get_rate_limited_rom_names,
+    get_taxonomy_languages,
     note_rate_limited_rom,
     reset_rate_limited_roms,
 )
@@ -38,6 +40,7 @@ def _make_config(
     region_priority: list[str] | None = None,
     scan_media: list[str] | None = None,
     region_mode: str = "prefer_rom_tags",
+    language_priority: list[str] | None = None,
 ) -> Config:
     """Build a minimal Config object for testing."""
     return Config(
@@ -53,7 +56,9 @@ def _make_config(
         ROMS_FOLDER_NAME="roms",
         FIRMWARE_FOLDER_NAME="bios",
         SCAN_REGION_PRIORITY=region_priority or [],
-        SCAN_LANGUAGE_PRIORITY=["en"],
+        SCAN_LANGUAGE_PRIORITY=(
+            language_priority if language_priority is not None else ["en"]
+        ),
         SCAN_MEDIA=(
             scan_media if scan_media is not None else ["box2d", "box3d", "screenshot"]
         ),
@@ -172,6 +177,40 @@ class TestGetPreferredRegions:
             regions = get_preferred_regions(rom)
 
         assert regions.index("eu") < regions.index("fr")
+
+
+class TestGetPreferredLanguages:
+    def test_returns_configured_order(self):
+        config = _make_config(language_priority=["de", "es"])
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            assert get_preferred_languages() == ["de", "es"]
+
+    def test_does_not_append_french(self):
+        """A configured language list is honored as-is, so descriptions are not
+        silently served in a language the user did not ask for."""
+        config = _make_config(language_priority=["de"])
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            assert get_preferred_languages() == ["de"]
+
+    def test_empty_falls_back_to_english(self):
+        config = _make_config(language_priority=[])
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            assert get_preferred_languages() == ["en"]
+
+    def test_drops_duplicates(self):
+        config = _make_config(language_priority=["de", "en", "de"])
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            assert get_preferred_languages() == ["de", "en"]
+
+    def test_taxonomy_languages_append_fallbacks(self):
+        config = _make_config(language_priority=["de"])
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            assert get_taxonomy_languages() == ["de", "en", "fr"]
+
+    def test_taxonomy_languages_keep_user_order(self):
+        config = _make_config(language_priority=["fr", "de"])
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            assert get_taxonomy_languages() == ["fr", "de", "en"]
 
 
 class TestExtractMediaFromSsGame:
@@ -510,6 +549,47 @@ class TestExtractMetadataFromSsRom:
 
         assert metadata["first_release_date"] == 593568000
 
+    def test_franchises_fall_back_to_french(self):
+        """ScreenScraper's taxonomy is often French-only, so those fields still
+        fall back even when the user asked for another language."""
+        config = _make_config(language_priority=["de"])
+        game = cast(
+            SSGame,
+            {
+                "familles": [{"noms": [{"langue": "fr", "text": "Mario"}]}],
+                "modes": [{"noms": [{"langue": "fr", "text": "Solo"}]}],
+                "medias": [],
+            },
+        )
+
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            metadata = extract_metadata_from_ss_rom(self._make_rom(), game)
+
+        assert metadata["franchises"] == ["Mario"]
+        assert metadata["game_modes"] == ["Solo"]
+
+    def test_taxonomy_prefers_configured_language(self):
+        config = _make_config(language_priority=["de"])
+        game = cast(
+            SSGame,
+            {
+                "familles": [
+                    {
+                        "noms": [
+                            {"langue": "fr", "text": "Mario"},
+                            {"langue": "de", "text": "Mario DE"},
+                        ]
+                    }
+                ],
+                "medias": [],
+            },
+        )
+
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            metadata = extract_metadata_from_ss_rom(self._make_rom(), game)
+
+        assert metadata["franchises"] == ["Mario DE"]
+
 
 class TestBuildSSGame:
     def _make_rom(self) -> MagicMock:
@@ -565,6 +645,43 @@ class TestBuildSSGame:
         # Dedicated media folders are still populated.
         assert result["ss_metadata"]["title_screen_path"]
         assert result["ss_metadata"]["fanart_path"]
+
+    def test_summary_does_not_fall_back_to_unrequested_language(self):
+        """An untranslated synopsis is left empty rather than served in French."""
+        config = _make_config(language_priority=["de"])
+        game = cast(
+            SSGame,
+            {
+                "id": "42",
+                "medias": [],
+                "synopsis": [{"langue": "fr", "text": "Un jeu."}],
+            },
+        )
+
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            result = build_ss_game(self._make_rom(), game)
+
+        # Empty values are stripped from the returned dict.
+        assert "summary" not in result
+
+    def test_summary_uses_configured_language(self):
+        config = _make_config(language_priority=["de", "en"])
+        game = cast(
+            SSGame,
+            {
+                "id": "42",
+                "medias": [],
+                "synopsis": [
+                    {"langue": "en", "text": "A game."},
+                    {"langue": "de", "text": "Ein Spiel."},
+                ],
+            },
+        )
+
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            result = build_ss_game(self._make_rom(), game)
+
+        assert result["summary"] == "Ein Spiel."
 
 
 class TestIsNotgame:


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

The scan language priority defaulted to `["en", "fr"]`, and `get_preferred_languages()` appended `["en", "fr"]` unconditionally on top of whatever was configured:

```python
return list(dict.fromkeys(config.SCAN_LANGUAGE_PRIORITY + ["en", "fr"]))
```

Two consequences:

- French was impossible to remove. `[]`, `["en"]`, and `["en", "fr"]` all resolved to the same list, so the settings UI showed `en, fr` chips that could be reordered or deleted with no effect on the scan.
- A user configuring a single language still got French descriptions for anything untranslated.

Tracing the history, the `fr` was never a decision about description language. It entered in `cfbcd825` (Feb 2025) as a hardcoded per-field fallback for exactly two fields, `familles` (franchises) and `modes` (game modes), which are French-authored in ScreenScraper and frequently have no English entry. The synopsis at the time was hardcoded to `en` with no fallback. `da8e7fd9` collapsed those two `or` chains into a local `preferred_languages = ["en", "fr"]`, and `ce4809ea` lifted that literal into the config default when the setting was added, at which point it started applying to the synopsis too.

This PR splits the two concerns:

- `get_preferred_languages()` honors the configured order verbatim, falling back to `["en"]` only when the list is empty (so clearing the setting doesn't blank every description). It drives the **synopsis**.
- New `get_taxonomy_languages()` appends `TAXONOMY_FALLBACK_LANGUAGES = ["en", "fr"]` after the user's order. It drives **franchises** and **game modes**, restoring the original per-field semantics.
- The config default for `scan.priority.language` drops to `["en"]`.

Net effect: configuring `["de"]` now yields a German description or none, instead of a silently French one, while French franchise and mode names are still used where no English entry exists. Users with `en` first see no change to the synopsis; taxonomy behavior is unchanged for everyone.

No API schema or route signature changed, so no frontend type regeneration is needed. The existing `settings.scan-language-priority-desc` string is still accurate and was left alone.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**Tests**

`TestGetPreferredLanguages` covers configured order, the absence of the French append, empty→`en`, dedup, and the taxonomy extension. Behavioral cases cover franchises and modes still falling back to French under `["de"]`, taxonomy preferring the configured language when present, and the synopsis not falling back.

Verified locally: `pytest tests/handler/metadata/` (362 passed), `pytest tests/config/ tests/endpoints/test_config.py` (111 passed with the metadata suite), and `trunk check` clean on all three files.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The AI traced the history of the `en`/`fr` default through `git log -S`, proposed the split between synopsis and taxonomy handling, and wrote the implementation and tests. The approach was chosen and reviewed by me.

#### Screenshots (if applicable)

N/A — backend only.
