### PR TITLE
fix(docker): always start the RQ scheduler

### DIFF
--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -376,10 +376,7 @@ run_startup
 while ! ((exited)); do
 	watchdog_process_pid gunicorn
 
-	# The scheduler always runs. startup.py registers the netplay, upload-tmp and
-	# zip-cache cleanups unconditionally, and the watcher defers its rescans
-	# through the scheduler, so gating it on the ENABLE_SCHEDULED_* flags left
-	# those jobs queued with nothing to execute them.
+	# always run the scheduler
 	watchdog_process_pid rq_scheduler
 
 	watchdog_process_pid rq_worker

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -376,10 +376,11 @@ run_startup
 while ! ((exited)); do
 	watchdog_process_pid gunicorn
 
-	# only start the scheduler if enabled
-	if [[ ${ENABLE_SCHEDULED_RESCAN} == "true" || ${ENABLE_SCHEDULED_UPDATE_SWITCH_TITLEDB} == "true" || ${ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA} == "true" || ${ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES} == "true" ]]; then
-		watchdog_process_pid rq_scheduler
-	fi
+	# The scheduler always runs. startup.py registers the netplay, upload-tmp and
+	# zip-cache cleanups unconditionally, and the watcher defers its rescans
+	# through the scheduler, so gating it on the ENABLE_SCHEDULED_* flags left
+	# those jobs queued with nothing to execute them.
+	watchdog_process_pid rq_scheduler
 
 	watchdog_process_pid rq_worker
 


### PR DESCRIPTION
**Description**

<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The RQ scheduler only starts when one of four `ENABLE_SCHEDULED_*` flags is true:

```bash
# only start the scheduler if enabled
if [[ ${ENABLE_SCHEDULED_RESCAN} == "true" || ${ENABLE_SCHEDULED_UPDATE_SWITCH_TITLEDB} == "true" \
   || ${ENABLE_SCHEDULED_UPDATE_LAUNCHBOX_METADATA} == "true" || ${ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES} == "true" ]]; then
    watchdog_process_pid rq_scheduler
fi
```

Nothing else respects that condition, and the list has fallen behind in three separate ways:

- **`startup.py` registers three cleanups unconditionally.** `cleanup_netplay` (every 30 min), `cleanup_upload_tmp` (hourly) and `cleanup_zip_cache` (daily) are declared `enabled=True` with cron strings and `init()`ed regardless of any flag. **On a default install none of them ever run.**
- **Three more flags gate periodic tasks but are absent from the condition:** `ENABLE_SCHEDULED_CONVERT_IMAGES_TO_WEBP`, `ENABLE_SCHEDULED_RETROACHIEVEMENTS_PROGRESS_SYNC` and `ENABLE_SYNC_PUSH_PULL`. Enabling any one of those alone silently does nothing.
- **The filesystem watcher defers its rescans through the scheduler** (`watcher.py:214`, `tasks_scheduler.enqueue_in(...)`), but `ENABLE_RESCAN_ON_FILESYSTEM_CHANGE` is not in the list either.

`entrypoint.sh` starts the scheduler unconditionally and always has, so the two entry paths already disagree about this.

**The user-visible failure**

Reported in Discord on 5.1.0: clicking Scan is refused immediately and permanently with `🛑 Scan already in progress, ignoring request`, with no scan running.

With the watcher on and none of the four listed tasks enabled, the watcher runs but the scheduler does not. A filesystem change leaves a delayed `scan_platforms` entry in the scheduler registry that nothing will ever execute, and #3974's concurrent scan guard counts it as a queued scan, so every manual scan is refused.

Only one entry is needed to cause this. The watcher deduplicates before scheduling (`get_pending_scan_jobs()` in `watcher.py`, which bails when a full rescan is already pending and skips per-platform slugs that already have one), so entries do not pile up. A single stuck one blocks indefinitely.

That matches the report: restarting the container does not help, because it is persisted Redis state rather than a running process; clearing `redis-data` does help; and the block returns once the next scan finishes, because that scan writes resources, the watcher fires, and a fresh entry is scheduled.

Reproduced on a live instance by creating one watcher-style entry:

```
queued scans BEFORE: []
created scheduler entry: a1f0a558-… | func: endpoints.sockets.scan.scan_platforms
queued scans AFTER : ['a1f0a558-…']
>>> GUARD WOULD BLOCK: True
```

The reporter's configuration, confirmed after the fact, is `ENABLE_RESCAN_ON_FILESYSTEM_CHANGE`, `ENABLE_SCHEDULED_CONVERT_IMAGES_TO_WEBP` and `ENABLE_SCHEDULED_RETROACHIEVEMENTS_PROGRESS_SYNC` all true. Three scheduler-dependent features enabled, none of which starts the scheduler.

The silent variant is visible on any default install. These are the unconditional cleanups on my own instance, all overdue, because no scheduler exists to run them:

```
cleanup_netplay             scheduled_for=2026-07-25 06:30:00
cleanup_upload_tmp          scheduled_for=2026-07-25 07:00:00
cleanup_zip_cache           scheduled_for=2026-07-30 04:00:00
cleanup_orphaned_resources  scheduled_for=2026-07-30 05:00:00
```

**Changes**

Start the scheduler unconditionally, matching `entrypoint.sh`. A hand-maintained boolean chain in bash is what drifted here, and since three periodic tasks are registered regardless of configuration, there is no case left for the condition to express.

No cleanup step is needed for instances already stuck: rq-scheduler enqueues past-due jobs as soon as it starts, so the orphaned entry is picked up, run, and gone.

**Testing**

- Traced on a live 5.1.0 instance: reproduced the block by creating a single watcher-style scheduler entry, and confirmed `rqscheduler` is absent from the process list with the default configuration.
- `bash -n`, `shellcheck`, `shfmt 3.6.0` clean.

No new tests. The change is one line of the init script, which has no test harness in-repo, and the guard behaviour it feeds is already covered by `TestScanConcurrency`.

**Note for #4019**

The s6-overlay rewrite copies the same four-flag condition verbatim into `docker/s6-overlay/s6-rc.d/romm-rq-scheduler/run` and calls `disable_service`, so it currently reintroduces all of the above. Commented there. Whichever lands second should carry this across.

**Checklist**

<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this change was written with AI assistance (Claude Code). The root cause was traced from the Discord report and reproduced on my own instance; the AI wrote the patch, and I reviewed the result.
