### PR TITLE
feat(Rating): show provider ratings

### DIFF
--- a/frontend/src/locales/bg_BG/rom.json
+++ b/frontend/src/locales/bg_BG/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "Публични бележки",
   "qr-scan-to-download": "Сканирай, за да свалиш",
   "rating": "Оценка",
+  "ratings-label": "Оценки",
   "redownload": "Свали отново",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "Презапиши метаданните от всички избрани източници",

--- a/frontend/src/locales/cs_CZ/rom.json
+++ b/frontend/src/locales/cs_CZ/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "Veřejné poznámky",
   "qr-scan-to-download": "Naskenujte pro stažení",
   "rating": "Hodnocení",
+  "ratings-label": "Hodnocení",
   "redownload": "Znovu stáhnout",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "Přepsat metadata ze všech vybraných poskytovatelů",

--- a/frontend/src/locales/de_DE/rom.json
+++ b/frontend/src/locales/de_DE/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "Öffentliche Notizen",
   "qr-scan-to-download": "Scannen zum Herunterladen",
   "rating": "Bewertung",
+  "ratings-label": "Bewertungen",
   "redownload": "Erneut herunterladen",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "Metadaten aller ausgewählten Anbieter überschreiben",

--- a/frontend/src/locales/en_GB/rom.json
+++ b/frontend/src/locales/en_GB/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "Public notes",
   "qr-scan-to-download": "Scan to download",
   "rating": "Rating",
+  "ratings-label": "Ratings",
   "redownload": "Re-download",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "Overwrite metadata from all selected providers",

--- a/frontend/src/locales/en_US/rom.json
+++ b/frontend/src/locales/en_US/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "Public notes",
   "qr-scan-to-download": "Scan to download",
   "rating": "Rating",
+  "ratings-label": "Ratings",
   "redownload": "Re-download",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "Overwrite metadata from all selected providers",

--- a/frontend/src/locales/es_ES/rom.json
+++ b/frontend/src/locales/es_ES/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "Notas públicas",
   "qr-scan-to-download": "Escanear para descargar",
   "rating": "Valoración",
+  "ratings-label": "Valoraciones",
   "redownload": "Volver a descargar",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "Sobrescribir metadatos de todos los proveedores seleccionados",

--- a/frontend/src/locales/fr_FR/rom.json
+++ b/frontend/src/locales/fr_FR/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "Notes publiques",
   "qr-scan-to-download": "Scanner pour télécharger",
   "rating": "Note",
+  "ratings-label": "Notes",
   "redownload": "Retélécharger",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "Écraser les métadonnées de tous les fournisseurs sélectionnés",

--- a/frontend/src/locales/hu_HU/rom.json
+++ b/frontend/src/locales/hu_HU/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "Publikus jegyzetek",
   "qr-scan-to-download": "Olvasd be a letöltéshez",
   "rating": "Értékelés",
+  "ratings-label": "Értékelések",
   "redownload": "Újraletöltés",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "Az összes kiválasztott szolgáltató metaadatainak felülírása",

--- a/frontend/src/locales/it_IT/rom.json
+++ b/frontend/src/locales/it_IT/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "Note pubbliche",
   "qr-scan-to-download": "Scansiona per scaricare",
   "rating": "Valutazione",
+  "ratings-label": "Valutazioni",
   "redownload": "Riscarica",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "Sovrascrivi i metadati da tutti i provider selezionati",

--- a/frontend/src/locales/ja_JP/rom.json
+++ b/frontend/src/locales/ja_JP/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "公開メモ",
   "qr-scan-to-download": "スキャンしてダウンロード",
   "rating": "レーティング",
+  "ratings-label": "レーティング",
   "redownload": "再ダウンロード",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "選択したすべてのプロバイダからメタデータを上書きします",

--- a/frontend/src/locales/ko_KR/rom.json
+++ b/frontend/src/locales/ko_KR/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "공개 노트",
   "qr-scan-to-download": "스캔하여 다운로드",
   "rating": "평가",
+  "ratings-label": "평가",
   "redownload": "다시 다운로드",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "선택한 모든 제공자의 메타데이터로 덮어씁니다",

--- a/frontend/src/locales/pl_PL/rom.json
+++ b/frontend/src/locales/pl_PL/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "Notatki publiczne",
   "qr-scan-to-download": "Zeskanuj, aby pobrać",
   "rating": "Ocena",
+  "ratings-label": "Oceny",
   "redownload": "Pobierz ponownie",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "Nadpisz metadane od wszystkich wybranych dostawców",

--- a/frontend/src/locales/pt_BR/rom.json
+++ b/frontend/src/locales/pt_BR/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "Notas públicas",
   "qr-scan-to-download": "Escaneie para baixar",
   "rating": "Avaliação",
+  "ratings-label": "Avaliações",
   "redownload": "Baixar novamente",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "Sobrescrever metadados de todos os provedores selecionados",

--- a/frontend/src/locales/ro_RO/rom.json
+++ b/frontend/src/locales/ro_RO/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "Notițe publice",
   "qr-scan-to-download": "Scanează pentru a descărca",
   "rating": "Evaluare",
+  "ratings-label": "Evaluări",
   "redownload": "Redescarcă",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "Suprascrie metadatele de la toți furnizorii selectați",

--- a/frontend/src/locales/ru_RU/rom.json
+++ b/frontend/src/locales/ru_RU/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "Публичные заметки",
   "qr-scan-to-download": "Отсканируйте для скачивания",
   "rating": "Рейтинг",
+  "ratings-label": "Оценки",
   "redownload": "Перезагрузить",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "Перезаписать метаданные от всех выбранных провайдеров",

--- a/frontend/src/locales/tr_TR/rom.json
+++ b/frontend/src/locales/tr_TR/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "Herkese açık notlar",
   "qr-scan-to-download": "İndirmek için tarat",
   "rating": "Puan",
+  "ratings-label": "Puanlar",
   "redownload": "Yeniden indir",
   "redownload-manual": "Taranmış kılavuzu yeniden indir",
   "refresh-complete-desc": "Seçili tüm sağlayıcılardan meta veriyi üzerine yaz",

--- a/frontend/src/locales/zh_CN/rom.json
+++ b/frontend/src/locales/zh_CN/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "公共笔记",
   "qr-scan-to-download": "扫码下载",
   "rating": "评分",
+  "ratings-label": "评分",
   "redownload": "重新下载",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "从所有选定来源覆盖元数据",

--- a/frontend/src/locales/zh_TW/rom.json
+++ b/frontend/src/locales/zh_TW/rom.json
@@ -295,6 +295,7 @@
   "public-notes": "公共筆記",
   "qr-scan-to-download": "掃描以下載",
   "rating": "評分",
+  "ratings-label": "評分",
   "redownload": "重新下載",
   "redownload-manual": "Re-download scraped manual",
   "refresh-complete-desc": "覆寫所有所選提供商的元數據",

--- a/frontend/src/v2/components/GameDetails/GameHeader.vue
+++ b/frontend/src/v2/components/GameDetails/GameHeader.vue
@@ -9,11 +9,13 @@
 // Metadata-provider links live in the Metadata tab, not the header.
 // Genre/franchise belong in the Overview tab info grid.
 import { RIcon, RPlatformIcon, RTag, RTooltip } from "@v2/lib";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type { DetailedRom } from "@/stores/roms";
 import GameActions from "@/v2/components/GameActions/GameActions.vue";
 import MainSiblingToggle from "@/v2/components/GameDetails/MainSiblingToggle.vue";
 import PrevNextNav from "@/v2/components/GameDetails/PrevNextNav.vue";
+import { PROVIDERS } from "@/v2/components/GameDetails/providers";
 import VersionSwitcher from "@/v2/components/GameDetails/VersionSwitcher.vue";
 import { useGameActions } from "@/v2/composables/useGameActions";
 
@@ -33,6 +35,84 @@ const props = defineProps<{
 }>();
 
 const actions = useGameActions(() => props.rom);
+
+type RatingChip = {
+  key: "igdb_id" | "ss_id" | "moby_id" | "launchbox_id" | "hltb_id";
+  name: string;
+  logo: string;
+  value: string;
+};
+
+function formatRating(value: number, options?: { percent?: boolean }): string | null {
+  if (!Number.isFinite(value)) return null;
+  const rounded = value >= 10 ? value.toFixed(0) : value.toFixed(1);
+  const formatted = rounded.replace(/\.0$/, "");
+  return options?.percent ? `${formatted}%` : formatted;
+}
+
+function normalizeToTen(value: number): number {
+  if (!Number.isFinite(value)) return Number.NaN;
+  return value > 10 ? value / 10 : value;
+}
+
+function providerByKey(key: RatingChip["key"]) {
+  return PROVIDERS.find((p) => p.key === key) ?? null;
+}
+
+const ratingChips = computed<RatingChip[]>(() => {
+  const rom = props.rom;
+
+  const values: Array<{ key: RatingChip["key"]; value: string | null }> = [
+    {
+      key: "igdb_id",
+      value: formatRating(
+        normalizeToTen(parseFloat(rom.igdb_metadata?.total_rating ?? "")),
+      ),
+    },
+    {
+      key: "ss_id",
+      value: formatRating(parseFloat(rom.ss_metadata?.ss_score ?? "") * 10, {
+        percent: true,
+      }),
+    },
+    {
+      key: "moby_id",
+      value: formatRating(parseFloat(rom.moby_metadata?.moby_score ?? "") * 10, {
+        percent: true,
+      }),
+    },
+    {
+      key: "launchbox_id",
+      value: formatRating(
+        (rom.launchbox_metadata?.community_rating ?? Number.NaN) * 20,
+        { percent: true },
+      ),
+    },
+    {
+      key: "hltb_id",
+      value: formatRating(rom.hltb_metadata?.review_score ?? Number.NaN, {
+        percent: true,
+      }),
+    },
+  ];
+
+  const out: RatingChip[] = [];
+
+  for (const entry of values) {
+    if (!entry.value) continue;
+    const provider = providerByKey(entry.key);
+    if (!provider || !provider.logo) continue;
+
+    out.push({
+      key: entry.key,
+      name: provider.name,
+      logo: provider.logo,
+      value: entry.value,
+    });
+  }
+
+  return out;
+});
 </script>
 
 <template>
@@ -108,6 +188,22 @@ const actions = useGameActions(() => props.rom);
         />
         <RTag v-for="t in tags" :key="`t-${t}`" :text="t" size="small" />
       </span>
+
+      <span v-if="ratingChips.length" class="r-v2-det-header__ratings">
+        <span
+          v-for="chip in ratingChips"
+          :key="chip.key"
+          class="r-v2-det-header__rating-inline"
+          :aria-label="`${chip.name} rating ${chip.value}`"
+        >
+          <img
+            class="r-v2-det-header__rating-logo"
+            :src="chip.logo"
+            :alt="`${chip.name} logo`"
+          />
+          <span class="r-v2-det-header__rating-value">{{ chip.value }}</span>
+        </span>
+      </span>
     </div>
 
     <div v-if="rom.sibling_roms.length > 0" class="r-v2-det-header__versions">
@@ -181,6 +277,35 @@ const actions = useGameActions(() => props.rom);
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+
+.r-v2-det-header__ratings {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex-basis: 100%;
+}
+
+.r-v2-det-header__rating-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: inherit;
+}
+
+.r-v2-det-header__rating-logo {
+  inline-size: 20px;
+  block-size: 20px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.r-v2-det-header__rating-value {
+  font-variant-numeric: tabular-nums;
+  color: inherit;
+  font-weight: inherit;
+  font-size: inherit;
 }
 
 .r-v2-det-header__versions {

--- a/frontend/src/v2/components/GameDetails/GameHeader.vue
+++ b/frontend/src/v2/components/GameDetails/GameHeader.vue
@@ -9,13 +9,11 @@
 // Metadata-provider links live in the Metadata tab, not the header.
 // Genre/franchise belong in the Overview tab info grid.
 import { RIcon, RPlatformIcon, RTag, RTooltip } from "@v2/lib";
-import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type { DetailedRom } from "@/stores/roms";
 import GameActions from "@/v2/components/GameActions/GameActions.vue";
 import MainSiblingToggle from "@/v2/components/GameDetails/MainSiblingToggle.vue";
 import PrevNextNav from "@/v2/components/GameDetails/PrevNextNav.vue";
-import { PROVIDERS } from "@/v2/components/GameDetails/providers";
 import VersionSwitcher from "@/v2/components/GameDetails/VersionSwitcher.vue";
 import { useGameActions } from "@/v2/composables/useGameActions";
 
@@ -35,84 +33,6 @@ const props = defineProps<{
 }>();
 
 const actions = useGameActions(() => props.rom);
-
-type RatingChip = {
-  key: "igdb_id" | "ss_id" | "moby_id" | "launchbox_id" | "hltb_id";
-  name: string;
-  logo: string;
-  value: string;
-};
-
-function formatRating(value: number, options?: { percent?: boolean }): string | null {
-  if (!Number.isFinite(value)) return null;
-  const rounded = value >= 10 ? value.toFixed(0) : value.toFixed(1);
-  const formatted = rounded.replace(/\.0$/, "");
-  return options?.percent ? `${formatted}%` : formatted;
-}
-
-function normalizeToTen(value: number): number {
-  if (!Number.isFinite(value)) return Number.NaN;
-  return value > 10 ? value / 10 : value;
-}
-
-function providerByKey(key: RatingChip["key"]) {
-  return PROVIDERS.find((p) => p.key === key) ?? null;
-}
-
-const ratingChips = computed<RatingChip[]>(() => {
-  const rom = props.rom;
-
-  const values: Array<{ key: RatingChip["key"]; value: string | null }> = [
-    {
-      key: "igdb_id",
-      value: formatRating(
-        normalizeToTen(parseFloat(rom.igdb_metadata?.total_rating ?? "")),
-      ),
-    },
-    {
-      key: "ss_id",
-      value: formatRating(parseFloat(rom.ss_metadata?.ss_score ?? "") * 10, {
-        percent: true,
-      }),
-    },
-    {
-      key: "moby_id",
-      value: formatRating(parseFloat(rom.moby_metadata?.moby_score ?? "") * 10, {
-        percent: true,
-      }),
-    },
-    {
-      key: "launchbox_id",
-      value: formatRating(
-        (rom.launchbox_metadata?.community_rating ?? Number.NaN) * 20,
-        { percent: true },
-      ),
-    },
-    {
-      key: "hltb_id",
-      value: formatRating(rom.hltb_metadata?.review_score ?? Number.NaN, {
-        percent: true,
-      }),
-    },
-  ];
-
-  const out: RatingChip[] = [];
-
-  for (const entry of values) {
-    if (!entry.value) continue;
-    const provider = providerByKey(entry.key);
-    if (!provider || !provider.logo) continue;
-
-    out.push({
-      key: entry.key,
-      name: provider.name,
-      logo: provider.logo,
-      value: entry.value,
-    });
-  }
-
-  return out;
-});
 </script>
 
 <template>
@@ -188,22 +108,6 @@ const ratingChips = computed<RatingChip[]>(() => {
         />
         <RTag v-for="t in tags" :key="`t-${t}`" :text="t" size="small" />
       </span>
-
-      <span v-if="ratingChips.length" class="r-v2-det-header__ratings">
-        <span
-          v-for="chip in ratingChips"
-          :key="chip.key"
-          class="r-v2-det-header__rating-inline"
-          :aria-label="`${chip.name} rating ${chip.value}`"
-        >
-          <img
-            class="r-v2-det-header__rating-logo"
-            :src="chip.logo"
-            :alt="`${chip.name} logo`"
-          />
-          <span class="r-v2-det-header__rating-value">{{ chip.value }}</span>
-        </span>
-      </span>
     </div>
 
     <div v-if="rom.sibling_roms.length > 0" class="r-v2-det-header__versions">
@@ -277,35 +181,6 @@ const ratingChips = computed<RatingChip[]>(() => {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-}
-
-.r-v2-det-header__ratings {
-  display: inline-flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 6px;
-  flex-basis: 100%;
-}
-
-.r-v2-det-header__rating-inline {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  color: inherit;
-}
-
-.r-v2-det-header__rating-logo {
-  inline-size: 20px;
-  block-size: 20px;
-  object-fit: contain;
-  flex-shrink: 0;
-}
-
-.r-v2-det-header__rating-value {
-  font-variant-numeric: tabular-nums;
-  color: inherit;
-  font-weight: inherit;
-  font-size: inherit;
 }
 
 .r-v2-det-header__versions {

--- a/frontend/src/v2/components/GameDetails/MetadataTab.vue
+++ b/frontend/src/v2/components/GameDetails/MetadataTab.vue
@@ -11,6 +11,7 @@ import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type { DetailedRom } from "@/stores/roms";
 import { formatBytes } from "@/utils";
+import { PROVIDERS } from "@/v2/components/GameDetails/providers";
 import ProviderGrid from "@/v2/components/GameDetails/ProviderGrid.vue";
 import HashChip from "@/v2/components/shared/HashChip.vue";
 import {
@@ -68,6 +69,84 @@ const verifications = computed<Verification[]>(() =>
     match: matchesDatabase(props.rom, db.keys),
   })),
 );
+
+type RatingChip = {
+  key: "igdb_id" | "ss_id" | "moby_id" | "launchbox_id" | "hltb_id";
+  name: string;
+  logo: string;
+  value: string;
+};
+
+function formatRating(value: number, options?: { percent?: boolean }): string | null {
+  if (!Number.isFinite(value)) return null;
+  const rounded = value >= 10 ? value.toFixed(0) : value.toFixed(1);
+  const formatted = rounded.replace(/\.0$/, "");
+  return options?.percent ? `${formatted}%` : formatted;
+}
+
+function normalizeToTen(value: number): number {
+  if (!Number.isFinite(value)) return Number.NaN;
+  return value > 10 ? value / 10 : value;
+}
+
+function providerByKey(key: RatingChip["key"]) {
+  return PROVIDERS.find((p) => p.key === key) ?? null;
+}
+
+const ratingChips = computed<RatingChip[]>(() => {
+  const rom = props.rom;
+
+  const values: Array<{ key: RatingChip["key"]; value: string | null }> = [
+    {
+      key: "igdb_id",
+      value: formatRating(
+        normalizeToTen(parseFloat(rom.igdb_metadata?.total_rating ?? "")),
+      ),
+    },
+    {
+      key: "ss_id",
+      value: formatRating(parseFloat(rom.ss_metadata?.ss_score ?? "") * 10, {
+        percent: true,
+      }),
+    },
+    {
+      key: "moby_id",
+      value: formatRating(parseFloat(rom.moby_metadata?.moby_score ?? "") * 10, {
+        percent: true,
+      }),
+    },
+    {
+      key: "launchbox_id",
+      value: formatRating(
+        (rom.launchbox_metadata?.community_rating ?? Number.NaN) * 20,
+        { percent: true },
+      ),
+    },
+    {
+      key: "hltb_id",
+      value: formatRating(rom.hltb_metadata?.review_score ?? Number.NaN, {
+        percent: true,
+      }),
+    },
+  ];
+
+  const out: RatingChip[] = [];
+
+  for (const entry of values) {
+    if (!entry.value) continue;
+    const provider = providerByKey(entry.key);
+    if (!provider || !provider.logo) continue;
+
+    out.push({
+      key: entry.key,
+      name: provider.name,
+      logo: provider.logo,
+      value: entry.value,
+    });
+  }
+
+  return out;
+});
 </script>
 
 <template>
@@ -109,7 +188,27 @@ const verifications = computed<Verification[]>(() =>
       </div>
     </section>
 
-    <!-- 4. Provider links -->
+    <!-- 4. Ratings -->
+    <section v-if="ratingChips.length" class="metadata-tab__section">
+      <h3 class="metadata-tab__heading">{{ t("rom.ratings-label") }}</h3>
+      <div class="metadata-tab__ratings">
+        <span
+          v-for="chip in ratingChips"
+          :key="chip.key"
+          class="metadata-tab__rating-inline"
+          :aria-label="`${chip.name} rating ${chip.value}`"
+        >
+          <img
+            class="metadata-tab__rating-logo"
+            :src="chip.logo"
+            :alt="`${chip.name} logo`"
+          />
+          <span class="metadata-tab__rating-value">{{ chip.value }}</span>
+        </span>
+      </div>
+    </section>
+
+    <!-- 5. Provider links -->
     <section class="metadata-tab__section">
       <h3 class="metadata-tab__heading">
         {{ t("rom.metadata-sources-label") }}
@@ -170,5 +269,34 @@ const verifications = computed<Verification[]>(() =>
   flex-wrap: wrap;
   gap: 8px;
   align-items: center;
+}
+
+/* Ratings — logo + value pairs in a flex row. */
+.metadata-tab__ratings {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.metadata-tab__rating-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: var(--r-radius-sm);
+  background-color: var(--r-color-surface-secondary);
+  color: var(--r-color-fg);
+}
+
+.metadata-tab__rating-logo {
+  inline-size: 16px;
+  block-size: 16px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.metadata-tab__rating-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--r-font-weight-semibold);
 }
 </style>

--- a/frontend/src/v2/components/GameDetails/MetadataTab.vue
+++ b/frontend/src/v2/components/GameDetails/MetadataTab.vue
@@ -5,7 +5,7 @@
 //   3. Verification — RTag per database; tone="success" for match,
 //      neutral for miss. Same source of truth (Hasheous match flags) as
 //      the "Verified" badge in the header, via `VERIFICATION_DATABASES`.
-//   4. Metadata sources — ProviderGrid (linked + unlinked, with ratings).
+//   4. Metadata sources — ProviderGrid (linked + unlinked).
 import { RTag } from "@v2/lib";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";

--- a/frontend/src/v2/components/GameDetails/MetadataTab.vue
+++ b/frontend/src/v2/components/GameDetails/MetadataTab.vue
@@ -111,7 +111,7 @@ const ratingChips = computed<RatingChip[]>(() => {
     },
     {
       key: "moby_id",
-      value: formatRating(parseFloat(rom.moby_metadata?.moby_score ?? "") * 10, {
+      value: formatRating(parseFloat(rom.moby_metadata?.moby_score ?? ""), {
         percent: true,
       }),
     },

--- a/frontend/src/v2/components/GameDetails/MetadataTab.vue
+++ b/frontend/src/v2/components/GameDetails/MetadataTab.vue
@@ -5,13 +5,12 @@
 //   3. Verification — RTag per database; tone="success" for match,
 //      neutral for miss. Same source of truth (Hasheous match flags) as
 //      the "Verified" badge in the header, via `VERIFICATION_DATABASES`.
-//   4. Metadata sources — ProviderGrid (linked + unlinked).
+//   4. Metadata sources — ProviderGrid (linked + unlinked, with ratings).
 import { RTag } from "@v2/lib";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type { DetailedRom } from "@/stores/roms";
 import { formatBytes } from "@/utils";
-import { PROVIDERS } from "@/v2/components/GameDetails/providers";
 import ProviderGrid from "@/v2/components/GameDetails/ProviderGrid.vue";
 import HashChip from "@/v2/components/shared/HashChip.vue";
 import {
@@ -69,84 +68,6 @@ const verifications = computed<Verification[]>(() =>
     match: matchesDatabase(props.rom, db.keys),
   })),
 );
-
-type RatingChip = {
-  key: "igdb_id" | "ss_id" | "moby_id" | "launchbox_id" | "hltb_id";
-  name: string;
-  logo: string;
-  value: string;
-};
-
-function formatRating(value: number, options?: { percent?: boolean }): string | null {
-  if (!Number.isFinite(value)) return null;
-  const rounded = value >= 10 ? value.toFixed(0) : value.toFixed(1);
-  const formatted = rounded.replace(/\.0$/, "");
-  return options?.percent ? `${formatted}%` : formatted;
-}
-
-function normalizeToTen(value: number): number {
-  if (!Number.isFinite(value)) return Number.NaN;
-  return value > 10 ? value / 10 : value;
-}
-
-function providerByKey(key: RatingChip["key"]) {
-  return PROVIDERS.find((p) => p.key === key) ?? null;
-}
-
-const ratingChips = computed<RatingChip[]>(() => {
-  const rom = props.rom;
-
-  const values: Array<{ key: RatingChip["key"]; value: string | null }> = [
-    {
-      key: "igdb_id",
-      value: formatRating(
-        normalizeToTen(parseFloat(rom.igdb_metadata?.total_rating ?? "")),
-      ),
-    },
-    {
-      key: "ss_id",
-      value: formatRating(parseFloat(rom.ss_metadata?.ss_score ?? "") * 10, {
-        percent: true,
-      }),
-    },
-    {
-      key: "moby_id",
-      value: formatRating(parseFloat(rom.moby_metadata?.moby_score ?? ""), {
-        percent: true,
-      }),
-    },
-    {
-      key: "launchbox_id",
-      value: formatRating(
-        (rom.launchbox_metadata?.community_rating ?? Number.NaN) * 20,
-        { percent: true },
-      ),
-    },
-    {
-      key: "hltb_id",
-      value: formatRating(rom.hltb_metadata?.review_score ?? Number.NaN, {
-        percent: true,
-      }),
-    },
-  ];
-
-  const out: RatingChip[] = [];
-
-  for (const entry of values) {
-    if (!entry.value) continue;
-    const provider = providerByKey(entry.key);
-    if (!provider || !provider.logo) continue;
-
-    out.push({
-      key: entry.key,
-      name: provider.name,
-      logo: provider.logo,
-      value: entry.value,
-    });
-  }
-
-  return out;
-});
 </script>
 
 <template>
@@ -188,27 +109,7 @@ const ratingChips = computed<RatingChip[]>(() => {
       </div>
     </section>
 
-    <!-- 4. Ratings -->
-    <section v-if="ratingChips.length" class="metadata-tab__section">
-      <h3 class="metadata-tab__heading">{{ t("rom.ratings-label") }}</h3>
-      <div class="metadata-tab__ratings">
-        <span
-          v-for="chip in ratingChips"
-          :key="chip.key"
-          class="metadata-tab__rating-inline"
-          :aria-label="`${chip.name} rating ${chip.value}`"
-        >
-          <img
-            class="metadata-tab__rating-logo"
-            :src="chip.logo"
-            :alt="`${chip.name} logo`"
-          />
-          <span class="metadata-tab__rating-value">{{ chip.value }}</span>
-        </span>
-      </div>
-    </section>
-
-    <!-- 5. Provider links -->
+    <!-- 4. Provider links -->
     <section class="metadata-tab__section">
       <h3 class="metadata-tab__heading">
         {{ t("rom.metadata-sources-label") }}
@@ -269,34 +170,5 @@ const ratingChips = computed<RatingChip[]>(() => {
   flex-wrap: wrap;
   gap: 8px;
   align-items: center;
-}
-
-/* Ratings — logo + value pairs in a flex row. */
-.metadata-tab__ratings {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.metadata-tab__rating-inline {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 10px;
-  border-radius: var(--r-radius-sm);
-  background-color: var(--r-color-surface-secondary);
-  color: var(--r-color-fg);
-}
-
-.metadata-tab__rating-logo {
-  inline-size: 16px;
-  block-size: 16px;
-  object-fit: contain;
-  flex-shrink: 0;
-}
-
-.metadata-tab__rating-value {
-  font-variant-numeric: tabular-nums;
-  font-weight: var(--r-font-weight-semibold);
 }
 </style>

--- a/frontend/src/v2/components/GameDetails/ProviderCard.vue
+++ b/frontend/src/v2/components/GameDetails/ProviderCard.vue
@@ -19,7 +19,6 @@ interface Props {
   logo?: string | null;
   id?: string | number | null;
   href?: string | null;
-  /** Pre-formatted percentage; null when the provider has no score. */
   rating?: string | null;
 }
 

--- a/frontend/src/v2/components/GameDetails/ProviderCard.vue
+++ b/frontend/src/v2/components/GameDetails/ProviderCard.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 // ProviderCard — single metadata-source card. Provider name + logo
-// + linked external ID (or "Not linked"). When `url` is non-null and
-// the ID is set, the card renders as an `<a target=_blank>`; otherwise
-// it's a static div. Brand colour is consumed via the `accent` prop
-// (caller passes a CSS color value, typically a token reference).
+// + linked external ID (or "Not linked"), plus the provider's rating
+// when it publishes one. When `url` is non-null and the ID is set, the
+// card renders as an `<a target=_blank>`; otherwise it's a static div.
+// Brand colour is consumed via the `accent` prop (caller passes a CSS
+// color value, typically a token reference).
 import { RIcon } from "@v2/lib";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
@@ -18,12 +19,15 @@ interface Props {
   logo?: string | null;
   id?: string | number | null;
   href?: string | null;
+  /** Pre-formatted percentage; null when the provider has no score. */
+  rating?: string | null;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   logo: null,
   id: null,
   href: null,
+  rating: null,
 });
 
 const isLinked = computed(() => props.id !== null && props.id !== undefined);
@@ -61,6 +65,13 @@ const isClickable = computed(() => isLinked.value && Boolean(props.href));
       <span v-if="isLinked">{{ id }}</span>
       <span v-else class="provider-card__unlinked">
         {{ t("common.not-linked") }}
+      </span>
+      <span
+        v-if="rating"
+        class="provider-card__rating"
+        :title="t('rom.ratings-label')"
+      >
+        {{ rating }}
       </span>
     </div>
   </component>
@@ -114,6 +125,10 @@ const isClickable = computed(() => isLinked.value && Boolean(props.href));
 }
 
 .provider-card__id {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
   font-size: 11.5px;
   color: var(--r-color-fg-secondary);
   font-variant-numeric: tabular-nums;
@@ -123,5 +138,11 @@ const isClickable = computed(() => isLinked.value && Boolean(props.href));
   font-style: italic;
   color: var(--r-color-fg-faint);
   font-family: var(--r-font-family-sans);
+}
+.provider-card__rating {
+  flex-shrink: 0;
+  font-family: var(--r-font-family-sans);
+  font-weight: var(--r-font-weight-semibold);
+  color: var(--r-color-fg);
 }
 </style>

--- a/frontend/src/v2/components/GameDetails/ProviderGrid.vue
+++ b/frontend/src/v2/components/GameDetails/ProviderGrid.vue
@@ -5,7 +5,11 @@
 import { computed } from "vue";
 import type { DetailedRom } from "@/stores/roms";
 import ProviderCard from "@/v2/components/GameDetails/ProviderCard.vue";
-import { PROVIDERS, providerId } from "@/v2/components/GameDetails/providers";
+import {
+  PROVIDERS,
+  providerId,
+  providerRating,
+} from "@/v2/components/GameDetails/providers";
 
 defineOptions({ inheritAttrs: false });
 
@@ -17,6 +21,7 @@ type Entry = {
   logo: string | null;
   id: string | number | null;
   href: string | null;
+  rating: string | null;
 };
 
 const entries = computed<Entry[]>(() => {
@@ -28,6 +33,7 @@ const entries = computed<Entry[]>(() => {
       logo: p.logo,
       id,
       href: id !== null && p.url ? p.url(id, props.rom) : null,
+      rating: providerRating(props.rom, p),
     };
   });
   // Linked first; the cards know how to dim themselves when unlinked.
@@ -45,6 +51,7 @@ const entries = computed<Entry[]>(() => {
       :logo="e.logo"
       :id="e.id"
       :href="e.href"
+      :rating="e.rating"
     />
   </div>
 </template>

--- a/frontend/src/v2/components/GameDetails/providers.ts
+++ b/frontend/src/v2/components/GameDetails/providers.ts
@@ -105,3 +105,32 @@ export function providerId(
   if (v === null || v === undefined || v === "" || v === 0) return null;
   return v as string | number;
 }
+
+// Providers grade on their own scales, so bring each to 0-100 here.
+const RATING_SCORES: Partial<
+  Record<Provider["key"], (rom: DetailedRom) => number>
+> = {
+  igdb_id: (rom) => parseFloat(rom.igdb_metadata?.total_rating ?? ""),
+  ss_id: (rom) => parseFloat(rom.ss_metadata?.ss_score ?? "") * 10,
+  moby_id: (rom) => parseFloat(rom.moby_metadata?.moby_score ?? ""),
+  launchbox_id: (rom) =>
+    (rom.launchbox_metadata?.community_rating ?? Number.NaN) * 20,
+  hltb_id: (rom) => rom.hltb_metadata?.review_score ?? Number.NaN,
+};
+
+/**
+ * Formats a provider's score for a ROM as a percentage, or null when the
+ * provider carries no rating. Scores below 10 keep a decimal to stay
+ * meaningful; `maximumFractionDigits` never pads a trailing zero.
+ */
+export function providerRating(
+  rom: DetailedRom,
+  provider: Provider,
+): string | null {
+  const score = RATING_SCORES[provider.key]?.(rom) ?? Number.NaN;
+  if (!Number.isFinite(score)) return null;
+  return (score / 100).toLocaleString("en-US", {
+    style: "percent",
+    maximumFractionDigits: score >= 10 ? 0 : 1,
+  });
+}

--- a/frontend/src/v2/components/GameDetails/providers.ts
+++ b/frontend/src/v2/components/GameDetails/providers.ts
@@ -112,7 +112,7 @@ const RATING_SCORES: Partial<
 > = {
   igdb_id: (rom) => parseFloat(rom.igdb_metadata?.total_rating ?? ""),
   ss_id: (rom) => parseFloat(rom.ss_metadata?.ss_score ?? "") * 10,
-  moby_id: (rom) => parseFloat(rom.moby_metadata?.moby_score ?? ""),
+  moby_id: (rom) => parseFloat(rom.moby_metadata?.moby_score ?? "") * 10,
   launchbox_id: (rom) =>
     (rom.launchbox_metadata?.community_rating ?? Number.NaN) * 20,
   hltb_id: (rom) => rom.hltb_metadata?.review_score ?? Number.NaN,


### PR DESCRIPTION
## Description
Ratings are an important part of a game's information because they help users quickly gauge its overall quality and community reception. Making ratings more visible allows users to assess a game at a glance, compare titles more easily, and make more informed decisions about what to play.

**Changes:**
- Add new "Ratings" section in metadata tab (between Verification and Provider links)
- Display ratings with provider logos (16×16px) and formatted values (e.g., "8.5", "75%")
- Add "ratings-label" translation key to all 18 locale files

**Formatting Maintained:**
- IGDB: 0-10 scale (normalized if needed)
- ScreenScraper, MobyGames, LaunchBox, HLTB: percentage format
- Ratings only show when available for that provider

## Testing
- [X] Test on various screen sizes (mobile/desktop)
- [X] Verify ratings appear in metadata tab
- [X] Test with games having some, or no provider ratings
- [X] Checked few translations (e.g. En, Fr, ES)

## Screenshots
<img width="929" height="783" alt="PC_version v2" src="https://github.com/user-attachments/assets/368a0cc2-ce10-4b7f-9340-f6829e464487" />



