### PR TITLE
fix(hasheous): read the CHD and DOS signature sources

### DIFF
--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -849,6 +849,7 @@ class DBRomsHandler(DBBaseHandler):
             "mame_mess_match",
             "nointro_match",
             "redump_match",
+            "mame_redump_match",
             "whdload_match",
             "ra_match",
             "fbneo_match",

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -856,9 +856,15 @@ class DBRomsHandler(DBBaseHandler):
             "puredos_match",
         ]
 
+        # A key absent from `hasheous_metadata` (rows stored before it existed, or
+        # rows with no Hasheous match at all) extracts as NULL, and NULL poisons
+        # both the OR and its negation, so the unverified side would drop those
+        # rows. The JSON path below folds a missing key into false on its own;
+        # `->>` does not, hence the coalesce.
         if ROMM_DB_DRIVER == "postgresql":
             conditions = " OR ".join(
-                f"(hasheous_metadata->>'{key}')::boolean" for key in keys_to_check
+                f"COALESCE((hasheous_metadata->>'{key}')::boolean, false)"
+                for key in keys_to_check
             )
             predicate = text(f"({conditions})")
             if not value:

--- a/backend/handler/metadata/hasheous_handler.py
+++ b/backend/handler/metadata/hasheous_handler.py
@@ -28,6 +28,7 @@ class HasheousMetadata(TypedDict):
     mame_mess_match: bool
     nointro_match: bool
     redump_match: bool
+    mame_redump_match: bool
     whdload_match: bool
     ra_match: bool
     fbneo_match: bool
@@ -346,16 +347,19 @@ class HasheousHandler(MetadataHandler):
                 tgdb_id=int(tgdb_id) if tgdb_id else None,
                 ra_id=int(ra_id) if ra_id else None,
                 url_cover=url_cover,
+                # Keys are Hasheous' SignatureSourceType names, spelled exactly
+                # as its API returns them.
                 hasheous_metadata=HasheousMetadata(
                     tosec_match="TOSEC" in signatures,
                     mame_arcade_match="MAMEArcade" in signatures,
                     mame_mess_match="MAMEMess" in signatures,
                     nointro_match="NoIntros" in signatures,
                     redump_match="Redump" in signatures,
+                    mame_redump_match="MAMERedump" in signatures,
                     whdload_match="WHDLoad" in signatures,
                     ra_match="RetroAchievements" in signatures,
                     fbneo_match="FBNeo" in signatures,
-                    puredos_match="PureDOS" in signatures,
+                    puredos_match="PureDOSDAT" in signatures,
                 ),
             ),
             True,

--- a/backend/tests/handler/database/test_roms_verified_filter.py
+++ b/backend/tests/handler/database/test_roms_verified_filter.py
@@ -1,0 +1,142 @@
+"""The `verified` filter over the Hasheous signature-match flags.
+
+`hasheous_metadata` is a JSON blob whose keys grow as RomM maps more of
+Hasheous' signature sources (`mame_redump_match` was the latest addition), so
+rows written before a key existed simply don't carry it. Extracting a missing
+key yields NULL, and an OR chain containing a NULL is NULL rather than false,
+which makes `NOT (...)` NULL too: the unverified side would drop every row it
+should have returned.
+
+The JSON path already collapses a missing key into false (SQLAlchemy compiles
+`as_boolean()` to a CASE whose ELSE branch catches it), so only the PostgreSQL
+`->>` extraction needs the coalesce. The suite runs against one driver at a
+time, hence the compiled-SQL check below.
+"""
+
+import pytest
+
+from handler.database import db_rom_handler
+from handler.database.roms_handler import DBRomsHandler
+from models.platform import Platform
+from models.rom import Rom
+from models.user import User
+
+# The keys as they were written before `mame_redump_match` joined them.
+LEGACY_KEYS = [
+    "tosec_match",
+    "mame_arcade_match",
+    "mame_mess_match",
+    "nointro_match",
+    "redump_match",
+    "whdload_match",
+    "ra_match",
+    "fbneo_match",
+    "puredos_match",
+]
+
+
+def _add_rom(platform: Platform, user: User, name: str, metadata: dict) -> Rom:
+    rom = db_rom_handler.add_rom(
+        Rom(
+            platform_id=platform.id,
+            name=name,
+            slug=name,
+            fs_name=f"{name}.zip",
+            fs_name_no_tags=name,
+            fs_name_no_ext=name,
+            fs_extension="zip",
+            fs_path=f"{platform.slug}/roms",
+            hasheous_metadata=metadata,
+        )
+    )
+    db_rom_handler.add_rom_user(rom_id=rom.id, user_id=user.id)
+    return rom
+
+
+@pytest.fixture
+def legacy_unverified_rom(platform: Platform, admin_user: User) -> Rom:
+    """Scanned before `mame_redump_match` existed, and matched nothing."""
+    return _add_rom(
+        platform,
+        admin_user,
+        "legacy_unverified",
+        {key: False for key in LEGACY_KEYS},
+    )
+
+
+@pytest.fixture
+def legacy_verified_rom(platform: Platform, admin_user: User) -> Rom:
+    return _add_rom(
+        platform,
+        admin_user,
+        "legacy_verified",
+        {key: key == "nointro_match" for key in LEGACY_KEYS},
+    )
+
+
+@pytest.fixture
+def chd_verified_rom(platform: Platform, admin_user: User) -> Rom:
+    """Only the newest key is set, as a CHD rescan writes it."""
+    return _add_rom(
+        platform,
+        admin_user,
+        "chd_verified",
+        {key: False for key in LEGACY_KEYS} | {"mame_redump_match": True},
+    )
+
+
+class TestVerifiedFilter:
+    def test_unverified_keeps_roms_missing_the_newest_key(
+        self,
+        admin_user: User,
+        legacy_unverified_rom: Rom,
+        legacy_verified_rom: Rom,
+        chd_verified_rom: Rom,
+    ):
+        roms = db_rom_handler.get_roms_scalar(user_id=admin_user.id, verified=False)
+
+        assert [r.id for r in roms] == [legacy_unverified_rom.id]
+
+    def test_verified_matches_both_legacy_and_newest_keys(
+        self,
+        admin_user: User,
+        legacy_unverified_rom: Rom,
+        legacy_verified_rom: Rom,
+        chd_verified_rom: Rom,
+    ):
+        roms = db_rom_handler.get_roms_scalar(user_id=admin_user.id, verified=True)
+
+        assert sorted(r.id for r in roms) == sorted(
+            [legacy_verified_rom.id, chd_verified_rom.id]
+        )
+
+    def test_unverified_keeps_roms_without_any_hasheous_metadata(
+        self, admin_user: User, rom: Rom, legacy_verified_rom: Rom
+    ):
+        roms = db_rom_handler.get_roms_scalar(user_id=admin_user.id, verified=False)
+
+        assert [r.id for r in roms] == [rom.id]
+
+
+class TestVerifiedPostgresPredicate:
+    """The PostgreSQL branch builds raw SQL, so it can only be checked by
+    compiling it (the suite runs on a single driver at a time)."""
+
+    @pytest.fixture
+    def postgres_handler(self, monkeypatch: pytest.MonkeyPatch) -> DBRomsHandler:
+        monkeypatch.setattr(
+            "handler.database.roms_handler.ROMM_DB_DRIVER", "postgresql"
+        )
+        return db_rom_handler
+
+    @pytest.mark.parametrize("verified", [True, False])
+    def test_every_key_is_coalesced_to_false(
+        self, postgres_handler: DBRomsHandler, verified: bool
+    ):
+        query, _ = postgres_handler.get_roms_query()
+        filtered = postgres_handler.filter_roms(query=query, verified=verified)
+
+        sql = str(filtered.compile(compile_kwargs={"literal_binds": True}))
+
+        for key in [*LEGACY_KEYS, "mame_redump_match"]:
+            assert f"COALESCE((hasheous_metadata->>'{key}')::boolean, false)" in sql

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -534,6 +534,7 @@ async def test_scan_rom_hashes_rematches_hasheous(
             mame_mess_match=False,
             nointro_match=True,
             redump_match=False,
+            mame_redump_match=False,
             whdload_match=False,
             ra_match=True,
             fbneo_match=False,
@@ -768,6 +769,59 @@ async def test_lookup_rom_sends_all_top_level_file_hashes(
         {"mD5": "md5one", "shA1": "sha1one", "crc": "crcone"},
         {"shA1": "chdsha1"},
     ]
+
+
+@patch.object(meta_hasheous_handler, "_request", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "is_enabled", return_value=True)
+async def test_lookup_rom_maps_every_hasheous_signature_source(
+    mock_is_enabled, mock_request
+):
+    """Each match flag reads a Hasheous SignatureSourceType name verbatim, so a
+    typo silently pins that flag to False."""
+    mock_request.return_value = {
+        "id": 1,
+        "signatures": {
+            "TOSEC": {},
+            "MAMEArcade": {},
+            "MAMEMess": {},
+            "NoIntros": {},
+            "Redump": {},
+            "MAMERedump": {},
+            "WHDLoad": {},
+            "RetroAchievements": {},
+            "FBNeo": {},
+            "PureDOSDAT": {},
+        },
+    }
+
+    files = [
+        _top_level_rom_file(file_name="game.n64", file_size_bytes=100, md5_hash="md5")
+    ]
+
+    result, _ = await meta_hasheous_handler.lookup_rom("n64", files)
+
+    assert all(result["hasheous_metadata"].values())
+
+
+@patch.object(meta_hasheous_handler, "_request", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "is_enabled", return_value=True)
+async def test_lookup_rom_marks_a_chd_matched_by_mameredump_as_verified(
+    mock_is_enabled, mock_request
+):
+    """Hasheous indexes CHD conversions under MAMERedump, not Redump, so a CHD
+    match sets no other flag and the ROM would otherwise never read as
+    verified."""
+    mock_request.return_value = {"id": 1, "signatures": {"MAMERedump": {}}}
+
+    files = [
+        _top_level_rom_file(
+            file_name="game.chd", file_size_bytes=100, chd_sha1_hash="discsha1"
+        )
+    ]
+
+    result, _ = await meta_hasheous_handler.lookup_rom("dc", files)
+
+    assert result["hasheous_metadata"]["mame_redump_match"] is True
 
 
 @patch.object(meta_hasheous_handler, "_request", new_callable=AsyncMock)

--- a/backend/tools/generate_test_data.py
+++ b/backend/tools/generate_test_data.py
@@ -616,6 +616,7 @@ def build_hasheous_metadata(rng: random.Random) -> dict[str, Any]:
         "mame_mess_match": rng.random() < 0.1,
         "nointro_match": rng.random() < 0.6,
         "redump_match": rng.random() < 0.4,
+        "mame_redump_match": rng.random() < 0.1,
         "whdload_match": False,
         "ra_match": rng.random() < 0.3,
         "fbneo_match": rng.random() < 0.1,

--- a/frontend/src/__generated__/models/RomHasheousMetadata.ts
+++ b/frontend/src/__generated__/models/RomHasheousMetadata.ts
@@ -8,6 +8,7 @@ export type RomHasheousMetadata = {
     mame_mess_match?: boolean;
     nointro_match?: boolean;
     redump_match?: boolean;
+    mame_redump_match?: boolean;
     whdload_match?: boolean;
     ra_match?: boolean;
     fbneo_match?: boolean;

--- a/frontend/src/v2/utils/romVerification.test.ts
+++ b/frontend/src/v2/utils/romVerification.test.ts
@@ -45,6 +45,17 @@ describe("matchesDatabase", () => {
     );
   });
 
+  it("matches Redump on either the disc-image or the CHD flag", () => {
+    const redump = VERIFICATION_DATABASES.find((db) => db.label === "Redump")!;
+    expect(matchesDatabase(rom({ redump_match: true }), redump.keys)).toBe(
+      true,
+    );
+    // Hasheous indexes CHD conversions under its own MAMERedump source.
+    expect(matchesDatabase(rom({ mame_redump_match: true }), redump.keys)).toBe(
+      true,
+    );
+  });
+
   it("treats RetroAchievements as a database match (ra_match, not ra_id)", () => {
     const ra = VERIFICATION_DATABASES.find(
       (db) => db.label === "RetroAchievements",

--- a/frontend/src/v2/utils/romVerification.ts
+++ b/frontend/src/v2/utils/romVerification.ts
@@ -9,15 +9,16 @@ import type { SimpleRom } from "@/stores/roms";
 
 // Each database this ROM's hash can be checked against, with the Hasheous
 // match flag(s) that count as a hit. MAME reports Arcade and MESS
-// separately; either one means the ROM matched MAME. Order is the display
-// order for the Metadata tab chips.
+// separately; either one means the ROM matched MAME. Redump likewise
+// reports disc images and their CHD conversions separately. Order is the
+// display order for the Metadata tab chips.
 export const VERIFICATION_DATABASES: {
   label: string;
   keys: (keyof RomHasheousMetadata)[];
 }[] = [
   { label: "TOSEC", keys: ["tosec_match"] },
   { label: "No-Intro", keys: ["nointro_match"] },
-  { label: "Redump", keys: ["redump_match"] },
+  { label: "Redump", keys: ["redump_match", "mame_redump_match"] },
   { label: "MAME", keys: ["mame_arcade_match", "mame_mess_match"] },
   { label: "FBNeo", keys: ["fbneo_match"] },
   { label: "WHDLoad", keys: ["whdload_match"] },


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Every flag on `hasheous_metadata` is a membership test against the `signatures` dict Hasheous returns, whose keys are its `SignatureSourceType` names. Two of ours never matched a real name:

| flag | looked for | actual source name |
| --- | --- | --- |
| *(none)* | — | `MAMERedump` |
| `puredos_match` | `PureDOS` | `PureDOSDAT` |

`MAMERedump` is the source holding Redump's disc images in CHD form — the one `extract_chd_hash` targets when it pulls the disc-data SHA1 out of a v5 header. So a CHD would match Hasheous, get its IGDB/RA metadata, and still come back with every match flag `False`, which is exactly the reported symptom: correctly matched, never verified. `puredos_match` was simply dead — pinned to `False` for every ROM since it was added.

The full enum, from Hasheous' [swagger](https://hasheous.org/swagger/v1/swagger.json) (`RomSignatureObject_Game_Rom_SignatureSourceType`):

> None, TOSEC, MAMEArcade, MAMEMess, NoIntros, Redump, WHDLoad, RetroAchievements, FBNeo, **PureDOSDAT**, Pleasuredome, **MAMERedump**, TotalDOSCollection, eXo, ScreenScraper, Generic, Unknown

Changes:

- `HasheousMetadata` gains `mame_redump_match`; `puredos_match` now reads `PureDOSDAT`.
- `_filter_by_verified` counts the new flag, so the library's "verified" filter picks CHDs up.
- The Metadata tab folds it into the existing **Redump** chip rather than adding a new one — same database, different distribution format, the way MAME already collapses Arcade + MESS.

Not included: Hasheous also exposes `Pleasuredome`, `TotalDOSCollection`, `eXo`, `ScreenScraper` and `Generic`, none of which RomM maps. Folding those in widens what "verified" means (`ScreenScraper` especially is a scraper, not a preservation DAT), so that's a separate call to make.

Existing ROMs pick the flag up on their next rescan, same as any new metadata field.

The RetroAchievements half of the report (comment on #4030) is a different path: `ra_match` only trips when Hasheous itself holds an RA signature for the hash we send, which is the CHD disc SHA1, not the RA hash RomM computes separately. Worth its own issue if it persists after this.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Tests added: one asserting every source name maps to a flag (a typo in any of them now fails), one for the CHD-via-MAMERedump case, and a frontend case for the Redump chip covering both flags.

#### Screenshots (if applicable)

n/a — no visual change beyond the badge appearing where it previously didn't.

Fixes #4030

---

🤖 AI assistance disclosure: this change was written with Claude Code (Claude Opus 5). The root cause was found by diffing RomM's expected source names against the live Hasheous OpenAPI schema. Reviewed by me before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
