### PR TITLE
feat(home): make the random pick widget clickable and denser

### DIFF
--- a/frontend/src/locales/bg_BG/home.json
+++ b/frontend/src/locales/bg_BG/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "Статистика на библиотеката",
   "widget-random-pick": "Случаен избор",
   "widget-random-pick-empty": "Все още няма заредени игри",
-  "widget-random-pick-open": "Отвори",
   "widget-random-pick-reroll": "Избери отново"
 }

--- a/frontend/src/locales/bg_BG/home.json
+++ b/frontend/src/locales/bg_BG/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "Статистика на библиотеката",
   "widget-random-pick": "Случаен избор",
   "widget-random-pick-empty": "Все още няма заредени игри",
+  "widget-random-pick-error": "Неуспешен избор на игра",
   "widget-random-pick-reroll": "Избери отново"
 }

--- a/frontend/src/locales/cs_CZ/home.json
+++ b/frontend/src/locales/cs_CZ/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "Statistiky knihovny",
   "widget-random-pick": "Náhodný výběr",
   "widget-random-pick-empty": "Zatím nebyly načteny žádné hry",
+  "widget-random-pick-error": "Nepodařilo se vybrat hru",
   "widget-random-pick-reroll": "Vybrat znovu"
 }

--- a/frontend/src/locales/cs_CZ/home.json
+++ b/frontend/src/locales/cs_CZ/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "Statistiky knihovny",
   "widget-random-pick": "Náhodný výběr",
   "widget-random-pick-empty": "Zatím nebyly načteny žádné hry",
-  "widget-random-pick-open": "Otevřít",
   "widget-random-pick-reroll": "Vybrat znovu"
 }

--- a/frontend/src/locales/de_DE/home.json
+++ b/frontend/src/locales/de_DE/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "Bibliotheksstatistik",
   "widget-random-pick": "Zufallsauswahl",
   "widget-random-pick-empty": "Noch keine Spiele geladen",
-  "widget-random-pick-open": "Öffnen",
   "widget-random-pick-reroll": "Neu würfeln"
 }

--- a/frontend/src/locales/de_DE/home.json
+++ b/frontend/src/locales/de_DE/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "Bibliotheksstatistik",
   "widget-random-pick": "Zufallsauswahl",
   "widget-random-pick-empty": "Noch keine Spiele geladen",
+  "widget-random-pick-error": "Spiel konnte nicht ausgewählt werden",
   "widget-random-pick-reroll": "Neu würfeln"
 }

--- a/frontend/src/locales/en_GB/home.json
+++ b/frontend/src/locales/en_GB/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "Library stats",
   "widget-random-pick": "Random pick",
   "widget-random-pick-empty": "No games loaded yet",
-  "widget-random-pick-open": "Open",
   "widget-random-pick-reroll": "Reroll"
 }

--- a/frontend/src/locales/en_GB/home.json
+++ b/frontend/src/locales/en_GB/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "Library stats",
   "widget-random-pick": "Random pick",
   "widget-random-pick-empty": "No games loaded yet",
+  "widget-random-pick-error": "Couldn't pick a game",
   "widget-random-pick-reroll": "Reroll"
 }

--- a/frontend/src/locales/en_US/home.json
+++ b/frontend/src/locales/en_US/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "Library stats",
   "widget-random-pick": "Random pick",
   "widget-random-pick-empty": "No games loaded yet",
-  "widget-random-pick-open": "Open",
   "widget-random-pick-reroll": "Reroll"
 }

--- a/frontend/src/locales/en_US/home.json
+++ b/frontend/src/locales/en_US/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "Library stats",
   "widget-random-pick": "Random pick",
   "widget-random-pick-empty": "No games loaded yet",
+  "widget-random-pick-error": "Couldn't pick a game",
   "widget-random-pick-reroll": "Reroll"
 }

--- a/frontend/src/locales/es_ES/home.json
+++ b/frontend/src/locales/es_ES/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "Estadísticas de la biblioteca",
   "widget-random-pick": "Selección aleatoria",
   "widget-random-pick-empty": "Aún no se han cargado juegos",
+  "widget-random-pick-error": "No se pudo elegir un juego",
   "widget-random-pick-reroll": "Volver a sortear"
 }

--- a/frontend/src/locales/es_ES/home.json
+++ b/frontend/src/locales/es_ES/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "Estadísticas de la biblioteca",
   "widget-random-pick": "Selección aleatoria",
   "widget-random-pick-empty": "Aún no se han cargado juegos",
-  "widget-random-pick-open": "Abrir",
   "widget-random-pick-reroll": "Volver a sortear"
 }

--- a/frontend/src/locales/fr_FR/home.json
+++ b/frontend/src/locales/fr_FR/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "Statistiques de la bibliothèque",
   "widget-random-pick": "Choix aléatoire",
   "widget-random-pick-empty": "Aucun jeu chargé pour l'instant",
-  "widget-random-pick-open": "Ouvrir",
   "widget-random-pick-reroll": "Relancer"
 }

--- a/frontend/src/locales/fr_FR/home.json
+++ b/frontend/src/locales/fr_FR/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "Statistiques de la bibliothèque",
   "widget-random-pick": "Choix aléatoire",
   "widget-random-pick-empty": "Aucun jeu chargé pour l'instant",
+  "widget-random-pick-error": "Impossible de choisir un jeu",
   "widget-random-pick-reroll": "Relancer"
 }

--- a/frontend/src/locales/hu_HU/home.json
+++ b/frontend/src/locales/hu_HU/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "Könyvtárstatisztika",
   "widget-random-pick": "Véletlen választás",
   "widget-random-pick-empty": "Még nincsenek betöltve játékok",
+  "widget-random-pick-error": "Nem sikerült játékot választani",
   "widget-random-pick-reroll": "Újradobás"
 }

--- a/frontend/src/locales/hu_HU/home.json
+++ b/frontend/src/locales/hu_HU/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "Könyvtárstatisztika",
   "widget-random-pick": "Véletlen választás",
   "widget-random-pick-empty": "Még nincsenek betöltve játékok",
-  "widget-random-pick-open": "Megnyitás",
   "widget-random-pick-reroll": "Újradobás"
 }

--- a/frontend/src/locales/it_IT/home.json
+++ b/frontend/src/locales/it_IT/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "Statistiche della libreria",
   "widget-random-pick": "Scelta casuale",
   "widget-random-pick-empty": "Nessun gioco ancora caricato",
+  "widget-random-pick-error": "Impossibile scegliere un gioco",
   "widget-random-pick-reroll": "Rilancia"
 }

--- a/frontend/src/locales/it_IT/home.json
+++ b/frontend/src/locales/it_IT/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "Statistiche della libreria",
   "widget-random-pick": "Scelta casuale",
   "widget-random-pick-empty": "Nessun gioco ancora caricato",
-  "widget-random-pick-open": "Apri",
   "widget-random-pick-reroll": "Rilancia"
 }

--- a/frontend/src/locales/ja_JP/home.json
+++ b/frontend/src/locales/ja_JP/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "ライブラリ統計",
   "widget-random-pick": "ランダムピック",
   "widget-random-pick-empty": "まだゲームが読み込まれていません",
-  "widget-random-pick-open": "開く",
   "widget-random-pick-reroll": "引き直す"
 }

--- a/frontend/src/locales/ja_JP/home.json
+++ b/frontend/src/locales/ja_JP/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "ライブラリ統計",
   "widget-random-pick": "ランダムピック",
   "widget-random-pick-empty": "まだゲームが読み込まれていません",
+  "widget-random-pick-error": "ゲームを選べませんでした",
   "widget-random-pick-reroll": "引き直す"
 }

--- a/frontend/src/locales/ko_KR/home.json
+++ b/frontend/src/locales/ko_KR/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "라이브러리 통계",
   "widget-random-pick": "랜덤 선택",
   "widget-random-pick-empty": "아직 불러온 게임이 없습니다",
-  "widget-random-pick-open": "열기",
   "widget-random-pick-reroll": "다시 뽑기"
 }

--- a/frontend/src/locales/ko_KR/home.json
+++ b/frontend/src/locales/ko_KR/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "라이브러리 통계",
   "widget-random-pick": "랜덤 선택",
   "widget-random-pick-empty": "아직 불러온 게임이 없습니다",
+  "widget-random-pick-error": "게임을 뽑지 못했습니다",
   "widget-random-pick-reroll": "다시 뽑기"
 }

--- a/frontend/src/locales/pl_PL/home.json
+++ b/frontend/src/locales/pl_PL/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "Statystyki biblioteki",
   "widget-random-pick": "Losowy wybór",
   "widget-random-pick-empty": "Nie wczytano jeszcze żadnych gier",
-  "widget-random-pick-open": "Otwórz",
   "widget-random-pick-reroll": "Losuj ponownie"
 }

--- a/frontend/src/locales/pl_PL/home.json
+++ b/frontend/src/locales/pl_PL/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "Statystyki biblioteki",
   "widget-random-pick": "Losowy wybór",
   "widget-random-pick-empty": "Nie wczytano jeszcze żadnych gier",
+  "widget-random-pick-error": "Nie udało się wylosować gry",
   "widget-random-pick-reroll": "Losuj ponownie"
 }

--- a/frontend/src/locales/pt_BR/home.json
+++ b/frontend/src/locales/pt_BR/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "Estatísticas da biblioteca",
   "widget-random-pick": "Escolha aleatória",
   "widget-random-pick-empty": "Nenhum jogo carregado ainda",
+  "widget-random-pick-error": "Não foi possível sortear um jogo",
   "widget-random-pick-reroll": "Sortear de novo"
 }

--- a/frontend/src/locales/pt_BR/home.json
+++ b/frontend/src/locales/pt_BR/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "Estatísticas da biblioteca",
   "widget-random-pick": "Escolha aleatória",
   "widget-random-pick-empty": "Nenhum jogo carregado ainda",
-  "widget-random-pick-open": "Abrir",
   "widget-random-pick-reroll": "Sortear de novo"
 }

--- a/frontend/src/locales/ro_RO/home.json
+++ b/frontend/src/locales/ro_RO/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "Statistici bibliotecă",
   "widget-random-pick": "Alegere aleatorie",
   "widget-random-pick-empty": "Niciun joc încărcat încă",
-  "widget-random-pick-open": "Deschide",
   "widget-random-pick-reroll": "Reîncearcă"
 }

--- a/frontend/src/locales/ro_RO/home.json
+++ b/frontend/src/locales/ro_RO/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "Statistici bibliotecă",
   "widget-random-pick": "Alegere aleatorie",
   "widget-random-pick-empty": "Niciun joc încărcat încă",
+  "widget-random-pick-error": "Nu s-a putut alege un joc",
   "widget-random-pick-reroll": "Reîncearcă"
 }

--- a/frontend/src/locales/ru_RU/home.json
+++ b/frontend/src/locales/ru_RU/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "Статистика библиотеки",
   "widget-random-pick": "Случайный выбор",
   "widget-random-pick-empty": "Игры ещё не загружены",
+  "widget-random-pick-error": "Не удалось выбрать игру",
   "widget-random-pick-reroll": "Выбрать заново"
 }

--- a/frontend/src/locales/ru_RU/home.json
+++ b/frontend/src/locales/ru_RU/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "Статистика библиотеки",
   "widget-random-pick": "Случайный выбор",
   "widget-random-pick-empty": "Игры ещё не загружены",
-  "widget-random-pick-open": "Открыть",
   "widget-random-pick-reroll": "Выбрать заново"
 }

--- a/frontend/src/locales/tr_TR/home.json
+++ b/frontend/src/locales/tr_TR/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "Kütüphane istatistikleri",
   "widget-random-pick": "Rastgele seçim",
   "widget-random-pick-empty": "Henüz oyun yüklenmedi",
-  "widget-random-pick-open": "Aç",
   "widget-random-pick-reroll": "Yeniden çevir"
 }

--- a/frontend/src/locales/tr_TR/home.json
+++ b/frontend/src/locales/tr_TR/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "Kütüphane istatistikleri",
   "widget-random-pick": "Rastgele seçim",
   "widget-random-pick-empty": "Henüz oyun yüklenmedi",
+  "widget-random-pick-error": "Oyun seçilemedi",
   "widget-random-pick-reroll": "Yeniden çevir"
 }

--- a/frontend/src/locales/zh_CN/home.json
+++ b/frontend/src/locales/zh_CN/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "库统计",
   "widget-random-pick": "随机推荐",
   "widget-random-pick-empty": "尚未加载游戏",
+  "widget-random-pick-error": "无法抽取游戏",
   "widget-random-pick-reroll": "重新抽取"
 }

--- a/frontend/src/locales/zh_CN/home.json
+++ b/frontend/src/locales/zh_CN/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "库统计",
   "widget-random-pick": "随机推荐",
   "widget-random-pick-empty": "尚未加载游戏",
-  "widget-random-pick-open": "打开",
   "widget-random-pick-reroll": "重新抽取"
 }

--- a/frontend/src/locales/zh_TW/home.json
+++ b/frontend/src/locales/zh_TW/home.json
@@ -17,6 +17,5 @@
   "widget-library-stats": "庫統計",
   "widget-random-pick": "隨機推薦",
   "widget-random-pick-empty": "尚未載入遊戲",
-  "widget-random-pick-open": "開啟",
   "widget-random-pick-reroll": "重新抽取"
 }

--- a/frontend/src/locales/zh_TW/home.json
+++ b/frontend/src/locales/zh_TW/home.json
@@ -17,5 +17,6 @@
   "widget-library-stats": "庫統計",
   "widget-random-pick": "隨機推薦",
   "widget-random-pick-empty": "尚未載入遊戲",
+  "widget-random-pick-error": "無法抽取遊戲",
   "widget-random-pick-reroll": "重新抽取"
 }

--- a/frontend/src/v2/components/Home/Widgets/RandomPickWidget.vue
+++ b/frontend/src/v2/components/Home/Widgets/RandomPickWidget.vue
@@ -15,11 +15,13 @@ import romApi from "@/services/api/rom";
 import type { SimpleRom } from "@/stores/roms";
 import CachedPlatformIcon from "@/v2/components/shared/CachedPlatformIcon.vue";
 import GameCover from "@/v2/components/shared/GameCover.vue";
+import { useSnackbar } from "@/v2/composables/useSnackbar";
 import WidgetCard from "./WidgetCard.vue";
 
 defineOptions({ inheritAttrs: false });
 
 const { t } = useI18n();
+const snackbar = useSnackbar();
 
 // The reroll button shows a real die face rather than the stacked
 // `dice-multiple` glyph, which reads as two windows at this size. Each
@@ -33,8 +35,19 @@ const DICE_FACES = [
   "mdi-dice-6-outline",
 ];
 
+// A pick needs a single row, so it opts out of the char index, filter
+// values and rom id index the endpoint returns by default: each of them
+// spans the whole library and dwarfs the row itself.
+const PICK_QUERY = {
+  limit: 1,
+  withCharIndex: false,
+  withFilterValues: false,
+  withRomIdIndex: false,
+} as const;
+
 const pick = ref<SimpleRom | null>(null);
 const loading = ref(false);
+const failed = ref(false);
 const diceFace = ref(DICE_FACES[Math.floor(Math.random() * DICE_FACES.length)]);
 const rerollBtn = ref<ComponentPublicInstance | null>(null);
 
@@ -53,33 +66,50 @@ const releaseYear = computed(() => {
 
 const region = computed(() => pick.value?.regions?.[0] ?? null);
 
+const placeholder = computed(() =>
+  failed.value
+    ? t("home.widget-random-pick-error")
+    : t("home.widget-random-pick-empty"),
+);
+
 function rollDiceFace() {
   const others = DICE_FACES.filter((face) => face !== diceFace.value);
   diceFace.value = others[Math.floor(Math.random() * others.length)];
 }
 
-async function reroll() {
+// One attempt at a pick. `null` means the library holds no roms;
+// `undefined` means the offset came back empty, which the backend's
+// cached id index makes possible when it drifts from the database
+// between the two calls (a scan, a deletion).
+async function pickOnce(): Promise<SimpleRom | null | undefined> {
+  const { data: head } = await romApi.getRoms({ ...PICK_QUERY, offset: 0 });
+  if (!head.total) return null;
+
+  const { data: result } = await romApi.getRoms({
+    ...PICK_QUERY,
+    offset: Math.floor(Math.random() * head.total),
+  });
+  return result.items.at(0);
+}
+
+async function reroll({ notify }: { notify: boolean }) {
   if (loading.value) return;
   rollDiceFace();
   // Disabling the button pulls focus to <body>; hand it back after.
   const hadFocus = document.activeElement === rerollEl();
   loading.value = true;
   try {
-    // First call: get the library total. limit=1/offset=0 is cheap and
-    // gives us the `total` we need to pick a random offset from.
-    const { data: head } = await romApi.getRoms({ limit: 1, offset: 0 });
-    if (!head.total || head.total === 0) {
-      pick.value = null;
-      return;
-    }
-    const randomOffset = Math.floor(Math.random() * head.total);
-    const { data: result } = await romApi.getRoms({
-      limit: 1,
-      offset: randomOffset,
-    });
-    pick.value = result.items[0] ?? null;
+    let rom = await pickOnce();
+    // Drift is worth one retry, since the second attempt re-reads the total.
+    if (rom === undefined) rom = await pickOnce();
+    if (rom === undefined) throw new Error("random pick came back empty");
+    pick.value = rom;
+    failed.value = false;
   } catch {
-    pick.value = null;
+    // Keep the previous pick: a failed request says nothing about whether
+    // the library holds games, so falling back to the empty copy would lie.
+    failed.value = true;
+    if (notify) snackbar.error(t("home.widget-random-pick-error"));
   } finally {
     loading.value = false;
     if (hadFocus) {
@@ -89,7 +119,13 @@ async function reroll() {
   }
 }
 
-onMounted(reroll);
+function onReroll() {
+  void reroll({ notify: true });
+}
+
+// The first pick is ours, not the user's: the card carries its own
+// failure copy, so it stays out of the snackbar stack.
+onMounted(() => reroll({ notify: false }));
 </script>
 
 <template>
@@ -104,7 +140,7 @@ onMounted(reroll);
         class="r-v2-widget-pick__reroll"
         :tooltip="t('home.widget-random-pick-reroll')"
         :aria-label="t('home.widget-random-pick-reroll')"
-        @click="reroll"
+        @click="onReroll"
       />
     </template>
     <router-link
@@ -141,7 +177,7 @@ onMounted(reroll);
       </div>
     </router-link>
     <div v-else class="r-v2-widget-pick__empty">
-      {{ t("home.widget-random-pick-empty") }}
+      {{ placeholder }}
     </div>
   </WidgetCard>
 </template>

--- a/frontend/src/v2/components/Home/Widgets/RandomPickWidget.vue
+++ b/frontend/src/v2/components/Home/Widgets/RandomPickWidget.vue
@@ -1,29 +1,60 @@
 <script setup lang="ts">
 // RandomPickWidget — picks a random ROM from the library and surfaces
-// it on the Home dashboard. Body: cover + name + an "Open" / reroll
-// button pair. Reroll reshuffles in place without navigating. Two API
-// calls per pick: one to learn the library total, one to fetch the
-// selected offset; same approach the v1 RandomBtn uses. The pick is
-// intentionally not cached so each mount re-shuffles.
-import { RBtn } from "@v2/lib";
-import { onMounted, ref } from "vue";
+// it on the Home dashboard. Body: cover + name + platform + release
+// year / region, the whole thing a link to the rom. Reroll lives in
+// the card's top-right action slot and reshuffles in place without
+// navigating. Two API calls per pick: one to learn the library total,
+// one to fetch the selected offset; same approach the v1 RandomBtn
+// uses. The pick is intentionally not cached so each mount re-shuffles.
+import { RBtn, RChip } from "@v2/lib";
+import { computed, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
-import { useRouter } from "vue-router";
 import { ROUTES } from "@/plugins/router";
 import romApi from "@/services/api/rom";
 import type { SimpleRom } from "@/stores/roms";
+import CachedPlatformIcon from "@/v2/components/shared/CachedPlatformIcon.vue";
 import GameCover from "@/v2/components/shared/GameCover.vue";
 import WidgetCard from "./WidgetCard.vue";
 
 defineOptions({ inheritAttrs: false });
 
 const { t } = useI18n();
-const router = useRouter();
+
+// The reroll button shows a real die face rather than the stacked
+// `dice-multiple` glyph, which reads as two windows at this size. Each
+// roll lands on a different face.
+const DICE_FACES = [
+  "mdi-dice-1-outline",
+  "mdi-dice-2-outline",
+  "mdi-dice-3-outline",
+  "mdi-dice-4-outline",
+  "mdi-dice-5-outline",
+  "mdi-dice-6-outline",
+];
 
 const pick = ref<SimpleRom | null>(null);
 const loading = ref(false);
+const diceFace = ref(DICE_FACES[Math.floor(Math.random() * DICE_FACES.length)]);
+
+const title = computed(() => pick.value?.name || pick.value?.fs_name || "");
+
+const releaseYear = computed(() => {
+  const ts = pick.value?.metadatum?.first_release_date;
+  if (!ts) return null;
+  const date = new Date(Number(ts));
+  return Number.isNaN(date.getTime()) ? null : date.getFullYear();
+});
+
+const region = computed(() => pick.value?.regions?.[0] ?? null);
+
+function rollDiceFace() {
+  const others = DICE_FACES.filter((face) => face !== diceFace.value);
+  diceFace.value = others[Math.floor(Math.random() * others.length)];
+}
 
 async function reroll() {
+  rollDiceFace();
+  if (loading.value) return;
   loading.value = true;
   try {
     // First call: get the library total. limit=1/offset=0 is cheap and
@@ -46,53 +77,55 @@ async function reroll() {
   }
 }
 
-function openPick() {
-  if (!pick.value) return;
-  router.push({ name: ROUTES.ROM, params: { rom: pick.value.id } });
-}
-
 onMounted(reroll);
 </script>
 
 <template>
   <WidgetCard :title="t('home.widget-random-pick')" :loading="loading">
-    <div v-if="pick" class="r-v2-widget-pick__body">
+    <template #action>
+      <RBtn
+        variant="text"
+        size="small"
+        :icon="diceFace"
+        class="r-v2-widget-pick__reroll"
+        :tooltip="t('home.widget-random-pick-reroll')"
+        :aria-label="t('home.widget-random-pick-reroll')"
+        @click="reroll"
+      />
+    </template>
+    <router-link
+      v-if="pick"
+      class="r-v2-widget-pick__body"
+      :to="{ name: ROUTES.ROM, params: { rom: pick.id } }"
+    >
       <GameCover
         :rom="pick"
-        :title="pick.name || pick.fs_name"
+        :title="title"
         :identified="pick.is_identified"
         class="r-v2-widget-pick__cover"
       />
       <div class="r-v2-widget-pick__info">
-        <div class="r-v2-widget-pick__name">
-          {{ pick.name || pick.fs_name }}
-        </div>
-        <!-- Open + reroll sit together at the bottom of the info
-             column — paired controls read as one cluster instead of
-             scattering the reroll up in the card's top-right action
-             slot. -->
-        <div class="r-v2-widget-pick__actions">
-          <RBtn
-            variant="outlined"
-            surface
-            size="x-small"
-            prepend-icon="mdi-open-in-new"
-            @click="openPick"
-          >
-            {{ t("home.widget-random-pick-open") }}
-          </RBtn>
-          <RBtn
-            variant="outlined"
-            surface
-            size="x-small"
-            icon="mdi-dice-multiple-outline"
-            :tooltip="t('home.widget-random-pick-reroll')"
-            :aria-label="t('home.widget-random-pick-reroll')"
-            @click="reroll"
+        <div class="r-v2-widget-pick__name">{{ title }}</div>
+        <div class="r-v2-widget-pick__platform">
+          <CachedPlatformIcon
+            :slug="pick.platform_slug"
+            :name="pick.platform_display_name"
+            :size="14"
           />
+          <span class="r-v2-widget-pick__platform-name">
+            {{ pick.platform_display_name }}
+          </span>
+        </div>
+        <!-- Year + region disambiguate the pick when a library holds
+             several variations of the same title. -->
+        <div v-if="releaseYear || region" class="r-v2-widget-pick__meta">
+          <span v-if="releaseYear">{{ releaseYear }}</span>
+          <RChip v-if="region" size="x-small" variant="translucent">
+            {{ region }}
+          </RChip>
         </div>
       </div>
-    </div>
+    </router-link>
     <div v-else class="r-v2-widget-pick__empty">
       {{ t("home.widget-random-pick-empty") }}
     </div>
@@ -105,6 +138,10 @@ onMounted(reroll);
   gap: 10px;
   flex: 1;
   min-width: 0;
+  overflow: hidden;
+  color: inherit;
+  text-decoration: none;
+  border-radius: var(--r-radius-sm);
 }
 
 /* Fixed height, natural width — the cover renders at its image's true
@@ -121,14 +158,16 @@ onMounted(reroll);
 .r-v2-widget-pick__info {
   flex: 1;
   min-width: 0;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 4px;
 }
 
 .r-v2-widget-pick__name {
   font-size: 12.5px;
   font-weight: var(--r-font-weight-semibold);
+  line-height: 1.2;
   color: var(--r-color-fg);
   /* Clamp at 2 lines — random covers + 70px height keep the card from
      growing when the picked title is long. */
@@ -136,13 +175,45 @@ onMounted(reroll);
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  transition: color var(--r-motion-fast) var(--r-motion-ease-out);
 }
 
-.r-v2-widget-pick__actions {
+/* Hover is gated to pointer modalities so a parked cursor doesn't
+   compete with the focused element under keyboard / gamepad. */
+html[data-input="mouse"] .r-v2-widget-pick__body:hover .r-v2-widget-pick__name,
+html[data-input="touch"] .r-v2-widget-pick__body:hover .r-v2-widget-pick__name,
+.r-v2-widget-pick__body:focus-visible .r-v2-widget-pick__name {
+  color: var(--r-color-brand-primary);
+}
+
+.r-v2-widget-pick__platform {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  font-size: 11px;
+  color: var(--r-color-fg-muted);
+}
+
+.r-v2-widget-pick__platform-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.r-v2-widget-pick__meta {
   display: flex;
   align-items: center;
   gap: 6px;
   margin-top: auto;
+  font-size: 11px;
+  color: var(--r-color-fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* The die reads as a die only above the button's default 1.25em glyph. */
+.r-v2-widget-pick__reroll :deep(.r-btn__icon) {
+  font-size: 19px;
 }
 
 .r-v2-widget-pick__empty {

--- a/frontend/src/v2/components/Home/Widgets/RandomPickWidget.vue
+++ b/frontend/src/v2/components/Home/Widgets/RandomPickWidget.vue
@@ -7,7 +7,8 @@
 // one to fetch the selected offset; same approach the v1 RandomBtn
 // uses. The pick is intentionally not cached so each mount re-shuffles.
 import { RBtn, RChip } from "@v2/lib";
-import { computed, onMounted, ref } from "vue";
+import { computed, nextTick, onMounted, ref } from "vue";
+import type { ComponentPublicInstance } from "vue";
 import { useI18n } from "vue-i18n";
 import { ROUTES } from "@/plugins/router";
 import romApi from "@/services/api/rom";
@@ -35,6 +36,11 @@ const DICE_FACES = [
 const pick = ref<SimpleRom | null>(null);
 const loading = ref(false);
 const diceFace = ref(DICE_FACES[Math.floor(Math.random() * DICE_FACES.length)]);
+const rerollBtn = ref<ComponentPublicInstance | null>(null);
+
+function rerollEl(): HTMLElement | null {
+  return (rerollBtn.value?.$el as HTMLElement | undefined) ?? null;
+}
 
 const title = computed(() => pick.value?.name || pick.value?.fs_name || "");
 
@@ -53,11 +59,10 @@ function rollDiceFace() {
 }
 
 async function reroll() {
-  // The face only turns for a roll that actually happens — flipping it
-  // on a click the in-flight guard discards would signal a new pick
-  // that never lands.
   if (loading.value) return;
   rollDiceFace();
+  // Disabling the button pulls focus to <body>; hand it back after.
+  const hadFocus = document.activeElement === rerollEl();
   loading.value = true;
   try {
     // First call: get the library total. limit=1/offset=0 is cheap and
@@ -77,6 +82,10 @@ async function reroll() {
     pick.value = null;
   } finally {
     loading.value = false;
+    if (hadFocus) {
+      await nextTick();
+      rerollEl()?.focus();
+    }
   }
 }
 
@@ -87,9 +96,11 @@ onMounted(reroll);
   <WidgetCard :title="t('home.widget-random-pick')" :loading="loading">
     <template #action>
       <RBtn
+        ref="rerollBtn"
         variant="text"
         size="small"
         :icon="diceFace"
+        :disabled="loading"
         class="r-v2-widget-pick__reroll"
         :tooltip="t('home.widget-random-pick-reroll')"
         :aria-label="t('home.widget-random-pick-reroll')"

--- a/frontend/src/v2/components/Home/Widgets/RandomPickWidget.vue
+++ b/frontend/src/v2/components/Home/Widgets/RandomPickWidget.vue
@@ -53,8 +53,11 @@ function rollDiceFace() {
 }
 
 async function reroll() {
-  rollDiceFace();
+  // The face only turns for a roll that actually happens — flipping it
+  // on a click the in-flight guard discards would signal a new pick
+  // that never lands.
   if (loading.value) return;
+  rollDiceFace();
   loading.value = true;
   try {
     // First call: get the library total. limit=1/offset=0 is cheap and

--- a/frontend/src/v2/components/Home/Widgets/widgets.ts
+++ b/frontend/src/v2/components/Home/Widgets/widgets.ts
@@ -28,7 +28,7 @@ export const WIDGETS: readonly WidgetDef[] = [
     component: RandomPickWidget,
     enabledKey: "widgetRandomPick",
     labelKey: "settings.widget-random-pick",
-    icon: "mdi-dice-multiple-outline",
+    icon: "mdi-dice-5-outline",
   },
   {
     id: "libraryStats",


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Reworks the v2 Home "Random pick" widget along the lines of the mockup in #4048:

- **The "Open" button is gone.** The cover and title are the link now (a single `router-link` wrapping the whole body), so the affordance sits where users already expect to click.
- **The freed space shows platform + release year + region.** That makes it clear *which* copy was picked when a library holds several variations of the same title.
- **Reroll moved to the card's top-right action slot** (the slot `WidgetCard` already had), like a window control.
- **The die is readable now.** `mdi-dice-multiple-outline` at that size reads as two stacked windows, so the button shows an actual die face at a larger glyph size, and rerolls to a different face on every click.

The now-unused `home.widget-random-pick-open` key is removed from all 18 locales.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

Verified against a local build driven with Playwright:

- Fits the rail's fixed 128px card height with zero overflow across many picks — long titles clamp at two lines, long platform names ellipsize.
- Light and dark themes.
- Mouse hover and keyboard focus (real `Tab` traversal reaches both the reroll button and the link, `:focus-visible` ring paints, `Enter` navigates to the rom).
- `npm run typecheck`, `npm run test`, `npm run build`, both i18n scripts, and `trunk fmt && trunk check` are clean.

Closes #4048

---

**AI assistance disclosure:** this change was written with AI assistance (Claude Code). The implementation, the local browser verification described above, and the checks were performed by the agent; the design direction comes from the issue's mockup and was reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
