### PR TITLE
fix(roms): search the gallery by CRC32, MD5, SHA-1 and RA hash

### DIFF
--- a/backend/alembic/versions/0106_hash_search_indexes.py
+++ b/backend/alembic/versions/0106_hash_search_indexes.py
@@ -1,0 +1,43 @@
+"""Index the hash columns searched by the gallery search box
+
+Searching by a CRC32/MD5/SHA-1/RA digest now matches the hash columns on
+``roms`` and ``rom_files``. Neither table had an index on any of them, so every
+such search scanned both tables in full.
+
+Revision ID: 0106_hash_search_indexes
+Revises: 0105_fix_gamelist_epoch_ms
+Create Date: 2026-07-31 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0106_hash_search_indexes"
+down_revision = "0105_fix_gamelist_epoch_ms"
+branch_labels = None
+depends_on = None
+
+HASH_INDEXES: dict[str, tuple[str, ...]] = {
+    "roms": ("crc_hash", "md5_hash", "sha1_hash", "ra_hash"),
+    "rom_files": ("crc_hash", "md5_hash", "sha1_hash", "ra_hash", "chd_sha1_hash"),
+}
+
+
+def upgrade() -> None:
+    for table, columns in HASH_INDEXES.items():
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            for column in columns:
+                batch_op.create_index(
+                    f"idx_{table}_{column}",
+                    [column],
+                    unique=False,
+                    if_not_exists=True,
+                )
+
+
+def downgrade() -> None:
+    for table, columns in HASH_INDEXES.items():
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            for column in columns:
+                batch_op.drop_index(f"idx_{table}_{column}", if_exists=True)

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -25,6 +25,7 @@ from sqlalchemy import (
     select,
     text,
     true,
+    union,
     update,
 )
 from sqlalchemy.orm import (
@@ -131,6 +132,27 @@ FULLTEXT_BOOLEAN_OPERATORS_REGEX = re.compile(r'[+\-~<>()"@*]')
 
 # 3 is the default minimum size in InnoDB
 FULLTEXT_MIN_TOKEN_SIZE = 3
+
+# A term reaches the hash columns only when it is hex of exactly a digest
+# length, so an ordinary name search builds no hash SQL at all. Hashes are
+# stored lowercase, which keeps the lookup an indexed equality.
+HEX_DIGEST_REGEX = re.compile(r"[0-9a-fA-F]+")
+
+# CRC32 (8), MD5 and RetroAchievements (32), SHA-1 (40).
+ROM_HASH_COLUMNS_BY_DIGEST_LENGTH: dict[int, tuple[QueryableAttribute, ...]] = {
+    8: (Rom.crc_hash,),
+    32: (Rom.md5_hash, Rom.ra_hash),
+    40: (Rom.sha1_hash,),
+}
+
+# Multi-file games (multi-disc, multi-track) keep their hashes per file, which
+# is the hash a user has in hand. `chd_sha1_hash` is the uncompressed disc's
+# digest, the one datfiles publish for a CHD.
+ROM_FILE_HASH_COLUMNS_BY_DIGEST_LENGTH: dict[int, tuple[QueryableAttribute, ...]] = {
+    8: (RomFile.crc_hash,),
+    32: (RomFile.md5_hash, RomFile.ra_hash),
+    40: (RomFile.sha1_hash, RomFile.chd_sha1_hash),
+}
 
 # Filter dropdowns read the narrow `roms_facets` mirror instead of `roms`,
 # whose rows carry the raw metadata blobs. Column order matches the unpacking
@@ -583,12 +605,8 @@ class DBRomsHandler(DBBaseHandler):
                 parts.append('"' + " ".join(words) + '"')
         return " ".join(parts) if parts else None
 
-    def _filter_by_search_term(self, query: Query, search_term: str):
-        terms = [term.strip() for term in search_term.split("|")]
-        terms = [term for term in terms if term]
-        if not terms:
-            return query
-
+    def _build_name_conditions(self, terms: Sequence[str]) -> list[Any]:
+        """Match the term against the ROM's name and filename."""
         if ROMM_DB_DRIVER in ("mariadb", "mysql"):
             match_clauses: list[Any] = []
             for idx, term in enumerate(terms):
@@ -604,7 +622,7 @@ class DBRomsHandler(DBBaseHandler):
                     ).bindparams(**{param: boolean_query})
                 )
             if match_clauses:
-                return query.filter(or_(*match_clauses))
+                return match_clauses
 
         # psql and full-text fallback
         term_conditions = []
@@ -615,7 +633,56 @@ class DBRomsHandler(DBBaseHandler):
             ]
             if word_conditions:
                 term_conditions.append(and_(*word_conditions))
-        return query.filter(or_(*term_conditions))
+        return term_conditions
+
+    def _build_hash_selects(self, terms: Iterable[str]) -> list[Select]:
+        """Id-yielding selects for terms shaped like a hash digest.
+
+        A ROM's own hashes and its files' are queried separately so each side
+        keeps its own index. Returns nothing when no term looks like a digest,
+        which is the case for every ordinary name search.
+        """
+        rom_predicates: list[ColumnElement[bool]] = []
+        file_predicates: list[ColumnElement[bool]] = []
+
+        for term in terms:
+            rom_columns = ROM_HASH_COLUMNS_BY_DIGEST_LENGTH.get(len(term))
+            if rom_columns is None or not HEX_DIGEST_REGEX.fullmatch(term):
+                continue
+            digest = term.lower()
+            rom_predicates.extend(column == digest for column in rom_columns)
+            file_predicates.extend(
+                column == digest
+                for column in ROM_FILE_HASH_COLUMNS_BY_DIGEST_LENGTH[len(term)]
+            )
+
+        if not rom_predicates:
+            return []
+
+        return [
+            select(Rom.id).where(or_(*rom_predicates)),
+            select(RomFile.rom_id.label("id")).where(or_(*file_predicates)),
+        ]
+
+    def _filter_by_search_term(self, query: Query, search_term: str):
+        terms = [term.strip() for term in search_term.split("|")]
+        terms = [term for term in terms if term]
+        if not terms:
+            return query
+
+        name_conditions = self._build_name_conditions(terms)
+        hash_selects = self._build_hash_selects(terms)
+        if not hash_selects:
+            return query.filter(or_(*name_conditions))
+
+        # OR-ing the hash columns onto the name conditions would cost the
+        # full-text index its only chance to drive the query, scanning `roms`
+        # end to end. Resolving each side through its own index and unioning
+        # the ids searches both without giving up either index.
+        matches = union(
+            select(Rom.id).where(or_(*name_conditions)), *hash_selects
+        ).subquery()
+        return query.filter(Rom.id.in_(select(matches.c.id)))
 
     def _filter_by_matched(self, query: Query, value: bool) -> Query:
         """Filter based on whether the rom is matched to a metadata provider.

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -106,7 +106,15 @@ class RomArchiveMember(TypedDict):
 class RomFile(BaseModel):
     __tablename__ = "rom_files"
 
-    __table_args__ = (Index("idx_rom_files_rom_id", "rom_id"),)
+    __table_args__ = (
+        Index("idx_rom_files_rom_id", "rom_id"),
+        # Searching the gallery by a hash digest
+        Index("idx_rom_files_crc_hash", "crc_hash"),
+        Index("idx_rom_files_md5_hash", "md5_hash"),
+        Index("idx_rom_files_sha1_hash", "sha1_hash"),
+        Index("idx_rom_files_ra_hash", "ra_hash"),
+        Index("idx_rom_files_chd_sha1_hash", "chd_sha1_hash"),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     rom_id: Mapped[int] = mapped_column(ForeignKey("roms.id", ondelete="CASCADE"))
@@ -336,6 +344,11 @@ class Rom(BaseModel):
         Index("idx_roms_hltb_id", "hltb_id"),
         Index("idx_roms_gamelist_id", "gamelist_id"),
         Index("idx_roms_libretro_id", "libretro_id"),
+        # Searching the gallery by a hash digest
+        Index("idx_roms_crc_hash", "crc_hash"),
+        Index("idx_roms_md5_hash", "md5_hash"),
+        Index("idx_roms_sha1_hash", "sha1_hash"),
+        Index("idx_roms_ra_hash", "ra_hash"),
     )
 
     fs_name: Mapped[str] = mapped_column(String(length=FILE_NAME_MAX_LENGTH))

--- a/backend/tests/handler/database/test_roms_hash_search.py
+++ b/backend/tests/handler/database/test_roms_hash_search.py
@@ -1,0 +1,245 @@
+"""Searching the gallery by a hash digest.
+
+The search box offers "name, filename, hash", but the term only ever reached
+`roms.name` / `roms.fs_name`. A term shaped like a CRC32, MD5/RA or SHA-1
+digest now also matches the hash columns on `roms` and `rom_files`, without
+taking anything away from the name search.
+"""
+
+import pytest
+from sqlalchemy.orm import Query
+
+from handler.database import db_collection_handler, db_rom_handler
+from models.collection import SmartCollection
+from models.platform import Platform
+from models.rom import Rom, RomFile
+from models.user import User
+
+AERO_CRC = "95b07885"
+AERO_MD5 = "c5347ceb9cfdabb188d3a1bf5f3a7f94"
+AERO_SHA1 = "ddacbb35c87232d701240717aa1ed43ab7f4c253"
+AERO_RA = "1f0b3d7a4c9e2b8d6a5f0c3e7b1d9a4c"
+
+DISC_ONE_MD5 = "0bd9d1d0a2f6e4c8b7a5931e0f2c4d68"
+DISC_TWO_CRC = "1a2b3c4d"
+DISC_CHD_SHA1 = "aaaaaaaabbbbbbbbccccccccddddddddeeeeeeee"
+SHARED_TRACK_CRC = "beefcafe"
+
+
+def _add_rom(platform: Platform, name: str, **hashes: str) -> Rom:
+    fs_name = f"{name.replace(' ', '_')}.zip"
+    return db_rom_handler.add_rom(
+        Rom(
+            platform_id=platform.id,
+            name=name,
+            slug=name.lower().replace(" ", "-"),
+            fs_name=fs_name,
+            fs_name_no_tags=fs_name.removesuffix(".zip"),
+            fs_name_no_ext=fs_name.removesuffix(".zip"),
+            fs_extension="zip",
+            fs_path=f"{platform.slug}/roms",
+            **hashes,
+        )
+    )
+
+
+def _add_files(rom: Rom, files: list[RomFile]) -> None:
+    db_rom_handler.sync_rom_files(rom.id, files)
+
+
+def _file(rom: Rom, file_name: str, **hashes: str) -> RomFile:
+    return RomFile(
+        rom_id=rom.id,
+        file_name=file_name,
+        file_path=rom.fs_path,
+        file_size_bytes=100,
+        **hashes,
+    )
+
+
+def _search_ids(term: str) -> list[int]:
+    return [r.id for r in db_rom_handler.get_roms_scalar(search_term=term)]
+
+
+def _search_sql(term: str) -> str:
+    query = db_rom_handler._filter_by_search_term(Query(Rom.id), term)
+    return str(query.statement.compile(compile_kwargs={"literal_binds": True}))
+
+
+@pytest.fixture
+def aero(platform: Platform) -> Rom:
+    """A single-file ROM carrying every hash on the `roms` row itself."""
+    return _add_rom(
+        platform,
+        "Aero Fighters",
+        crc_hash=AERO_CRC,
+        md5_hash=AERO_MD5,
+        sha1_hash=AERO_SHA1,
+        ra_hash=AERO_RA,
+    )
+
+
+@pytest.fixture
+def multi_disc(platform: Platform) -> Rom:
+    """A multi-disc ROM whose hashes live on its files, not on the ROM."""
+    rom = _add_rom(platform, "Chrono Cross")
+    _add_files(
+        rom,
+        [
+            _file(rom, "disc1.chd", md5_hash=DISC_ONE_MD5, chd_sha1_hash=DISC_CHD_SHA1),
+            _file(rom, "disc2.chd", crc_hash=DISC_TWO_CRC),
+        ],
+    )
+    return rom
+
+
+class TestRomHashSearch:
+    @pytest.mark.parametrize(
+        "term",
+        [AERO_CRC, AERO_MD5, AERO_SHA1, AERO_RA],
+        ids=["crc", "md5", "sha1", "ra"],
+    )
+    def test_each_rom_hash_finds_the_rom(self, aero: Rom, term: str):
+        assert _search_ids(term) == [aero.id]
+
+    def test_hash_search_is_case_insensitive(self, aero: Rom):
+        assert _search_ids(AERO_MD5.upper()) == [aero.id]
+
+    def test_hash_of_another_rom_is_not_matched(self, aero: Rom, platform: Platform):
+        other = _add_rom(platform, "Gunstar Heroes", md5_hash=DISC_ONE_MD5)
+
+        assert _search_ids(AERO_MD5) == [aero.id]
+        assert _search_ids(DISC_ONE_MD5) == [other.id]
+
+    def test_partial_hash_prefix_finds_nothing(self, aero: Rom):
+        assert _search_ids(AERO_MD5[:16]) == []
+        assert _search_ids(AERO_CRC[:7]) == []
+
+
+class TestRomFileHashSearch:
+    """For multi-file games the hash a user has in hand is a file's, not the
+    game's, so the file rows have to be searched too."""
+
+    def test_file_md5_returns_the_owning_rom(self, multi_disc: Rom):
+        assert _search_ids(DISC_ONE_MD5) == [multi_disc.id]
+
+    def test_file_crc_returns_the_owning_rom(self, multi_disc: Rom):
+        assert _search_ids(DISC_TWO_CRC) == [multi_disc.id]
+
+    def test_chd_data_sha1_returns_the_owning_rom(self, multi_disc: Rom):
+        assert _search_ids(DISC_CHD_SHA1) == [multi_disc.id]
+
+    def test_rom_matching_on_several_files_is_returned_once(self, platform: Platform):
+        """Identical tracks share a hash; the ROM must not come back twice."""
+        rom = _add_rom(platform, "Policenauts")
+        _add_files(
+            rom,
+            [
+                _file(rom, "track02.bin", crc_hash=SHARED_TRACK_CRC),
+                _file(rom, "track03.bin", crc_hash=SHARED_TRACK_CRC),
+            ],
+        )
+
+        assert _search_ids(SHARED_TRACK_CRC) == [rom.id]
+
+    def test_rom_and_file_hash_match_returns_it_once(self, platform: Platform):
+        rom = _add_rom(platform, "Einhander", md5_hash=DISC_ONE_MD5)
+        _add_files(rom, [_file(rom, "einhander.bin", md5_hash=DISC_ONE_MD5)])
+
+        assert _search_ids(DISC_ONE_MD5) == [rom.id]
+
+
+class TestNameSearchIsNotDegraded:
+    """Hash conditions are added to the name conditions, never swapped in for
+    them, so a term that happens to look like a digest still searches names."""
+
+    def test_hash_shaped_term_still_matches_names(self, platform: Platform):
+        named = _add_rom(platform, "deadbeef")
+        hashed = _add_rom(platform, "Some Other Game", crc_hash="deadbeef")
+
+        assert set(_search_ids("deadbeef")) == {named.id, hashed.id}
+
+    def test_plain_name_search_is_unchanged(self, aero: Rom, platform: Platform):
+        _add_rom(platform, "Super Mario World")
+
+        assert _search_ids("Aero Fighters") == [aero.id]
+        assert _search_ids("aerofgt") == []
+
+    def test_filename_search_is_unchanged(self, aero: Rom):
+        assert _search_ids("Aero_Fighters.zip") == [aero.id]
+
+    def test_hash_term_combines_with_name_terms(self, aero: Rom, platform: Platform):
+        mario = _add_rom(platform, "Super Mario World")
+
+        assert set(_search_ids(f"Super Mario|{AERO_MD5}")) == {mario.id, aero.id}
+
+    def test_non_digest_length_hex_term_is_a_name_search_only(self, platform: Platform):
+        """16 hex chars is not a digest length, so it must not reach the hash
+        columns, and a name containing it still matches."""
+        named = _add_rom(platform, "abcdef0123456789 Edition")
+        _add_rom(platform, "Unrelated", md5_hash=AERO_MD5)
+
+        assert _search_ids("abcdef0123456789") == [named.id]
+
+
+class TestSmartCollectionSearchTerm:
+    """A smart collection's "search term" criterion runs through the same
+    filter, so one built on a hash used to always be empty."""
+
+    def _smart_collection(self, user: User, term: str) -> SmartCollection:
+        return db_collection_handler.add_smart_collection(
+            SmartCollection(
+                name=f"Hash {term}",
+                description="",
+                user_id=user.id,
+                filter_criteria={"search_term": term},
+            )
+        )
+
+    def test_hash_criterion_resolves_members(self, aero: Rom, admin_user: User):
+        collection = self._smart_collection(admin_user, AERO_MD5)
+
+        roms = db_collection_handler.get_smart_collection_roms(
+            collection, user_id=admin_user.id
+        )
+
+        assert [rom.id for rom in roms] == [aero.id]
+
+    def test_file_hash_criterion_resolves_members(
+        self, multi_disc: Rom, admin_user: User
+    ):
+        collection = self._smart_collection(admin_user, DISC_ONE_MD5)
+
+        roms = db_collection_handler.get_smart_collection_roms(
+            collection, user_id=admin_user.id
+        )
+
+        assert [rom.id for rom in roms] == [multi_disc.id]
+
+
+class TestSearchQueryShape:
+    """The two sides are unioned rather than OR'd. OR-ing them costs the
+    name side its index (no engine merges a full-text index with a B-tree
+    one), turning every hash search into a full scan of `roms`."""
+
+    def test_name_search_builds_no_hash_sql(self):
+        sql = _search_sql("Aero Fighters")
+
+        assert "hash" not in sql
+        assert "UNION" not in sql.upper()
+
+    def test_hash_search_unions_the_two_sides(self):
+        sql = _search_sql(AERO_MD5)
+
+        assert "UNION" in sql.upper()
+        assert "roms.md5_hash" in sql
+        assert "rom_files.md5_hash" in sql
+        # The name side must reach the union on its own, never OR'd onto a hash.
+        assert "MATCH" not in sql.split("UNION")[1].upper()
+
+    def test_hash_search_queries_only_the_matching_digest_length(self):
+        sql = _search_sql(AERO_CRC)
+
+        assert "crc_hash" in sql
+        assert "md5_hash" not in sql
+        assert "sha1_hash" not in sql


### PR DESCRIPTION
**Description**

Fixes #4008.

The search box promises "Search by name, filename, hash…", but `_filter_by_search_term`
only ever queried `roms.name` and `roms.fs_name`, so pasting a hash always returned
nothing. This extends that filter to the hash columns.

When a term is hex of exactly a digest length (8 for CRC32, 32 for MD5 and RA, 40 for
SHA-1) it is also matched, lowercased, against the hash columns on `roms` **and**
`rom_files`. Matching `rom_files` is what makes multi-disc and multi-track games work,
since the hash a user has in hand is usually a file's rather than the game's.

Two things shaped the implementation:

**1. Name search must not get worse.** A term only reaches the hash columns if it is hex
of exactly a digest length, so an ordinary name search compiles to byte-identical SQL to
before. When a hash-shaped term *is* present, both sides still run: a game named
`deadbeef` and a different game whose CRC is `deadbeef` both come back. Detecting a hash
never costs you the name match.

**2. The two sides are unioned, not OR'd.** This is the important part. No engine merges
a full-text index with a B-tree index, so `MATCH(...) OR hash = ...` discards the
fulltext index and scans `roms` end to end. Measured on a 300k-row MariaDB table:

| Query shape | Time | Plan |
| --- | --- | --- |
| Name only (baseline) | 0.294s | `fulltext` |
| Hash only, indexed | 0.038s | `index_merge` |
| `MATCH(...) OR hash = ...` | 3.306s | `ALL` (full scan) |
| `id IN (name UNION hash)` | 14.271s | `DEPENDENT SUBQUERY` |
| `id IN (SELECT ... FROM (name UNION hash) t)` | **0.005s** | every branch indexed |

Pre-resolving hash ids in Python and OR-ing them in was also measured, and
`MATCH(...) OR id IN (const)` is a full scan for the same reason. So each side resolves
through its own index and the id sets are unioned via a derived table, which forces
MariaDB to materialize instead of correlating.

Neither table had an index on any hash column, so the migration adds them.

No frontend changes: the v2 placeholder already advertised this, and v1 is frozen.

**Files modified**

| File | What changed |
| --- | --- |
| `backend/handler/database/roms_handler.py` | Split `_filter_by_search_term` into `_build_name_conditions` (the existing logic, unchanged) and a new `_build_hash_selects`. When a digest-shaped term is present, the two id sets are unioned through a derived table; otherwise the query is exactly what it was before. |
| `backend/models/rom.py` | Declared the nine hash indexes on `Rom` and `RomFile` so `alembic revision --autogenerate` does not propose dropping them. |
| `backend/alembic/versions/0106_hash_search_indexes.py` | New migration creating those indexes. Mirrors `0104_roms_missing_from_fs_index.py`, including `if_not_exists` / `if_exists`. |
| `backend/tests/handler/database/test_roms_hash_search.py` | New, 22 tests. |

**Testing notes**

- Full backend suite on MariaDB: 2653 passed, 2 skipped, 0 failed.
- New file: 22/22 on MariaDB, and re-run against a scratch PostgreSQL 16 alongside the
  existing `test_db_handler.py` (59 passed) to confirm the ILIKE fallback path.
- Migration verified `upgrade` + `downgrade` on MariaDB, and `upgrade` on PostgreSQL.
- The tests were written before the implementation. To confirm they are meaningful I
  stashed only the handler change and re-ran: the hash and smart-collection tests fail
  without it and pass with it.
- `trunk fmt && trunk check` clean.

Coverage spans each digest type, case-insensitivity, file-level hashes on a multi-disc
game, deduplication when several files share a hash, and a set of tests asserting name
search is not degraded.

**Anything a reviewer should pay attention to**

1. **The union-instead-of-OR shape is load-bearing**, not a style choice. Three tests in
   `TestSearchQueryShape` assert on the compiled SQL specifically to stop it silently
   regressing to an `OR`, which is a ~600x cliff that no functional test would catch.
   They are white-box, and that is deliberate.
2. **`rom_files.chd_sha1_hash` is included**, slightly beyond the column list in the
   issue. It is the SHA-1 datfiles publish for a CHD, so it is the digest a user is most
   likely to paste for a CHD. Easy to drop if you would rather keep to the issue's scope.
3. **Matching is exact-length only.** A partial prefix still returns nothing, because
   prefix matching would forfeit the index and put us back on a full scan. Worth
   confirming that is the trade-off you want.
4. **Nine new indexes.** Creating them is online in InnoDB but not instant on a large
   library, and they add a small write cost to every scan that populates hashes.
5. **Relevance ordering.** `_build_fulltext_relevance` only emits a clause for
   multi-word terms, so a pure hash search is unaffected. On a mixed
   `Super Mario|<hash>` search the hash-matched game scores zero relevance and sorts
   last. That seemed right, but it is a judgment call.
6. **Smart collections are fixed as a side effect.** Their "search term" criterion runs
   through this same filter, so a hash-based smart collection was always empty. Two
   end-to-end tests cover it. This is unrelated to #4029, which is about smart-collection
   *load performance* and is untouched here. Note that #4029 touches
   `_filter_by_smart_collection_id`, roughly 50 lines from the function this PR changes,
   so expect a light conflict if both land.

**AI assistance disclosure**

This PR was written primarily by Claude Code (Opus 5), covering the implementation,
tests, migration, benchmarking and this description, under my direction and review. The
performance investigation that led to the union shape was run against a real 300k-row
MariaDB table rather than reasoned about. Any follow-up review responses I post with AI
help will say so.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**Screenshots**
<img width="880" height="810" alt="image" src="https://github.com/user-attachments/assets/f02f0e3f-b476-48ce-a33e-d786330c7715" />