### PR TITLE
fix(auth): accept a stale user-bound CSRF token on anonymous requests

### DIFF
--- a/backend/handler/auth/middleware/csrf_middleware.py
+++ b/backend/handler/auth/middleware/csrf_middleware.py
@@ -166,14 +166,29 @@ class CSRFMiddleware:
             decoded_doc_cookie = self.serializer.loads(document_cookie)
             decoded_header_cookie = self.serializer.loads(header_cookie)
 
-            # Verify that the tokens match, the user IDs match
-            # and the user_id matches the authenticated user
+            # The cookie and the submitted header must always agree, that is
+            # the double-submit check itself, and it holds regardless of who
+            # the caller is.
+            if not secrets.compare_digest(
+                decoded_doc_cookie["token"], decoded_header_cookie["token"]
+            ):
+                return False
+            if decoded_doc_cookie["user_id"] != decoded_header_cookie["user_id"]:
+                return False
+
+            # Bind the token to the caller only when there *is* one. An
+            # anonymous request holding a token from a dead session (server
+            # restart, expired session, cleared Redis) would otherwise be
+            # rejected once, and since the rejection response rotates the
+            # cookie, the retry would succeed. That is the "had to log in
+            # twice" bug. Double-submit still protects the anonymous case: an
+            # attacker cannot read the cookie cross-origin, so it cannot forge
+            # the matching header.
+            if user_id is None:
+                return True
+
             return (
-                secrets.compare_digest(
-                    decoded_doc_cookie["token"], decoded_header_cookie["token"]
-                )
-                and decoded_doc_cookie["user_id"] == decoded_header_cookie["user_id"]
-                and decoded_doc_cookie["user_id"] == user_id
+                decoded_doc_cookie["user_id"] == user_id
                 and decoded_header_cookie["user_id"] == user_id
             )
         except (TypeError, BadSignature):

--- a/backend/handler/auth/middleware/csrf_middleware.py
+++ b/backend/handler/auth/middleware/csrf_middleware.py
@@ -176,14 +176,8 @@ class CSRFMiddleware:
             if decoded_doc_cookie["user_id"] != decoded_header_cookie["user_id"]:
                 return False
 
-            # Bind the token to the caller only when there *is* one. An
-            # anonymous request holding a token from a dead session (server
-            # restart, expired session, cleared Redis) would otherwise be
-            # rejected once, and since the rejection response rotates the
-            # cookie, the retry would succeed. That is the "had to log in
-            # twice" bug. Double-submit still protects the anonymous case: an
-            # attacker cannot read the cookie cross-origin, so it cannot forge
-            # the matching header.
+            # Bind the token to the caller only when there *is* one.
+            # An anonymous request holding a token from a dead session would otherwise be rejected.
             if user_id is None:
                 return True
 

--- a/backend/tests/handler/auth/test_csrf_middleware.py
+++ b/backend/tests/handler/auth/test_csrf_middleware.py
@@ -253,6 +253,52 @@ class TestCSRFMiddleware:
         # user1_token should not validate for user_id=2
         assert not mw._csrf_tokens_match(user1_token, user1_token, user_id=2)
 
+    def test_stale_user_token_accepted_when_anonymous(self) -> None:
+        """A token left over from a dead session must still authorise an
+        anonymous request.
+
+        Regression test for the "had to log in twice" bug: the browser keeps a
+        CSRF cookie bound to user N, the server-side session is gone (restart /
+        expiry), so the login POST is anonymous. Rejecting it here failed the
+        first attempt and rotated the cookie, letting the retry through.
+        Double-submit still protects this case, since an attacker can't read
+        the cookie to forge the matching header.
+        """
+
+        async def noop_app(scope, receive, send):
+            pass
+
+        mw = CSRFMiddleware(app=noop_app, secret="test")
+        stale_token = mw._generate_csrf_token(user_id=7)
+
+        assert mw._csrf_tokens_match(stale_token, stale_token, user_id=None)
+
+    def test_anonymous_still_requires_cookie_and_header_to_match(self) -> None:
+        """Relaxing the user binding must not relax double-submit itself."""
+
+        async def noop_app(scope, receive, send):
+            pass
+
+        mw = CSRFMiddleware(app=noop_app, secret="test")
+        token_a = mw._generate_csrf_token(user_id=None)
+        token_b = mw._generate_csrf_token(user_id=None)
+
+        assert not mw._csrf_tokens_match(token_a, token_b, user_id=None)
+
+    def test_authenticated_user_binding_still_enforced(self) -> None:
+        """The security property: a signed-in caller can't use another user's
+        token, even though the anonymous case is now lenient."""
+
+        async def noop_app(scope, receive, send):
+            pass
+
+        mw = CSRFMiddleware(app=noop_app, secret="test")
+        other_user_token = mw._generate_csrf_token(user_id=1)
+        anonymous_token = mw._generate_csrf_token(user_id=None)
+
+        assert not mw._csrf_tokens_match(other_user_token, other_user_token, user_id=2)
+        assert not mw._csrf_tokens_match(anonymous_token, anonymous_token, user_id=2)
+
     def test_post_with_mismatched_but_valid_tokens_fails(self) -> None:
         """POST with a valid header token that doesn't match the cookie token should fail."""
         app = create_test_app()


### PR DESCRIPTION
Logging in failed once with a CSRF error and succeeded on retry.

`_csrf_tokens_match` validates the user id embedded in the token against the current request's user. A browser holding a token bound to user N, whose server-side session is gone (container restart, session expiry, Redis flush), makes an anonymous login POST. N != None, so the request is rejected. The rejection response then rotates the cookie, which is why the second attempt works.

Keep the double-submit check and the cookie/header user agreement unconditionally, and enforce the caller binding only when there is a caller. An anonymous request cannot be forged this way regardless: an attacker cannot read the cookie cross-origin, so it cannot produce the matching header.

This is the mirror of #3420, which fixed the authenticated direction by rotating the cookie on safe requests. That path is untouched here, and test_authenticated_user_binding_still_enforced pins it.

<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #4088

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)
