### PR TITLE
fix(home): stop scanning the library filesystem on every home page load

### DIFF
--- a/backend/endpoints/heartbeat.py
+++ b/backend/endpoints/heartbeat.py
@@ -29,7 +29,7 @@ from decorators.auth import protected_route
 from endpoints.responses.heartbeat import HeartbeatResponse
 from exceptions.fs_exceptions import PlatformAlreadyExistsException
 from handler.auth.constants import Scope
-from handler.database import db_user_handler
+from handler.database import db_rom_handler, db_user_handler
 from handler.filesystem import fs_platform_handler
 from handler.filesystem.base_handler import LibraryStructure
 from handler.metadata import (
@@ -213,6 +213,17 @@ async def get_setup_library_info(request: Request):
         )
 
     detected_structure = fs_platform_handler.detect_library_structure()
+
+    # The per-platform rom counts below are a first-run hint, so a fresh
+    # instance can show what RomM already sees on disk. Once the database
+    # holds ROMs that hint is dead weight, and building it walks every
+    # platform directory: tens of seconds on a large library.
+    if db_rom_handler.has_any_rom():
+        return {
+            "detected_structure": detected_structure,
+            "existing_platforms": [],
+            "supported_platforms": get_supported_platforms(),
+        }
 
     # Get existing platforms from filesystem
     try:

--- a/backend/endpoints/heartbeat.py
+++ b/backend/endpoints/heartbeat.py
@@ -29,7 +29,7 @@ from decorators.auth import protected_route
 from endpoints.responses.heartbeat import HeartbeatResponse
 from exceptions.fs_exceptions import PlatformAlreadyExistsException
 from handler.auth.constants import Scope
-from handler.database import db_rom_handler, db_user_handler
+from handler.database import db_stats_handler, db_user_handler
 from handler.filesystem import fs_platform_handler
 from handler.filesystem.base_handler import LibraryStructure
 from handler.metadata import (
@@ -218,7 +218,7 @@ async def get_setup_library_info(request: Request):
     # instance can show what RomM already sees on disk. Once the database
     # holds ROMs that hint is dead weight, and building it walks every
     # platform directory: tens of seconds on a large library.
-    if db_rom_handler.has_any_rom():
+    if db_stats_handler.get_roms_count() > 0:
         return {
             "detected_structure": detected_structure,
             "existing_platforms": [],

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -1643,6 +1643,19 @@ class DBRomsHandler(DBBaseHandler):
         )
 
     @begin_session
+    def has_any_rom(
+        self,
+        *,
+        session: Session = None,  # type: ignore
+    ) -> bool:
+        """Whether the library holds at least one ROM.
+
+        An existence probe rather than a count, for callers that only
+        need to know whether the library has ever been scanned.
+        """
+        return session.scalar(select(Rom.id).limit(1)) is not None
+
+    @begin_session
     def get_roms_by_fs_name(
         self,
         platform_id: int,

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -1643,19 +1643,6 @@ class DBRomsHandler(DBBaseHandler):
         )
 
     @begin_session
-    def has_any_rom(
-        self,
-        *,
-        session: Session = None,  # type: ignore
-    ) -> bool:
-        """Whether the library holds at least one ROM.
-
-        An existence probe rather than a count, for callers that only
-        need to know whether the library has ever been scanned.
-        """
-        return session.scalar(select(Rom.id).limit(1)) is not None
-
-    @begin_session
     def get_roms_by_fs_name(
         self,
         platform_id: int,

--- a/backend/tests/endpoints/test_heartbeat.py
+++ b/backend/tests/endpoints/test_heartbeat.py
@@ -239,6 +239,72 @@ def test_get_setup_library_info_handles_errors(client, admin_user, access_token)
             assert data["existing_platforms"] == []
 
 
+def test_get_setup_library_info_skips_filesystem_walk_when_roms_exist(
+    client, rom, access_token
+):
+    """A library with scanned ROMs never needs the on-disk hint, so skip the walk."""
+    with (
+        patch(
+            "endpoints.heartbeat.fs_platform_handler.detect_library_structure"
+        ) as mock_detect,
+        patch(
+            "endpoints.heartbeat.fs_platform_handler.get_platforms"
+        ) as mock_get_platforms,
+    ):
+        mock_detect.return_value = "struct_a"
+        mock_get_platforms.return_value = ["n64"]
+
+        response = client.get(
+            "/api/setup/library",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+
+    assert data["detected_structure"] == "struct_a"
+    assert data["existing_platforms"] == []
+    assert len(data["supported_platforms"]) > 0
+    mock_get_platforms.assert_not_called()
+
+
+def test_get_setup_library_info_walks_when_platforms_have_no_roms(
+    client, platform, access_token
+):
+    """Platform rows without ROMs still need the hint: that is the case it exists for."""
+    with (
+        patch(
+            "endpoints.heartbeat.fs_platform_handler.detect_library_structure"
+        ) as mock_detect,
+        patch(
+            "endpoints.heartbeat.fs_platform_handler.get_platforms"
+        ) as mock_get_platforms,
+        patch("endpoints.heartbeat.AnyioPath") as mock_anyio_path,
+    ):
+        mock_detect.return_value = "struct_a"
+        mock_get_platforms.return_value = ["n64"]
+
+        async def mock_iterdir():
+            entry = MagicMock()
+            entry.name = "game1.z64"
+            yield entry
+
+        mock_path = AsyncMock()
+        mock_path.exists = AsyncMock(return_value=True)
+        mock_path.iterdir = mock_iterdir
+        mock_anyio_path.return_value = mock_path
+
+        response = client.get(
+            "/api/setup/library",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+
+    assert data["existing_platforms"] == [{"fs_slug": "n64", "rom_count": 1}]
+
+
 def test_create_setup_platforms_success(client, admin_user, access_token):
     """Test create_setup_platforms successfully creates platforms"""
     platform_slugs = ["n64", "psx", "gba"]

--- a/frontend/src/v2/views/Home.test.ts
+++ b/frontend/src/v2/views/Home.test.ts
@@ -1,0 +1,223 @@
+/* eslint-disable vue/one-component-per-file */
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, ref } from "vue";
+import storeCollections, { type Collection } from "@/stores/collections";
+import storePlatforms, { type Platform } from "@/stores/platforms";
+import storeRoms, { type SimpleRom } from "@/stores/roms";
+import Home from "./Home.vue";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const { getLibraryInfo } = vi.hoisted(() => ({
+  getLibraryInfo: vi.fn(),
+}));
+
+vi.mock("@/services/api/setup", () => ({
+  default: { getLibraryInfo },
+}));
+
+vi.mock("@v2/lib", () => ({
+  RChip: defineComponent({ template: "<span><slot /></span>" }),
+  RDivider: defineComponent({ template: "<hr />" }),
+  RIcon: defineComponent({ template: "<i />" }),
+  RSkeletonBlock: defineComponent({ template: "<div />" }),
+}));
+
+vi.mock("@/v2/components/Collections/CollectionTile.vue", () => ({
+  default: defineComponent({ template: "<div />" }),
+}));
+
+vi.mock("@/v2/components/GameCard", () => ({
+  GameCard: defineComponent({ template: "<div />" }),
+  GameCardSkeleton: defineComponent({ template: "<div />" }),
+}));
+
+vi.mock("@/v2/components/Home/CardRow.vue", () => ({
+  default: defineComponent({ template: "<section><slot /></section>" }),
+}));
+
+vi.mock("@/v2/components/Home/Widgets/WidgetBar.vue", () => ({
+  default: defineComponent({ template: "<div />" }),
+}));
+
+vi.mock("@/v2/components/Platforms/PlatformTile.vue", () => ({
+  default: defineComponent({ template: "<div />" }),
+}));
+
+vi.mock("@/v2/composables/useGridNav", () => ({
+  useGridNav: vi.fn(),
+}));
+
+vi.mock("@/v2/composables/useWebpSupport", () => ({
+  useWebpSupport: () => ({
+    supportsWebp: ref(false),
+    toWebp: (url: string) => url,
+  }),
+}));
+
+vi.mock("@/composables/useUISettings", () => ({
+  useUISettings: () => ({
+    showHomeWidgets: ref(true),
+    showRecentRoms: ref(true),
+    showContinuePlaying: ref(true),
+    showPlatforms: ref(true),
+    showCollections: ref(true),
+    showSmartCollections: ref(false),
+    showVirtualCollections: ref(false),
+    virtualCollectionType: ref("collection"),
+  }),
+}));
+
+function platform(id: number): Platform {
+  return {
+    id,
+    display_name: `Platform ${id}`,
+    name: `Platform ${id}`,
+    slug: `platform-${id}`,
+    fs_slug: `platform-${id}`,
+    rom_count: 12,
+  } as Platform;
+}
+
+function collection(id: number): Collection {
+  return {
+    id,
+    name: `Collection ${id}`,
+    rom_count: 3,
+    rom_ids: [],
+  } as unknown as Collection;
+}
+
+function rom(id: number): SimpleRom {
+  return { id, name: `Rom ${id}` } as SimpleRom;
+}
+
+/**
+ * Resolve on a later microtask, the way a real request does. Anything
+ * asserting on the home page's initial-load ordering has to see the
+ * stores fill in after setup, not during it.
+ */
+async function afterRoundTrip<T>(populate: () => T): Promise<T> {
+  await Promise.resolve();
+  return populate();
+}
+
+/** Wire up every home page fetch; `populated` decides what comes back. */
+function stubHomeFetches(populated: boolean) {
+  const platforms = storePlatforms();
+  const collections = storeCollections();
+  const roms = storeRoms();
+
+  vi.spyOn(platforms, "fetchPlatforms").mockImplementation(() => {
+    platforms.fetchingPlatforms = true;
+    return afterRoundTrip(() => {
+      const loaded = populated ? [platform(1)] : [];
+      platforms.set(loaded);
+      platforms.fetchingPlatforms = false;
+      return loaded;
+    });
+  });
+
+  vi.spyOn(collections, "fetchCollections").mockImplementation(() => {
+    collections.fetchingCollections = true;
+    return afterRoundTrip(() => {
+      const loaded = populated ? [collection(1)] : [];
+      collections.setCollections(loaded);
+      collections.fetchingCollections = false;
+      return loaded;
+    });
+  });
+
+  vi.spyOn(collections, "fetchSmartCollections").mockImplementation(() => {
+    collections.fetchingSmartCollections = true;
+    return afterRoundTrip(() => {
+      collections.fetchingSmartCollections = false;
+      return [];
+    });
+  });
+
+  vi.spyOn(collections, "fetchVirtualCollections").mockImplementation(() => {
+    collections.fetchingVirtualCollections = true;
+    return afterRoundTrip(() => {
+      collections.fetchingVirtualCollections = false;
+      return [];
+    });
+  });
+
+  vi.spyOn(roms, "fetchRecentRoms").mockImplementation(() =>
+    afterRoundTrip(() => {
+      const loaded = populated ? [rom(1)] : [];
+      roms.setRecentRoms(loaded);
+      return loaded;
+    }),
+  );
+
+  vi.spyOn(roms, "fetchContinuePlayingRoms").mockImplementation(() =>
+    afterRoundTrip(() => {
+      const loaded = populated ? [rom(2)] : [];
+      roms.setContinuePlayingRoms(loaded);
+      return loaded;
+    }),
+  );
+
+  return { platforms, collections, roms };
+}
+
+function mountHome() {
+  return mount(Home, {
+    global: {
+      stubs: { RouterLink: defineComponent({ template: "<a><slot /></a>" }) },
+    },
+  });
+}
+
+describe("Home", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    getLibraryInfo.mockReset();
+    getLibraryInfo.mockResolvedValue({
+      data: { detected_structure: "struct_a", existing_platforms: [] },
+    });
+  });
+
+  it("never walks the filesystem for a populated library", async () => {
+    stubHomeFetches(true);
+
+    const wrapper = mountHome();
+
+    // Setup has run but nothing has resolved: the stores are still empty,
+    // which is exactly the transient state that used to fire the request.
+    expect(getLibraryInfo).not.toHaveBeenCalled();
+
+    await flushPromises();
+
+    expect(getLibraryInfo).not.toHaveBeenCalled();
+    expect(wrapper.text()).not.toContain("home.empty-headline");
+  });
+
+  it("fetches the filesystem hint once the library is confirmed empty", async () => {
+    stubHomeFetches(false);
+
+    const wrapper = mountHome();
+    await flushPromises();
+
+    expect(getLibraryInfo).toHaveBeenCalledTimes(1);
+    expect(wrapper.text()).toContain("home.empty-headline");
+  });
+
+  it("does not render the empty state before the initial loads settle", async () => {
+    stubHomeFetches(false);
+
+    const wrapper = mountHome();
+
+    expect(wrapper.text()).not.toContain("home.empty-headline");
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("home.empty-headline");
+  });
+});

--- a/frontend/src/v2/views/Home.vue
+++ b/frontend/src/v2/views/Home.vue
@@ -61,29 +61,45 @@ const fetchingContinue = ref(false);
 const gridRoot = ref<HTMLElement | null>(null);
 useGridNav(gridRoot);
 
-onMounted(() => {
+// Flips once every initial request has settled. Until then the store
+// `fetching*` flags are still false and the stores are still empty, so
+// `isEmpty` reads true for a library that simply hasn't loaded yet.
+const initialLoadDone = ref(false);
+
+onMounted(async () => {
+  const initialLoads: Promise<unknown>[] = [];
+
   if (platformsStore.allPlatforms.length === 0) {
-    platformsStore.fetchPlatforms();
+    initialLoads.push(platformsStore.fetchPlatforms());
   }
   if (collectionsStore.allCollections.length === 0) {
-    collectionsStore.fetchCollections();
+    initialLoads.push(collectionsStore.fetchCollections());
   }
   if (showSmartCollections.value && smartCollections.value.length === 0) {
-    collectionsStore.fetchSmartCollections();
+    initialLoads.push(collectionsStore.fetchSmartCollections());
   }
   if (showVirtualCollections.value && virtualCollections.value.length === 0) {
-    collectionsStore.fetchVirtualCollections(virtualCollectionType.value);
+    initialLoads.push(
+      collectionsStore.fetchVirtualCollections(virtualCollectionType.value),
+    );
   }
   if (recentRoms.value.length === 0) {
     fetchingRecent.value = true;
-    romsStore.fetchRecentRoms().finally(() => (fetchingRecent.value = false));
+    initialLoads.push(
+      romsStore.fetchRecentRoms().finally(() => (fetchingRecent.value = false)),
+    );
   }
   if (continuePlayingRoms.value.length === 0) {
     fetchingContinue.value = true;
-    romsStore
-      .fetchContinuePlayingRoms()
-      .finally(() => (fetchingContinue.value = false));
+    initialLoads.push(
+      romsStore
+        .fetchContinuePlayingRoms()
+        .finally(() => (fetchingContinue.value = false)),
+    );
   }
+
+  await Promise.allSettled(initialLoads);
+  initialLoadDone.value = true;
 });
 
 // True when nothing has been added yet AND we're no longer fetching —
@@ -104,6 +120,10 @@ const isEmpty = computed(
     (!showSmartCollections.value || smartCollections.value.length === 0) &&
     (!showVirtualCollections.value || virtualCollections.value.length === 0),
 );
+
+// Gate on the load having actually happened: `isEmpty` alone is true
+// during setup, before any request has been made.
+const showEmptyState = computed(() => initialLoadDone.value && isEmpty.value);
 
 // Filesystem snapshot for the empty state — shows the user what RomM
 // can already see on disk so the "run a scan" CTA isn't a leap of
@@ -137,13 +157,9 @@ async function loadLibraryInfo() {
   }
 }
 
-watch(
-  isEmpty,
-  (empty) => {
-    if (empty) void loadLibraryInfo();
-  },
-  { immediate: true },
-);
+watch(showEmptyState, (empty) => {
+  if (empty) void loadLibraryInfo();
+});
 
 // Favorite ROMs — derived from the Favorites collection's rom_ids.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- false positive: used in <template>; @typescript-eslint+projectService doesn't see Vue templates
@@ -175,7 +191,7 @@ function collectionCovers(c: {
     <!-- Empty library state — shown when nothing has been ingested
          yet. Hides every section underneath so the user lands on a
          decision (upload vs scan), not on a row of skeletons. -->
-    <section v-if="isEmpty" class="r-v2-home-empty">
+    <section v-if="showEmptyState" class="r-v2-home-empty">
       <div class="r-v2-home-empty__hero">
         <RIcon
           icon="mdi-controller-classic-outline"


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

Fixes #4063

The v2 home page called `GET /api/setup/library` on **every** page load, even on a
fully populated library. That endpoint walks the ROM library on disk (`iterdir()`
per platform directory) to build a first-run "here's what we see on disk" hint,
and the home page threw the result away because the library isn't empty.

Measured cost of the wasted walk:

- 17.0s on an 83,000-game instance with the DB on SSD (16.8s on a second run, so
  the OS page cache doesn't rescue it)
- 38.3s on a 23,698-game instance with a 5200 RPM HDD

**Root cause.** `loadLibraryInfo()` was driven by `watch(isEmpty, ..., { immediate: true })`.
An immediate watcher runs during `setup()`, which is strictly earlier than
`onMounted`, so at that moment no data request has even started: every store
`fetching*` flag is still `false` and every store array is still empty. `isEmpty`
therefore read `true` for any library, and the walk fired unconditionally.

Fixed on both sides of the stack, since either one alone leaves a sharp edge:

1. **Frontend.** `onMounted` now collects its conditional fetches and awaits
   `Promise.allSettled` before flipping a new `initialLoadDone` flag. The
   watcher and the empty-state `v-if` both gate on
   `showEmptyState = initialLoadDone && isEmpty`, so the filesystem hint is
   requested only once the library is *confirmed* empty. `allSettled` rather
   than `all` so a rejected fetch still releases the gate.
2. **Backend.** `/setup/library` returns early with `existing_platforms: []`
   when the database already holds at least one ROM, so any other caller (or an
   older frontend) can't trigger the walk either.

**Note on scope of the user-visible symptom.** This is a wasted-request fix, not
a visible-flash fix. I verified with a `requestAnimationFrame` frame sampler that
the empty-library hero rendered in **0 frames** on a populated library both before
and after the change: `onMounted` sets the fetching flags before the first paint,
so only the setup-time watcher was ever wrong. Please don't expect a visual
difference on a populated library; the difference is one fewer multi-second
request per page load.

**Design note for reviewers.** The backend bail-out is gated on **ROMs only**,
deliberately not on "platforms and ROMs". A ROM row implies a platform row via
FK, and a database with platform rows but zero ROMs is precisely the case the
filesystem hint exists to serve, so that case must still walk. Both behaviours
are pinned by tests.

**Files modified**

| File | Change |
| --- | --- |
| `frontend/src/v2/views/Home.vue` | `onMounted` awaits `Promise.allSettled` of the initial fetches, then sets `initialLoadDone`. New `showEmptyState` computed gates both the watcher and the empty-state `v-if`. `immediate: true` removed from the watcher. |
| `frontend/src/v2/views/Home.test.ts` | New. Covers the populated-library case (no request, at setup time or after settle), the empty-library case (exactly one request), and the template gate. |
| `backend/endpoints/heartbeat.py` | `get_setup_library_info` returns early with an empty `existing_platforms` when `db_stats_handler.get_roms_count() > 0`. Placed after the existing scope check, and still returns `detected_structure` + `supported_platforms`. |
| `backend/handler/database/roms_handler.py` | New `has_any_rom()` existence probe (`SELECT id LIMIT 1`, not `COUNT(*)`). |
| `backend/tests/endpoints/test_heartbeat.py` | Two tests: the walk is skipped when ROMs exist (asserts `fs_platform_handler.get_platforms` is never called), and the walk still happens for platform rows with no ROMs. |

**Testing notes**

- Backend: `uv run pytest` → 2704 passed, 2 skipped.
- The ROM existence check reuses `db_stats_handler.get_roms_count()` per review.
  On a 92,800-ROM replica (`roms` 963 MB, 256 MB buffer pool) it is an
  index-only scan of a 2.5 MB secondary index (`type=index`, `Using index`),
  measured at 25 ms cold and warm, against the 17-38 s walk it prevents.
- Frontend: `npm run test` → 615 passed across 48 files. `vue-tsc --noEmit` clean.
- `trunk fmt && trunk check` clean.
- Browser-verified against a real dev stack in both light and dark themes:
  - Populated library: **0** `/api/setup/library` requests (pre-fix: 1, firing in
    the same millisecond as the other initial requests).
  - Empty library: **1** correctly-deferred request, with the "9 platforms
    detected" / "16 games detected" chips still rendering as before.
  - The template gate removes an intermediate paint for empty-library users
    rather than adding one (`rows:5 → rows:4 → hero @377ms` became
    `rows:5 → hero @271ms`).
- No API contract change: the endpoint has no `response_model` and the response
  keys are unchanged, so no `npm run generate` is needed.
- No new user-visible strings, so no locale changes.
- No v1 files touched.

**Reviewer attention**

- **The ROMs-only gating** described above is the one judgement call in this PR
  that the issue text did not specify. If you'd rather it also considered
  platform rows, that flips the behaviour of
  `test_get_setup_library_info_walks_when_platforms_have_no_roms`.
- **Setup wizard is unaffected**, but it's the natural regression risk and worth
  a second pair of eyes: `SHOW_SETUP_WIZARD` is only true when there are zero
  admin users, at which point there are no ROMs, so the bail-out cannot trigger
  mid-wizard. The early return also preserves `detected_structure` and all 460
  `supported_platforms` entries the wizard reads.
- **`Promise.allSettled` semantics**: a failed initial fetch still flips
  `initialLoadDone`, which is intentional. A user whose requests all failed will
  see the empty state and one filesystem-hint request, which is the same thing
  they'd have seen before.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this change was written with AI assistance (Claude Code).
The AI wrote the tests and implementation, ran the test suites, and performed the
browser verification described above. I reviewed the diff, and the measurements in
the linked issue are my own from my instances.
