### PR TITLE
perf(roms): sort metadata fields on the indexed roms column

### DIFF
--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -156,11 +156,7 @@ ROM_FILE_HASH_COLUMNS_BY_DIGEST_LENGTH: dict[int, tuple[QueryableAttribute, ...]
     40: (RomFile.sha1_hash, RomFile.chd_sha1_hash),
 }
 
-# `roms_metadata` is a view over STORED generated columns on `roms`, so these
-# read the same values the view exposes without joining it. Ordering through the
-# view leaves the sort key on a joined table, which the engine cannot serve from
-# an index: it filesorts the whole library for every page. Every column here is
-# indexed on `roms`, so the sort walks the index and stops at the page.
+# Every column here is indexed on `roms`, so the sort walks the index and stops at the page.
 ROM_METADATA_ORDER_COLUMNS: dict[str, QueryableAttribute] = {
     "first_release_date": Rom.generated_first_release_date,
     "average_rating": Rom.generated_average_rating,
@@ -1423,8 +1419,6 @@ class DBRomsHandler(DBBaseHandler):
         elif order_by in ROM_METADATA_ORDER_COLUMNS:
             order_attr = ROM_METADATA_ORDER_COLUMNS[order_by]
         elif hasattr(RomMetadata, order_by) and not hasattr(Rom, order_by):
-            # The rest of the view is JSON arrays with no index to sort on, and
-            # nothing offers them as a sort, so they keep reading the view.
             order_attr = getattr(RomMetadata, order_by)
             query = query.outerjoin(RomMetadata, RomMetadata.rom_id == Rom.id)
         elif hasattr(Rom, order_by):

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -156,6 +156,17 @@ ROM_FILE_HASH_COLUMNS_BY_DIGEST_LENGTH: dict[int, tuple[QueryableAttribute, ...]
     40: (RomFile.sha1_hash, RomFile.chd_sha1_hash),
 }
 
+# `roms_metadata` is a view over STORED generated columns on `roms`, so these
+# read the same values the view exposes without joining it. Ordering through the
+# view leaves the sort key on a joined table, which the engine cannot serve from
+# an index: it filesorts the whole library for every page. Every column here is
+# indexed on `roms`, so the sort walks the index and stops at the page.
+ROM_METADATA_ORDER_COLUMNS: dict[str, QueryableAttribute] = {
+    "first_release_date": Rom.generated_first_release_date,
+    "average_rating": Rom.generated_average_rating,
+    "player_count": Rom.generated_player_count,
+}
+
 # Filter dropdowns read the narrow `roms_facets` mirror instead of `roms`,
 # whose rows carry the raw metadata blobs. Column order matches the unpacking
 # in `_collect_filter_values`.
@@ -1409,7 +1420,11 @@ class DBRomsHandler(DBBaseHandler):
         if user_id and hasattr(RomUser, order_by) and not hasattr(Rom, order_by):
             order_attr = getattr(RomUser, order_by)
             query = query.filter(RomUser.user_id == user_id)
+        elif order_by in ROM_METADATA_ORDER_COLUMNS:
+            order_attr = ROM_METADATA_ORDER_COLUMNS[order_by]
         elif hasattr(RomMetadata, order_by) and not hasattr(Rom, order_by):
+            # The rest of the view is JSON arrays with no index to sort on, and
+            # nothing offers them as a sort, so they keep reading the view.
             order_attr = getattr(RomMetadata, order_by)
             query = query.outerjoin(RomMetadata, RomMetadata.rom_id == Rom.id)
         elif hasattr(Rom, order_by):

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     Enum,
+    FetchedValue,
     Float,
     ForeignKey,
     Index,
@@ -399,6 +400,24 @@ class Rom(BaseModel):
     )
     manual_metadata: Mapped[dict[str, Any] | None] = mapped_column(
         CustomJSON(), default=dict
+    )
+
+    # The sortable slice of the STORED generated columns migration 0098 derives
+    # from the blobs above; `roms_metadata` is a thin view over them. Mapped
+    # here so a sort reads the indexed `roms` column directly: going through the
+    # view puts the sort key on a joined table, which rules the index out and
+    # filesorts the whole library. The engine owns the values, so these are
+    # read-only (see `RomMetadata` for the names the API exposes them under).
+    generated_first_release_date: Mapped[int | None] = mapped_column(
+        BigInteger(), server_default=FetchedValue(), server_onupdate=FetchedValue()
+    )
+    generated_average_rating: Mapped[float | None] = mapped_column(
+        Float(), server_default=FetchedValue(), server_onupdate=FetchedValue()
+    )
+    generated_player_count: Mapped[str | None] = mapped_column(
+        String(length=100),
+        server_default=FetchedValue(),
+        server_onupdate=FetchedValue(),
     )
 
     path_cover_s: Mapped[str | None] = mapped_column(Text, default="")

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -402,12 +402,7 @@ class Rom(BaseModel):
         CustomJSON(), default=dict
     )
 
-    # The sortable slice of the STORED generated columns migration 0098 derives
-    # from the blobs above; `roms_metadata` is a thin view over them. Mapped
-    # here so a sort reads the indexed `roms` column directly: going through the
-    # view puts the sort key on a joined table, which rules the index out and
-    # filesorts the whole library. The engine owns the values, so these are
-    # read-only (see `RomMetadata` for the names the API exposes them under).
+    # Read-only slice of the stored generated columns from the `roms_metadata` view
     generated_first_release_date: Mapped[int | None] = mapped_column(
         BigInteger(), server_default=FetchedValue(), server_onupdate=FetchedValue()
     )

--- a/backend/tests/handler/database/test_roms_metadata_sort.py
+++ b/backend/tests/handler/database/test_roms_metadata_sort.py
@@ -1,0 +1,148 @@
+"""Ordering the gallery by a `roms_metadata` field.
+
+`roms_metadata` is a thin view over STORED generated columns on `roms`
+(migration 0098). Resolving one of its columns as the sort key used to join the
+view back in, which re-joins `roms` to itself and leaves the sort key on the
+joined table: the database cannot read that from an index, so it filesorts the
+whole library on every page. The generated columns are indexed on `roms`, so
+these tests pin both the ordering results and the query reading them directly.
+"""
+
+import pytest
+
+from handler.database import db_rom_handler
+from models.platform import Platform
+from models.rom import Rom
+from models.user import User
+
+
+def _make_rom(platform: Platform, fs_name: str, **metadata) -> Rom:
+    rom = db_rom_handler.add_rom(
+        Rom(
+            platform_id=platform.id,
+            name=fs_name,
+            slug=fs_name,
+            fs_name=f"{fs_name}.zip",
+            fs_name_no_tags=fs_name,
+            fs_name_no_ext=fs_name,
+            fs_extension="zip",
+            fs_path=f"{platform.slug}/roms",
+        )
+    )
+    if metadata:
+        rom = db_rom_handler.update_rom(rom.id, metadata)
+    return rom
+
+
+def _ordered_names(**kwargs) -> list[str]:
+    return [rom.name for rom in db_rom_handler.get_roms_scalar(**kwargs)]
+
+
+class TestMetadataSortQueryShape:
+    """The sort key has to be a `roms` column for its index to be usable."""
+
+    @pytest.mark.parametrize(
+        ("order_by", "expected_column"),
+        [
+            ("first_release_date", "generated_first_release_date"),
+            ("average_rating", "generated_average_rating"),
+            ("player_count", "generated_player_count"),
+        ],
+    )
+    def test_orders_by_the_indexed_roms_column(
+        self, order_by: str, expected_column: str
+    ):
+        query, order_column = db_rom_handler.get_roms_query(order_by=order_by)
+        sql = str(query)
+
+        assert f"ORDER BY roms.{expected_column} ASC" in sql
+        assert order_column is getattr(Rom, expected_column)
+        # `Rom.metadatum` is a `lazy="joined"` eager load, so one join to the
+        # view is expected; the sort must not add a second one.
+        assert sql.count("JOIN roms_metadata") == 1
+
+    def test_descending_metadata_sort_keeps_the_roms_column(self):
+        query, _ = db_rom_handler.get_roms_query(
+            order_by="first_release_date", order_dir="desc"
+        )
+
+        assert "ORDER BY roms.generated_first_release_date DESC" in str(query)
+
+    def test_rom_column_sort_is_unchanged(self):
+        query, order_column = db_rom_handler.get_roms_query(order_by="fs_size_bytes")
+
+        assert "ORDER BY roms.fs_size_bytes ASC" in str(query)
+        assert order_column is Rom.fs_size_bytes
+
+    def test_metadata_sort_does_not_join_the_view_for_a_user(
+        self, admin_user: User, platform: Platform
+    ):
+        query, _ = db_rom_handler.get_roms_query(
+            order_by="first_release_date", user_id=admin_user.id
+        )
+        sql = str(query)
+
+        # The rom_user join still has to be there, only the self-join goes.
+        assert sql.count("JOIN roms_metadata") == 1
+        assert "JOIN rom_user" in sql
+
+
+class TestMetadataSortResults:
+    """The values sorted on are the ones the view exposes."""
+
+    @pytest.fixture
+    def dated_roms(self, platform: Platform) -> None:
+        _make_rom(
+            platform, "middle", igdb_metadata={"first_release_date": "1000000000"}
+        )
+        _make_rom(platform, "oldest", igdb_metadata={"first_release_date": "100000000"})
+        _make_rom(
+            platform, "newest", igdb_metadata={"first_release_date": "1700000000"}
+        )
+
+    def test_first_release_date_ascending(self, dated_roms: None):
+        assert _ordered_names(order_by="first_release_date", order_dir="asc") == [
+            "oldest",
+            "middle",
+            "newest",
+        ]
+
+    def test_average_rating_descending(self, platform: Platform):
+        _make_rom(platform, "mediocre", igdb_metadata={"total_rating": "50"})
+        _make_rom(platform, "great", igdb_metadata={"total_rating": "95"})
+        _make_rom(platform, "poor", igdb_metadata={"total_rating": "10"})
+
+        assert _ordered_names(order_by="average_rating", order_dir="desc") == [
+            "great",
+            "mediocre",
+            "poor",
+        ]
+
+    def test_player_count_ascending(self, platform: Platform):
+        _make_rom(platform, "four", igdb_metadata={"player_count": "4"})
+        _make_rom(platform, "two", igdb_metadata={"player_count": "2"})
+
+        assert _ordered_names(order_by="player_count", order_dir="asc") == [
+            "two",
+            "four",
+        ]
+
+    def test_roms_without_metadata_are_still_returned(self, platform: Platform):
+        """An unmatched rom has no release date, and must not be filtered out."""
+        _make_rom(platform, "dated", igdb_metadata={"first_release_date": "100000000"})
+        _make_rom(platform, "undated")
+
+        names = _ordered_names(order_by="first_release_date", order_dir="asc")
+
+        # NULL ordering differs per engine, so only membership is asserted.
+        assert sorted(names) == ["dated", "undated"]
+
+    def test_sort_matches_the_values_the_view_exposes(self, platform: Platform):
+        rom = _make_rom(
+            platform, "quoted", igdb_metadata={"first_release_date": "1569369600"}
+        )
+
+        reloaded = db_rom_handler.get_rom(rom.id)
+        assert reloaded is not None
+        assert reloaded.metadatum.first_release_date == 1569369600000
+        assert reloaded.generated_first_release_date == 1569369600000


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

Fixes #4067

Sorting a gallery by `first_release_date` took **20.3s** against **0.27s** for the
default sort on an 83k-game library. The issue guessed the cause was a missing
index, but the indexes were already there (`idx_roms_generated_first_release_date`
and friends, created by migration `0098`). The real cause is *where the sort key
sits*.

`roms_metadata` is not a table. It is a thin view over the STORED generated
columns on `roms`. Resolving one of its columns as the sort key did:

```python
order_attr = getattr(RomMetadata, order_by)
query = query.outerjoin(RomMetadata, RomMetadata.rom_id == Rom.id)
```

That joins `roms` back to itself and leaves the sort key on the *joined* table.
MariaDB/MySQL can only use an index for `ORDER BY` when the sort column belongs
to the **first** table in the join order, and the right side of a `LEFT JOIN`
never can be. So the planner fell back to a full scan of `roms` plus a filesort
of the entire library, on every page, to return 72 rows.

The three view columns that are actually offered as sorts now resolve straight
to the indexed `roms` column and the join disappears. Measured on a 120k-row
copy of the real `roms` schema (169 MB), with `Rom.metadatum`'s `lazy="joined"`
eager load present in **both** shapes so the comparison is honest:

| Sort | Before | After |
| --- | --- | --- |
| `first_release_date` ASC, LIMIT 72 | 6.02s | 0.004s |
| `average_rating` DESC, LIMIT 72 | 2.16s | 0.002s |

`EXPLAIN` before: `type: ALL`, 113,534 rows, `Using temporary; Using filesort`.
After: `type: index`, key `idx_roms_generated_first_release_date`, 72 rows, no
filesort — the same plan shape as the default `name_sort_key` sort.

No migration, no new index, no schema change: the columns and their indexes
already existed, they just weren't being read.

**Scope note:** the remaining `roms_metadata` columns (`genres`, `franchises`,
`collections`, `companies`, `game_modes`, `age_ratings`) are JSON arrays with no
index to sort on, and nothing in the UI offers them as a sort. Since `/api/roms`
has no `order_by` allowlist and accepts any string, the view-join fallback is
deliberately kept so those keep behaving exactly as they do today.

**Files changed**

| File | What |
| --- | --- |
| `backend/handler/database/roms_handler.py` | New `ROM_METADATA_ORDER_COLUMNS` map, plus a branch in `get_roms_query()` that resolves those three keys to the indexed `roms` column instead of joining the view. |
| `backend/models/rom.py` | Maps `generated_first_release_date`, `generated_average_rating` and `generated_player_count` on `Rom` as read-only (`FetchedValue()`), so the sort has an attribute to reference. |
| `backend/tests/handler/database/test_roms_metadata_sort.py` | New. 11 cases covering both the emitted SQL and the resulting order. |

**Testing notes**

- Full backend suite: 2715 passed, 2 skipped.
- `trunk fmt && trunk check` clean.
- End-to-end against a running app: all six sort paths return 200 with correct
  ordering (`first_release_date`, `average_rating`, `player_count`, each
  direction).
- Perf numbers above measured on a 120k-row seeded `roms` table, since a normal
  dev library is too small to show the difference.

**What a reviewer should look at**

1. **The read-only mapping.** `generated_*` are STORED generated columns owned by
   the engine, mapped with `server_default`/`server_onupdate=FetchedValue()` so
   SQLAlchemy never tries to write them. Worth confirming that reasoning holds:
   `add_rom` goes through `session.merge()`, `update_rom` uses a Core `update()`
   with caller-supplied keys, and `_nullable_columns()` is only ever called with
   `RomFile`/`TrackMeta`, so nothing enumerates `Rom`'s columns to build a write.
2. **No API surface change.** The response schemas in `endpoints/responses/rom.py`
   declare their fields explicitly, so the new attributes don't leak into
   OpenAPI and the frontend types are unchanged.
3. **Alembic.** `env.py` already excludes any `generated_*` column from
   autogenerate, so adding them to the model shouldn't produce a spurious
   revision. I could not run `alembic revision --autogenerate` to prove this —
   it currently fails on `master` for an unrelated reason
   (`NoReferencedTableError` on `saves.origin_device_id`).
4. **`player_count` ordering is lexicographic** (`VARCHAR(100)`, so `"10" < "2"`).
   That is unchanged: the view projects the same `VARCHAR` column, so this PR
   preserves the existing behavior rather than introducing it.

**Out of scope, but found while in here:** the `RomUser` branch of the same
function applies `query.filter(RomUser.user_id == user_id)` on top of an outer
join whose `ON` clause already carries that condition, which collapses it to an
effective inner join. Sorting by `last_played` therefore silently drops every ROM
with no `rom_user` row — 12,000 rows returned instead of 120,000 in my test data.
It is fast only because it discards 90% of the library. Left alone to keep this
PR focused; happy to open a separate issue.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this change was written with AI assistance (Claude Code).
The AI performed the root-cause investigation, wrote the tests first, implemented
the fix, and ran the benchmarks and the full test suite. I reviewed the diff, the
benchmark methodology and the test coverage before opening this PR.