### PR TITLE
fix(rom-details): render the manual viewer on mobile

### DIFF
--- a/frontend/src/v2/components/GameDetails/ManualSubtab.vue
+++ b/frontend/src/v2/components/GameDetails/ManualSubtab.vue
@@ -323,6 +323,15 @@ function requestDeleteManual() {
   flex-direction: column;
 }
 
+/* On mobile the details view scrolls as one document (GameDetails unwinds its
+   fixed-height chain), so no ancestor hands the viewer a height to fill. Pin
+   it to a slice of the viewport instead. */
+html[data-bp~="sm-and-down"] .r-v2-manual__fill {
+  flex: none;
+  height: 70dvh;
+  min-height: 20rem;
+}
+
 /* Viewer — fills the available panel height so the inner PDF / Markdown uses
    100% and only its own scroll triggers. */
 .r-v2-manual__viewer {

--- a/frontend/src/v2/components/GameDetails/ManualSubtab.vue
+++ b/frontend/src/v2/components/GameDetails/ManualSubtab.vue
@@ -328,6 +328,7 @@ function requestDeleteManual() {
    it to a slice of the viewport instead. */
 html[data-bp~="sm-and-down"] .r-v2-manual__fill {
   flex: none;
+  height: 70vh;
   height: 70dvh;
   min-height: 20rem;
 }

--- a/frontend/src/v2/components/GameDetails/MediaTab.vue
+++ b/frontend/src/v2/components/GameDetails/MediaTab.vue
@@ -448,6 +448,13 @@ async function deleteSoundtrack(fileId: number) {
   flex-direction: column;
 }
 
+/* Mobile has no fixed-height chain to fill (GameDetails scrolls as one
+   document there), so a zero flex-basis would collapse the player. */
+html[data-bp~="sm-and-down"] .r-v2-media__fill {
+  flex: none;
+  height: auto;
+}
+
 html[data-bp~="xs"] .r-v2-media {
   flex-direction: column;
   gap: 14px;

--- a/frontend/src/v2/components/GameDetails/PdfViewer.vue
+++ b/frontend/src/v2/components/GameDetails/PdfViewer.vue
@@ -11,7 +11,6 @@ import { RIcon, RTooltip } from "@v2/lib";
 import { computed } from "vue";
 import VuePdfApp from "vue3-pdf-app";
 import { useI18n } from "vue-i18n";
-import { useBreakpoint } from "@/v2/composables/useBreakpoint";
 import { useThemeMode } from "@/v2/composables/useThemeMode";
 
 defineProps<{
@@ -31,7 +30,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-const { xs } = useBreakpoint();
 const { isLight } = useThemeMode();
 const pdfTheme = computed<"light" | "dark">(() =>
   isLight.value ? "light" : "dark",
@@ -84,13 +82,13 @@ const ids = {
         </template>
       </RTooltip>
 
-      <RTooltip v-if="!xs" :text="t('common.previous-page')">
+      <RTooltip :text="t('common.previous-page')">
         <template #activator="{ props: activator }">
           <button
             :id="ids.previousPage"
             v-bind="activator"
             type="button"
-            class="r-v2-pdfv__btn"
+            class="r-v2-pdfv__btn r-v2-pdfv__btn--step"
           >
             <RIcon icon="mdi-chevron-left" size="18" />
           </button>
@@ -105,13 +103,13 @@ const ids = {
       />
       <span :id="ids.numPages" class="r-v2-pdfv__page-total" />
 
-      <RTooltip v-if="!xs" :text="t('common.next-page')">
+      <RTooltip :text="t('common.next-page')">
         <template #activator="{ props: activator }">
           <button
             :id="ids.nextPage"
             v-bind="activator"
             type="button"
-            class="r-v2-pdfv__btn"
+            class="r-v2-pdfv__btn r-v2-pdfv__btn--step"
           >
             <RIcon icon="mdi-chevron-right" size="18" />
           </button>
@@ -263,6 +261,13 @@ const ids = {
 .r-v2-pdfv__btn:hover {
   background: var(--r-color-surface-hover);
   color: var(--r-color-fg);
+}
+
+/* vue3-pdf-app wires its controls by `id` on mount and gives up on the whole
+   viewer when one is missing, so the page-step buttons are always rendered and
+   only hidden on the narrowest toolbar (first/last page still cover it). */
+html[data-bp~="xs"] .r-v2-pdfv__btn--step {
+  display: none;
 }
 /* Danger variant — Delete sits at the end of the toolbar, so it takes
    a danger-tinted foreground + hover so the destructive action reads

--- a/frontend/src/v2/lib/forms/RDropzone/RDropzone.vue
+++ b/frontend/src/v2/lib/forms/RDropzone/RDropzone.vue
@@ -16,6 +16,8 @@ import { useDropZone } from "@vueuse/core";
 import { ref } from "vue";
 import RIcon from "../../primitives/RIcon/RIcon.vue";
 
+// Attrs land on the root (see `v-bind="$attrs"` below) rather than on the
+// hidden file input, so a consumer's `class` sizes the drop target.
 defineOptions({ inheritAttrs: false });
 
 interface Props {
@@ -88,6 +90,7 @@ defineExpose({ open, isOver: isOverDropZone });
 <template>
   <div
     ref="rootRef"
+    v-bind="$attrs"
     class="r-dropzone"
     :class="{
       'r-dropzone--active': isOverDropZone && !disabled,


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

On phones the Media tab's Manual panel rendered the PDF toolbar and nothing else. Two independent faults stack up to produce that:

1. **The viewer never initialised at `xs`.** `PdfViewer` hid the prev/next page buttons with `v-if="!xs"`. `vue3-pdf-app` wires its controls by `id` when it mounts and gives up on the whole viewer when one of the configured ids is missing, so no page was ever laid out. The buttons now always render and are hidden with CSS at `xs` instead.
2. **The viewer had no height.** `RDropzone` declares `inheritAttrs: false` but never binds `$attrs`, so the sizing class its consumers pass (`.r-v2-manual__fill`, `.r-v2-media__fill`) was silently dropped. Desktop hid that because the details view's fixed-height chain already sized the panel; on mobile `GameDetails` unwinds that chain and scrolls as one document, so nothing gave the viewer a height and it collapsed to the toolbar. `RDropzone` now forwards attrs, the manual viewer takes an explicit `70dvh` slice on mobile, and the soundtrack panel opts out of the zero-basis fill there so it keeps sizing to its content.

Verified in a Pixel 7 viewport (light + dark) and at 1440x900: the manual renders, and the soundtrack panel and desktop layout are unchanged.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

Before (5.1.0), from the issue — the bordered panel hugs the toolbar, no page area:

<img width="320" src="https://github.com/user-attachments/assets/d53f4689-94e8-4d80-b6a8-484e01c87fb3" />

After, same Pixel-sized viewport: the toolbar reports `1 of 1` and the page renders in a `70dvh` panel.

Fixes #4046

---

🤖 AI assistance disclosure: this change was written with Claude Code (Claude Opus 5). The root-cause analysis, the fix, and the browser verification were AI-driven and reviewed by me before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
