### PR TITLE
feat(v2): show existing provider ratings in game header

### DIFF
--- a/frontend/src/v2/components/GameDetails/GameHeader.vue
+++ b/frontend/src/v2/components/GameDetails/GameHeader.vue
@@ -9,11 +9,13 @@
 // Metadata-provider links live in the Metadata tab, not the header.
 // Genre/franchise belong in the Overview tab info grid.
 import { RIcon, RPlatformIcon, RTag, RTooltip } from "@v2/lib";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type { DetailedRom } from "@/stores/roms";
 import GameActions from "@/v2/components/GameActions/GameActions.vue";
 import MainSiblingToggle from "@/v2/components/GameDetails/MainSiblingToggle.vue";
 import PrevNextNav from "@/v2/components/GameDetails/PrevNextNav.vue";
+import { PROVIDERS } from "@/v2/components/GameDetails/providers";
 import VersionSwitcher from "@/v2/components/GameDetails/VersionSwitcher.vue";
 import { useGameActions } from "@/v2/composables/useGameActions";
 
@@ -33,6 +35,88 @@ const props = defineProps<{
 }>();
 
 const actions = useGameActions(() => props.rom);
+
+type RatingChip = {
+  key: "igdb_id" | "ss_id" | "moby_id" | "launchbox_id" | "hltb_id";
+  name: string;
+  logo: string;
+  value: string;
+};
+
+function formatRating(value: number, options?: { percent?: boolean }): string | null {
+  if (!Number.isFinite(value)) return null;
+  const rounded = value >= 10 ? value.toFixed(0) : value.toFixed(1);
+  const formatted = rounded.replace(/\.0$/, "");
+  return options?.percent ? `${formatted}%` : formatted;
+}
+
+function normalizeToTen(value: number): number {
+  if (!Number.isFinite(value)) return Number.NaN;
+  return value > 10 ? value / 10 : value;
+}
+
+function providerByKey(key: RatingChip["key"]) {
+  return PROVIDERS.find((p) => p.key === key) ?? null;
+}
+
+const visibleRegions = computed(() =>
+  props.regions.filter((r) => r.trim().toLowerCase() !== "world"),
+);
+
+const ratingChips = computed<RatingChip[]>(() => {
+  const rom = props.rom;
+
+  const values: Array<{ key: RatingChip["key"]; value: string | null }> = [
+    {
+      key: "igdb_id",
+      value: formatRating(
+        normalizeToTen(parseFloat(rom.igdb_metadata?.total_rating ?? "")),
+      ),
+    },
+    {
+      key: "ss_id",
+      value: formatRating(parseFloat(rom.ss_metadata?.ss_score ?? "") * 10, {
+        percent: true,
+      }),
+    },
+    {
+      key: "moby_id",
+      value: formatRating(parseFloat(rom.moby_metadata?.moby_score ?? "") * 10, {
+        percent: true,
+      }),
+    },
+    {
+      key: "launchbox_id",
+      value: formatRating(
+        (rom.launchbox_metadata?.community_rating ?? Number.NaN) * 20,
+        { percent: true },
+      ),
+    },
+    {
+      key: "hltb_id",
+      value: formatRating(rom.hltb_metadata?.review_score ?? Number.NaN, {
+        percent: true,
+      }),
+    },
+  ];
+
+  const out: RatingChip[] = [];
+
+  for (const entry of values) {
+    if (!entry.value) continue;
+    const provider = providerByKey(entry.key);
+    if (!provider || !provider.logo) continue;
+
+    out.push({
+      key: entry.key,
+      name: provider.name,
+      logo: provider.logo,
+      value: entry.value,
+    });
+  }
+
+  return out;
+});
 </script>
 
 <template>
@@ -82,18 +166,34 @@ const actions = useGameActions(() => props.rom);
       </span>
 
       <span
-        v-if="regions.length || languages.length || tags.length"
+        v-if="ratingChips.length || visibleRegions.length || languages.length || tags.length"
         class="r-v2-det-header__sep"
       >
         ·
       </span>
 
+      <span v-if="ratingChips.length" class="r-v2-det-header__ratings">
+        <span
+          v-for="chip in ratingChips"
+          :key="chip.key"
+          class="r-v2-det-header__rating-inline"
+          :aria-label="`${chip.name} rating ${chip.value}`"
+        >
+          <img
+            class="r-v2-det-header__rating-logo"
+            :src="chip.logo"
+            :alt="`${chip.name} logo`"
+          />
+          <span class="r-v2-det-header__rating-value">{{ chip.value }}</span>
+        </span>
+      </span>
+
       <span
-        v-if="regions.length || languages.length || tags.length"
+        v-if="visibleRegions.length || languages.length || tags.length"
         class="r-v2-det-header__tags"
       >
         <RTag
-          v-for="r in regions"
+          v-for="r in visibleRegions"
           :key="`r-${r}`"
           :text="r"
           tone="info"
@@ -181,6 +281,33 @@ const actions = useGameActions(() => props.rom);
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+
+.r-v2-det-header__ratings {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.r-v2-det-header__rating-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: inherit;
+}
+
+.r-v2-det-header__rating-logo {
+  inline-size: 15px;
+  block-size: 15px;
+  object-fit: contain;
+}
+
+.r-v2-det-header__rating-value {
+  font-variant-numeric: tabular-nums;
+  color: inherit;
+  font-weight: inherit;
+  font-size: inherit;
 }
 
 .r-v2-det-header__versions {


### PR DESCRIPTION
**Description**

Inspired by Radarr-like presentation, this PR improves the v2 game details header by surfacing provider ratings inline in the meta row.

1. Adds inline provider rating chips in Game Details header meta.
2. Displays only ratings that actually exist for the current game.
3. Enforces display order: IGDB, ScreenScraper, MobyGames, LaunchBox, HowLongToBeat.
4. Formats percent-based providers with a percent sign (example: HLTB 57%).
5. Keeps IGDB normalized to a 10-point scale (for example: 54 -> 5.4).
6. Keeps rating chips non-clickable and visually aligned with existing header typography.

**Files changed**
- frontend/src/v2/components/GameDetails/GameHeader.vue

**Testing**
- Vue/TS diagnostics checked for the modified file (no errors).
- Manual visual verification from the provided screenshot:
  - ratings appear inline,
  - percent formatting is present,
  - provider order is stable,
  - only available ratings are shown.

**Checklist**
- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshot
<img width="607" height="227" alt="show provider ratings in game details header" src="https://github.com/user-attachments/assets/fbab2519-17f7-477a-b212-88f8c601cf62" />


