### PR TITLE
perf(roms): let a gallery window fetch skip the library count

### DIFF
--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -325,7 +325,6 @@ class CustomLimitOffsetParams(LimitOffsetParams):
 
 
 class CustomLimitOffsetPage[T: BaseModel](LimitOffsetPage[T]):
-    # Null when the caller opted out of the count with with_total=false.
     total: GreaterEqualZero | None
     char_index: dict[str, int]
     rom_id_index: list[int]

--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -27,6 +27,7 @@ from fastapi import (
 from fastapi.responses import Response
 from fastapi_pagination import resolve_params
 from fastapi_pagination.limit_offset import LimitOffsetPage, LimitOffsetParams
+from fastapi_pagination.types import GreaterEqualZero
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
 from starlette.responses import FileResponse
@@ -324,6 +325,8 @@ class CustomLimitOffsetParams(LimitOffsetParams):
 
 
 class CustomLimitOffsetPage[T: BaseModel](LimitOffsetPage[T]):
+    # Null when the caller opted out of the count with with_total=false.
+    total: GreaterEqualZero | None
     char_index: dict[str, int]
     rom_id_index: list[int]
     filter_values: RomFiltersDict
@@ -345,6 +348,17 @@ def get_roms(
         Query(
             description=(
                 "Whether to return the full ordered rom id index that backs virtual scroll."
+            )
+        ),
+    ] = True,
+    with_total: Annotated[
+        bool,
+        Query(
+            description=(
+                "Whether to count the full result set. Set to false when the caller"
+                " already knows the total, e.g. paging through a gallery it has"
+                " sized; total then comes back null, unless the rom id index is"
+                " being built and already carries it."
             )
         ),
     ] = True,
@@ -832,7 +846,9 @@ def get_roms(
             ]
 
         params = resolve_params()
+        total: int | None
         if with_rom_id_index:
+            # The index already spans the result set, so the count is free.
             total = len(rom_id_index)
             page_ids = list(rom_id_index[params.offset : params.offset + params.limit])
             if page_ids:
@@ -847,7 +863,13 @@ def get_roms(
             page_items = list(
                 session.scalars(query.offset(params.offset).limit(params.limit)).all()
             )
-            total = db_rom_handler.get_rom_count(query=query, session=session)
+            # Without the index the count is its own scan of the filtered set,
+            # so a caller scrolling a gallery it already sized opts out.
+            total = (
+                db_rom_handler.get_rom_count(query=query, session=session)
+                if with_total
+                else None
+            )
 
         return CustomLimitOffsetPage.create(
             _transform(page_items),

--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -845,11 +845,20 @@ def get_roms(
                 for item in items
             ]
 
+        def resolve_total() -> int | None:
+            if with_rom_id_index:
+                # The index already spans the result set, so the count is free.
+                return len(rom_id_index)
+            # Without the index the count is its own scan of the filtered set,
+            # so a caller scrolling a gallery it already sized opts out.
+            return (
+                db_rom_handler.get_rom_count(query=query, session=session)
+                if with_total
+                else None
+            )
+
         params = resolve_params()
-        total: int | None
         if with_rom_id_index:
-            # The index already spans the result set, so the count is free.
-            total = len(rom_id_index)
             page_ids = list(rom_id_index[params.offset : params.offset + params.limit])
             if page_ids:
                 page_rows = session.scalars(query.where(Rom.id.in_(page_ids))).all()
@@ -863,18 +872,11 @@ def get_roms(
             page_items = list(
                 session.scalars(query.offset(params.offset).limit(params.limit)).all()
             )
-            # Without the index the count is its own scan of the filtered set,
-            # so a caller scrolling a gallery it already sized opts out.
-            total = (
-                db_rom_handler.get_rom_count(query=query, session=session)
-                if with_total
-                else None
-            )
 
         return CustomLimitOffsetPage.create(
             _transform(page_items),
             params,
-            total=total,
+            total=resolve_total(),
             char_index=char_index_dict,
             rom_id_index=list(rom_id_index),
             filter_values=filter_values,

--- a/backend/tests/endpoints/roms/test_rom.py
+++ b/backend/tests/endpoints/roms/test_rom.py
@@ -313,6 +313,63 @@ def test_get_roms_without_rom_id_index(
     assert items[0]["id"] == rom.id
 
 
+def test_get_roms_without_total(
+    client: TestClient, access_token: str, rom: Rom, platform: Platform
+):
+    params = {
+        "platform_id": platform.id,
+        "limit": 15,
+        "with_rom_id_index": False,
+    }
+
+    with patch.object(
+        db_rom_handler, "get_rom_count", wraps=db_rom_handler.get_rom_count
+    ) as get_rom_count:
+        response = client.get(
+            "/api/roms",
+            headers={"Authorization": f"Bearer {access_token}"},
+            params={**params, "with_total": False},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        # The point of the opt-out: no second scan of the filtered set.
+        get_rom_count.assert_not_called()
+
+        body = response.json()
+        assert body["total"] is None
+
+        items = body["items"]
+        assert len(items) == 1
+        assert items[0]["id"] == rom.id
+
+        # Control: the count still runs for callers that ask for it.
+        response = client.get(
+            "/api/roms",
+            headers={"Authorization": f"Bearer {access_token}"},
+            params=params,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["total"] == 1
+        get_rom_count.assert_called_once()
+
+
+def test_get_roms_keeps_total_from_the_rom_id_index(
+    client: TestClient, access_token: str, rom: Rom, platform: Platform
+):
+    # The index already carries the count, so opting out of the separate
+    # count query costs the caller nothing there.
+    response = client.get(
+        "/api/roms",
+        headers={"Authorization": f"Bearer {access_token}"},
+        params={"platform_id": platform.id, "with_total": False},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    body = response.json()
+    assert body["total"] == 1
+    assert body["rom_id_index"] == [rom.id]
+
+
 def test_get_roms_filter_by_metadata_providers(
     client: TestClient, access_token: str, rom: Rom, platform: Platform
 ):

--- a/frontend/src/__generated__/models/CustomLimitOffsetPage_SimpleRomSchema_.ts
+++ b/frontend/src/__generated__/models/CustomLimitOffsetPage_SimpleRomSchema_.ts
@@ -6,7 +6,7 @@ import type { RomFiltersDict } from './RomFiltersDict';
 import type { SimpleRomSchema } from './SimpleRomSchema';
 export type CustomLimitOffsetPage_SimpleRomSchema_ = {
     items: Array<SimpleRomSchema>;
-    total: number;
+    total: (number | null);
     limit: number;
     offset: number;
     char_index: Record<string, number>;

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -187,6 +187,8 @@ export interface GetRomsParams {
   withCharIndex?: boolean;
   withFilterValues?: boolean;
   withRomIdIndex?: boolean;
+  // Skip the result-set count server-side; `total` comes back null
+  withTotal?: boolean;
   // Cancel an in-flight request
   signal?: AbortSignal;
 }
@@ -238,6 +240,7 @@ async function getRoms({
   withCharIndex = undefined,
   withFilterValues = undefined,
   withRomIdIndex = undefined,
+  withTotal = undefined,
   signal = undefined,
 }: GetRomsParams) {
   const params = {
@@ -351,6 +354,7 @@ async function getRoms({
     ...(withRomIdIndex !== undefined
       ? { with_rom_id_index: withRomIdIndex }
       : {}),
+    ...(withTotal !== undefined ? { with_total: withTotal } : {}),
   };
 
   return api.get<GetRomsResponse>(`/roms`, {

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -183,7 +183,6 @@ export interface GetRomsParams {
   playerCountsLogic?: string | null;
   metadataProvidersLogic?: string | null;
   tagsLogic?: string | null;
-  // Skip the char index / filter-value / id-index aggregations server-side
   withCharIndex?: boolean;
   withFilterValues?: boolean;
   withRomIdIndex?: boolean;

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -186,7 +186,6 @@ export interface GetRomsParams {
   withCharIndex?: boolean;
   withFilterValues?: boolean;
   withRomIdIndex?: boolean;
-  // Skip the result-set count server-side; `total` comes back null
   withTotal?: boolean;
   // Cancel an in-flight request
   signal?: AbortSignal;

--- a/frontend/src/v2/stores/galleryRoms.test.ts
+++ b/frontend/src/v2/stores/galleryRoms.test.ts
@@ -165,6 +165,7 @@ describe("galleryRoms windowed fetch", () => {
     expect(params.withCharIndex).toBeUndefined();
     expect(params.withFilterValues).toBeUndefined();
     expect(params.withRomIdIndex).toBeUndefined();
+    expect(params.withTotal).toBeUndefined();
   });
 
   it("does not clobber the filter drawer when filter values are skipped", async () => {
@@ -223,6 +224,48 @@ describe("galleryRoms windowed fetch", () => {
     // the bootstrap already paid for.
     expect(windowCall?.[0].withRomIdIndex).toBe(false);
     expect(store.charIndex).toEqual({ A: 0, B: 10 });
+  });
+
+  // Skipping the id index used to make the backend fall back to a full COUNT,
+  // so every scroll batch re-counted the library for a total the page already
+  // had (issue #4053).
+  it("skips the total on a window the bootstrap already sized", async () => {
+    getRoms.mockImplementation((params: { limit?: number }) => {
+      if (params.limit === 1) {
+        return Promise.resolve({
+          data: { total: 500, items: [], char_index: {}, rom_id_index: [] },
+        });
+      }
+      // The backend returns a null total when the count is skipped.
+      return Promise.resolve({
+        data: { total: null, items: [], char_index: {}, rom_id_index: [] },
+      });
+    });
+    const store = storeGalleryRoms();
+
+    await store.fetchInitialMetadata();
+    expect(store.total).toBe(500);
+
+    store.syncVisibleWindows([72]);
+    await flushPromises();
+
+    const windowCall = getRoms.mock.calls.find((c) => c[0].offset === 72);
+    expect(windowCall?.[0].withTotal).toBe(false);
+    // The null total must not blank the size the bootstrap established.
+    expect(store.total).toBe(500);
+  });
+
+  // The very first window doubles as the bootstrap when nothing has loaded
+  // yet, so it still has to bring the total back with it.
+  it("asks for the total on the first window when no bootstrap ran", async () => {
+    getRoms.mockResolvedValue(windowResponse(0, 300));
+    const store = storeGalleryRoms();
+
+    store.syncVisibleWindows([0]);
+    await flushPromises();
+
+    expect(getRoms.mock.calls[0][0].withTotal).toBeUndefined();
+    expect(store.total).toBe(300);
   });
 
   it("does not mark a window loaded when the context is invalidated mid-apply", async () => {

--- a/frontend/src/v2/stores/galleryRoms.ts
+++ b/frontend/src/v2/stores/galleryRoms.ts
@@ -523,7 +523,10 @@ export default defineStore("v2GalleryRoms", {
       // object when these are skipped, so re-applying it would wipe the
       // populated values and blank the AlphaStrip / filter drawer. The id
       // index is a full-library scan we already paid for in the bootstrap, so
-      // window fetches opt out of recomputing it.
+      // window fetches opt out of recomputing it. Dropping it makes the backend
+      // count the result set separately instead, which is the same scan under
+      // another name for a total the bootstrap already gave us, so opt out of
+      // that too and keep the window fetch to just its page of covers.
       const withAggregations = !this.metadataLoaded;
 
       try {
@@ -535,6 +538,7 @@ export default defineStore("v2GalleryRoms", {
                 withCharIndex: false,
                 withFilterValues: false,
                 withRomIdIndex: false,
+                withTotal: false,
               }),
           signal: controller.signal,
         });
@@ -547,9 +551,10 @@ export default defineStore("v2GalleryRoms", {
 
         const data = response.data;
         // Only apply the full metadata when this window actually fetched the
-        // aggregations (the very first window before the bootstrap resolved).
+        // aggregations (a window reached before the bootstrap resolved).
         // Otherwise char_index / filter_values come back empty and would
-        // clobber what the bootstrap populated, so just refresh `total`.
+        // clobber what the bootstrap populated; `total` comes back null and
+        // the guard below leaves the established size alone.
         if (offset === 0 && withAggregations) {
           this._applyMetadata(data, galleryFilter, platformsStore);
         } else if (data.total !== null && data.total !== undefined) {


### PR DESCRIPTION
**Description**

Fixes #4053

Loading more covers into a gallery you are already looking at makes the server re-count
the whole filtered library, every single time.

The page already knows that total. It learned it on its first request, and nothing can
change it mid-scroll. But the flags a window fetch sends to *save* work
(`with_char_index=false`, `with_filter_values=false`, `with_rom_id_index=false`) are
exactly what puts the backend on its non-index path, and that path answers `total` with a
separate `COUNT` over the filtered set. So the opt-out meant to avoid a full-library scan
quietly swapped it for a different one, and the frontend then wrote the result over the
identical number it already had.

This PR mirrors the existing `with_rom_id_index` opt-out with a `with_total` one, and has
the gallery's window fetch use it. Follow-up to #4054, where I flagged this as
deliberately out of scope.

**What changed**

| File | Why |
| --- | --- |
| `backend/endpoints/roms/__init__.py` | Adds the `with_total` query parameter (defaults to `true`, so existing callers are unaffected) and skips `get_rom_count` when it is false. `CustomLimitOffsetPage.total` is redeclared as `GreaterEqualZero \| None` so the page can carry a null. |
| `backend/tests/endpoints/roms/test_rom.py` | Two tests. The first spies on `get_rom_count` and asserts it is never called, so it guards the query being skipped rather than merely the field being null, with a control request proving the count still runs by default. The second pins the deliberate asymmetry below. |
| `frontend/src/__generated__/models/CustomLimitOffsetPage_SimpleRomSchema_.ts` | Regenerated from the backend schema. One line: `total: number` becomes `total: (number \| null)`. |
| `frontend/src/services/api/rom.ts` | Optional `withTotal` on `GetRomsParams`, forwarded only when explicitly set. Purely additive, so no existing call site changes. |
| `frontend/src/v2/stores/galleryRoms.ts` | `fetchWindowAt` sends `withTotal: false` alongside the three sidecar opt-outs it already sends, but only once the bootstrap has established the size. The existing null guard on `data.total` then leaves that size alone. |
| `frontend/src/v2/stores/galleryRoms.test.ts` | A window after the bootstrap sends the flag and the null response does not blank the established total; a first window with no bootstrap still asks for the total; the default path still sends no flag at all. |

**Results**

Cost of the redundant `COUNT` alone, per scroll batch, measured on my library and reported
in #4053:

| | Wasted per scroll batch |
| --- | --- |
| Before #4054, with "Group ROMs" on | 6.13s |
| After #4054 landed | ~1.0s |
| With this PR | none, the query is never issued |

The saving is the whole figure rather than a fraction of it, because this removes the
query instead of making it faster.

**What a reviewer should look at**

- **`total` becomes nullable in the API contract.** This is the part worth scrutiny.
  Runtime behaviour is unchanged for every existing caller, since the flag defaults to
  `true`, but the OpenAPI type widens from `number` to `number | null`, which any
  generated client outside this repo will see. I declared it as `GreaterEqualZero | None`
  rather than giving it a default, so the field stays *required* in the schema (nullable,
  not optional) and keeps its `ge=0` constraint.
- **The rom-id-index branch deliberately ignores the flag.** When `with_rom_id_index=true`
  the total is just `len(rom_id_index)`, already in hand, so suppressing it would save
  nothing and cost the caller information. That asymmetry is documented in the parameter
  description and pinned by a test so it does not read as an oversight later.
- **No v1 files change**, so `check-v1-frozen` stays green. The two v1 consumers of `total`
  (`RandomBtn.vue`, `ContextualRandomBtn.vue`) already guard with
  `if (!romsResponse.total)`, so they narrow the nullable type with no edit, and
  `withTotal` is optional on `GetRomsParams`.
- **The bootstrap cannot accidentally opt out.** `SidecarOptions`, the type
  `fetchInitialMetadata` accepts, has no `withTotal` member, so the request that
  establishes the gallery's size structurally cannot skip the count.
- **No stale totals across a filter change.** Both `resetGallery()` and
  `invalidateWindows()` clear `total` and `metadataLoaded`, so the first request under a
  new filter always re-bootstraps with the count.

**Testing**

- Full backend suite green, plus `tests/endpoints/roms/test_rom.py` and the v2
  `galleryRoms` store suite re-run individually.
- Full frontend suite green (613 tests, 47 files), `vue-tsc` clean, `trunk fmt` and
  `trunk check` clean.
- Both new backend tests were checked against the pre-fix tree, where they fail. The
  count-skip test asserts on the query not being issued, not just on the response field,
  so it cannot pass by serialisation alone.
- Verified in a browser against a running instance: the bootstrap request carries `total`,
  the follow-up window fetch sends `with_total=false` and comes back with `total: null`,
  and the gallery, its count badge and the AlphaStrip all render unchanged.
- Limitation worth stating: my dev library is small enough that only window 0 exists, so
  the second-and-later window path is covered by the store unit tests rather than by the
  browser check. The timings above come from my large library, not from the dev instance.

**Known follow-up, deliberately not in this PR**

`getRecentRoms` and `getRecentPlayedRoms` still send `with_rom_id_index=false` and discard
the `total` they get back, so every home page load pays two counts for nothing. It is the
same one-line opt-out, but it lives in both `services/api/rom.ts` and
`services/cache/api.ts`, and in the latter the parameter map is duplicated into
`clearRecentRomsCache` / `clearRecentPlayedRomsCache` as a cache-key pattern. Adding the
flag to the request without adding it there too would silently break cache invalidation,
so it deserves its own PR rather than a rider on this one.

**AI assistance disclosure**

This PR was written primarily by Claude Code (Claude Opus 5), including the backend
change, the frontend change, the tests and this description. I directed the work, reviewed
every change, and the performance numbers come from measurements against my own library
rather than from estimates.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
