### PR TITLE
perf(roms): pick a random rom without paging to a random offset

### DIFF
--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -898,6 +898,62 @@ def get_rom_identifiers(
     return [r.id for r in db_roms]
 
 
+@protected_route(router.get, "/random", [Scope.ROMS_READ])
+def get_random_rom(
+    request: Request,
+    platform_ids: Annotated[
+        list[int] | None,
+        Query(
+            description=(
+                "Platform internal ids. Multiple values are allowed by repeating the"
+                " parameter, and the pick will match any of the values."
+            ),
+        ),
+    ] = None,
+    collection_id: Annotated[
+        int | None,
+        Query(description="Collection internal id.", ge=1),
+    ] = None,
+    virtual_collection_id: Annotated[
+        str | None,
+        Query(description="Virtual collection internal id."),
+    ] = None,
+    smart_collection_id: Annotated[
+        int | None,
+        Query(description="Smart collection internal id.", ge=1),
+    ] = None,
+) -> SimpleRomSchema | None:
+    """Retrieve one rom picked at random, or null when the scope holds none.
+
+    Sampled on the primary key instead of paged to, so the pick doesn't get
+    slower as the library grows.
+    """
+    perms = get_permissions(request)
+
+    base_query, _ = db_rom_handler.get_roms_query(user_id=request.user.id)
+    query = db_rom_handler.filter_roms(
+        query=base_query,
+        user_id=request.user.id,
+        hidden_platform_ids=perms.hidden_platform_ids,  # type: ignore
+        hidden_rom_ids=perms.hidden_rom_ids,  # type: ignore
+        platform_ids=platform_ids,
+        collection_id=collection_id,
+        virtual_collection_id=virtual_collection_id,
+        smart_collection_id=smart_collection_id,
+        include_related=False,
+    )
+
+    rom_id = db_rom_handler.get_random_rom_id(query=query)
+    if rom_id is None:
+        return None
+
+    rom = db_rom_handler.get_rom_simple(rom_id)
+    if not rom:
+        return None
+
+    return SimpleRomSchema.from_orm_with_request(rom, request)
+
+
 @protected_route(
     router.get,
     "/download",

--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -951,6 +951,13 @@ def get_random_rom(
     if not rom:
         return None
 
+    # The fetch is by raw id, so it re-checks the row it actually loaded rather
+    # than trusting the filter that chose the id: a rom that moved to a hidden
+    # platform in between was picked under its old one. Reads no database, and
+    # null keeps a hidden rom indistinguishable from an empty scope.
+    if not perms.can_see_rom(rom.id, rom.platform_id):
+        return None
+
     return SimpleRomSchema.from_orm_with_request(rom, request)
 
 

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -2,6 +2,7 @@ import functools
 import hashlib
 import json
 import re
+import secrets
 from collections.abc import Iterable, Sequence
 from datetime import datetime
 from typing import Any, NamedTuple
@@ -139,6 +140,11 @@ FULLTEXT_MIN_TOKEN_SIZE = 3
 # length, so an ordinary name search builds no hash SQL at all. Hashes are
 # stored lowercase, which keeps the lookup an indexed equality.
 HEX_DIGEST_REGEX = re.compile(r"[0-9a-fA-F]+")
+
+# Primary keys offered per round trip when picking a random rom. Sixteen
+# lands a hit ~99% of the time on a library occupying a quarter of its id
+# range, which is what deletions leave behind on a long-lived instance.
+RANDOM_ID_SAMPLE_SIZE = 16
 
 # CRC32 (8), MD5 and RetroAchievements (32), SHA-1 (40).
 ROM_HASH_COLUMNS_BY_DIGEST_LENGTH: dict[int, tuple[QueryableAttribute, ...]] = {
@@ -1641,6 +1647,51 @@ class DBRomsHandler(DBBaseHandler):
             )
             or 0
         )
+
+    @begin_session
+    def get_random_rom_id(
+        self,
+        query: Query,
+        *,
+        session: Session = None,  # type: ignore
+    ) -> int | None:
+        """Pick one rom id at random, uniformly, from a filtered query.
+
+        Two mechanisms, both uniform. First a batch of random primary keys is
+        offered to the query: every id in the table is equally likely to be
+        offered, so any hit is an unbiased pick, and the whole batch costs one
+        index lookup per candidate no matter how large the library is.
+
+        A batch misses when the query matches too little of the id space (a
+        scoped gallery, an id range left full of gaps by deletions). It then
+        falls back to counting the set and taking the row at a random position
+        in it. That reads no rows, only index entries, since the statement
+        selects nothing but the id.
+        """
+        id_query = query.order_by(None).with_only_columns(Rom.id)  # type: ignore
+
+        # Bounds come from the table rather than the filtered set: they only
+        # need to cover it, and MIN/MAX over an untouched primary key are two
+        # index seeks, where the same pair over a joined and filtered set is a
+        # scan of it.
+        lowest, highest = session.execute(
+            select(func.min(Rom.id), func.max(Rom.id))
+        ).one()
+        if lowest is None or highest is None:
+            return None
+
+        span = highest - lowest + 1
+        candidates = {
+            lowest + secrets.randbelow(span) for _ in range(RANDOM_ID_SAMPLE_SIZE)
+        }
+        hits = session.scalars(id_query.where(Rom.id.in_(candidates))).all()
+        if hits:
+            return secrets.choice(hits)
+
+        total = self.get_rom_count(query=query, session=session)
+        if total == 0:
+            return None
+        return session.scalar(id_query.limit(1).offset(secrets.randbelow(total)))
 
     @begin_session
     def get_roms_by_fs_name(

--- a/backend/tests/endpoints/roms/test_random.py
+++ b/backend/tests/endpoints/roms/test_random.py
@@ -1,0 +1,279 @@
+"""Tests for `GET /api/roms/random` (issue #4066).
+
+The endpoint replaces the two-call "count the library, then fetch the row at a
+random offset" dance the Home widget used to run. Paging to a random offset
+costs more the bigger the library gets, so these tests pin both the behaviour
+(a rom from the requested scope, every rom reachable) and the mechanism (no
+offset walk, no full count).
+"""
+
+from collections import Counter
+from typing import Iterator
+from unittest.mock import patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+
+from handler.database import (
+    db_collection_handler,
+    db_platform_handler,
+    db_rom_handler,
+    roms_handler,
+)
+from handler.database.base_handler import sync_engine, sync_session
+from models.collection import Collection
+from models.permission import HiddenEntity, PermEntity
+from models.platform import Platform
+from models.rom import Rom
+from models.user import User
+
+
+def _add_rom(platform: Platform, name: str) -> Rom:
+    return db_rom_handler.add_rom(
+        Rom(
+            platform_id=platform.id,
+            name=name,
+            slug=name,
+            fs_name=f"{name}.zip",
+            fs_name_no_tags=name,
+            fs_name_no_ext=name,
+            fs_extension="zip",
+            fs_path=f"{platform.slug}/roms",
+        )
+    )
+
+
+@pytest.fixture
+def other_platform() -> Platform:
+    return db_platform_handler.add_platform(
+        Platform(
+            name="other_platform",
+            slug="other_platform_slug",
+            fs_slug="other_platform_slug",
+        )
+    )
+
+
+@pytest.fixture
+def captured_sql() -> Iterator[list[str]]:
+    """Every statement the engine runs while the fixture is active."""
+    statements: list[str] = []
+
+    def before_cursor_execute(conn, cursor, statement, parameters, context, many):
+        statements.append(statement)
+
+    event.listen(sync_engine, "before_cursor_execute", before_cursor_execute)
+    try:
+        yield statements
+    finally:
+        event.remove(sync_engine, "before_cursor_execute", before_cursor_execute)
+
+
+def test_get_random_rom_returns_a_rom(
+    client: TestClient, access_token: str, rom: Rom
+) -> None:
+    response = client.get(
+        "/api/roms/random",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    body = response.json()
+    assert body is not None
+    assert body["id"] == rom.id
+    # The widget renders cover, platform and release year straight off the pick.
+    assert body["platform_slug"] == rom.platform_slug
+
+
+def test_get_random_rom_requires_auth(client: TestClient) -> None:
+    response = client.get("/api/roms/random")
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_get_random_rom_without_roms_returns_null(
+    client: TestClient, access_token: str, platform: Platform
+) -> None:
+    """An empty library is not an error: the widget shows its own empty copy."""
+    response = client.get(
+        "/api/roms/random",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() is None
+
+
+def test_get_random_rom_reaches_every_rom(
+    client: TestClient, access_token: str, rom: Rom, platform: Platform
+) -> None:
+    """Sampling must cover the whole set, not park on one end of it."""
+    ids = {rom.id} | {_add_rom(platform, f"rom_{i}").id for i in range(4)}
+
+    seen: Counter[int] = Counter()
+    for _ in range(120):
+        response = client.get(
+            "/api/roms/random",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        seen[response.json()["id"]] += 1
+
+    assert set(seen) == ids
+
+
+def test_get_random_rom_scoped_to_platform(
+    client: TestClient,
+    access_token: str,
+    rom: Rom,
+    platform: Platform,
+    other_platform: Platform,
+) -> None:
+    other_ids = {_add_rom(other_platform, f"other_{i}").id for i in range(3)}
+
+    for _ in range(20):
+        response = client.get(
+            "/api/roms/random",
+            headers={"Authorization": f"Bearer {access_token}"},
+            params={"platform_ids": [other_platform.id]},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["id"] in other_ids
+
+    response = client.get(
+        "/api/roms/random",
+        headers={"Authorization": f"Bearer {access_token}"},
+        params={"platform_ids": [platform.id]},
+    )
+    assert response.json()["id"] == rom.id
+
+
+def test_get_random_rom_scoped_to_collection(
+    client: TestClient,
+    access_token: str,
+    admin_user: User,
+    rom: Rom,
+    platform: Platform,
+) -> None:
+    in_collection = _add_rom(platform, "in_collection")
+    _add_rom(platform, "out_of_collection")
+
+    collection = db_collection_handler.add_collection(
+        Collection(name="Picks", description="", user_id=admin_user.id)
+    )
+    db_collection_handler.add_roms_to_collection(collection.id, [in_collection.id])
+
+    for _ in range(10):
+        response = client.get(
+            "/api/roms/random",
+            headers={"Authorization": f"Bearer {access_token}"},
+            params={"collection_id": collection.id},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["id"] == in_collection.id
+
+
+def test_get_random_rom_scoped_to_empty_collection_returns_null(
+    client: TestClient, access_token: str, admin_user: User, rom: Rom
+) -> None:
+    """No sampled key can land in an empty scope, so this is the fallback's null."""
+    collection = db_collection_handler.add_collection(
+        Collection(name="Empty", description="", user_id=admin_user.id)
+    )
+
+    response = client.get(
+        "/api/roms/random",
+        headers={"Authorization": f"Bearer {access_token}"},
+        params={"collection_id": collection.id},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() is None
+
+
+def test_get_random_rom_skips_hidden_roms(
+    client: TestClient,
+    viewer_user: User,
+    viewer_access_token: str,
+    rom: Rom,
+    platform: Platform,
+) -> None:
+    """Admin-hidden roms are out of scope for the pick, like any other list."""
+    visible = _add_rom(platform, "visible_rom")
+    with sync_session.begin() as session:
+        session.add(
+            HiddenEntity(
+                entity=PermEntity.ROMS, entity_id=rom.id, user_id=viewer_user.id
+            )
+        )
+
+    for _ in range(30):
+        response = client.get(
+            "/api/roms/random",
+            headers={"Authorization": f"Bearer {viewer_access_token}"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["id"] == visible.id
+
+
+def test_get_random_rom_does_not_page_or_count(
+    client: TestClient,
+    access_token: str,
+    rom: Rom,
+    platform: Platform,
+    captured_sql: list[str],
+) -> None:
+    """The point of the endpoint: cost that doesn't grow with the library.
+
+    Both mechanisms it replaces walk the whole filtered set: an OFFSET steps
+    over every preceding row, and the total was its own count of the library.
+    Sampling primary keys does neither, and consecutively-numbered roms always
+    land it a hit.
+    """
+    for i in range(5):
+        _add_rom(platform, f"rom_{i}")
+    captured_sql.clear()
+
+    with (
+        patch.object(
+            db_rom_handler, "get_rom_count", wraps=db_rom_handler.get_rom_count
+        ) as get_rom_count,
+        patch.object(
+            db_rom_handler, "get_rom_id_index", wraps=db_rom_handler.get_rom_id_index
+        ) as get_rom_id_index,
+    ):
+        response = client.get(
+            "/api/roms/random",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        get_rom_count.assert_not_called()
+        get_rom_id_index.assert_not_called()
+
+    rom_queries = [sql for sql in captured_sql if " roms" in sql.lower()]
+    assert rom_queries, "expected the pick to query the roms table"
+    assert not [sql for sql in rom_queries if "offset" in sql.lower()]
+
+
+def test_get_random_rom_falls_back_when_sampling_misses(
+    client: TestClient, access_token: str, rom: Rom, platform: Platform
+) -> None:
+    """A scope the sampled keys never hit still resolves a pick.
+
+    Sampling zero keys stands in for the real cases: a narrow filter, or an id
+    space left sparse by deletions.
+    """
+    ids = {rom.id} | {_add_rom(platform, f"rom_{i}").id for i in range(4)}
+
+    seen: set[int] = set()
+    with patch.object(roms_handler, "RANDOM_ID_SAMPLE_SIZE", 0):
+        for _ in range(120):
+            response = client.get(
+                "/api/roms/random",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            assert response.status_code == status.HTTP_200_OK
+            seen.add(response.json()["id"])
+
+    # The fallback is a position in the set, so it reaches all of it too.
+    assert seen == ids

--- a/backend/tests/endpoints/roms/test_random.py
+++ b/backend/tests/endpoints/roms/test_random.py
@@ -215,6 +215,40 @@ def test_get_random_rom_skips_hidden_roms(
         assert response.json()["id"] == visible.id
 
 
+def test_get_random_rom_rechecks_visibility_after_fetching(
+    client: TestClient,
+    viewer_user: User,
+    viewer_access_token: str,
+    rom: Rom,
+    platform: Platform,
+) -> None:
+    """The pick is re-checked against the row that came back, not the filter.
+
+    The id is chosen by a filtered query but fetched by raw id, so a rom that
+    moved to a hidden platform in between would arrive hidden. Standing in for
+    that race by handing the endpoint a rom the filter would have excluded.
+    """
+    # A visible rom so the pick resolves an id, otherwise the empty scope
+    # returns null on its own and the fetch is never reached.
+    _add_rom(platform, "visible_rom")
+    with sync_session.begin() as session:
+        session.add(
+            HiddenEntity(
+                entity=PermEntity.ROMS, entity_id=rom.id, user_id=viewer_user.id
+            )
+        )
+
+    with patch.object(db_rom_handler, "get_rom_simple", return_value=rom):
+        response = client.get(
+            "/api/roms/random",
+            headers={"Authorization": f"Bearer {viewer_access_token}"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    # Null, not 404: a hidden rom stays indistinguishable from an empty scope.
+    assert response.json() is None
+
+
 def test_get_random_rom_does_not_page_or_count(
     client: TestClient,
     access_token: str,

--- a/docs/BACKEND_ARCHITECTURE.md
+++ b/docs/BACKEND_ARCHITECTURE.md
@@ -855,6 +855,7 @@ Migrations support batch mode for SQLite and DB-specific SQL for MariaDB/MySQL/P
 | ------ | ---------------------------- | ---------- | ------------------------------------------------ |
 | GET    | `/`                          | ROMS_READ  | List ROMs (paginated, filterable)                |
 | GET    | `/identifiers`               | ROMS_READ  | Get ROM IDs                                      |
+| GET    | `/random`                    | ROMS_READ  | Get one ROM picked at random (optionally scoped) |
 | GET    | `/{id}`                      | ROMS_READ  | Get ROM details                                  |
 | PUT    | `/{id}`                      | ROMS_WRITE | Update ROM metadata                              |
 | POST   | `/{id}/convert-to-folder`    | ROMS_WRITE | Promote single-file ROM to a folder ROM in place |

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -415,6 +415,31 @@ async function getRomSimple({
   return api.get<SimpleRom>(`/roms/${romId}/simple`, { signal });
 }
 
+async function getRandomRom({
+  platformIds = null,
+  collectionId = null,
+  virtualCollectionId = null,
+  smartCollectionId = null,
+}: {
+  platformIds?: number[] | null;
+  collectionId?: number | null;
+  virtualCollectionId?: string | null;
+  smartCollectionId?: number | null;
+} = {}) {
+  // `/roms/random` samples the primary key server-side, so one request
+  // resolves a pick regardless of library size. `null` means the scope
+  // holds no roms.
+  return api.get<SimpleRom | null>("/roms/random", {
+    params: {
+      platform_ids:
+        platformIds && platformIds.length > 0 ? platformIds : undefined,
+      collection_id: collectionId,
+      virtual_collection_id: virtualCollectionId,
+      smart_collection_id: smartCollectionId,
+    },
+  });
+}
+
 async function getRomByMetadataProvider({
   field,
   id,
@@ -924,6 +949,7 @@ export default {
   getRecentPlayedRoms,
   getRom,
   getRomSimple,
+  getRandomRom,
   getRomByMetadataProvider,
   downloadRom,
   bulkDownloadRoms,

--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -426,9 +426,6 @@ async function getRandomRom({
   virtualCollectionId?: string | null;
   smartCollectionId?: number | null;
 } = {}) {
-  // `/roms/random` samples the primary key server-side, so one request
-  // resolves a pick regardless of library size. `null` means the scope
-  // holds no roms.
   return api.get<SimpleRom | null>("/roms/random", {
     params: {
       platform_ids:

--- a/frontend/src/v2/components/Home/Widgets/RandomPickWidget.test.ts
+++ b/frontend/src/v2/components/Home/Widgets/RandomPickWidget.test.ts
@@ -1,0 +1,125 @@
+/* eslint-disable vue/one-component-per-file */
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent } from "vue";
+import type { SimpleRom } from "@/stores/roms";
+import RandomPickWidget from "./RandomPickWidget.vue";
+
+const { getRandomRom, snackbarError } = vi.hoisted(() => ({
+  getRandomRom: vi.fn(),
+  snackbarError: vi.fn(),
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/plugins/router", () => ({
+  ROUTES: { ROM: "rom" },
+}));
+
+vi.mock("@/services/api/rom", () => ({
+  default: { getRandomRom },
+}));
+
+vi.mock("@/v2/composables/useSnackbar", () => ({
+  useSnackbar: () => ({ error: snackbarError }),
+}));
+
+vi.mock("@v2/lib", () => ({
+  RBtn: defineComponent({
+    props: { disabled: { type: Boolean, default: false } },
+    emits: ["click"],
+    template:
+      '<button class="reroll" :disabled="disabled" @click="$emit(\'click\')" />',
+  }),
+  RChip: defineComponent({ template: "<span><slot /></span>" }),
+}));
+
+vi.mock("@/v2/components/shared/CachedPlatformIcon.vue", () => ({
+  default: defineComponent({ template: "<i />" }),
+}));
+
+vi.mock("@/v2/components/shared/GameCover.vue", () => ({
+  default: defineComponent({ template: "<figure />" }),
+}));
+
+vi.mock("./WidgetCard.vue", () => ({
+  default: defineComponent({
+    template: "<section><slot name='action' /><slot /></section>",
+  }),
+}));
+
+function rom(overrides: Partial<SimpleRom> = {}): SimpleRom {
+  return {
+    id: 42,
+    name: "Chrono Trigger",
+    fs_name: "chrono-trigger.sfc",
+    platform_slug: "snes",
+    platform_display_name: "Super Nintendo",
+    regions: ["USA"],
+    is_identified: true,
+    ...overrides,
+  } as SimpleRom;
+}
+
+function mountWidget() {
+  return mount(RandomPickWidget, {
+    global: { stubs: { RouterLink: { template: "<a><slot /></a>" } } },
+  });
+}
+
+describe("RandomPickWidget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves a pick with a single request", async () => {
+    // Issue #4066: the pick used to cost a count request plus a fetch at a
+    // random offset, which got slower the bigger the library was.
+    getRandomRom.mockResolvedValue({ data: rom() });
+
+    const wrapper = mountWidget();
+    await flushPromises();
+
+    expect(getRandomRom).toHaveBeenCalledTimes(1);
+    expect(wrapper.text()).toContain("Chrono Trigger");
+  });
+
+  it("shows the empty copy when the library holds no roms", async () => {
+    getRandomRom.mockResolvedValue({ data: null });
+
+    const wrapper = mountWidget();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("home.widget-random-pick-empty");
+    expect(snackbarError).not.toHaveBeenCalled();
+  });
+
+  it("shows the error copy without a snackbar on the first pick", async () => {
+    getRandomRom.mockRejectedValue(new Error("boom"));
+
+    const wrapper = mountWidget();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("home.widget-random-pick-error");
+    expect(snackbarError).not.toHaveBeenCalled();
+  });
+
+  it("rerolls on demand and keeps the previous pick when the reroll fails", async () => {
+    getRandomRom.mockResolvedValue({ data: rom() });
+
+    const wrapper = mountWidget();
+    await flushPromises();
+
+    getRandomRom.mockRejectedValue(new Error("boom"));
+    await wrapper.get("button.reroll").trigger("click");
+    await flushPromises();
+
+    expect(getRandomRom).toHaveBeenCalledTimes(2);
+    // A failed request says nothing about the library, so the card keeps
+    // showing the game it already had and reports through the snackbar.
+    expect(wrapper.text()).toContain("Chrono Trigger");
+    expect(snackbarError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/v2/components/Home/Widgets/RandomPickWidget.vue
+++ b/frontend/src/v2/components/Home/Widgets/RandomPickWidget.vue
@@ -3,9 +3,9 @@
 // it on the Home dashboard. Body: cover + name + platform + release
 // year / region, the whole thing a link to the rom. Reroll lives in
 // the card's top-right action slot and reshuffles in place without
-// navigating. Two API calls per pick: one to learn the library total,
-// one to fetch the selected offset; same approach the v1 RandomBtn
-// uses. The pick is intentionally not cached so each mount re-shuffles.
+// navigating. One request per pick: `/roms/random` samples the pick
+// server-side, so it costs the same on any library size. The pick is
+// intentionally not cached so each mount re-shuffles.
 import { RBtn, RChip } from "@v2/lib";
 import { computed, nextTick, onMounted, ref } from "vue";
 import type { ComponentPublicInstance } from "vue";
@@ -34,16 +34,6 @@ const DICE_FACES = [
   "mdi-dice-5-outline",
   "mdi-dice-6-outline",
 ];
-
-// A pick needs a single row, so it opts out of the char index, filter
-// values and rom id index the endpoint returns by default: each of them
-// spans the whole library and dwarfs the row itself.
-const PICK_QUERY = {
-  limit: 1,
-  withCharIndex: false,
-  withFilterValues: false,
-  withRomIdIndex: false,
-} as const;
 
 const pick = ref<SimpleRom | null>(null);
 const loading = ref(false);
@@ -77,21 +67,6 @@ function rollDiceFace() {
   diceFace.value = others[Math.floor(Math.random() * others.length)];
 }
 
-// One attempt at a pick. `null` means the library holds no roms;
-// `undefined` means the offset came back empty, which the backend's
-// cached id index makes possible when it drifts from the database
-// between the two calls (a scan, a deletion).
-async function pickOnce(): Promise<SimpleRom | null | undefined> {
-  const { data: head } = await romApi.getRoms({ ...PICK_QUERY, offset: 0 });
-  if (!head.total) return null;
-
-  const { data: result } = await romApi.getRoms({
-    ...PICK_QUERY,
-    offset: Math.floor(Math.random() * head.total),
-  });
-  return result.items.at(0);
-}
-
 async function reroll({ notify }: { notify: boolean }) {
   if (loading.value) return;
   rollDiceFace();
@@ -99,11 +74,9 @@ async function reroll({ notify }: { notify: boolean }) {
   const hadFocus = document.activeElement === rerollEl();
   loading.value = true;
   try {
-    let rom = await pickOnce();
-    // Drift is worth one retry, since the second attempt re-reads the total.
-    if (rom === undefined) rom = await pickOnce();
-    if (rom === undefined) throw new Error("random pick came back empty");
-    pick.value = rom;
+    // `null` means the library holds no roms.
+    const { data } = await romApi.getRandomRom();
+    pick.value = data;
     failed.value = false;
   } catch {
     // Keep the previous pick: a failed request says nothing about whether


### PR DESCRIPTION
**Description**

Fixes #4066.

The v2 Home "Random Pick" widget resolved a pick by paging to it: one request to
learn the library total, a second at `offset: <random>`. An offset makes the
database walk and discard every preceding row, so the cost grew with the library.
On an 83k-rom instance a pick took **1.7s median and up to 6.9s**, and the widget
runs one on every Home mount.

This adds `GET /api/roms/random`, which samples on the primary key instead.

Two mechanisms, both uniform:

1. **Batch sampling (the fast path).** Sixteen random primary keys are offered to
   the filtered query in a single `IN (...)`. Every id in the table is equally
   likely to be offered, so any hit is an unbiased pick, and the batch costs one
   index lookup per candidate no matter how large the library is. Bounds come
   from `MIN`/`MAX` over the untouched primary key (two index seeks) rather than
   over the filtered set, which would be a scan of it.
2. **Uniform offset fallback.** A batch misses when the query matches too little
   of the id space (a narrow scope, or an id range left sparse by deletions). It
   then counts the set and takes the row at a random position. The statement
   selects nothing but the id and carries **no `ORDER BY`**, so it reads index
   entries rather than rows.

Measured on a real 83,132-rom library (read-only, production data):

| | before | after |
| --- | --- | --- |
| unscoped pick, median | 1.70 s | **2.9 ms** |
| unscoped pick, worst of 30 | 6.90 s | 5.7 ms |
| fallback path (0.58% of unscoped picks) | - | 236 ms |
| scoped to a large platform | 9.20 s | 19-25 ms |

Distribution over 200k draws against that same id space: 75,495 of 83,132 roms
drawn (exactly what uniform predicts for that many draws), stdev 1.55 against a
Poisson expectation of 1.55.

The endpoint accepts the platform/collection/virtual/smart scope params, so the
gallery "Random ROM" buttons tracked in #4068 can move onto it without a
signature change. Rewiring those call sites is deliberately left out of this PR.

**Files modified**

- `backend/handler/database/roms_handler.py` - new `get_random_rom_id(query)`
  implementing both mechanisms, plus the `RANDOM_ID_SAMPLE_SIZE` constant. Uses
  `secrets` rather than `random`.
- `backend/endpoints/roms/__init__.py` - new `GET /random` route returning
  `SimpleRomSchema | None`. Declared before `/{id}` so the int path param doesn't
  swallow it. Scope params and permission filtering mirror `GET /api/roms`, and
  the picked row is re-checked against the caller's permissions after the fetch
  (see reviewer notes).
- `backend/tests/endpoints/roms/test_random.py` - new, 11 tests covering both
  mechanisms (see testing notes).
- `frontend/src/services/api/rom.ts` - new `getRandomRom()` wrapper.
- `frontend/src/v2/components/Home/Widgets/RandomPickWidget.vue` - `reroll()` now
  makes one request. Drops `pickOnce()`, the `PICK_QUERY` opt-outs and the
  retry-on-drift branch, all of which existed only to work around the two-call
  approach.
- `frontend/src/v2/components/Home/Widgets/RandomPickWidget.test.ts` - new, 4
  tests.
- `docs/BACKEND_ARCHITECTURE.md` - endpoint table entry.

No migration, no schema change, and no regenerated types: the route reuses
`SimpleRomSchema`.

**Testing notes**

- Full backend suite: **2715 passed, 2 skipped**. The new file is 11 tests,
  covering auth, an empty library, platform/collection scoping, admin-hidden roms
  staying out of the pick, post-fetch visibility, and both code paths reaching
  every rom in the set. Two mechanism guards: one asserts `get_rom_count` and
  `get_rom_id_index` are never called and that no statement carries an `OFFSET`;
  the other patches the sample size to 0 to force the fallback.
- Frontend: 4 new tests (single request per pick, empty-library copy, error copy
  on first load, reroll keeping the previous pick on failure). Full vitest run
  green.
- Verified in the browser in both themes: pick renders, reroll reshuffles in
  place without navigating, keyboard focus survives the reroll.
- `trunk fmt && trunk check` clean.
- Timings and the distribution check above were run against a production
  database over a read-only account, `SELECT`/`EXPLAIN` only.

**What reviewers should look at**

- **Uniformity of the batch path.** The argument is exchangeability: the sampling
  procedure treats every existing id identically, so conditional on a non-empty
  hit set each is equally likely to be returned. Worth a second opinion.
- **Scoped picks mostly take the fallback.** Sampled keys rarely land inside a
  narrow scope, so #4068's call sites will pay the count-plus-offset path. That
  measured 19-25 ms on large platforms, but it is not the constant-time path and
  shouldn't be described as one.
- **The fallback deliberately has no `ORDER BY`.** Adding `ORDER BY roms.id` back
  looks harmless and is not: a PK-ordered scan *is* the clustered index, so it
  drags whole rows off disk. That measured 4.6 s against 0.067 s for the same
  query without it. Uniformity doesn't depend on the ordering, only on each row
  appearing exactly once.
- **`RANDOM_ID_SAMPLE_SIZE = 16`** is tuned for an id space roughly a quarter
  occupied, which is what deletions leave behind on a long-lived instance
  (mine is 27% dense). Happy to change it if that assumption seems wrong.
- **Post-fetch visibility re-check.** The id is chosen by a permission-filtered
  query but the row is fetched by raw id, so the loaded row is re-tested with
  `perms.can_see_rom(...)`, matching what every other raw-id ROM lookup does via
  `assert_rom_visible`. It returns `null` rather than raising 404, to keep a
  hidden ROM indistinguishable from an empty scope and to keep an error path out
  of a contract that otherwise has none.
- **Race on delete.** If a ROM is deleted between the id pick and the fetch, the
  endpoint returns `null` and the widget briefly shows its empty-library copy.
  I judged a third round trip not worth avoiding that.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**AI assistance**

This PR was written primarily by Claude Code, including this description and the
replies on the review thread. I directed the work, required that the approach be
measured against my own production database before it was accepted, and reviewed
the result.

Two things it got wrong that the process caught, noted so reviewers can calibrate
how much scrutiny to apply. The first implementation sampled a random point in
the id range and took the nearest row at or above it, which is only uniform on a
dense id space; on my 27%-dense library it skewed 10,840x toward one ROM and
could reach only 2,773 of 83,132 ROMs. It was replaced with the batch-sampling
mechanism above and re-validated the same way. Separately, the first version of
the visibility regression test passed with the fix reverted, because the query
returned empty before control flow ever reached the guard; it was rewritten to
actually exercise it.