### PR TITLE
fix(docker): keep the Redis password out of the RQ worker command line

### DIFF
--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -251,15 +251,18 @@ start_bin_rq_worker() {
 	fi
 
 	# Set PYTHONPATH so RQ can find the tasks module.
+	# The connection URL goes through RQ_REDIS_URL rather than --url, so the
+	# embedded password stays out of the worker's world-readable command line.
 	# Use a worker class that drops the noisy per-sweep "cleaning registries for
 	# queue" log line. The maintenance interval keeps its default (~10 min) so
 	# orphaned STARTED jobs and stale workers are still pruned promptly, which the
 	# watcher's Worker.all() scan dedupe relies on.
-	PYTHONPATH="/backend:${PYTHONPATH-}" rq worker \
+	PYTHONPATH="/backend:${PYTHONPATH-}" \
+		RQ_REDIS_URL="${redis_url}" \
+		rq worker \
 		--path /backend \
 		--worker-class handler.rq_worker.RomMWorker \
 		--pid /tmp/rq_worker.pid \
-		--url "${redis_url}" \
 		--results-ttl "${TASK_RESULT_TTL:-86400}" \
 		--logging_level "${LOGLEVEL}" \
 		high default low &

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,15 +69,18 @@ else
 fi
 
 # Set PYTHONPATH so RQ can find the tasks module.
+# The connection URL goes through RQ_REDIS_URL rather than --url, so the
+# embedded password stays out of the worker's world-readable command line.
 # Use a worker class that drops the noisy per-sweep "cleaning registries for
 # queue" log line. The maintenance interval keeps its default (~10 min) so
 # orphaned STARTED jobs and stale workers are still pruned promptly, which the
 # watcher's Worker.all() scan dedupe relies on.
-PYTHONPATH="/app/backend:${PYTHONPATH-}" rq worker \
+PYTHONPATH="/app/backend:${PYTHONPATH-}" \
+	RQ_REDIS_URL="${REDIS_URL}" \
+	rq worker \
 	--path /app/backend \
 	--worker-class handler.rq_worker.RomMWorker \
 	--pid /tmp/rq_worker.pid \
-	--url "${REDIS_URL}" \
 	--logging_level "${LOGLEVEL:-INFO}" \
 	high default low &
 


### PR DESCRIPTION
**Description**

The RQ worker received its Redis connection string through `rq worker --url`, which placed the fully-authenticated URL (including `REDIS_PASSWORD`) into the process's argv for the life of the worker. Command-line arguments are readable via world-readable `/proc/<pid>/cmdline`, `ps`, container diagnostics, and any monitoring agent or support bundle that collects process listings (CWE-214). Operators pointing RomM at an external password-authenticated Redis/Valkey/Dragonfly were exposing that credential to anyone with process-inspection access in the container.

RQ's `--url` option already declares `envvar='RQ_REDIS_URL'`, so passing the URL through the environment instead is behavior-preserving and needs no version bump. This also brings the worker in line with the `rqscheduler` started next to it, which was already taking its credentials as `RQ_REDIS_*` environment variables.

Fixed in both places the worker is launched:

- `docker/init_scripts/init` (production container)
- `entrypoint.sh` (dev-mode compose entrypoint, which had the same pattern)

The credential still lives in the process environment, visible in `/proc/<pid>/environ`. That is a meaningful narrowing rather than a full elimination: `environ` is restricted to the same UID or root, unlike world-readable `cmdline`, and it adds no new exposure because `REDIS_PASSWORD` is already in the container environment and inherited by every child process. Removing environment-based exposure entirely would require a credentials file or an `--config` module, which is a larger change than this fix warrants.

**Verification**

- Confirmed RQ honors the env var: ran `RQ_REDIS_URL="redis://:PW@127.0.0.1:6399/0" rq worker` with no `--url` flag and it attempted `127.0.0.1:6399`, a port that could only have come from the environment (the default is 6379).
- `bash -n` on both scripts, plus `trunk fmt` and `trunk check` clean.

I did not rebuild the container to re-run the original reproduction against a patched image; the CLI-level check above establishes that the flag is read from the environment, and the password is absent from argv by construction.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The report was reviewed and confirmed against the source, the fix and its verification were AI-authored, and I reviewed the result before submitting.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

<sup>No unit tests added: these are container startup shell scripts with no existing test harness in the repo.</sup>
