### PR TITLE
fix(scan): refresh stale ScreenScraper data on update metadata scans

### DIFF
--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -1812,29 +1812,38 @@ async def update_rom(
             if badge_url and badge_path:
                 await fs_resource_handler.store_ra_badge(badge_url, badge_path)
 
-    # Handle special media files from Screenscraper when the ID has changed
-    if cleaned_data["ss_id"] and int(cleaned_data["ss_id"]) != rom.ss_id:
+    # Handle special media files from Screenscraper. A re-match to the same game
+    # still runs, to fill in media that never made it to disk.
+    if cleaned_data["ss_id"]:
+        ss_id_changed = int(cleaned_data["ss_id"]) != rom.ss_id
         preferred_media_types = get_preferred_media_types()
+        # Only a changed ID refetches the game, so only then is there a hash that
+        # describes something other than the copy already on disk. Checking a
+        # stored hash against the file it was recorded from can only ever report
+        # "current", at the cost of reading every media file.
+        fresh_metadata = cleaned_data.get("ss_metadata") if ss_id_changed else None
+        ss_metadata = fresh_metadata or rom.ss_metadata or {}
 
         for media_type in preferred_media_types:
-            # Remove old media files if the ss_id is changing
-            if rom.ss_metadata and rom.ss_metadata.get(f"{media_type.value}_path"):
+            # Media from the previous match is unrelated to the new game
+            if (
+                ss_id_changed
+                and rom.ss_metadata
+                and rom.ss_metadata.get(f"{media_type.value}_path")
+            ):
                 await fs_resource_handler.remove_media_resources_path(
                     rom.platform_id,
                     rom.id,
                     media_type,
                 )
 
-            media_path = cleaned_data.get("ss_metadata", {}).get(
-                f"{media_type.value}_path"
-            )
-            media_url = cleaned_data.get("ss_metadata", {}).get(
-                f"{media_type.value}_url"
-            )
+            media_path = ss_metadata.get(f"{media_type.value}_path")
+            media_url = ss_metadata.get(f"{media_type.value}_url")
             if media_path and media_url:
                 await fs_resource_handler.store_media_file(
                     add_ss_auth_to_url(media_url),
                     media_path,
+                    expected_md5=(fresh_metadata or {}).get(f"{media_type.value}_md5"),
                 )
 
     # Handle local media files from LaunchBox when the ID has changed

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -40,6 +40,7 @@ from handler.metadata.ss_handler import begin_scan as begin_ss_scan
 from handler.metadata.ss_handler import get_preferred_media_types
 from handler.metadata.ss_handler import log_quota as log_ss_quota
 from handler.metadata.ss_handler import log_scan_summary as log_ss_scan_summary
+from handler.metadata.ss_handler import ss_resource_needs_refresh
 from handler.redis_handler import (
     get_job_func_name,
     high_prio_queue,
@@ -512,12 +513,37 @@ async def _identify_rom(
     if scan_type == ScanType.HASHES:
         return
 
+    # ScreenScraper serves every media from a fixed endpoint, so its URLs stay
+    # byte-identical when the artwork behind them is replaced. The md5 it reports
+    # per media entry is the only signal that a stored file went stale.
+    async def _ss_media_changed(
+        media_key: str, resolved_url: str | None, stored_path: str | None
+    ) -> bool:
+        if MetadataSource.SS not in metadata_sources:
+            return False
+
+        return await ss_resource_needs_refresh(
+            previous_metadata=rom.ss_metadata,
+            fresh_metadata=_added_rom.ss_metadata,
+            media_key=media_key,
+            resolved_url=resolved_url,
+            stored_path=stored_path,
+        )
+
     path_cover_s, path_cover_l = await fs_resource_handler.get_cover(
         entity=_added_rom,
-        overwrite=_added_rom.url_cover != rom.url_cover,
+        overwrite=_added_rom.url_cover != rom.url_cover
+        or await _ss_media_changed(
+            "box2d",
+            _added_rom.url_cover,
+            fs_resource_handler.get_downloaded_cover_path(_added_rom),
+        ),
         url_cover=add_ss_auth_to_url(_added_rom.url_cover),
     )
 
+    # Manuals are left out of the hash check: an upload writes `path_manual` but
+    # leaves any scraped `url_manual` in place, so a refresh here would overwrite
+    # it with the provider's copy.
     path_manual = await fs_resource_handler.get_manual(
         rom=_added_rom,
         overwrite=_added_rom.url_manual != rom.url_manual,
@@ -528,9 +554,22 @@ async def _identify_rom(
         _added_rom.url_screenshots or [], rom.url_screenshots or []
     )
     url_screenshots = _added_rom.url_screenshots or []
+    # Screenshots are stored by their position in the URL list, so the one
+    # ScreenScraper supplied is at the index its URL sits at.
+    stored_screenshots = _added_rom.path_screenshots or []
+    ss_screenshot_url = (_added_rom.ss_metadata or {}).get("screenshot_url")
+    ss_screenshot_path = next(
+        (
+            path
+            for url, path in zip(url_screenshots, stored_screenshots, strict=False)
+            if url == ss_screenshot_url
+        ),
+        None,
+    )
     path_screenshots = await fs_resource_handler.get_rom_screenshots(
         rom=_added_rom,
-        overwrite=bool(screenshots_changed),
+        overwrite=bool(screenshots_changed)
+        or await _ss_media_changed("screenshot", ss_screenshot_url, ss_screenshot_path),
         url_screenshots=[add_ss_auth_to_url(u) for u in url_screenshots],
     )
 
@@ -560,6 +599,7 @@ async def _identify_rom(
                 await fs_resource_handler.store_media_file(
                     add_ss_auth_to_url(media_url),
                     media_path,
+                    expected_md5=_added_rom.ss_metadata.get(f"{media_type.value}_md5"),
                 )
 
     # Handle special media files from ES-DE gamelist.xml

--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -1,4 +1,5 @@
 import gzip
+import hashlib
 import os
 from io import BytesIO
 from pathlib import Path
@@ -111,6 +112,49 @@ class FSResourcesHandler(FSHandler):
     def __init__(self) -> None:
         super().__init__(base_path=RESOURCES_BASE_PATH)
         self.image_converter = ImageConverter()
+
+    async def file_md5(self, relative_path: str) -> str | None:
+        """md5 of a stored resource, or None when it can't be read."""
+        try:
+            full_path = self.validate_path(relative_path)
+        except ValueError:
+            return None
+
+        digest = hashlib.md5(usedforsecurity=False)
+        try:
+            async with await AnyioPath(full_path).open("rb") as f:
+                while chunk := await f.read(64 * 1024):
+                    digest.update(chunk)
+        except OSError:
+            return None
+
+        return digest.hexdigest()
+
+    async def file_matches_md5(
+        self, relative_path: str, expected_md5: str | None
+    ) -> bool:
+        """Whether a stored resource is byte-identical to the expected hash."""
+        if not expected_md5:
+            return False
+
+        return await self.file_md5(relative_path) == expected_md5.lower()
+
+    async def file_has_size(self, relative_path: str, expected_size: int) -> bool:
+        """Whether a stored resource is exactly the expected number of bytes.
+
+        Downloads stream straight to their final path, so one cut short by a
+        killed process leaves a short file that still satisfies the `*_exists`
+        checks. A stat() spots that without reading the file.
+        """
+        try:
+            full_path = self.validate_path(relative_path)
+        except ValueError:
+            return False
+
+        try:
+            return (await AnyioPath(full_path).stat()).st_size == expected_size
+        except OSError:
+            return False
 
     def get_platform_resources_path(self, platform_id: int) -> str:
         return os.path.join("roms", str(platform_id))
@@ -283,6 +327,15 @@ class FSResourcesHandler(FSHandler):
             except UnidentifiedImageError as exc:
                 log.error(f"Unable to identify image {cover_file}: {str(exc)}")
                 return None
+
+    def get_downloaded_cover_path(self, entity: Rom | Collection) -> str:
+        """Path of the cover exactly as downloaded, before any WebP conversion.
+
+        The converter writes a sibling `.webp` and leaves this file in place, so
+        it stays the only copy whose bytes can be compared against a provider's
+        reported hash.
+        """
+        return f"{entity.fs_resources_path}/cover/{CoverSize.BIG.value}.png"
 
     def _get_cover_path(self, entity: Rom | Collection, size: CoverSize) -> str | None:
         """Returns rom cover filesystem path adapted to frontend folder structure
@@ -661,11 +714,19 @@ class FSResourcesHandler(FSHandler):
     ) -> str:
         return os.path.join("roms", str(platform_id), str(rom_id), media_type.value)
 
-    async def store_media_file(self, url_media: str, dest_path: str) -> None:
+    async def store_media_file(
+        self, url_media: str, dest_path: str, expected_md5: str | None = None
+    ) -> None:
         directory, filename = os.path.split(dest_path)
 
-        if await self.file_exists(dest_path):
-            log.debug(f"Media file {dest_path} already exists, skipping download")
+        # Providers that publish a hash for the media let a stale local copy be
+        # detected without downloading it; the rest can only check for presence.
+        is_current = await self.file_exists(dest_path) and (
+            not expected_md5 or await self.file_matches_md5(dest_path, expected_md5)
+        )
+
+        if is_current:
+            log.debug(f"Media file {dest_path} is up to date, skipping download")
         else:
             # Ensure destination directory exists
             await self.make_directory(directory)

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -2,7 +2,7 @@ import html
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Final, NotRequired, TypedDict
+from typing import Any, Final, NotRequired, TypedDict
 
 import pydash
 from fastapi import HTTPException, status
@@ -305,6 +305,70 @@ class SSMetadataMedia(TypedDict):
     video_path: str | None
     video_normalized_path: str | None
 
+    # md5 ScreenScraper reports for each media entry, so a later scan can tell
+    # whether the online file still matches the local copy.
+    bezel_md5: str | None
+    box2d_md5: str | None
+    box2d_side_md5: str | None
+    box2d_back_md5: str | None
+    box3d_md5: str | None
+    fanart_md5: str | None
+    fullbox_md5: str | None
+    logo_md5: str | None
+    manual_md5: str | None
+    marquee_md5: str | None
+    miximage_md5: str | None
+    miximage_v2_md5: str | None
+    physical_md5: str | None
+    screenshot_md5: str | None
+    steamgrid_md5: str | None
+    title_screen_md5: str | None
+    video_md5: str | None
+    video_normalized_md5: str | None
+
+    # Byte size ScreenScraper reports for the same entry. A download cut short
+    # leaves a shorter file behind, which a stat() catches without reading it.
+    bezel_size: int | None
+    box2d_size: int | None
+    box2d_side_size: int | None
+    box2d_back_size: int | None
+    box3d_size: int | None
+    fanart_size: int | None
+    fullbox_size: int | None
+    logo_size: int | None
+    manual_size: int | None
+    marquee_size: int | None
+    miximage_size: int | None
+    miximage_v2_size: int | None
+    physical_size: int | None
+    screenshot_size: int | None
+    steamgrid_size: int | None
+    title_screen_size: int | None
+    video_size: int | None
+    video_normalized_size: int | None
+
+
+SS_MEDIA_KEYS: Final = (
+    "bezel",
+    "box2d",
+    "box2d_back",
+    "box2d_side",
+    "box3d",
+    "fanart",
+    "fullbox",
+    "logo",
+    "manual",
+    "marquee",
+    "miximage",
+    "miximage_v2",
+    "physical",
+    "screenshot",
+    "steamgrid",
+    "title_screen",
+    "video",
+    "video_normalized",
+)
+
 
 class SSMetadata(SSMetadataMedia):
     ss_score: str | None
@@ -366,7 +430,62 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
         title_screen_path=None,
         video_path=None,
         video_normalized_path=None,
+        bezel_md5=None,
+        box2d_md5=None,
+        box2d_side_md5=None,
+        box2d_back_md5=None,
+        box3d_md5=None,
+        fanart_md5=None,
+        fullbox_md5=None,
+        logo_md5=None,
+        manual_md5=None,
+        marquee_md5=None,
+        miximage_md5=None,
+        miximage_v2_md5=None,
+        physical_md5=None,
+        screenshot_md5=None,
+        steamgrid_md5=None,
+        title_screen_md5=None,
+        video_md5=None,
+        video_normalized_md5=None,
+        bezel_size=None,
+        box2d_size=None,
+        box2d_side_size=None,
+        box2d_back_size=None,
+        box3d_size=None,
+        fanart_size=None,
+        fullbox_size=None,
+        logo_size=None,
+        manual_size=None,
+        marquee_size=None,
+        miximage_size=None,
+        miximage_v2_size=None,
+        physical_size=None,
+        screenshot_size=None,
+        steamgrid_size=None,
+        title_screen_size=None,
+        video_size=None,
+        video_normalized_size=None,
     )
+
+    # Keyed by the same stripped URL that lands in `*_url`, so the hash and size
+    # of the entry that actually won its slot can be looked up once the loop is
+    # done. ScreenScraper lists one entry per region, and only the selected one
+    # describes the bytes RomM ends up storing.
+    fingerprint_by_url: dict[str, tuple[str | None, int | None]] = {}
+    for media in game.get("medias", []):
+        url = media.get("url")
+        if not url:
+            continue
+        entry_md5 = media.get("md5")
+        try:
+            entry_size: int | None = int(media["size"])
+        except (KeyError, TypeError, ValueError):
+            entry_size = None
+        fingerprint_by_url[strip_sensitive_query_params(url, SENSITIVE_KEYS)] = (
+            entry_md5.lower() if entry_md5 else None,
+            entry_size,
+        )
 
     for region in get_preferred_regions(rom, for_media=True):
         for media in game.get("medias", []):
@@ -514,7 +633,78 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                         f"{fs_resource_handler.get_media_resources_path(rom.platform_id, rom.id, MetadataMediaType.VIDEO_NORMALIZED)}/video-normalized.mp4"
                     )
 
+    for key in SS_MEDIA_KEYS:
+        url = ss_media[f"{key}_url"]  # type: ignore[literal-required]
+        md5, size = fingerprint_by_url.get(url, (None, None)) if url else (None, None)
+        ss_media[f"{key}_md5"] = md5  # type: ignore[literal-required]
+        ss_media[f"{key}_size"] = size  # type: ignore[literal-required]
+
     return ss_media
+
+
+async def ss_media_is_stale(
+    stored_path: str | None,
+    recorded_md5: str | None,
+    fresh_md5: str | None,
+    fresh_size: int | None = None,
+) -> bool:
+    """True when ScreenScraper serves a different file than the one RomM holds.
+
+    ScreenScraper publishes an md5 per media entry so clients can check whether
+    the online media matches their local copy before downloading it. The hash
+    recorded by the previous scan answers that for free; falling back to hashing
+    the file on disk keeps libraries scanned before hashes were recorded from
+    redownloading media that is already current.
+
+    The recorded hash is only trustworthy about a file that finished
+    downloading. It is written before the download runs, so a scan killed
+    mid-stream leaves a short file described by a hash that still matches.
+    Comparing the reported size first catches that for the price of a stat().
+    """
+    if not fresh_md5:
+        return False
+
+    if (
+        stored_path
+        and fresh_size
+        and not await fs_resource_handler.file_has_size(stored_path, fresh_size)
+    ):
+        return True
+
+    if recorded_md5 and recorded_md5.lower() == fresh_md5.lower():
+        return False
+
+    if not stored_path:
+        return True
+
+    return not await fs_resource_handler.file_matches_md5(stored_path, fresh_md5)
+
+
+async def ss_resource_needs_refresh(
+    *,
+    previous_metadata: dict[str, Any] | None,
+    fresh_metadata: dict[str, Any] | None,
+    media_key: str,
+    resolved_url: str | None,
+    stored_path: str | None,
+) -> bool:
+    """Whether a resource sourced from ScreenScraper went stale.
+
+    Artwork priority can hand a field to another provider, whose URL says nothing
+    about ScreenScraper's hash, so the check only applies while ScreenScraper is
+    the source of the resolved URL.
+    """
+    fresh = fresh_metadata or {}
+    ss_url = fresh.get(f"{media_key}_url")
+    if not ss_url or not resolved_url or ss_url != resolved_url:
+        return False
+
+    return await ss_media_is_stale(
+        stored_path,
+        (previous_metadata or {}).get(f"{media_key}_md5"),
+        fresh.get(f"{media_key}_md5"),
+        fresh.get(f"{media_key}_size"),
+    )
 
 
 def extract_metadata_from_ss_rom(rom: Rom, game: SSGame) -> SSMetadata:

--- a/backend/tests/endpoints/sockets/test_scan_ss_refresh.py
+++ b/backend/tests/endpoints/sockets/test_scan_ss_refresh.py
@@ -1,0 +1,179 @@
+"""Update scans must refresh stale ScreenScraper resources (issue #4002).
+
+ScreenScraper media URLs are fixed endpoints, so the URL-diff gate that guards
+the cover and screenshot downloads can never fire for it. These tests drive
+`_identify_rom` through an UPDATE scan and assert the md5 ScreenScraper reports
+is what decides whether a resource is refetched.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+from endpoints.sockets import scan as scan_module
+from endpoints.sockets.scan import _identify_rom
+from handler.filesystem.roms_handler import FSRom, ParsedRomFiles, ParsedTags
+from handler.scan_handler import MetadataSource, ScanType
+from models.platform import Platform
+
+COVER_URL = "https://screenscraper.fr/api2/mediaJeu.php?media=box-2D"
+LOGO_URL = "https://screenscraper.fr/api2/mediaJeu.php?media=wheel"
+
+
+def _ss_metadata(cover_md5: str, logo_md5: str) -> dict:
+    return {
+        "box2d_url": COVER_URL,
+        "box2d_md5": cover_md5,
+        "logo_url": LOGO_URL,
+        "logo_md5": logo_md5,
+        "logo_path": "roms/1/42/logo/logo.png",
+    }
+
+
+class TestUpdateScanRefreshesScreenScraperMedia:
+    @pytest.fixture
+    def resources(self, mocker):
+        resources = mocker.patch.object(scan_module, "fs_resource_handler")
+        resources.get_cover = AsyncMock(return_value=("small.png", "big.png"))
+        resources.get_manual = AsyncMock(return_value="manual.pdf")
+        resources.get_rom_screenshots = AsyncMock(return_value=[])
+        resources.store_media_file = AsyncMock()
+        resources.get_downloaded_cover_path = Mock(
+            return_value="roms/1/42/cover/big.png"
+        )
+        return resources
+
+    @pytest.fixture
+    def patched(self, mocker, resources):
+        mocker.patch.object(
+            scan_module, "redis_client", Mock(get=Mock(return_value=None))
+        )
+
+        fs = scan_module.fs_rom_handler
+        mocker.patch.object(
+            fs,
+            "parse_tags",
+            return_value=ParsedTags(
+                version="", revision="", regions=[], languages=[], other_tags=[]
+            ),
+        )
+        mocker.patch.object(fs, "get_roms_fs_structure", return_value="test/roms")
+        mocker.patch.object(fs, "get_file_name_with_no_tags", return_value="Game")
+        mocker.patch.object(
+            fs,
+            "get_rom_files",
+            AsyncMock(
+                return_value=ParsedRomFiles(
+                    rom_files=[], crc_hash="", md5_hash="", sha1_hash="", ra_hash=""
+                )
+            ),
+        )
+
+        config = MagicMock()
+        config.SKIP_HASH_CALCULATION = True
+        mocker.patch.object(scan_module.cm, "get_config", return_value=config)
+        mocker.patch.object(
+            scan_module,
+            "get_preferred_media_types",
+            return_value=[scan_module.MetadataMediaType.LOGO],
+        )
+
+        # The closing emit serializes the ROM, which these stand-ins can't satisfy.
+        mocker.patch.object(scan_module, "SimpleRomSchema")
+
+        db = mocker.patch.object(scan_module, "db_rom_handler")
+        return db
+
+    def _stored_rom(self, ss_metadata: dict):
+        """The ROM as it sits in the database before the scan."""
+        return MagicMock(
+            id=42,
+            fs_name="Game.zip",
+            fs_path="test/roms",
+            url_cover=COVER_URL,
+            url_manual="",
+            url_screenshots=[],
+            path_cover_s="roms/1/42/cover/small.png",
+            path_cover_l="roms/1/42/cover/big.png",
+            path_screenshots=[],
+            path_manual="",
+            ss_metadata=ss_metadata,
+        )
+
+    def _scanned_rom(self, ss_metadata: dict):
+        """What the scan produced, with a freshly fetched ScreenScraper blob."""
+        return MagicMock(
+            id=42,
+            is_identified=True,
+            url_cover=COVER_URL,
+            url_manual="",
+            url_screenshots=[],
+            path_cover_s="roms/1/42/cover/small.png",
+            path_cover_l="roms/1/42/cover/big.png",
+            path_screenshots=[],
+            path_manual="",
+            ss_metadata=ss_metadata,
+        )
+
+    async def _run(self, mocker, db, stored, scanned):
+        mocker.patch.object(scan_module, "scan_rom", AsyncMock(return_value=scanned))
+        db.add_rom.return_value = scanned
+        db.sync_rom_files.return_value = MagicMock(files=[], orphaned_cover_paths=[])
+
+        platform = Platform(name="Test", slug="test", fs_slug="test")
+        platform.id = 1
+        fs_rom: FSRom = {
+            "fs_name": "Game.zip",
+            "flat": True,
+            "nested": False,
+            "files": [],
+            "crc_hash": "",
+            "md5_hash": "",
+            "sha1_hash": "",
+            "ra_hash": "",
+        }
+
+        await _identify_rom(
+            platform=platform,
+            fs_rom=fs_rom,
+            rom=stored,
+            scan_type=ScanType.UPDATE,
+            roms_ids=[],
+            metadata_sources=[MetadataSource.SS],
+            launchbox_remote_enabled=False,
+            playmatch_enabled=False,
+            socket_manager=AsyncMock(),
+            scan_stats=AsyncMock(),
+        )
+
+    async def test_cover_is_refetched_when_screenscraper_reports_a_new_hash(
+        self, mocker, patched, resources
+    ):
+        stored = self._stored_rom(_ss_metadata("oldcover", "logo1"))
+        scanned = self._scanned_rom(_ss_metadata("newcover", "logo1"))
+
+        await self._run(mocker, patched, stored, scanned)
+
+        assert resources.get_cover.await_args.kwargs["overwrite"] is True
+
+    async def test_cover_is_left_alone_when_the_hash_is_unchanged(
+        self, mocker, patched, resources
+    ):
+        stored = self._stored_rom(_ss_metadata("samecover", "logo1"))
+        scanned = self._scanned_rom(_ss_metadata("samecover", "logo1"))
+
+        await self._run(mocker, patched, stored, scanned)
+
+        assert resources.get_cover.await_args.kwargs["overwrite"] is False
+
+    async def test_extra_media_downloads_carry_the_expected_hash(
+        self, mocker, patched, resources
+    ):
+        """`store_media_file` needs the hash to tell a stale file from a current one."""
+        stored = self._stored_rom(_ss_metadata("cover1", "logo1"))
+        scanned = self._scanned_rom(_ss_metadata("cover1", "logo2"))
+
+        await self._run(mocker, patched, stored, scanned)
+
+        resources.store_media_file.assert_awaited_once()
+        assert resources.store_media_file.await_args.kwargs["expected_md5"] == "logo2"

--- a/backend/tests/handler/filesystem/test_resources_md5.py
+++ b/backend/tests/handler/filesystem/test_resources_md5.py
@@ -1,0 +1,170 @@
+"""Tests for md5-gated resource downloads (issue #4002).
+
+ScreenScraper serves its media from fixed endpoints, so a changed artwork never
+changes the URL. The only signal that a stored file went stale is the md5
+ScreenScraper reports for that media entry, compared against the local copy.
+"""
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from handler.filesystem.resources_handler import FSResourcesHandler
+
+
+class _StreamedResponse:
+    """Minimal stand-in for an httpx streaming response serving fixed bytes."""
+
+    def __init__(self, payload: bytes):
+        self.status_code = 200
+        self.headers = {"content-type": "image/png"}
+        self._payload = payload
+
+    async def aiter_raw(self):
+        yield self._payload
+
+
+class _StreamContext:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _HttpxClient:
+    def __init__(self, response):
+        self._response = response
+        self.calls = 0
+
+    def stream(self, *_args, **_kwargs):
+        self.calls += 1
+        return _StreamContext(self._response)
+
+
+@pytest.fixture
+def handler(tmp_path):
+    handler = FSResourcesHandler()
+    handler.base_path = tmp_path
+    return handler
+
+
+def _write(path: Path, payload: bytes) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+    return hashlib.md5(payload, usedforsecurity=False).hexdigest()
+
+
+class TestFileMd5:
+    async def test_hashes_a_stored_file(self, handler, tmp_path):
+        digest = _write(tmp_path / "roms/1/1/logo/logo.png", b"artwork")
+
+        assert await handler.file_md5("roms/1/1/logo/logo.png") == digest
+
+    async def test_missing_file_has_no_hash(self, handler):
+        assert await handler.file_md5("roms/1/1/logo/logo.png") is None
+
+    async def test_traversal_path_has_no_hash(self, handler):
+        assert await handler.file_md5("../../etc/passwd") is None
+
+    async def test_matches_is_case_insensitive(self, handler, tmp_path):
+        digest = _write(tmp_path / "roms/1/1/logo/logo.png", b"artwork")
+
+        assert await handler.file_matches_md5("roms/1/1/logo/logo.png", digest.upper())
+
+    async def test_does_not_match_different_content(self, handler, tmp_path):
+        _write(tmp_path / "roms/1/1/logo/logo.png", b"old artwork")
+        other = hashlib.md5(b"new artwork", usedforsecurity=False).hexdigest()
+
+        assert not await handler.file_matches_md5("roms/1/1/logo/logo.png", other)
+
+    async def test_no_expected_hash_never_matches(self, handler, tmp_path):
+        _write(tmp_path / "roms/1/1/logo/logo.png", b"artwork")
+
+        assert not await handler.file_matches_md5("roms/1/1/logo/logo.png", None)
+
+
+class TestDownloadedCoverPath:
+    """The hash check has to read the original bytes, not a converted sibling."""
+
+    def test_points_at_the_unconverted_download(self, handler):
+        rom = SimpleNamespace(fs_resources_path="roms/1/42")
+
+        assert handler.get_downloaded_cover_path(rom) == "roms/1/42/cover/big.png"
+
+    async def test_hash_still_matches_once_a_webp_sibling_exists(
+        self, handler, tmp_path
+    ):
+        rom = SimpleNamespace(fs_resources_path="roms/1/42")
+        digest = _write(tmp_path / "roms/1/42/cover/big.png", b"cover bytes")
+        _write(tmp_path / "roms/1/42/cover/big.webp", b"a re-encoded copy")
+
+        path = handler.get_downloaded_cover_path(rom)
+
+        assert await handler.file_matches_md5(path, digest)
+
+
+class TestStoreMediaFileMd5Gate:
+    """`store_media_file` must refetch a file ScreenScraper reports as changed."""
+
+    REL = "roms/1/1/logo/logo.png"
+
+    async def _store(self, handler, payload: bytes, expected_md5: str | None):
+        client = _HttpxClient(_StreamedResponse(payload))
+        with (
+            patch("handler.filesystem.resources_handler.ctx_httpx_client") as ctx,
+            patch.object(
+                handler, "_discard_if_chroma_key", AsyncMock(return_value=False)
+            ),
+        ):
+            ctx.get.return_value = client
+            await handler.store_media_file(
+                "http://example.com/logo.png", self.REL, expected_md5=expected_md5
+            )
+        return client
+
+    async def test_existing_file_is_replaced_when_the_hash_differs(
+        self, handler, tmp_path
+    ):
+        _write(tmp_path / self.REL, b"old artwork")
+        new_payload = b"new artwork"
+        new_md5 = hashlib.md5(new_payload, usedforsecurity=False).hexdigest()
+
+        client = await self._store(handler, new_payload, new_md5)
+
+        assert client.calls == 1
+        assert (tmp_path / self.REL).read_bytes() == new_payload
+
+    async def test_existing_file_is_kept_when_the_hash_matches(self, handler, tmp_path):
+        digest = _write(tmp_path / self.REL, b"current artwork")
+
+        client = await self._store(handler, b"never used", digest)
+
+        assert client.calls == 0
+        assert (tmp_path / self.REL).read_bytes() == b"current artwork"
+
+    async def test_existing_file_is_kept_without_an_expected_hash(
+        self, handler, tmp_path
+    ):
+        """Providers that publish no hash keep the pre-#4002 behaviour."""
+        _write(tmp_path / self.REL, b"current artwork")
+
+        client = await self._store(handler, b"never used", None)
+
+        assert client.calls == 0
+        assert (tmp_path / self.REL).read_bytes() == b"current artwork"
+
+    async def test_missing_file_is_downloaded(self, handler, tmp_path):
+        payload = b"fresh artwork"
+        digest = hashlib.md5(payload, usedforsecurity=False).hexdigest()
+
+        client = await self._store(handler, payload, digest)
+
+        assert client.calls == 1
+        assert (tmp_path / self.REL).read_bytes() == payload

--- a/backend/tests/handler/metadata/test_ss_media_freshness.py
+++ b/backend/tests/handler/metadata/test_ss_media_freshness.py
@@ -1,0 +1,364 @@
+"""Tests for ScreenScraper media freshness (issue #4002).
+
+ScreenScraper publishes a `crc`/`md5`/`sha1` alongside every media entry in
+`jeuInfos` so a client can tell whether the online file differs from its local
+copy before downloading it. These tests cover extracting that hash and using it
+to decide whether a stored resource is stale.
+"""
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from adapters.services.screenscraper_types import SSGame
+from config.config_manager import Config, MetadataMediaType
+from handler.metadata.ss_handler import (
+    SS_MEDIA_KEYS,
+    extract_media_from_ss_game,
+    ss_media_is_stale,
+    ss_resource_needs_refresh,
+)
+
+
+def _make_config(scan_media: list[str] | None = None) -> Config:
+    return Config(
+        SCAN_REGION_MODE="prefer_rom_tags",
+        EXCLUDED_PLATFORMS=[],
+        EXCLUDED_SINGLE_EXT=[],
+        EXCLUDED_SINGLE_FILES=[],
+        EXCLUDED_MULTI_FILES=[],
+        EXCLUDED_MULTI_PARTS_EXT=[],
+        EXCLUDED_MULTI_PARTS_FILES=[],
+        PLATFORMS_BINDING={},
+        PLATFORMS_VERSIONS={},
+        ROMS_FOLDER_NAME="roms",
+        FIRMWARE_FOLDER_NAME="bios",
+        SCAN_REGION_PRIORITY=[],
+        SCAN_LANGUAGE_PRIORITY=["en"],
+        SCAN_MEDIA=(
+            scan_media if scan_media is not None else ["box2d", "logo", "screenshot"]
+        ),
+        GAMELIST_MEDIA_THUMBNAIL=MetadataMediaType.BOX2D,
+        GAMELIST_MEDIA_IMAGE=MetadataMediaType.SCREENSHOT,
+    )
+
+
+def _make_rom() -> MagicMock:
+    rom = MagicMock()
+    rom.platform_id = 1
+    rom.id = 100
+    rom.regions = None
+    return rom
+
+
+def _media(
+    media_type: str, url: str, md5: str | None = "aabbcc", region: str = "us"
+) -> dict:
+    entry = {
+        "type": media_type,
+        "parent": "jeu",
+        "region": region,
+        "url": url,
+        "crc": "11223344",
+        "sha1": "cafebabe",
+        "size": "12345",
+        "format": "png",
+    }
+    if md5 is not None:
+        entry["md5"] = md5
+    return entry
+
+
+def _extract(game: SSGame, scan_media: list[str] | None = None):
+    with (
+        patch(
+            "handler.metadata.ss_handler.cm.get_config",
+            return_value=_make_config(scan_media),
+        ),
+        patch(
+            "handler.metadata.ss_handler.fs_resource_handler.get_media_resources_path",
+            side_effect=lambda pid, rid, mt: f"roms/{pid}/{rid}/{mt.value}",
+        ),
+    ):
+        return extract_media_from_ss_game(_make_rom(), game)
+
+
+class TestExtractMediaMd5:
+    """`extract_media_from_ss_game` must carry each media entry's md5 through."""
+
+    def test_md5_recorded_next_to_its_url(self):
+        game = cast(
+            SSGame,
+            {
+                "medias": [
+                    _media("box-2D", "https://ss.example/box-2D", md5="COVERMD5"),
+                    _media("wheel", "https://ss.example/wheel", md5="LOGOMD5"),
+                ]
+            },
+        )
+
+        result = _extract(game)
+
+        assert result["box2d_url"] == "https://ss.example/box-2D"
+        assert result["box2d_md5"] == "covermd5"
+        assert result["logo_url"] == "https://ss.example/wheel"
+        assert result["logo_md5"] == "logomd5"
+
+    def test_md5_matches_the_selected_region(self):
+        """The hash must belong to the media entry that actually won."""
+        game = cast(
+            SSGame,
+            {
+                "medias": [
+                    _media(
+                        "box-2D",
+                        "https://ss.example/box-2D(cus)",
+                        md5="cusmd5",
+                        region="cus",
+                    ),
+                    _media(
+                        "box-2D",
+                        "https://ss.example/box-2D(us)",
+                        md5="usmd5",
+                        region="us",
+                    ),
+                ]
+            },
+        )
+
+        result = _extract(game)
+
+        assert result["box2d_url"] == "https://ss.example/box-2D(us)"
+        assert result["box2d_md5"] == "usmd5"
+
+    def test_md5_recorded_for_urls_with_credentials_stripped(self):
+        """URLs are stored stripped of credentials; the md5 must still line up."""
+        game = cast(
+            SSGame,
+            {
+                "medias": [
+                    _media(
+                        "box-2D",
+                        "https://screenscraper.fr/api2/mediaJeu.php?ssid=u&sspassword=p&media=box-2D",
+                        md5="strippedmd5",
+                    )
+                ]
+            },
+        )
+
+        result = _extract(game)
+
+        assert result["box2d_url"] is not None
+        assert "sspassword" not in result["box2d_url"]
+        assert result["box2d_md5"] == "strippedmd5"
+
+    def test_missing_md5_is_none(self):
+        game = cast(
+            SSGame,
+            {"medias": [_media("box-2D", "https://ss.example/box-2D", md5=None)]},
+        )
+
+        result = _extract(game)
+
+        assert result["box2d_url"] == "https://ss.example/box-2D"
+        assert result["box2d_md5"] is None
+
+    def test_every_media_key_has_an_md5_slot(self):
+        """Absent media leave their md5 slot present but empty."""
+        result = _extract(cast(SSGame, {"medias": []}))
+
+        for key in SS_MEDIA_KEYS:
+            assert f"{key}_md5" in result, f"{key}_md5 missing from extracted media"
+            assert result[f"{key}_md5"] is None  # type: ignore[literal-required]
+
+    def test_size_recorded_next_to_its_url(self):
+        game = cast(
+            SSGame,
+            {"medias": [_media("box-2D", "https://ss.example/box-2D", md5="covermd5")]},
+        )
+
+        result = _extract(game)
+
+        assert result["box2d_size"] == 12345
+
+    def test_size_matches_the_selected_region(self):
+        """ScreenScraper lists one entry per region; only the winner's size counts."""
+        game = cast(
+            SSGame,
+            {
+                "medias": [
+                    {
+                        **_media("box-2D", "https://ss.example/(cus)", region="cus"),
+                        "size": "111",
+                    },
+                    {
+                        **_media("box-2D", "https://ss.example/(us)", region="us"),
+                        "size": "222",
+                    },
+                ]
+            },
+        )
+
+        result = _extract(game)
+
+        assert result["box2d_url"] == "https://ss.example/(us)"
+        assert result["box2d_size"] == 222
+
+    @pytest.mark.parametrize("bad", ["", "not-a-number", None])
+    def test_unusable_size_is_none(self, bad):
+        entry = _media("box-2D", "https://ss.example/box-2D")
+        if bad is None:
+            entry.pop("size")
+        else:
+            entry["size"] = bad
+
+        result = _extract(cast(SSGame, {"medias": [entry]}))
+
+        assert result["box2d_size"] is None
+        assert result["box2d_md5"] == "aabbcc"
+
+
+class TestSSMediaIsStale:
+    """The staleness rule that decides whether a stored resource is refetched."""
+
+    @pytest.fixture(autouse=True)
+    def _no_disk(self):
+        """Default: nothing on disk matches, so only the recorded hash can decide."""
+        with patch(
+            "handler.metadata.ss_handler.fs_resource_handler.file_matches_md5",
+            AsyncMock(return_value=False),
+        ) as mock:
+            yield mock
+
+    async def test_no_fresh_hash_is_never_stale(self):
+        """Without a hash from ScreenScraper there is nothing to compare."""
+        assert not await ss_media_is_stale("roms/1/1/logo/logo.png", "abc", None)
+
+    async def test_unchanged_recorded_hash_is_not_stale(self, _no_disk):
+        assert not await ss_media_is_stale("roms/1/1/logo/logo.png", "abc", "abc")
+        _no_disk.assert_not_awaited()
+
+    async def test_recorded_hash_comparison_is_case_insensitive(self):
+        assert not await ss_media_is_stale("roms/1/1/logo/logo.png", "ABC", "abc")
+
+    async def test_changed_recorded_hash_is_stale(self):
+        assert await ss_media_is_stale("roms/1/1/logo/logo.png", "abc", "def")
+
+    async def test_missing_recorded_hash_falls_back_to_the_file_on_disk(self, _no_disk):
+        """Libraries scanned before hashes existed must not redownload for nothing."""
+        _no_disk.return_value = True
+
+        assert not await ss_media_is_stale("roms/1/1/logo/logo.png", None, "abc")
+        _no_disk.assert_awaited_once_with("roms/1/1/logo/logo.png", "abc")
+
+    async def test_missing_recorded_hash_with_differing_file_is_stale(self):
+        assert await ss_media_is_stale("roms/1/1/logo/logo.png", None, "abc")
+
+    async def test_stale_recorded_hash_is_rescued_by_a_matching_file(self, _no_disk):
+        """A recorded hash that disagrees with a matching file is not a redownload."""
+        _no_disk.return_value = True
+
+        assert not await ss_media_is_stale("roms/1/1/logo/logo.png", "old", "abc")
+
+    async def test_no_stored_path_is_stale(self, _no_disk):
+        """Nothing on disk to compare against, so the media has to be fetched."""
+        assert await ss_media_is_stale(None, None, "abc")
+        _no_disk.assert_not_awaited()
+
+
+class TestSSMediaSizeCheck:
+    """A partial download is caught by size before the recorded hash is trusted.
+
+    The hash is recorded when the ROM row is written, which happens before the
+    download runs, so a scan killed mid-stream leaves a short file that the
+    recorded hash still claims is current.
+    """
+
+    PATH = "roms/1/1/cover/big.png"
+
+    @pytest.fixture
+    def disk(self):
+        with (
+            patch(
+                "handler.metadata.ss_handler.fs_resource_handler.file_has_size",
+                AsyncMock(return_value=True),
+            ) as size_mock,
+            patch(
+                "handler.metadata.ss_handler.fs_resource_handler.file_matches_md5",
+                AsyncMock(return_value=False),
+            ) as md5_mock,
+        ):
+            yield size_mock, md5_mock
+
+    async def test_short_file_is_stale_despite_a_matching_hash(self, disk):
+        size_mock, md5_mock = disk
+        size_mock.return_value = False
+
+        assert await ss_media_is_stale(self.PATH, "abc", "abc", 1234)
+        size_mock.assert_awaited_once_with(self.PATH, 1234)
+        md5_mock.assert_not_awaited()
+
+    async def test_correct_size_keeps_the_cheap_hash_shortcut(self, disk):
+        size_mock, md5_mock = disk
+
+        assert not await ss_media_is_stale(self.PATH, "abc", "abc", 1234)
+        md5_mock.assert_not_awaited()
+
+    async def test_no_reported_size_skips_the_check(self, disk):
+        size_mock, _ = disk
+
+        assert not await ss_media_is_stale(self.PATH, "abc", "abc", None)
+        size_mock.assert_not_awaited()
+
+    async def test_no_stored_path_skips_the_check(self, disk):
+        """With no file to stat, the recorded hash decides as it did before."""
+        size_mock, _ = disk
+
+        assert not await ss_media_is_stale(None, "abc", "abc", 1234)
+        size_mock.assert_not_awaited()
+
+
+class TestSSResourceNeedsRefresh:
+    """Cover/screenshot refresh, which only applies when SS is the source."""
+
+    def _refresh(self, **overrides: Any):
+        kwargs: dict[str, Any] = {
+            "previous_metadata": {"box2d_md5": "old"},
+            "fresh_metadata": {
+                "box2d_url": "https://ss.example/box-2D",
+                "box2d_md5": "new",
+            },
+            "media_key": "box2d",
+            "resolved_url": "https://ss.example/box-2D",
+            "stored_path": "roms/1/1/cover/big.png",
+        }
+        kwargs.update(overrides)
+        return ss_resource_needs_refresh(**kwargs)
+
+    @pytest.fixture(autouse=True)
+    def _no_disk(self):
+        with patch(
+            "handler.metadata.ss_handler.fs_resource_handler.file_matches_md5",
+            AsyncMock(return_value=False),
+        ) as mock:
+            yield mock
+
+    async def test_changed_hash_triggers_a_refresh(self):
+        assert await self._refresh()
+
+    async def test_unchanged_hash_does_not(self):
+        assert not await self._refresh(previous_metadata={"box2d_md5": "new"})
+
+    async def test_another_provider_won_the_field(self):
+        """SS's hash says nothing about a cover IGDB supplied."""
+        assert not await self._refresh(resolved_url="https://igdb.example/cover.jpg")
+
+    async def test_no_ss_media_for_that_key(self):
+        assert not await self._refresh(fresh_metadata={})
+
+    async def test_no_stored_metadata_at_all(self):
+        assert not await self._refresh(fresh_metadata=None)
+
+    async def test_missing_resolved_url(self):
+        assert not await self._refresh(resolved_url=None)


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

Part of #4002.

Rescoped at review request: this now carries only the ScreenScraper media hash
comparison. The `user_edited_fields` tracking is gone, along with its column and
migration, and will be superseded by explicit metadata field locking.

ScreenScraper serves every media from a fixed endpoint, so its URLs stay
byte-identical when the artwork behind them is replaced. The cover and screenshot
downloads are gated on a URL diff, which for ScreenScraper can therefore never
fire, and the extra media step exits early whenever a file is already on disk. So
an update scan never refreshes ScreenScraper artwork, no matter how stale it is.

`jeuInfos` returns a `crc`/`md5`/`sha1` alongside every media entry precisely so a
client can tell whether the online file still matches its local copy. Those hashes
are now recorded in `ss_metadata`, and a resource is refetched when the reported
hash differs from the one the previous scan recorded, falling back to hashing the
file on disk so libraries scanned before hashes were recorded don't redownload
what is already current. The cover is hashed at `cover/big.png`, the copy that
still holds the bytes as downloaded once WebP conversion has run.

ScreenScraper also reports a byte size per media entry. That is checked first,
because the recorded hash is written to the database before the download runs, so
a scan killed mid-stream leaves a short file described by a hash that still
matches. A `stat()` catches that without reading the file.

Re-matching a ROM to the same ScreenScraper game now also fills in media that
never made it to disk, rather than only running when `ss_id` changes.

**What this does not do**

- `name` and `summary` are still pinned to their stored values on an update scan.
  Reversing that needs a way to tell a provider-written value from a hand-edited
  one, which is what field locking will provide. #4002 stays open for it.
- Manuals are deliberately left out of the hash check. `POST /roms/{id}/manuals`
  writes `path_manual` but leaves any scraped `url_manual` in place, and both
  uploaded and downloaded manuals land at the same path, so nothing distinguishes
  them. On master that is harmless, since the URL-diff gate never fires for
  ScreenScraper. A hash check would make it live and overwrite an uploaded manual
  with the provider's copy. That ambiguity is a pre-existing gap and gets its own
  PR; manuals pick up the hash check once a scan can tell the two apart.
- `manual_md5` and `manual_size` are still recorded in `ss_metadata` alongside the
  other media, and are simply unread until that follow-up lands.

**Files modified**

| File | Change |
| --- | --- |
| `backend/handler/metadata/ss_handler.py` | Carries an `*_md5` and `*_size` through for each of the 18 media slots, keyed on the same stripped URL that lands in `*_url`. Adds `ss_media_is_stale()` and `ss_resource_needs_refresh()`. |
| `backend/handler/filesystem/resources_handler.py` | `file_md5()`, `file_matches_md5()` and `file_has_size()` (all path-validated), `get_downloaded_cover_path()`, and an `expected_md5` argument on `store_media_file()`. |
| `backend/endpoints/sockets/scan.py` | The cover and screenshot overwrite gates now also consult the ScreenScraper hash; extra media downloads carry their expected md5. |
| `backend/endpoints/roms/__init__.py` | The ScreenScraper media block also runs on a re-match to the same game, to fill in media that never made it to disk. |
| `backend/tests/**` | New coverage for md5 and size extraction, the staleness rule, the `store_media_file` gate, and the scan wiring. |

No schema change, no migration, and no response schema touched, so no OpenAPI
regeneration.

**Testing notes**

- `uv run pytest` — 2696 passed, 2 skipped.
- `trunk check` clean on every changed file.

Three update scans against a live ScreenScraper account, on a 16 ROM library
across 8 platforms whose resources had been scanned by master's code, so no
hashes were recorded to begin with.

1. **Upgrade path.** 16 `jeuInfos` calls, zero media requests, zero bytes
   downloaded. 76 extra media were confirmed current by comparing ScreenScraper's
   md5 against the bytes on disk, and the hashes were recorded for next time.
   Nothing redownloaded, which is the thing to check when a hash column arrives
   empty on an existing library.
2. **Steady state.** Identical counts, and the 1517 file resource tree came out
   byte-identical.
3. **Forced staleness.** Truncated a cover to 5000 bytes (from 431121) and an
   extra media file to 5000 bytes (from 936485), leaving both recorded hashes
   correct. The scan refetched exactly those two and restored both byte for byte,
   with the other 1515 files untouched. The truncated cover is detectable only by
   size, since its recorded md5 still matches what ScreenScraper reports, so this
   also exercises the partial-download check.

That first scan doubles as a check on ScreenScraper's own data: the reported size
matched the stored bytes for all 16 covers and the reported md5 matched for all 76
extra media, since any mismatch would have forced a redownload.

**Things to look at**

- In the scan path, `store_media_file` hashes the file on disk rather than first
  comparing the freshly reported hash against the one the previous scan recorded,
  the way the cover check does. Correct, but it means a scan reads every extra
  ScreenScraper media file in full.
- The first update scan after upgrading re-hashes covers from disk, since no
  recorded md5 exists yet. One-time cost per library.
- A refreshed cover costs two requests, not one, because `get_cover` calls
  `_store_cover` once per size and each fetches the URL. That is existing
  behaviour on any `overwrite=True`, unchanged here, but the hash check gives it a
  new way to trigger. Worth folding into whichever PR takes on the atomic-write
  change, since both live in the same download path.
- Screenshot reordering still goes undetected, because `pydash.xor` compares URL
  sets while files are named by index. That is unchanged from master and this
  branch leaves it no worse; flagged in review and worth its own issue.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**AI assistance**

This PR was written primarily by Claude Code (Opus 5), including the code, tests
and this description. I reviewed and tested the result locally, and verified the
ScreenScraper media-hash behaviour against a live account.
