### PR TITLE
fix(config): map tic80 to the tic-80 platform slug

### DIFF
--- a/examples/config.batocera-retrobat.yml
+++ b/examples/config.batocera-retrobat.yml
@@ -160,7 +160,7 @@ system:
     supracan: super-acan
     switch: switch
     thomson: thomson-mo5
-    tic80: tic
+    tic80: tic-80
     triforce: arcade
     tutor: tomy-tutor
     uzebox: uzebox


### PR DESCRIPTION
**Description**

<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

`examples/config.batocera-retrobat.yml` binds the `tic80` folder to `tic`, which is not a member of `UniversalPlatformSlug`. The real slug is `tic-80`.

A binding to an unknown slug is not inert. `scan_platform` assigns it unconditionally:

```python
if fs_slug in cnfg.PLATFORMS_BINDING.keys():
    platform_attrs["slug"] = cnfg.PLATFORMS_BINDING[fs_slug]
```

so the platform is created with `slug="tic"`, every metadata handler returns nothing for it, and the name falls back to the slug string. The folder ends up worse off than with no binding at all, because the failure looks like a normal unidentified platform rather than a typo.

Found while auditing my own library's folder names against the 460 slugs in `UniversalPlatformSlug`.

**Four more entries point at slugs that do not exist**

I checked all 169 mappings in the file against the enum. Five targets are invalid; this PR fixes the one with an unambiguous answer. The other four have no corresponding slug at all, so I have not guessed:

| Entry | Target | Notes |
| --- | --- | --- |
| `daphne: daphne` | no `daphne` slug | Identity mapping, so it behaves the same as having no entry. Looks like a no-op line. |
| `gzdoom: doom` | no `doom` slug | Groups `gzdoom` and `prboom` under one platform named "Doom". No provider will ever match it, but the grouping may well be deliberate. |
| `prboom: doom` | no `doom` slug | As above. |
| `easyrpg: rpgmaker` | no `rpgmaker` slug | Same shape. |

These are all source ports and engines rather than hardware, so it is not obvious RomM should have slugs for them. There seem to be three defensible options and the choice is a maintainer call rather than mine:

1. Leave them. The cosmetic grouping is intentional and the lack of metadata is expected.
2. Drop the lines, so each folder keeps its own name instead of an unmatchable shared one.
3. Add slugs to `UniversalPlatformSlug` for the engines that warrant them.

Happy to follow up with whichever you prefer.

**A regression test is possible, but only once the above is settled**

The whole class of bug is catchable by asserting every value in the shipped example configs is a valid `UniversalPlatformSlug`. I did not add one here because it would fail on those four entries, and I did not want to bundle a behaviour decision into a typo fix. Glad to add it as a follow-up.

**Testing**

- Parsed the file and validated all 169 mappings against `UniversalPlatformSlug` on a running 5.1.0 instance. `tic-80` is present; `tic`, `doom`, `rpgmaker` and `daphne` are not.
- Applied the corrected mapping to my own instance and confirmed via `GET /api/config` that it loads with `CONFIG_FILE_PARSE_ERROR: null`.
- `prettier 3.9.5` clean. `yamllint 1.38.0` reports only a pre-existing long-line warning on line 2.

**Checklist**

<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

<sub>No test: the change is a one-token data fix in an example config, and the test that would cover the class of bug is blocked on the open question above.</sub>

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this change was written with AI assistance (Claude Code). The mismatch was found by cross-referencing my own library against the slug enum; the AI ran the audit and drafted the change, and I reviewed the result.
