### PR TITLE
perf(roms): extend the sibling covering index to cover the ROM grouping query

### DIFF
--- a/backend/alembic/versions/0107_roms_dedup_cover_index.py
+++ b/backend/alembic/versions/0107_roms_dedup_cover_index.py
@@ -1,0 +1,87 @@
+"""Extend the sibling covering index to cover the group_by_meta_id dedup
+
+0090 added `idx_roms_sibling_cover` for the sibling_roms self-join. The
+group_by_meta_id dedup window in `filter_roms` reads the same shape, but two of
+its inputs are missing from that index: `flashpoint_id` (the last provider in
+the partition's COALESCE chain) and `fs_name_no_ext` (the tiebreaker the window
+sorts each partition by). A covering index has to carry every referenced
+column, so those two omissions dropped the window to a full scan of the wide
+roms row -- JSON metadata blobs and all -- once per query.
+
+The gallery runs that window up to four times per page load (page, count,
+char_index, rom_id_index), so the scan is paid repeatedly. Measured on a
+92.8k-rom MariaDB copy with a 256 MB buffer pool against a 963 MB roms table:
+each of those four queries went 5.4-5.6s -> 0.8-1.1s (21.9s -> 4.0s combined),
+with EXPLAIN moving from `type=ALL, key=NULL` to `type=index, Using index`.
+
+Adding `fs_name_no_ext` (varchar 450) widens the index, but real names are far
+shorter than the column's maximum: on that dataset the index grew 4 MB -> 7 MB.
+
+The wider index costs the sibling_roms join a little more to scan (~170ms ->
+~209ms for a 72-rom page, measured over alternating A/B runs). Keeping the old
+narrow index alongside a second dedup-only one recovers that, but the two would
+share their first eight columns, and per page load the totals came out the same
+(2.13s vs 2.12s), so one index wins on write amplification and on not letting
+the two consumers drift apart again.
+
+Revision ID: 0107_roms_dedup_cover_index
+Revises: 0106_hash_search_indexes
+Create Date: 2026-08-01 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0107_roms_dedup_cover_index"
+down_revision = "0106_hash_search_indexes"
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = "idx_roms_sibling_cover"
+OLD_INDEX_COLUMNS = [
+    "platform_id",
+    "igdb_id",
+    "moby_id",
+    "ss_id",
+    "launchbox_id",
+    "ra_id",
+    "hasheous_id",
+    "tgdb_id",
+    "id",
+]
+NEW_INDEX_COLUMNS = [
+    "platform_id",
+    "igdb_id",
+    "moby_id",
+    "ss_id",
+    "launchbox_id",
+    "ra_id",
+    "hasheous_id",
+    "tgdb_id",
+    "flashpoint_id",
+    "fs_name_no_ext",
+    "id",
+]
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("roms", schema=None) as batch_op:
+        batch_op.drop_index(INDEX_NAME, if_exists=True)
+        batch_op.create_index(
+            INDEX_NAME,
+            NEW_INDEX_COLUMNS,
+            unique=False,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("roms", schema=None) as batch_op:
+        batch_op.drop_index(INDEX_NAME, if_exists=True)
+        batch_op.create_index(
+            INDEX_NAME,
+            OLD_INDEX_COLUMNS,
+            unique=False,
+            if_not_exists=True,
+        )

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -315,7 +315,11 @@ class Rom(BaseModel):
     __table_args__ = (
         # Enforce unique fs name per platform to avoid duplicates
         Index("idx_roms_platform_id_fs_name", "platform_id", "fs_name", unique=True),
-        # Covers the sibling_roms view self-join
+        # Covers the sibling_roms view self-join and the group_by_meta_id dedup
+        # window. Both read only these columns, so the index has to carry every
+        # one of them: a single missing column (flashpoint_id or fs_name_no_ext,
+        # the window's partition tail and sort tiebreaker) drops the plan to a
+        # full scan of the wide roms row, JSON metadata blobs included.
         Index(
             "idx_roms_sibling_cover",
             "platform_id",
@@ -326,6 +330,8 @@ class Rom(BaseModel):
             "ra_id",
             "hasheous_id",
             "tgdb_id",
+            "flashpoint_id",
+            "fs_name_no_ext",
             "id",
         ),
         Index("idx_roms_platform_fs_size", "platform_id", "fs_size_bytes"),

--- a/backend/tests/handler/database/test_roms_group_by_index.py
+++ b/backend/tests/handler/database/test_roms_group_by_index.py
@@ -1,0 +1,90 @@
+"""The "Group ROMs" dedup window and the index that has to cover it.
+
+Grouping collapses versions of the same game into one gallery entry with a
+window function. The window materializes a narrow subquery first, because
+carrying the wide `roms` row (every provider's raw metadata) through the window
+spills its sort to disk. That narrowing only pays off if the index carries every
+column the subquery reads: a covering index is all-or-nothing, so one missing
+column drops the plan to a full table scan.
+
+`idx_roms_sibling_cover` was added in 0090 for the `sibling_roms` self-join and
+did not cover `flashpoint_id` or `fs_name_no_ext`, which the window needs for
+its partition tail and its sort tiebreaker. The gallery issues the grouped query
+up to four times per page load (page, count, char index, id index), so the scan
+was paid four times over. 0107 widened the index to close the gap.
+
+The failure mode is silent, and adding a metadata provider is the way back into
+it: a new id column joins the window's COALESCE chain, the index does not follow
+it, and the gallery quietly returns to full scans.
+"""
+
+from sqlalchemy import inspect
+from sqlalchemy.sql import Subquery
+from sqlalchemy.sql.expression import Select
+from tests.conftest import engine
+
+from handler.database import db_rom_handler
+from models.rom import Rom
+
+INDEX_COLUMNS = [
+    "platform_id",
+    "igdb_id",
+    "moby_id",
+    "ss_id",
+    "launchbox_id",
+    "ra_id",
+    "hasheous_id",
+    "tgdb_id",
+    "flashpoint_id",
+    "fs_name_no_ext",
+    "id",
+]
+
+
+def _subqueries(clause, found: list[Subquery] | None = None) -> list[Subquery]:
+    found = found if found is not None else []
+    for child in clause.get_children():
+        if isinstance(child, Subquery):
+            found.append(child)
+            _subqueries(child.element, found)
+        elif hasattr(child, "get_children"):
+            _subqueries(child, found)
+    return found
+
+
+def _dedup_window_columns() -> set[str]:
+    """The `roms` columns the grouped query materializes for its window."""
+    query, _ = db_rom_handler.get_roms_query()
+    grouped = db_rom_handler.filter_roms(query=query, group_by_meta_id=True)
+
+    for subquery in _subqueries(grouped):
+        if not isinstance(subquery.element, Select):
+            continue
+        columns = {
+            column.name
+            for column in subquery.element.selected_columns
+            if getattr(column, "table", None) is Rom.__table__
+        }
+        if columns:
+            return columns
+
+    raise AssertionError("the grouped query no longer materializes a roms subquery")
+
+
+class TestSiblingCoverIndex:
+    def test_migrations_create_covering_index(self):
+        indexes = [
+            index["column_names"] for index in inspect(engine).get_indexes("roms")
+        ]
+
+        assert INDEX_COLUMNS in indexes
+
+
+class TestGroupByMetaIdCoverage:
+    def test_dedup_window_reads_only_covered_columns(self):
+        assert _dedup_window_columns() <= set(INDEX_COLUMNS)
+
+    def test_dedup_window_excludes_the_wide_metadata_columns(self):
+        assert not {
+            column for column in _dedup_window_columns() if column.endswith("_metadata")
+        }


### PR DESCRIPTION
**Description**

Fixes #4052

Loading the gallery or `/search` on a large library is very slow when "Group ROMs" is
enabled (it is on by default). On my instance, 83k ROMs, the first load of `/search`
took **25.5s**, and every scroll afterwards cost another **12.9s**.

The cause is a missing pair of columns on an existing index.

When grouping is on, the backend runs a window function that collapses versions of the
same game into one gallery entry. That window reads eleven columns off `roms`.
`idx_roms_sibling_cover` (added in `0090` for the `sibling_roms` view) carries nine of
them: it is missing `flashpoint_id`, the last provider in the partition's `COALESCE`
chain, and `fs_name_no_ext`, the tiebreaker the window sorts each partition by.

A covering index has to carry *every* column the query touches. Two missing columns is
the same as twenty: the database gives up on the index and full-scans the `roms` table
instead, reading the whole wide row including its JSON metadata blobs. On a 943 MB table
against a 256 MB buffer pool, that is mostly disk I/O.

It gets paid up to four times per page load, because the gallery issues the same grouped
query four ways (the page itself, the total count, the character index, and the ROM id
index).

This PR adds the two missing columns to that index so the grouped query can be answered
from the index alone.

**What changed**

| File | Why |
| --- | --- |
| `backend/models/rom.py` | Adds `flashpoint_id` and `fs_name_no_ext` to the `idx_roms_sibling_cover` definition, before `id`, so the ORM matches the new schema. The comment above it now records why the index must carry every column the two consumers read. |
| `backend/alembic/versions/0107_roms_dedup_cover_index.py` | Migration that drops and recreates the index with the wider column list. `downgrade()` restores the original nine-column version. Revises `0106_hash_search_indexes`. |
| `backend/tests/handler/database/test_roms_group_by_index.py` | Regression guard. Pins the index shape the migrations build, and asserts the dedup window reads only columns that index covers, so the next provider added to the `COALESCE` chain fails here rather than silently restoring the full scan. |

No application logic, no API surface, and no frontend changes. Existing deployments pick
this up automatically the next time migrations run.

**Results**

Measured on a copy of a real 92.8k-ROM library (963 MB `roms` table, 256 MB buffer pool,
MariaDB 11.4) using the SQL the backend actually generates:

| Query the gallery issues | Before | After |
| --- | --- | --- |
| Page of 72 ROMs | 5.43s | 0.80s |
| Total count | 5.55s | 1.01s |
| ROM id index | 5.48s | 1.10s |
| Character index | 5.46s | 1.06s |
| **Combined page load** | **21.93s** | **3.97s** |

`EXPLAIN` moves from `type=ALL, key=NULL` (full table scan) to `type=index, Using index`.

**Trade-offs a reviewer should weigh**

- **The `sibling_roms` join gets slightly slower.** A wider index means more bytes to
  scan for the query the index was originally built for: roughly 170ms to 209ms for a
  72-ROM page, reproducible over alternating A/B rounds. Per page load the two effects
  cancel out (2.13s vs 2.12s), and the gallery win is two orders of magnitude larger.
- **Why one index and not two.** Keeping the narrow index and adding a separate
  dedup-only one recovers that 39ms, but the second index's first eight columns would be
  identical to the first's, costing write amplification on every ROM insert and update
  for no measurable page-load gain. One index also stops the two consumers from drifting
  apart again, which is how this bug happened.
- **Index size is not a concern.** `fs_name_no_ext` is `varchar(450)`, but real filenames
  are far shorter than the maximum. On the 92.8k-ROM dataset the index grew from 4 MB to
  7 MB.
- **Migration cost.** The index is dropped and recreated, which took 4.9s on 92.8k rows.
  Very large libraries will see a short pause on the first startup after upgrading.

**Testing**

- Full backend suite: 356 passed. `trunk fmt && trunk check`: clean.
- Alembic single head confirmed (`0107_roms_dedup_cover_index`).
- Migration applied, rolled back, and re-applied on **MariaDB** and on **PostgreSQL 16**.
  Index shape verified correct in both directions on both engines.
- Checked PostgreSQL's btree key-size limit with a worst-case row (450 multibyte
  characters in `fs_name_no_ext`, 100 in `flashpoint_id`). Indexes without error.
- The new test was verified against the pre-fix nine-column index, where both the shape
  assertion and the coverage assertion fail. It catches the bug it is guarding, rather
  than only passing on the fixed tree.
- Before/after timings above taken against a copy of a real large library, not synthetic
  data, running the queries SQLAlchemy actually emits.

**Known follow-up, deliberately not in this PR**

Every gallery scroll also calls `get_rom_count` to recompute a total the client already
received during its first request. That is about 1.0s of avoidable work per scroll even
after this index lands. It wants a `with_total=false` opt-out mirroring the existing
`with_rom_id_index` parameter, which is a behaviour change to the endpoint and belongs in
its own PR.

**AI assistance disclosure**

This PR was written primarily by Claude Code (Claude Opus 5), including the investigation,
the migration, the tests, and this description. I directed the work, reviewed every
change, and the performance numbers come from measurements against my own library rather
than from estimates.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes