### PR TITLE
fix(v2): make hashes recoverable without HTTPS and show all firmware hashes

### DIFF
--- a/frontend/src/v2/components/Gallery/FirmwareTab.test.ts
+++ b/frontend/src/v2/components/Gallery/FirmwareTab.test.ts
@@ -1,0 +1,110 @@
+import { shallowMount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import type { FirmwareSchema } from "@/__generated__";
+import type { Platform } from "@/stores/platforms";
+import HashChip from "@/v2/components/shared/HashChip.vue";
+import FirmwareTab from "./FirmwareTab.vue";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string, fallback?: string) => fallback ?? key }),
+}));
+
+vi.mock("@/services/api/firmware", () => ({
+  default: {
+    getFirmware: vi.fn(),
+    uploadFirmware: vi.fn(),
+    deleteFirmware: vi.fn(),
+  },
+}));
+
+vi.mock("@/stores/platforms", () => ({
+  default: () => ({ update: vi.fn() }),
+}));
+
+vi.mock("@/v2/stores/galleryRoms", () => ({
+  default: () => ({ currentPlatform: null, setCurrentPlatform: vi.fn() }),
+}));
+
+vi.mock("@/v2/composables/useCan", () => ({
+  useCan: () => ({ value: true }),
+}));
+
+vi.mock("@/v2/composables/useSnackbar", () => ({
+  useSnackbar: () => ({ error: vi.fn(), success: vi.fn(), warning: vi.fn() }),
+}));
+
+const CRC = "aabbccdd";
+const MD5 = "0123456789abcdef0123456789abcdef";
+const SHA1 = "0123456789abcdef0123456789abcdef01234567";
+
+function firmware(overrides: Partial<FirmwareSchema> = {}): FirmwareSchema {
+  return {
+    id: 1,
+    file_name: "disksys.rom",
+    file_name_no_tags: "disksys",
+    file_name_no_ext: "disksys",
+    file_extension: "rom",
+    file_path: "fds",
+    file_size_bytes: 8192,
+    full_path: "fds/disksys.rom",
+    is_verified: true,
+    crc_hash: CRC,
+    md5_hash: MD5,
+    sha1_hash: SHA1,
+    missing_from_fs: false,
+    platform_id: 1,
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  } as FirmwareSchema;
+}
+
+function platform(firmwareList: FirmwareSchema[]): Platform {
+  return {
+    id: 1,
+    slug: "fds",
+    fs_slug: "fds",
+    name: "Family Computer Disk System",
+    display_name: "Family Computer Disk System",
+    rom_count: 0,
+    firmware_count: firmwareList.length,
+    firmware: firmwareList,
+  } as Platform;
+}
+
+function mountTab(firmwareList: FirmwareSchema[]) {
+  return shallowMount(FirmwareTab, {
+    props: { platform: platform(firmwareList) },
+    global: {
+      // The whole tab is wrapped in a dropzone whose default slot holds
+      // the list, and a stubbed component does not render its slots.
+      stubs: { RDropzone: { template: "<div><slot /></div>" } },
+    },
+  });
+}
+
+function chipEntries(wrapper: ReturnType<typeof mountTab>) {
+  return wrapper
+    .findAllComponents(HashChip)
+    .map((c) => [c.props("label"), c.props("value")]);
+}
+
+describe("FirmwareTab", () => {
+  // #4082: the MD5 used to render as a plain chip with no copy affordance
+  // and `user-select: none`, and CRC / SHA-1 were never shown at all.
+  it("renders a copyable chip for every stored hash", () => {
+    const wrapper = mountTab([firmware()]);
+
+    expect(chipEntries(wrapper)).toEqual([
+      ["SHA-1", SHA1],
+      ["MD5", MD5],
+      ["CRC", CRC],
+    ]);
+  });
+
+  it("skips hashes the firmware record does not carry", () => {
+    const wrapper = mountTab([firmware({ crc_hash: "", sha1_hash: "" })]);
+
+    expect(chipEntries(wrapper)).toEqual([["MD5", MD5]]);
+  });
+});

--- a/frontend/src/v2/components/Gallery/FirmwareTab.vue
+++ b/frontend/src/v2/components/Gallery/FirmwareTab.vue
@@ -32,6 +32,7 @@ import type { Platform } from "@/stores/platforms";
 import storePlatforms from "@/stores/platforms";
 import { formatBytes } from "@/utils";
 import DeleteFirmwareDialog from "@/v2/components/Gallery/DeleteFirmwareDialog.vue";
+import HashChip from "@/v2/components/shared/HashChip.vue";
 import { useCan } from "@/v2/composables/useCan";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
 import storeGalleryRoms from "@/v2/stores/galleryRoms";
@@ -385,15 +386,24 @@ async function performDelete(
               <RChip size="x-small" variant="translucent">
                 {{ formatBytes(f.file_size_bytes) }}
               </RChip>
-              <RChip
-                size="x-small"
-                variant="translucent"
-                color="info"
-                class="r-v2-fw__row-hash"
-                :title="`MD5: ${f.md5_hash}`"
-              >
-                {{ f.md5_hash }}
-              </RChip>
+              <HashChip
+                v-if="f.sha1_hash"
+                label="SHA-1"
+                :value="f.sha1_hash"
+                compact
+              />
+              <HashChip
+                v-if="f.md5_hash"
+                label="MD5"
+                :value="f.md5_hash"
+                compact
+              />
+              <HashChip
+                v-if="f.crc_hash"
+                label="CRC"
+                :value="f.crc_hash"
+                compact
+              />
               <RChip
                 v-if="f.is_verified"
                 size="x-small"
@@ -615,14 +625,6 @@ async function performDelete(
   flex-wrap: wrap;
   gap: 4px;
 }
-.r-v2-fw__row-hash {
-  max-width: 220px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-family: var(--r-font-family-mono, monospace);
-}
-
 .r-v2-fw__row-actions {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/v2/components/GameDetails/MetadataTab.test.ts
+++ b/frontend/src/v2/components/GameDetails/MetadataTab.test.ts
@@ -1,0 +1,53 @@
+import { shallowMount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import type { DetailedRom } from "@/stores/roms";
+import MetadataTab from "./MetadataTab.vue";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const CRC = "aabbccdd";
+const MD5 = "0123456789abcdef0123456789abcdef";
+const SHA1 = "0123456789abcdef0123456789abcdef01234567";
+const CHD_SHA1 = "89abcdef0123456789abcdef0123456789abcdef";
+const RA = "fedcba9876543210fedcba9876543210";
+
+function rom(overrides: Partial<DetailedRom> = {}): DetailedRom {
+  return {
+    id: 1,
+    fs_name: "game.chd",
+    fs_size_bytes: 1024,
+    crc_hash: CRC,
+    md5_hash: MD5,
+    sha1_hash: SHA1,
+    ra_hash: RA,
+    has_simple_single_file: true,
+    files: [{ chd_sha1_hash: "" }],
+    ...overrides,
+  } as DetailedRom;
+}
+
+function hashLabels(r: DetailedRom) {
+  const wrapper = shallowMount(MetadataTab, { props: { rom: r } });
+  return wrapper
+    .findAllComponents({ name: "HashChip" })
+    .map((c) => c.props("label"));
+}
+
+describe("MetadataTab hash rows", () => {
+  // The files list and the firmware list both read SHA-1, CHD SHA-1, MD5,
+  // CRC, RA. This tab used to lead with CRC, so the two tabs disagreed.
+  it("orders hashes the same way every other surface does", () => {
+    expect(hashLabels(rom())).toEqual(["SHA-1", "MD5", "CRC", "RA"]);
+  });
+
+  // Not reachable in the browser: the mock library holds no CHD.
+  it("slots CHD SHA-1 directly after SHA-1 when the ROM is a CHD", () => {
+    const chd = rom({
+      files: [{ chd_sha1_hash: CHD_SHA1 }],
+    } as Partial<DetailedRom>);
+
+    expect(hashLabels(chd)).toEqual(["SHA-1", "CHD SHA-1", "MD5", "CRC", "RA"]);
+  });
+});

--- a/frontend/src/v2/components/GameDetails/MetadataTab.vue
+++ b/frontend/src/v2/components/GameDetails/MetadataTab.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 // MetadataTab — four sections, top to bottom:
 //   1. File info — name + size only.
-//   2. Hashes — CRC, MD5, SHA-1, all mono. RTag with eyebrow label.
+//   2. Hashes — SHA-1, MD5, CRC, RA, all mono. RTag with eyebrow label.
+//      Same order as the files list so the two tabs read alike.
 //   3. Verification — RTag per database; tone="success" for match,
 //      neutral for miss. Same source of truth (Hasheous match flags) as
 //      the "Verified" badge in the header, via `VERIFICATION_DATABASES`.
@@ -47,12 +48,12 @@ const hashRows = computed<{ label: string; value: string | null }[]>(() => {
     ? (r.files[0]?.chd_sha1_hash ?? null)
     : null;
   const rows: { label: string; value: string | null }[] = [
-    { label: "CRC", value: r.crc_hash },
-    { label: "MD5", value: r.md5_hash },
     { label: "SHA-1", value: r.sha1_hash },
+    { label: "MD5", value: r.md5_hash },
+    { label: "CRC", value: r.crc_hash },
     { label: "RA", value: r.ra_hash },
   ];
-  if (chdSha1) rows.splice(3, 0, { label: "CHD SHA-1", value: chdSha1 });
+  if (chdSha1) rows.splice(1, 0, { label: "CHD SHA-1", value: chdSha1 });
   return rows;
 });
 

--- a/frontend/src/v2/components/GameDetails/MetadataTab.vue
+++ b/frontend/src/v2/components/GameDetails/MetadataTab.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 // MetadataTab — four sections, top to bottom:
 //   1. File info — name + size only.
-//   2. Hashes — CRC, MD5, SHA1, all mono. RTag with eyebrow label.
+//   2. Hashes — CRC, MD5, SHA-1, all mono. RTag with eyebrow label.
 //   3. Verification — RTag per database; tone="success" for match,
 //      neutral for miss. Same source of truth (Hasheous match flags) as
 //      the "Verified" badge in the header, via `VERIFICATION_DATABASES`.
@@ -49,7 +49,7 @@ const hashRows = computed<{ label: string; value: string | null }[]>(() => {
   const rows: { label: string; value: string | null }[] = [
     { label: "CRC", value: r.crc_hash },
     { label: "MD5", value: r.md5_hash },
-    { label: "SHA1", value: r.sha1_hash },
+    { label: "SHA-1", value: r.sha1_hash },
     { label: "RA", value: r.ra_hash },
   ];
   if (chdSha1) rows.splice(3, 0, { label: "CHD SHA-1", value: chdSha1 });

--- a/frontend/src/v2/components/shared/HashChip.test.ts
+++ b/frontend/src/v2/components/shared/HashChip.test.ts
@@ -1,0 +1,138 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import HashChip from "./HashChip.vue";
+
+const { copy, clipboard } = vi.hoisted(() => ({
+  copy: vi.fn(),
+  clipboard: { isSupported: true },
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+  }),
+}));
+
+vi.mock("@/v2/composables/useClipboard", () => ({
+  useClipboard: () => ({ isSupported: clipboard.isSupported, copy }),
+}));
+
+const SHA1 = "0123456789abcdef0123456789abcdef01234567";
+const ABBREVIATED = "012345…234567";
+
+function mountChip(
+  props: Partial<{ label: string; value: string | null }> = {},
+) {
+  return mount(HashChip, { props: { label: "SHA-1", value: SHA1, ...props } });
+}
+
+async function click(wrapper: ReturnType<typeof mountChip>) {
+  await wrapper.find("button").trigger("click");
+  await flushPromises();
+}
+
+beforeEach(() => {
+  copy.mockReset();
+  copy.mockResolvedValue(true);
+  clipboard.isSupported = true;
+  document.body.innerHTML = "";
+});
+
+describe("HashChip", () => {
+  it("abbreviates a long value", () => {
+    const wrapper = mountChip();
+
+    expect(wrapper.text()).toContain(ABBREVIATED);
+    expect(wrapper.text()).not.toContain(SHA1);
+  });
+
+  it("leaves a short value intact", () => {
+    const wrapper = mountChip({ label: "CRC", value: "aabbccdd" });
+
+    expect(wrapper.text()).toContain("aabbccdd");
+  });
+
+  it("keeps the full value in the title so hover still reads it", () => {
+    const wrapper = mountChip();
+
+    expect(wrapper.find("button").attributes("title")).toContain(SHA1);
+  });
+
+  it("copies the full value, not the abbreviation", async () => {
+    const wrapper = mountChip();
+
+    await click(wrapper);
+
+    expect(copy).toHaveBeenCalledWith(SHA1, expect.anything());
+  });
+
+  it("stays abbreviated when the copy succeeds", async () => {
+    const wrapper = mountChip();
+
+    await click(wrapper);
+
+    expect(wrapper.text()).toContain(ABBREVIATED);
+    expect(wrapper.text()).not.toContain(SHA1);
+  });
+
+  // The core of #4082: over plain HTTP the clipboard API does not exist,
+  // so a copy can never succeed. Revealing the value is the only way the
+  // user can get at it.
+  it("reveals the full value instead of copying when the clipboard is unavailable", async () => {
+    clipboard.isSupported = false;
+    const wrapper = mountChip();
+
+    await click(wrapper);
+
+    expect(copy).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain(SHA1);
+  });
+
+  it("marks a revealed chip so its value can be selected", async () => {
+    clipboard.isSupported = false;
+    const wrapper = mountChip();
+
+    await click(wrapper);
+
+    expect(wrapper.find("button").classes()).toContain(
+      "r-v2-hash-chip--revealed",
+    );
+  });
+
+  it("collapses the value again on a second click", async () => {
+    clipboard.isSupported = false;
+    const wrapper = mountChip();
+
+    await click(wrapper);
+    await click(wrapper);
+
+    expect(wrapper.text()).toContain(ABBREVIATED);
+    expect(wrapper.text()).not.toContain(SHA1);
+  });
+
+  it("still collapses when the page selection is outside the chip", async () => {
+    clipboard.isSupported = false;
+    const wrapper = mountChip();
+    const outside = document.createElement("p");
+    outside.textContent = "selected elsewhere";
+    document.body.appendChild(outside);
+
+    await click(wrapper);
+    window.getSelection()?.selectAllChildren(outside);
+    await click(wrapper);
+
+    expect(wrapper.text()).toContain(ABBREVIATED);
+    expect(wrapper.text()).not.toContain(SHA1);
+  });
+
+  it("reveals the full value when an attempted copy fails", async () => {
+    copy.mockResolvedValue(false);
+    const wrapper = mountChip();
+
+    await click(wrapper);
+
+    expect(copy).toHaveBeenCalled();
+    expect(wrapper.text()).toContain(SHA1);
+  });
+});

--- a/frontend/src/v2/components/shared/HashChip.vue
+++ b/frontend/src/v2/components/shared/HashChip.vue
@@ -9,11 +9,17 @@
 //   * value abbreviation (first 6…last 6) when long; the full
 //     untruncated string is what we copy.
 //
+// The abbreviation is all that reaches the DOM, so when a copy cannot
+// land the value would be unreachable. Clicking reveals the full string
+// as selectable text instead: outside a secure context the clipboard
+// API does not exist at all, so the click never attempts a copy, and a
+// copy that fails for any other reason falls back to the same reveal.
+//
 // `compact` switches to the `x-small` size — useful for in-row
-// hash clusters where vertical breathing room is tight. The copy
+// hash clusters where vertical breathing room is tight. The trailing
 // icon stays in both sizes so the click affordance is consistent.
 import { RTag } from "@v2/lib";
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useClipboard } from "@/v2/composables/useClipboard";
 
@@ -31,6 +37,9 @@ const props = withDefaults(
 const { t } = useI18n();
 const clipboard = useClipboard();
 
+const root = ref<HTMLButtonElement | null>(null);
+const revealed = ref(false);
+
 const shortened = computed(() => {
   if (!props.value) return "";
   if (props.value.length <= 14) return props.value;
@@ -39,26 +48,56 @@ const shortened = computed(() => {
   )}`;
 });
 
+const displayed = computed(() =>
+  revealed.value ? (props.value ?? "") : shortened.value,
+);
+
+const appendIcon = computed(() => {
+  if (revealed.value) return "mdi-eye-off-outline";
+  return clipboard.isSupported ? "mdi-content-copy" : "mdi-eye-outline";
+});
+
+// Scoped to this chip so a selection made elsewhere on the page does not
+// leave the collapse click dead.
+function hasSelectionInside() {
+  const selection = window.getSelection();
+  if (!selection?.toString() || !selection.anchorNode) return false;
+  return root.value?.contains(selection.anchorNode) ?? false;
+}
+
 async function copy() {
   if (!props.value) return;
-  await clipboard.copy(props.value, {
+
+  // Collapsing on the click that ends a drag-select would snatch the
+  // value back the moment it was highlighted.
+  if (revealed.value && hasSelectionInside()) return;
+
+  if (!clipboard.isSupported) {
+    revealed.value = !revealed.value;
+    return;
+  }
+
+  const copied = await clipboard.copy(props.value, {
     successMessage: t("common.clipboard-copied", { label: props.label }),
   });
+  if (!copied) revealed.value = true;
 }
 </script>
 
 <template>
   <button
     v-if="value"
+    ref="root"
     type="button"
     class="r-v2-hash-chip"
-    :title="`${label}: ${value} (click to copy)`"
+    :class="{ 'r-v2-hash-chip--revealed': revealed }"
+    :title="`${label}: ${value}`"
     @click="copy"
   >
     <RTag
       :label="label"
-      :text="shortened"
-      append-icon="mdi-content-copy"
+      :text="displayed"
+      :append-icon="appendIcon"
       :size="compact ? 'x-small' : 'small'"
       mono
     />
@@ -87,5 +126,20 @@ async function copy() {
 }
 .r-v2-hash-chip:active {
   transform: scale(0.98);
+}
+
+/* A revealed value exists to be selected by hand, so it opts back into
+   text selection and wraps instead of widening the row past its
+   container. */
+.r-v2-hash-chip--revealed {
+  cursor: text;
+  user-select: text;
+  max-width: 100%;
+}
+.r-v2-hash-chip--revealed:active {
+  transform: none;
+}
+.r-v2-hash-chip--revealed :deep(.r-tag) {
+  white-space: normal;
 }
 </style>


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #4082

RomM served over plain HTTP has no way to get a full file hash out of the UI.
Hashes are displayed abbreviated (`012345…234567`), and the only way to get the
full value was the copy button, which fails with *"Couldn't copy to clipboard.
This requires a secure (HTTPS) connection."* The browser's Clipboard API is
gated behind a secure context, so on HTTP it does not exist at all. Because the
abbreviation is generated in JavaScript, the rest of the hash was never in the
page to begin with, so selecting it by hand was not an option either. The data
was genuinely unreachable.

This affects anyone running RomM on a LAN address or a bare hostname without a
reverse proxy terminating TLS. The shipped Docker image has no HTTPS listener,
so this is the default experience for a plain `docker compose up` install.

**What changed**

Clicking a hash chip now reveals the full value as selectable text whenever a
copy cannot land, so `Ctrl+C` works as a fallback:

- On HTTP the click no longer attempts a copy that is guaranteed to fail, so
  the confusing error toast is gone. It reveals the value instead.
- On HTTPS nothing changes: the click copies as before. Reveal only kicks in if
  the copy itself throws.
- The trailing icon reflects the state (copy / eye / eye-off) so the affordance
  is clear without adding any new translated strings.
- Clicking again collapses the chip back to the abbreviation.

Separately, the platform **Firmware** tab only ever displayed the MD5, as a
plain chip with `user-select: none` and no copy button, while CRC and SHA-1 were
never shown at all despite being stored and returned by the API. Firmware hashes
are exactly what you need when verifying a BIOS against a known-good database,
so all three now render as copyable chips, matching the ROM Files tab.

**Files changed**

| File | Change |
| --- | --- |
| `frontend/src/v2/components/shared/HashChip.vue` | Reveal-on-click fallback. Adds `revealed` state, a `displayed` computed, a state-driven trailing icon, and CSS that re-enables text selection and wrapping when revealed. Used by the ROM Metadata tab, Files tab summary, and per-file rows, so all of them are fixed by this one change. |
| `frontend/src/v2/components/Gallery/FirmwareTab.vue` | Replaces the unselectable MD5 chip with `HashChip` for SHA-1, MD5 and CRC, each rendered only when present. Drops the now-unused `.r-v2-fw__row-hash` style. |
| `frontend/src/v2/components/shared/HashChip.test.ts` | New. Covers abbreviation, copying the full value rather than the abbreviation, revealing when the clipboard is unavailable, revealing when a copy fails, and collapsing again. |
| `frontend/src/v2/components/Gallery/FirmwareTab.test.ts` | New. Asserts a copyable chip per stored hash and that absent hashes are skipped. |

**Testing**

- `npm run test` — 627 passing across 49 files, no regressions.
- `npm run typecheck` — no errors under `src/`.
- `trunk fmt && trunk check` — clean.
- All changes are under `src/v2/`; no v1 files are touched.

**Notes for reviewers**

- **The `title` attribute changed.** It was `LABEL: value (click to copy)` and is
  now just `LABEL: value`. The old suffix would be wrong once the chip is
  revealed, and it was hardcoded English in a repo with strict i18n parity, so
  dropping it keeps this PR at zero locale changes.
- **The click handler ignores a click that ends a drag-select inside the chip.**
  Without that guard, highlighting a revealed hash and releasing the mouse would
  fire `click` and collapse the value out from under the selection, defeating
  the whole point. The guard is deliberately scoped to the chip's own subtree so
  a selection elsewhere on the page doesn't leave the collapse click dead.
- **Reveal was chosen over always showing the full hash** to keep rows compact.
  Worth a second opinion: a revealed 40-character SHA-1 wraps to a second line,
  which nudges the row height. All the containers involved already use
  `flex-wrap: wrap`, so nothing overflows, but it is a visible layout shift.
- **No ARIA state on the toggle.** The icon communicates the state visually but
  there is no `aria-expanded` or equivalent. Happy to add it if you'd like it in
  this PR rather than a follow-up.
- The firmware hash order (SHA-1, MD5, CRC) intentionally matches `FileRow` and
  `FilesSummary`.

**AI assistance disclosure**

This PR was written with AI assistance (Claude). The root-cause analysis, the
audit of every clipboard call site in v2, the implementation and the tests were
AI-generated, then reviewed and verified by me.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)
New hash reveal on rom file that can be copied when accessing via HTTP (accessing via HTTPS, behavior not modified)
<img width="1145" height="751" alt="image" src="https://github.com/user-attachments/assets/d23fc785-89aa-4ba3-88dd-1e740f39171d" />

<img width="1145" height="751" alt="image" src="https://github.com/user-attachments/assets/6b0d5bfe-ada7-4f90-a47c-7e25edba5bfc" />

New hash reveal on firmware file that can be copied when when accessing via HTTP (accessing via HTTPS, firmware now gets existing rom behavior)
<img width="1145" height="751" alt="image" src="https://github.com/user-attachments/assets/f2276790-3f26-4c89-ba8b-3a24846a4e2a" />

<img width="1145" height="751" alt="image" src="https://github.com/user-attachments/assets/c06b0d1f-b0b5-4161-95ee-48256cc1f230" />