### PR TITLE
fix: batch of open bug fixes (#4027, #4034, #4035, #4038, #4040, #4043, #4045)

### DIFF
--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -54,6 +54,7 @@ DEFAULT_EXCLUDED_DIRS: Final = [
     "@eaDir",
     "assets",
     "__MACOSX",
+    "#recycle",
     "$RECYCLE.BIN",
     ".Trash-*",
     ".stfolder",

--- a/backend/decorators/auth.py
+++ b/backend/decorators/auth.py
@@ -1,13 +1,17 @@
+import functools
+import inspect
 from typing import Any
 
 from authlib.integrations.starlette_client import OAuth
 from authlib.oidc.discovery import get_well_known_url
-from fastapi import Security
+from fastapi import HTTPException, Security, status
 from fastapi.security.http import HTTPBasic
 from fastapi.security.oauth2 import OAuth2PasswordBearer
 from fastapi.types import DecoratedCallable
-from starlette.authentication import requires
+from starlette._utils import is_async_callable
+from starlette.authentication import has_required_scope
 from starlette.config import Config
+from starlette.requests import Request
 
 from config import (
     OIDC_CLAIM_ROLES,
@@ -65,6 +69,63 @@ oauth.register(
 )
 
 
+def _raise_auth_error(request: Request) -> None:
+    """Raise the status matching the caller's auth state.
+
+    401 tells the client it has no valid credentials (so it can redirect to
+    login), while 403 means the authenticated user lacks the required scope
+    (an inline permission error, not a session problem).
+    """
+    if not request.user.is_authenticated:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+
+def _requires_scopes(scopes: list[Scope]):
+    """Scope guard mirroring starlette's `requires`, with a 401/403 split."""
+
+    def decorator(func: DecoratedCallable) -> DecoratedCallable:
+        sig = inspect.signature(func)
+        idx = next(
+            (
+                i
+                for i, parameter in enumerate(sig.parameters.values())
+                if parameter.name == "request"
+            ),
+            None,
+        )
+        if idx is None:
+            raise Exception(f'No "request" argument on function "{func}"')
+
+        if is_async_callable(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(*args, **kwargs) -> Any:
+                request = kwargs.get("request", args[idx] if idx < len(args) else None)
+                assert isinstance(request, Request)
+                if not has_required_scope(request, scopes):
+                    _raise_auth_error(request)
+                return await func(*args, **kwargs)
+
+            return async_wrapper  # type: ignore[return-value]
+
+        @functools.wraps(func)
+        def sync_wrapper(*args, **kwargs) -> Any:
+            request = kwargs.get("request", args[idx] if idx < len(args) else None)
+            assert isinstance(request, Request)
+            if not has_required_scope(request, scopes):
+                _raise_auth_error(request)
+            return func(*args, **kwargs)
+
+        return sync_wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
 def protected_route(
     method: Any,
     path: str,
@@ -72,7 +133,7 @@ def protected_route(
     **kwargs,
 ):
     def decorator(func: DecoratedCallable) -> DecoratedCallable:
-        fn = requires(scopes or [])(func)
+        fn = _requires_scopes(scopes or [])(func)
         return method(
             path,
             dependencies=[

--- a/backend/handler/filesystem/platforms_handler.py
+++ b/backend/handler/filesystem/platforms_handler.py
@@ -1,3 +1,4 @@
+import fnmatch
 import os
 
 from anyio import Path as AnyioPath
@@ -19,7 +20,10 @@ class FSPlatformsHandler(FSHandler):
         return [
             platform
             for platform in platforms
-            if platform not in cnfg.EXCLUDED_PLATFORMS
+            if not any(
+                platform == excluded or fnmatch.fnmatch(platform, excluded)
+                for excluded in cnfg.EXCLUDED_PLATFORMS
+            )
         ]
 
     def create_library_structure(self) -> None:
@@ -114,6 +118,10 @@ class FSPlatformsHandler(FSHandler):
                 log.error("Failed to create default library structure", exc_info=True)
             return []
 
+        # Exclude before touching the directories so unreadable system folders
+        # (e.g. Synology's #recycle) are never stat'ed
+        platforms = self._exclude_platforms(platforms)
+
         # For Structure B, only include directories that have a roms subfolder
         structure = self.detect_library_structure()
         if structure == LibraryStructure.B:
@@ -122,8 +130,16 @@ class FSPlatformsHandler(FSHandler):
                 roms_path = AnyioPath(
                     os.path.join(LIBRARY_BASE_PATH, platform, cnfg.ROMS_FOLDER_NAME)
                 )
-                if await roms_path.exists():
+                try:
+                    has_roms_folder = await roms_path.exists()
+                except OSError:
+                    log.warning(
+                        f"Skipping unreadable library directory: {platform}",
+                        exc_info=True,
+                    )
+                    continue
+                if has_roms_folder:
                     filtered_platforms.append(platform)
             platforms = filtered_platforms
 
-        return self._exclude_platforms(platforms)
+        return platforms

--- a/backend/tests/endpoints/roms/test_rom.py
+++ b/backend/tests/endpoints/roms/test_rom.py
@@ -431,7 +431,7 @@ def test_get_all_roms_with_files(
 
 def test_get_rom_content_requires_auth(client: TestClient, rom: Rom, rom_file):
     response = client.get(f"/api/roms/{rom.id}/content/test_rom.zip")
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_get_rom_content_single_file(

--- a/backend/tests/endpoints/test_client_tokens.py
+++ b/backend/tests/endpoints/test_client_tokens.py
@@ -213,7 +213,7 @@ class TestClientTokenAuth:
             "/api/platforms",
             headers={"Authorization": f"Bearer {raw_token}"},
         )
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_revoked_token_rejected(self, client, access_token, admin_user):
         create_resp = client.post(
@@ -233,7 +233,7 @@ class TestClientTokenAuth:
             "/api/platforms",
             headers={"Authorization": f"Bearer {raw_token}"},
         )
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_scope_enforcement(self, client, access_token, admin_user):
         create_resp = client.post(
@@ -288,7 +288,7 @@ class TestClientTokenAuth:
             "/api/platforms",
             headers={"Authorization": f"Bearer {raw_token}"},
         )
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
         # Re-enable for other tests
         db_user_handler.update_user(admin_user.id, {"enabled": True})
@@ -298,7 +298,7 @@ class TestClientTokenAuth:
             "/api/platforms",
             headers={"Authorization": "Bearer rmm_invalidgarbage"},
         )
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_scopes_subset_validation(self, client, viewer_access_token, viewer_user):
         response = client.post(

--- a/backend/tests/endpoints/test_config.py
+++ b/backend/tests/endpoints/test_config.py
@@ -139,7 +139,7 @@ def test_update_scan_settings_payload_shape(client, access_token: str):
 
 def test_update_scan_settings_requires_auth(client):
     response = client.put("/api/config/scan", json=_scan_payload())
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_update_scan_settings_rejects_unknown_source(client, access_token: str):

--- a/backend/tests/endpoints/test_logs.py
+++ b/backend/tests/endpoints/test_logs.py
@@ -16,7 +16,7 @@ def _auth(token: str) -> dict[str, str]:
 
 def test_get_logs_requires_auth(client):
     response = client.get("/api/logs")
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_get_logs_forbidden_without_logs_read(client, viewer_access_token):

--- a/backend/tests/endpoints/test_permissions_me.py
+++ b/backend/tests/endpoints/test_permissions_me.py
@@ -21,7 +21,7 @@ def _actions(payload):
 
 
 def test_requires_auth(client):
-    assert client.get("/api/permissions/me").status_code == 403
+    assert client.get("/api/permissions/me").status_code == 401
 
 
 def test_admin_is_admin_and_all_actions(client, access_token):

--- a/backend/tests/endpoints/test_platform.py
+++ b/backend/tests/endpoints/test_platform.py
@@ -7,7 +7,7 @@ from models.platform import CUSTOM_NAME_MAX_LENGTH, DESCRIPTION_MAX_LENGTH
 
 def test_get_platforms(client, access_token, platform):
     response = client.get("/api/platforms")
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     response = client.get(
         "/api/platforms", headers={"Authorization": f"Bearer {access_token}"}
@@ -27,7 +27,7 @@ def test_get_filesystem_platforms(client, access_token, platform):
         mock_get_platforms.return_value = [platform.fs_slug, "segacd"]
 
         response = client.get("/api/platforms/filesystem")
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
         response = client.get(
             "/api/platforms/filesystem",
@@ -175,4 +175,4 @@ def test_update_platform_description_requires_write_scope(client, platform):
         f"/api/platforms/{platform.id}",
         json={"description": "Nope"},
     )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/backend/tests/endpoints/test_saves.py
+++ b/backend/tests/endpoints/test_saves.py
@@ -1971,7 +1971,7 @@ class TestSavesSummaryEndpoint:
     def test_get_saves_summary_requires_auth(self, client, rom: Rom):
         response = client.get(f"/api/saves/summary?rom_id={rom.id}")
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 class TestSaveDownload:

--- a/backend/tests/endpoints/test_streaming.py
+++ b/backend/tests/endpoints/test_streaming.py
@@ -124,7 +124,7 @@ def _claim_ok(client, token, rom_id):
 
 
 def test_get_config_requires_auth(client):
-    assert client.get("/api/streaming/config").status_code == 403
+    assert client.get("/api/streaming/config").status_code == 401
 
 
 def test_get_config_warns_on_missing_platform(client, access_token, caplog):
@@ -486,19 +486,19 @@ def test_force_release_all_stops_brokers(client, access_token, rom: Rom):
 
 
 def test_claim_session_requires_auth(client):
-    assert client.post("/api/streaming/sessions", json={"rom_id": 1}).status_code == 403
+    assert client.post("/api/streaming/sessions", json={"rom_id": 1}).status_code == 401
 
 
 def test_release_session_requires_auth(client):
-    assert client.delete("/api/streaming/sessions/ps2").status_code == 403
+    assert client.delete("/api/streaming/sessions/ps2").status_code == 401
 
 
 def test_force_release_all_requires_auth(client):
-    assert client.delete("/api/streaming/sessions").status_code == 403
+    assert client.delete("/api/streaming/sessions").status_code == 401
 
 
 def test_list_sessions_requires_auth(client):
-    assert client.get("/api/streaming/sessions").status_code == 403
+    assert client.get("/api/streaming/sessions").status_code == 401
 
 
 def test_list_sessions_requires_admin(client, viewer_access_token):

--- a/backend/tests/endpoints/test_tasks.py
+++ b/backend/tests/endpoints/test_tasks.py
@@ -186,7 +186,7 @@ class TestListTasks:
     def test_list_tasks_unauthorized(self, client):
         """Test that unauthorized requests are rejected"""
         response = client.get("/api/tasks")
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_list_tasks_insufficient_scope(self, client, admin_user):
         """Test that requests without proper scope are rejected"""
@@ -336,7 +336,7 @@ class TestRunSingleTask:
     def test_run_single_task_unauthorized(self, client):
         """Test running a task without authentication"""
         response = client.post("/api/tasks/run/test_task")
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 class TestGetTasksStatus:
@@ -492,7 +492,7 @@ class TestGetTaskById:
     def test_get_task_by_id_unauthorized(self, client):
         """Test retrieval of a task without authentication"""
         response = client.get("/api/tasks/test-job-id")
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 class TestTaskInfoBuilding:

--- a/backend/tests/handler/filesystem/test_platforms_handler.py
+++ b/backend/tests/handler/filesystem/test_platforms_handler.py
@@ -65,6 +65,20 @@ class TestFSPlatformsHandler:
             assert "romm" not in result
             assert "excluded_platform" not in result
 
+    def test_exclude_platforms_supports_glob_patterns(
+        self, handler: FSPlatformsHandler, config
+    ):
+        """Glob patterns in the exclusion list (e.g. .Trash-*) match directories"""
+        platforms = ["n64", ".Trash-1000", "#recycle", "psx"]
+        config.EXCLUDED_PLATFORMS = [".Trash-*", "#recycle"]
+
+        with patch(
+            "handler.filesystem.platforms_handler.cm.get_config", return_value=config
+        ):
+            result = handler._exclude_platforms(platforms)
+
+            assert result == ["n64", "psx"]
+
     def test_exclude_platforms_empty_list(self, handler: FSPlatformsHandler, config):
         """Test that _exclude_platforms handles empty list"""
         with patch(
@@ -270,6 +284,34 @@ class TestFSPlatformsHandler:
                     result = await handler.get_platforms()
 
                     assert result == []
+
+    async def test_get_platforms_skips_unreadable_directories(
+        self, handler: FSPlatformsHandler, config
+    ):
+        """Structure B: directories that raise PermissionError on stat are skipped
+        instead of crashing platform discovery (and the heartbeat with it)."""
+        config.has_structure_path_a = False
+        config.has_structure_path_b = True
+
+        class FakePath:
+            def __init__(self, path: str):
+                self._path = str(path)
+
+            async def exists(self) -> bool:
+                if "locked" in self._path:
+                    raise PermissionError(13, "Permission denied", self._path)
+                return True
+
+        with patch(
+            "handler.filesystem.platforms_handler.cm.get_config", return_value=config
+        ):
+            with patch.object(
+                handler, "list_directories", return_value=["n64", "locked", "psx"]
+            ):
+                with patch("handler.filesystem.platforms_handler.AnyioPath", FakePath):
+                    result = await handler.get_platforms()
+
+                    assert result == ["n64", "psx"]
 
     def test_integration_with_base_handler_methods(self, handler: FSPlatformsHandler):
         """Test that FSPlatformsHandler properly inherits from FSHandler"""

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -11,6 +11,37 @@ import "@/styles/fonts.css";
 import "@/styles/scrollbar.css";
 import "@/v2/styles/global.css";
 
+// Recover from stale chunks after a redeploy: hashed asset names change, so
+// a tab opened before the deploy 404s (or gets HTML) on its next lazy import
+// and the page goes blank. One reload picks up the new asset manifest; the
+// timestamp guard avoids a reload loop when an asset is genuinely missing.
+const CHUNK_RELOAD_KEY = "romm-chunk-reload-at";
+
+function reloadOnceForStaleChunk(url?: string): boolean {
+  const lastReload = Number(sessionStorage.getItem(CHUNK_RELOAD_KEY) ?? 0);
+  if (Date.now() - lastReload < 60_000) return false;
+  sessionStorage.setItem(CHUNK_RELOAD_KEY, String(Date.now()));
+  if (url) {
+    window.location.assign(url);
+  } else {
+    window.location.reload();
+  }
+  return true;
+}
+
+function isChunkLoadError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    /error loading dynamically imported module|failed to fetch dynamically imported module|importing a module script failed|unable to preload css/i.test(
+      error.message,
+    )
+  );
+}
+
+window.addEventListener("vite:preloadError", (event) => {
+  if (reloadOnceForStaleChunk()) event.preventDefault();
+});
+
 async function initializeData() {
   const heartbeatStore = storeHeartbeat();
   const authStore = storeAuth();
@@ -31,6 +62,14 @@ async function initializeApp() {
   registerPlugins(app);
 
   await initializeData();
+
+  // Route-level lazy imports fail outside vite's preload helper, so stale
+  // chunks during navigation surface here instead of as vite:preloadError.
+  router.onError((error, to) => {
+    if (isChunkLoadError(error)) {
+      reloadOnceForStaleChunk(to?.fullPath);
+    }
+  });
 
   app.use(router);
 

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -111,12 +111,26 @@ api.interceptors.response.use(
       document.dispatchEvent(new CustomEvent("backend-online"));
     }
 
-    if (error.response?.status === 403) {
+    // A 403 is a permission denial for an authenticated caller (or a CSRF
+    // failure): the session is still valid, so stay on the page and let the
+    // caller surface the error. Only refresh the CSRF token when the backend
+    // rejected it, so the next attempt uses a fresh one.
+    if (
+      error.response?.status === 403 &&
+      typeof error.response?.data === "string" &&
+      error.response.data.includes("CSRF")
+    ) {
+      await refetchCSRFToken().catch(() => {});
+    }
+
+    // A 401 means there are no valid credentials behind the request: clear
+    // the stale session and send the user to the login page.
+    if (error.response?.status === 401) {
       // Clear cookies and redirect to login page
       Cookies.remove("romm_session");
 
       // Refetch CSRF cookie
-      await refetchCSRFToken();
+      await refetchCSRFToken().catch(() => {});
 
       const pathname = window.location.pathname;
       const search = window.location.search;

--- a/frontend/src/v2/components/Dialogs/MatchRomDialog.vue
+++ b/frontend/src/v2/components/Dialogs/MatchRomDialog.vue
@@ -290,7 +290,14 @@ function closeDialog() {
     @close="closeDialog"
   >
     <template #header>
-      <span>{{ t("rom.match-rom") }}</span>
+      <div class="r-v2-match__header">
+        <span>{{ t("rom.match-rom") }}</span>
+        <!-- The file name is the ground truth for a mismatched game, so it
+             stays visible while the dialog covers the gallery card. -->
+        <span v-if="rom" class="r-v2-match__header-file" :title="rom.fs_name">
+          {{ rom.fs_name }}
+        </span>
+      </div>
     </template>
 
     <template #toolbar>
@@ -415,6 +422,25 @@ function closeDialog() {
 </template>
 
 <style scoped>
+/* Header — dialog title plus the ROM's file name, which truncates to a
+   single line and keeps the full name in the hover title. */
+.r-v2-match__header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+.r-v2-match__header-file {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--r-font-size-sm);
+  font-weight: var(--r-font-weight-regular);
+  color: var(--r-color-fg-muted);
+}
+
 /* Saving-overlay anchor — has to pass the dialog body's column layout
    through (`flex: 1`, `min-height: 0`, `display: flex; flex-direction:
    column`) so the variant inside still sees the same shape it would

--- a/frontend/src/v2/components/Gallery/PlatformHead.vue
+++ b/frontend/src/v2/components/Gallery/PlatformHead.vue
@@ -263,9 +263,10 @@ html[data-bp~="xs"] .r-v2-plat__panel-icon {
   color: var(--r-color-fg);
   transform: translateY(-1px);
 }
+/* Keep pointer events on passive chips so the native `title` tooltip still
+   shows on hover; only the pointer affordance is dropped. */
 .r-v2-plat__provider--passive {
   cursor: default;
-  pointer-events: none;
 }
 .r-v2-plat__provider--icon-only {
   padding: 2px 4px;

--- a/frontend/src/v2/components/GameCard/CardFlags.vue
+++ b/frontend/src/v2/components/GameCard/CardFlags.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+// CardFlags — region / language emoji chips over the cover's bottom-left
+// corner, the v2 counterpart of v1's cover flags. Visibility is driven by
+// the showRegions / showLanguages UI settings; each chip caps at three
+// emoji and carries the full list in its hover title. Purely informational:
+// pointer events pass through to the card, and the chips fade out under the
+// hover overlay so they never collide with the action row.
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import { useUISettings } from "@/composables/useUISettings";
+import type { SimpleRom } from "@/stores/roms";
+import { languageToEmoji, regionToEmoji } from "@/utils";
+
+const props = defineProps<{ rom: SimpleRom }>();
+
+const { t } = useI18n();
+const { showRegions, showLanguages } = useUISettings();
+
+const regions = computed(() =>
+  showRegions.value ? (props.rom.regions ?? []).filter(Boolean) : [],
+);
+const languages = computed(() =>
+  showLanguages.value ? (props.rom.languages ?? []).filter(Boolean) : [],
+);
+</script>
+
+<template>
+  <div v-if="regions.length || languages.length" class="card-flags">
+    <span
+      v-if="regions.length"
+      class="card-flags__chip"
+      :title="`${t('rom.regions')}: ${regions.join(', ')}`"
+    >
+      <span v-for="region in regions.slice(0, 3)" :key="region">
+        {{ regionToEmoji(region) }}
+      </span>
+    </span>
+    <span
+      v-if="languages.length"
+      class="card-flags__chip"
+      :title="`${t('rom.languages')}: ${languages.join(', ')}`"
+    >
+      <span v-for="language in languages.slice(0, 3)" :key="language">
+        {{ languageToEmoji(language) }}
+      </span>
+    </span>
+  </div>
+</template>
+
+<style scoped>
+.card-flags {
+  position: absolute;
+  bottom: 7px;
+  left: 7px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  max-width: calc(100% - 14px);
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+}
+
+.card-flags__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px 5px;
+  background: var(--r-color-overlay-scrim-soft);
+  border: 1px solid var(--r-color-overlay-border);
+  border-radius: var(--r-radius-pill);
+  font-size: 11px;
+  line-height: 1.2;
+  backdrop-filter: blur(6px);
+}
+</style>

--- a/frontend/src/v2/components/GameCard/GameCard.vue
+++ b/frontend/src/v2/components/GameCard/GameCard.vue
@@ -43,6 +43,7 @@ import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import type { SimpleRom } from "@/stores/roms";
 import GameActionBtn from "@/v2/components/GameActions/GameActionBtn.vue";
+import CardFlags from "@/v2/components/GameCard/CardFlags.vue";
 import SiblingBadge from "@/v2/components/GameCard/SiblingBadge.vue";
 import CoverArtPip from "@/v2/components/shared/CoverArtPip.vue";
 import GameCover from "@/v2/components/shared/GameCover.vue";
@@ -505,6 +506,10 @@ function onStaticKeydown(e: KeyboardEvent) {
 
         <SiblingBadge :rom="rom" />
 
+        <!-- Region / language flags — bottom-left, gated by the
+             showRegions / showLanguages UI settings. -->
+        <CardFlags :rom="rom" />
+
         <!-- Hover overlay — action buttons are the shared GameActionBtn. -->
         <div class="r-gc__overlay">
           <div class="r-gc__overlay-center">
@@ -783,6 +788,15 @@ html[data-input="mouse"] .r-gc:hover :deep(.cover-art-pip),
 html[data-input="touch"] .r-gc:hover :deep(.cover-art-pip),
 .r-gc:focus-visible :deep(.cover-art-pip),
 .r-gc--focused :deep(.cover-art-pip) {
+  opacity: 0;
+}
+
+/* Region / language flags fade out under the hover overlay so they never
+   collide with the bottom action row (same treatment as the cover PIP). */
+html[data-input="mouse"] .r-gc:hover :deep(.card-flags),
+html[data-input="touch"] .r-gc:hover :deep(.card-flags),
+.r-gc:focus-visible :deep(.card-flags),
+.r-gc--focused :deep(.card-flags) {
   opacity: 0;
 }
 html[data-input="mouse"] .r-gc:hover .r-gc__badge,

--- a/frontend/src/v2/components/Settings/FolderMappingsSection.vue
+++ b/frontend/src/v2/components/Settings/FolderMappingsSection.vue
@@ -306,6 +306,10 @@ const initialLoading = ref(false);
 onMounted(async () => {
   initialLoading.value = true;
   loading.value = true;
+  // FS_PLATFORMS is snapshotted into the heartbeat at app init, so folders
+  // created since then would only appear after a full page reload. Refresh
+  // it in the background whenever the section mounts.
+  heartbeat.fetchHeartbeat().catch(() => {});
   try {
     const { data } = await platformApi.getSupportedPlatforms();
     supportedPlatforms.value = data || [];

--- a/frontend/src/v2/components/Settings/FolderMappingsSection.vue
+++ b/frontend/src/v2/components/Settings/FolderMappingsSection.vue
@@ -306,9 +306,7 @@ const initialLoading = ref(false);
 onMounted(async () => {
   initialLoading.value = true;
   loading.value = true;
-  // FS_PLATFORMS is snapshotted into the heartbeat at app init, so folders
-  // created since then would only appear after a full page reload. Refresh
-  // it in the background whenever the section mounts.
+  // Refresh FS_PLATFORMS from heartbeat when this page mounts
   heartbeat.fetchHeartbeat().catch(() => {});
   try {
     const { data } = await platformApi.getSupportedPlatforms();

--- a/frontend/src/v2/composables/useGameActions/index.test.ts
+++ b/frontend/src/v2/composables/useGameActions/index.test.ts
@@ -214,7 +214,7 @@ describe("useGameActions — write/destructive gates", () => {
   });
 
   // A bare DELETE grant projects to no scope, so `POST /roms/delete` (which
-  // gates on ROMS_WRITE) would 403 and the interceptor would log the user out.
+  // gates on ROMS_WRITE) would 403, so the menu must not offer it.
   it("hides delete when the delete grant is held without the write grant", () => {
     grantedActions.value = new Set<ActionKey>(["rom.view", "rom.delete"]);
     const actions = useGameActions(() => makeRom());

--- a/frontend/src/v2/composables/useGameActions/index.ts
+++ b/frontend/src/v2/composables/useGameActions/index.ts
@@ -63,7 +63,7 @@ export function useGameActions(
   const canEditCollection = useCan("collection.edit");
   // Write/destructive gates, mirroring the backend grants. Surfaces that
   // offer these actions hide them outright rather than letting the request
-  // 403 (which the axios interceptor turns into a logout).
+  // 403 and surface a permission error the user can't act on.
   const canEdit = useCan("rom.edit");
   const canMatch = useCan("rom.match");
   const canRefresh = useCan("rom.refresh");


### PR DESCRIPTION
**Description**

A batch of seven independent fixes for open issues, one commit each so they can be reviewed (or dropped) separately.

**#4043 — `#recycle` folders scanned as platforms, unreadable folders 500 the heartbeat**

Adds Synology's `#recycle` to `DEFAULT_EXCLUDED_DIRS`, and makes the exclusion list match glob patterns so the long-standing `.Trash-*` entry actually excludes something (it was compared with `==` and never matched). Exclusions are now applied before the directories are stat'ed, and a directory that raises `OSError` during Structure B detection is skipped with a warning instead of propagating — an unreadable folder used to bubble a 500 out of `/api/heartbeat`, which the frontend retried in a loop during first-time setup.

Fixes #4043

**#4045 — every 403 logged the user out**

Protected routes answered 403 both for "no session" and for "authenticated but missing scope". The frontend read every 403 as session expiry, cleared the session cookie and redirected to `/login`, so a permission denial (e.g. writing a save without the save scope) tore down whatever the user was doing, including a running emulator session.

`protected_route` now uses its own scope guard: 401 (+ `WWW-Authenticate`) when the caller is unauthenticated, 403 when the caller is authenticated but under-scoped. The axios interceptor only redirects on 401, lets 403s surface inline to the caller, and refreshes the CSRF cookie when the backend rejected the CSRF token. Endpoint assertions for unauthenticated requests moved from 403 to 401; authenticated under-scoped cases stay 403.

Fixes #4045

**#4040 — no tooltip on passive provider chips**

Provider chips without a link (HowLongToBeat, Libretro, Flashpoint) were styled with `pointer-events: none`, which also suppressed their native `title` tooltip, leaving those icons unlabelled. Only the pointer affordance is dropped now.

Fixes #4040

**#4038 — file name hidden behind the match dialog**

The match dialog covers the gallery card it was opened from, hiding the file name, which is the one piece of ground truth when re-matching a mismatched game. The dialog header now shows it, truncated to a single line with the full name in the hover title.

Fixes #4038

**#4034 — blank page after a deploy**

Hashed asset names change on every deploy, so a tab left open across an upgrade fails its next lazy import and goes blank until the user reloads by hand. `main.ts` now listens for `vite:preloadError` and for router dynamic-import failures and reloads once; a session-scoped timestamp guards against a reload loop when an asset is genuinely missing.

Fixes #4034

**#4035 — new folders missing from the mapping menu**

The folder-mapping table lists `FS_PLATFORMS` from the heartbeat snapshot taken at app init, so a folder created after that only showed up after a full page reload. The section now refetches the heartbeat when it mounts.

Fixes #4035

**#4027 — region/language flags missing on v2 covers**

v2 exposed the "Show regions" and "Show languages" settings but nothing consumed them, so covers lost the region/language emblems 4.x showed. Adds a `CardFlags` overlay to `GameCard`: up to three emoji per chip with the full list in the hover title, fading out under the hover overlay so it never collides with the action row.

Fixes #4027

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**Verification**

- `cd backend && uv run pytest` — 2655 passed, 2 skipped (full suite)
- `cd frontend && npm run typecheck` — clean
- `cd frontend && npm run test` — 608 passed across 46 files (incl. Storybook `play()` tests)
- `cd frontend && npm run build` — clean
- `python3 src/locales/check_i18n_locales.py` / `check_i18n_sorted.py` — clean (no new keys; `CardFlags` reuses `rom.regions` / `rom.languages`)
- `trunk fmt && trunk check --upstream master` — no issues

Manual browser pass against a dev instance, light and dark:

- #4027 — flag chips render bottom-left on 72/72 covers in a platform gallery, with `Regions: …` / `Languages: …` hover titles, and fade out under the hover overlay.
- #4038 — match dialog header reads `Match ROM  1-2-Switch.zip`, with the full name in the `title`.
- #4040 — the HowLongToBeat chip now computes `pointer-events: auto` with `cursor: default` and keeps its `title`.
- #4035 — opening Library management → Folder mappings issues a fresh `GET /api/heartbeat`.

**AI assistance disclosure**

Per `CONTRIBUTING.md`: these changes were written by an AI agent (Claude) working under human direction — the agent wrote the code, the tests, and this description, and a human chose the issues, reviewed the result and is accountable for it. Every check listed under Verification above was run locally and passes.

#### Screenshots (if applicable)
