### PR TITLE
fix(scan): report only newly discovered firmware

### DIFF
--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -672,19 +672,23 @@ async def _identify_platform(
             fs_fw=fs_fw,
         )
 
+    # `new_firmware_count` is scoped to this scan: the client reports what the
+    # scan discovered, not the platform's total firmware library.
     await socket_manager.emit(
         "scan:scanning_platform",
-        PlatformSchema.model_validate(platform).model_dump(
-            include={
-                "id",
-                "name",
-                "display_name",
-                "slug",
-                "fs_slug",
-                "is_identified",
-                "firmware_count",
-            }
-        ),
+        {
+            **PlatformSchema.model_validate(platform).model_dump(
+                include={
+                    "id",
+                    "name",
+                    "display_name",
+                    "slug",
+                    "fs_slug",
+                    "is_identified",
+                }
+            ),
+            "new_firmware_count": new_firmware,
+        },
     )
 
     # This reduces the number of socket emissions

--- a/backend/tests/endpoints/sockets/test_scan.py
+++ b/backend/tests/endpoints/sockets/test_scan.py
@@ -26,6 +26,7 @@ from handler.filesystem.roms_handler import (
 )
 from handler.metadata.base_handler import UniversalPlatformSlug as UPS
 from handler.scan_handler import MetadataSource, ScanType
+from models.firmware import Firmware
 from models.platform import Platform
 from models.rom import Rom
 
@@ -864,6 +865,104 @@ class TestIdentifyPlatformEmitsRestoredRoms:
             call.args[0] == "scan:scanning_rom"
             for call in socket_manager.emit.call_args_list
         )
+
+
+class TestIdentifyPlatformFirmwareReporting:
+    """The platform emit reports firmware discovered by this scan only.
+
+    Reporting the platform's total firmware count made every re-scan look like
+    it had found new firmware.
+    """
+
+    @pytest.fixture
+    def patched(self, mocker):
+        mocker.patch.object(
+            scan_module, "redis_client", Mock(get=Mock(return_value=None))
+        )
+
+        platform = Platform(name="Test", slug="test", fs_slug="test")
+        platform.id = 1
+        platform.missing_from_fs = False
+        db_platform = mocker.patch.object(scan_module, "db_platform_handler")
+        db_platform.get_platform_by_fs_slug.return_value = platform
+        db_platform.add_platform.return_value = platform
+
+        mocker.patch.object(
+            scan_module, "scan_platform", AsyncMock(return_value=platform)
+        )
+        mocker.patch.object(
+            scan_module.PlatformSchema,
+            "model_validate",
+            return_value=Mock(model_dump=Mock(return_value={"id": platform.id})),
+        )
+        mocker.patch.object(
+            scan_module.fs_firmware_handler,
+            "get_firmware",
+            AsyncMock(return_value=["known.bin", "brand-new.bin"]),
+        )
+        mocker.patch.object(
+            scan_module,
+            "scan_firmware",
+            AsyncMock(return_value=Firmware(file_name="known.bin", platform_id=1)),
+        )
+        mocker.patch.object(
+            scan_module.Firmware, "verify_file_hashes", return_value=True
+        )
+        mocker.patch.object(
+            scan_module.fs_rom_handler, "get_roms", AsyncMock(return_value=[])
+        )
+
+        db_rom = mocker.patch.object(scan_module, "db_rom_handler")
+        db_rom.get_roms_by_fs_name.return_value = {}
+        db_rom.mark_missing_roms.return_value = []
+        db_rom.get_missing_rom_ids.return_value = set()
+
+        db_firmware = mocker.patch.object(scan_module, "db_firmware_handler")
+        db_firmware.mark_missing_firmware.return_value = []
+        # Only "brand-new.bin" is missing from the database.
+        db_firmware.get_firmware_by_filename.side_effect = (
+            lambda platform_id, file_name: (
+                Firmware(file_name=file_name, platform_id=platform_id)
+                if file_name == "known.bin"
+                else None
+            )
+        )
+        return db_firmware
+
+    async def _emitted_platform_payload(self, socket_manager):
+        await scan_module._identify_platform(
+            platform_slug="test",
+            scan_type=ScanType.QUICK,
+            fs_platforms=["test"],
+            roms_ids=[],
+            metadata_sources=[],
+            launchbox_remote_enabled=False,
+            playmatch_enabled=False,
+            socket_manager=socket_manager,
+            scan_stats=AsyncMock(),
+        )
+        return next(
+            call.args[1]
+            for call in socket_manager.emit.call_args_list
+            if call.args[0] == "scan:scanning_platform"
+        )
+
+    async def test_counts_only_firmware_missing_from_the_database(self, patched):
+        payload = await self._emitted_platform_payload(AsyncMock())
+
+        assert payload["new_firmware_count"] == 1
+        assert "firmware_count" not in payload
+
+    async def test_reports_zero_when_all_firmware_is_already_known(self, patched):
+        patched.get_firmware_by_filename.side_effect = (
+            lambda platform_id, file_name: Firmware(
+                file_name=file_name, platform_id=platform_id
+            )
+        )
+
+        payload = await self._emitted_platform_payload(AsyncMock())
+
+        assert payload["new_firmware_count"] == 0
 
 
 class TestGetPico8CoverUrl:

--- a/frontend/src/components/Scan/ScanPlatform.vue
+++ b/frontend/src/components/Scan/ScanPlatform.vue
@@ -30,15 +30,15 @@ const { t } = useI18n();
           {{ platform.roms.length }}
         </v-chip>
         <v-chip
-          v-if="platform.firmware_count > 0"
+          v-if="platform.new_firmware_count > 0"
           class="ml-1"
           color="secondary"
           size="x-small"
           label
-          :title="t('scan.firmware-found', platform.firmware_count)"
+          :title="t('scan.firmware-found', platform.new_firmware_count)"
         >
           <v-icon start size="x-small">mdi-memory</v-icon>
-          {{ platform.firmware_count }}
+          {{ platform.new_firmware_count }}
         </v-chip>
         <v-chip
           v-if="!platform.is_identified"
@@ -192,10 +192,7 @@ const { t } = useI18n();
         </template>
       </template>
     </RomListItem>
-    <v-list-item
-      v-if="platform.roms.length === 0 && platform.firmware_count === 0"
-      class="text-center my-2"
-    >
+    <v-list-item v-if="platform.roms.length === 0" class="text-center my-2">
       {{ t("scan.no-new-roms") }}
     </v-list-item>
   </v-expansion-panel-text>

--- a/frontend/src/components/common/Navigation/ScanBtn.vue
+++ b/frontend/src/components/common/Navigation/ScanBtn.vue
@@ -67,7 +67,7 @@ const processRomUpdates = debounce(() => {
         fs_slug: rom.platform_fs_slug,
         is_identified: true,
         roms: [],
-        firmware_count: 0,
+        new_firmware_count: 0,
       });
       scannedPlatform = scanningPlatforms.value.at(-1)!;
     }
@@ -95,7 +95,7 @@ socket.on(
     id,
     fs_slug,
     is_identified,
-    firmware_count,
+    new_firmware_count,
   }: ScanningPlatform) => {
     scanningStore.setScanning(true);
     scanningPlatforms.value = scanningPlatforms.value.filter(
@@ -108,7 +108,7 @@ socket.on(
       id,
       fs_slug,
       roms: [],
-      firmware_count,
+      new_firmware_count,
       is_identified,
     });
   },

--- a/frontend/src/stores/scanning.ts
+++ b/frontend/src/stores/scanning.ts
@@ -5,15 +5,11 @@ import type { Platform } from "./platforms";
 
 export interface ScanningPlatform extends Pick<
   Platform,
-  | "id"
-  | "name"
-  | "display_name"
-  | "slug"
-  | "fs_slug"
-  | "is_identified"
-  | "firmware_count"
+  "id" | "name" | "display_name" | "slug" | "fs_slug" | "is_identified"
 > {
   roms: SimpleRom[];
+  /** Firmware discovered by the running scan, not the platform's total. */
+  new_firmware_count: number;
 }
 
 export default defineStore("scanning", {

--- a/frontend/src/v2/components/Scan/ScanPlatform.test.ts
+++ b/frontend/src/v2/components/Scan/ScanPlatform.test.ts
@@ -1,0 +1,66 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import type { ScanningPlatform } from "@/stores/scanning";
+import ScanPlatform from "./ScanPlatform.vue";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+function mountPlatform(overrides: Partial<ScanningPlatform> = {}) {
+  const platform: ScanningPlatform = {
+    id: 1,
+    name: "Game Boy Color",
+    display_name: "Game Boy Color",
+    slug: "gbc",
+    fs_slug: "gbc",
+    is_identified: true,
+    roms: [],
+    new_firmware_count: 0,
+    ...overrides,
+  };
+
+  return mount(ScanPlatform, {
+    props: { platform, open: true },
+    global: {
+      stubs: {
+        RCollapsible: {
+          template: "<div><slot /><slot name='header-append' /></div>",
+        },
+        RPlatformIcon: true,
+        RTag: {
+          props: ["text"],
+          template: "<span class='r-tag'>{{ text }}</span>",
+        },
+        RVirtualScroller: true,
+      },
+    },
+  });
+}
+
+describe("ScanPlatform", () => {
+  // Firmware already in the library is not a scan result: the header used to
+  // show the platform's total firmware count, so every re-scan looked like it
+  // had discovered firmware (issue #4049).
+  it("hides the firmware tag when the scan found no new firmware", () => {
+    const wrapper = mountPlatform({ new_firmware_count: 0 });
+
+    expect(wrapper.findAll(".r-tag")).toHaveLength(1);
+  });
+
+  it("shows the count of firmware discovered by this scan", () => {
+    const wrapper = mountPlatform({ new_firmware_count: 2 });
+
+    const tags = wrapper.findAll(".r-tag");
+    expect(tags).toHaveLength(2);
+    expect(tags[1].text()).toBe("2");
+  });
+
+  // The body only lists ROMs, so a firmware-only platform rendered an empty
+  // panel instead of the "no new roms" message.
+  it("reports no new roms even when firmware was found", () => {
+    const wrapper = mountPlatform({ new_firmware_count: 2 });
+
+    expect(wrapper.text()).toContain("scan.no-new-roms");
+  });
+});

--- a/frontend/src/v2/components/Scan/ScanPlatform.vue
+++ b/frontend/src/v2/components/Scan/ScanPlatform.vue
@@ -78,12 +78,12 @@ function getItemKey(item: unknown) {
     <template #header-append>
       <RTag tone="brand" size="x-small" :text="String(platform.roms.length)" />
       <RTag
-        v-if="platform.firmware_count > 0"
+        v-if="platform.new_firmware_count > 0"
         tone="warning"
         size="x-small"
         icon="mdi-memory"
-        :text="String(platform.firmware_count)"
-        :title="t('scan.firmware-found', platform.firmware_count)"
+        :text="String(platform.new_firmware_count)"
+        :title="t('scan.firmware-found', platform.new_firmware_count)"
       />
       <RTag
         v-if="!platform.is_identified"
@@ -97,10 +97,7 @@ function getItemKey(item: unknown) {
     <!-- Always virtualised — keeps the body surface flush with its
          content height regardless of how many rows have streamed in,
          and bounds the DOM size on big platforms. -->
-    <div
-      v-if="platform.roms.length === 0 && platform.firmware_count === 0"
-      class="r-v2-scan-platform__empty"
-    >
+    <div v-if="platform.roms.length === 0" class="r-v2-scan-platform__empty">
       {{ t("scan.no-new-roms") }}
     </div>
     <RVirtualScroller

--- a/frontend/src/v2/composables/useScanLifecycle/index.ts
+++ b/frontend/src/v2/composables/useScanLifecycle/index.ts
@@ -49,7 +49,7 @@ export function installScanLifecycle() {
       id,
       fs_slug,
       is_identified,
-      firmware_count,
+      new_firmware_count,
     }) => {
       scanningStore.setScanning(true);
       // De-dupe by display_name so a re-scan of the same platform
@@ -66,7 +66,7 @@ export function installScanLifecycle() {
         id,
         fs_slug,
         roms: [],
-        firmware_count,
+        new_firmware_count,
         is_identified,
       });
 
@@ -132,7 +132,7 @@ export function installScanLifecycle() {
           fs_slug: rom.platform_fs_slug,
           is_identified: true,
           roms: [],
-          firmware_count: 0,
+          new_firmware_count: 0,
         });
         scannedPlatform = scanningStore.scanningPlatforms.at(0)!;
       }

--- a/frontend/src/v2/views/Scan.vue
+++ b/frontend/src/v2/views/Scan.vue
@@ -282,19 +282,18 @@ const effectiveMetadataSources = computed<MetadataOption[]>(() => {
   return [...general, ...specific];
 });
 
-// Auto-expand a platform's panel the moment it starts reporting roms
-// or firmware. We track by `id:hasContent` so the watch fires only on
-// the 0 → 1 transition, not per-ROM.
+// Auto-expand a platform's panel the moment it starts reporting roms. The
+// panel body only lists ROMs, so firmware alone leaves nothing to show. We
+// track by `id:hasRoms` so the watch fires only on the 0 → 1 transition,
+// not per-ROM.
 const platformsWithRomsKey = computed(() =>
   scanningPlatforms.value
-    .map((p) => `${p.id}:${p.roms.length > 0 || p.firmware_count > 0 ? 1 : 0}`)
+    .map((p) => `${p.id}:${p.roms.length > 0 ? 1 : 0}`)
     .join(","),
 );
 watch(platformsWithRomsKey, () => {
   openPlatforms.value = new Set(
-    scanningPlatforms.value
-      .filter((p) => p.roms.length > 0 || p.firmware_count > 0)
-      .map((p) => p.id),
+    scanningPlatforms.value.filter((p) => p.roms.length > 0).map((p) => p.id),
   );
 });
 

--- a/frontend/src/views/Scan.vue
+++ b/frontend/src/views/Scan.vue
@@ -87,18 +87,16 @@ watch(metadataOptions, (newOptions) => {
   );
 });
 
-// Track which platforms have ROMs/firmware without a deep watch on the entire array.
+// Track which platforms have ROMs without a deep watch on the entire array.
 // The computed returns a stable string that only changes when a platform
-// transitions from 0→1+ ROMs/firmware (or back), so the watch fires O(n_platforms)
+// transitions from 0→1+ ROMs (or back), so the watch fires O(n_platforms)
 // times rather than O(n_roms) times.
 const platformsWithRomsKey = computed(() =>
-  scanningPlatforms.value
-    .map((p) => (p.roms.length > 0 || p.firmware_count > 0 ? 1 : 0))
-    .join(""),
+  scanningPlatforms.value.map((p) => (p.roms.length > 0 ? 1 : 0)).join(""),
 );
 watch(platformsWithRomsKey, () => {
   panels.value = scanningPlatforms.value
-    .map((p, index) => (p.roms.length > 0 || p.firmware_count > 0 ? index : -1))
+    .map((p, index) => (p.roms.length > 0 ? index : -1))
     .filter((index) => index !== -1);
 });
 


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #4049

A quick scan over an unchanged library reported firmware as new for every platform, and expanded a platform panel that then rendered nothing.

The `scan:scanning_platform` socket payload carried `firmware_count`, the platform's **total** firmware (a derived field on `PlatformSchema`). The scan view used it both for the firmware chip and for the auto-expand condition, so already-known firmware looked like a scan result on every run. Since the panel body only lists ROMs, the expanded card was empty.

- Backend emits `new_firmware_count` instead, scoped to the running scan (the count `_identify_firmware` already tracks) and no longer leaks the platform total into the payload.
- `ScanningPlatform` carries `new_firmware_count`; the v1 and v2 scan views show the firmware chip only when the scan actually found firmware.
- Auto-expand now keys off the ROM list alone, since firmware is not listed in the panel body.
- The "no new ROMs" message shows whenever no ROMs were found, so a manually opened firmware-only panel is never blank.

AI assistance disclosure: this change was written with Claude Code (Claude Opus 5). I reviewed the diff and ran the checks below; the browser check is still outstanding (see checklist).

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Verified: `pytest tests/endpoints/sockets/test_scan.py` (74 passed, 2 new tests on the emitted payload), `npm run typecheck`, `npm run test` (611 passed, 3 new `ScanPlatform` tests), `trunk fmt && trunk check`. Not yet verified with a live re-scan in the browser.

#### Screenshots (if applicable)

Before (from #4049) — 0 ROMs but 2 firmware reported, panel expands empty:

<img width="962" height="336" alt="Image" src="https://github.com/user-attachments/assets/f36b02ea-b505-45aa-8211-e7662fae6001" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
