### PR TITLE
perf(gallery): resolve the random rom button in one request

### DIFF
--- a/frontend/src/v2/views/Gallery/Collection.test.ts
+++ b/frontend/src/v2/views/Gallery/Collection.test.ts
@@ -1,0 +1,258 @@
+/* eslint-disable vue/one-component-per-file */
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, ref } from "vue";
+import storeCollections, {
+  type Collection,
+  type SmartCollection,
+  type VirtualCollection,
+} from "@/stores/collections";
+import type { SimpleRom } from "@/stores/roms";
+import storeGalleryRoms from "@/v2/stores/galleryRoms";
+import CollectionView from "./Collection.vue";
+
+const {
+  getRandomRom,
+  getRoms,
+  push,
+  routeGuards,
+  snackbarError,
+  snackbarInfo,
+} = vi.hoisted(() => ({
+  getRandomRom: vi.fn(),
+  getRoms: vi.fn(),
+  push: vi.fn(),
+  routeGuards: [] as ((to: {
+    name: string;
+    params: Record<string, string>;
+  }) => unknown)[],
+  snackbarError: vi.fn(),
+  snackbarInfo: vi.fn(),
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const { routeState } = vi.hoisted(() => ({
+  routeState: {
+    name: "collection",
+    path: "/collection/1",
+    params: { collection: "1" } as Record<string, string>,
+    query: {} as Record<string, string>,
+  },
+}));
+
+vi.mock("vue-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-router")>()),
+  useRoute: () => routeState,
+  useRouter: () => ({ push, replace: vi.fn() }),
+  // Captured rather than dropped: calling the guard is how a test moves
+  // the view to another collection, which is what the stale check watches.
+  onBeforeRouteUpdate: vi.fn((guard) => routeGuards.push(guard)),
+}));
+
+vi.mock("@/plugins/router", () => ({
+  ROUTES: { ROM: "rom", COLLECTIONS: "collections" },
+}));
+
+vi.mock("@/services/api/rom", () => ({
+  default: { getRandomRom, getRoms, bulkDownloadRoms: vi.fn() },
+}));
+
+vi.mock("@/services/api/collection", () => ({
+  default: { deleteCollection: vi.fn() },
+}));
+
+vi.mock("@v2/lib", () => ({
+  RDivider: defineComponent({ template: "<hr />" }),
+}));
+
+vi.mock("@/v2/components/Gallery/GalleryShell.vue", () => ({
+  default: defineComponent({
+    setup(_props, { expose }) {
+      expose({ applyRestoredScroll: vi.fn() });
+    },
+    template: "<main><slot name='header' /></main>",
+  }),
+}));
+
+vi.mock("@/v2/components/Gallery/CollectionHead.vue", () => ({
+  default: defineComponent({
+    emits: ["random"],
+    template: `<header><button class="random" @click="$emit('random')" /></header>`,
+  }),
+}));
+
+vi.mock("@/v2/components/Gallery/CollectionSettingsTab.vue", () => ({
+  default: defineComponent({ template: "<div />" }),
+}));
+
+vi.mock("@/v2/composables/useCan", () => ({
+  useCan: () => ref(true),
+}));
+
+vi.mock("@/v2/composables/useConfirm", () => ({
+  useConfirm: () => vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("@/v2/composables/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+vi.mock("@/v2/composables/useSnackbar", () => ({
+  useSnackbar: () => ({ error: snackbarError, info: snackbarInfo }),
+}));
+
+vi.mock("@/v2/composables/useWebpSupport", () => ({
+  useWebpSupport: () => ({
+    supportsWebp: ref(false),
+    toWebp: (url: string) => url,
+  }),
+}));
+
+function collection(id: number): Collection {
+  return { id, name: `Collection ${id}`, rom_count: 9000 } as Collection;
+}
+
+function rom(id: number): SimpleRom {
+  return { id, name: "Chrono Trigger" } as SimpleRom;
+}
+
+async function mountView() {
+  const galleryRoms = storeGalleryRoms();
+  vi.spyOn(galleryRoms, "fetchInitialMetadata").mockResolvedValue();
+
+  const wrapper = mount(CollectionView);
+  await flushPromises();
+  // Only what the button does is under test, not the view's own load flow.
+  getRoms.mockClear();
+  return wrapper;
+}
+
+describe("Collection view random rom", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    routeGuards.length = 0;
+    routeState.name = "collection";
+    routeState.params = { collection: "1" };
+    getRoms.mockResolvedValue({ data: { items: [], total: 0 } });
+    storeCollections().setCollections([collection(1), collection(2)]);
+  });
+
+  it("resolves a pick with a single scoped request", async () => {
+    // Issue #4068: the pick used to cost a count request plus a fetch at a
+    // random offset, and a scoped request is never cached, so the whole
+    // collection was re-walked on every click.
+    getRandomRom.mockResolvedValue({ data: rom(42) });
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+    await flushPromises();
+
+    expect(getRandomRom).toHaveBeenCalledTimes(1);
+    expect(getRandomRom).toHaveBeenCalledWith({ collectionId: 1 });
+    expect(getRoms).not.toHaveBeenCalled();
+    expect(push).toHaveBeenCalledWith({ name: "rom", params: { rom: 42 } });
+  });
+
+  it("scopes the pick to a virtual collection", async () => {
+    routeState.name = "virtual-collection";
+    routeState.params = { collection: "genre-rpg" };
+    storeCollections().setVirtualCollections([
+      { id: "genre-rpg", name: "RPG", rom_count: 12 } as VirtualCollection,
+    ]);
+    getRandomRom.mockResolvedValue({ data: rom(7) });
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+    await flushPromises();
+
+    expect(getRandomRom).toHaveBeenCalledWith({
+      virtualCollectionId: "genre-rpg",
+    });
+  });
+
+  it("scopes the pick to a smart collection", async () => {
+    routeState.name = "smart-collection";
+    routeState.params = { collection: "5" };
+    storeCollections().setSmartCollection([
+      { id: 5, name: "Unplayed", rom_count: 12 } as SmartCollection,
+    ]);
+    getRandomRom.mockResolvedValue({ data: rom(7) });
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+    await flushPromises();
+
+    expect(getRandomRom).toHaveBeenCalledWith({ smartCollectionId: 5 });
+  });
+
+  it("reports an empty collection without navigating", async () => {
+    getRandomRom.mockResolvedValue({ data: null });
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+    await flushPromises();
+
+    expect(snackbarInfo).toHaveBeenCalledWith("collection.empty");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed pick without navigating", async () => {
+    getRandomRom.mockRejectedValue(new Error("boom"));
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+    await flushPromises();
+
+    expect(snackbarError).toHaveBeenCalledWith("platform.random-rom-error");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("drops a pick that lands after the view moved to another collection", async () => {
+    let resolvePick: (value: { data: SimpleRom }) => void = () => {};
+    getRandomRom.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePick = resolve;
+      }),
+    );
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+
+    routeState.params = { collection: "2" };
+    routeGuards.forEach((guard) =>
+      guard({ name: "collection", params: { collection: "2" } }),
+    );
+    await flushPromises();
+
+    resolvePick({ data: rom(42) });
+    await flushPromises();
+
+    // The pick belongs to the collection the user left, so following it
+    // would drop them into a game from a gallery they closed.
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("ignores a click while a pick is in flight", async () => {
+    let resolvePick: (value: { data: SimpleRom }) => void = () => {};
+    getRandomRom.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePick = resolve;
+      }),
+    );
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+    await wrapper.get("button.random").trigger("click");
+
+    expect(getRandomRom).toHaveBeenCalledTimes(1);
+
+    resolvePick({ data: rom(42) });
+    await flushPromises();
+    expect(push).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/v2/views/Gallery/Collection.vue
+++ b/frontend/src/v2/views/Gallery/Collection.vue
@@ -267,8 +267,7 @@ function onDownload() {
 // ── Random ROM ──────────────────────────────────────────────────
 // Pick one game from this collection and jump to its details. The scope is
 // keyed off the collection kind so regular / virtual / smart all route
-// to the correct `getRoms` filter param (the same split the download
-// flow uses).
+// to the correct filter param (the same split the download flow uses).
 function randomScope(): {
   collectionId?: number;
   virtualCollectionId?: string;
@@ -282,37 +281,22 @@ function randomScope(): {
   return { collectionId: Number(c.id) };
 }
 
+// `/roms/random` samples the pick server-side, so one request resolves it
+// whatever the collection holds. `null` means the collection holds no roms.
 async function onRandomGame() {
   const c = currentCollection.value;
   if (!c || randomLoading.value) return;
   randomLoading.value = true;
   const scopeId = c.id;
-  const stale = () => currentCollection.value?.id !== scopeId;
   try {
-    const scope = randomScope();
-    const { data: head } = await romApi.getRoms({
-      ...scope,
-      limit: 1,
-      offset: 0,
-    });
-    if (stale()) return;
-    if (!head.total) {
+    const { data } = await romApi.getRandomRom(randomScope());
+    // A pick from the collection the user just left leads nowhere useful.
+    if (currentCollection.value?.id !== scopeId) return;
+    if (!data) {
       snackbar.info(t("collection.empty"));
       return;
     }
-    const randomOffset = Math.floor(Math.random() * head.total);
-    const { data } = await romApi.getRoms({
-      ...scope,
-      limit: 1,
-      offset: randomOffset,
-    });
-    if (stale()) return;
-    const pick = data.items[0];
-    if (!pick) {
-      snackbar.info(t("collection.empty"));
-      return;
-    }
-    router.push({ name: ROUTES.ROM, params: { rom: pick.id } });
+    router.push({ name: ROUTES.ROM, params: { rom: data.id } });
   } catch {
     snackbar.error(t("platform.random-rom-error"));
   } finally {

--- a/frontend/src/v2/views/Gallery/Platform.test.ts
+++ b/frontend/src/v2/views/Gallery/Platform.test.ts
@@ -1,0 +1,199 @@
+/* eslint-disable vue/one-component-per-file */
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, ref } from "vue";
+import storePlatforms, { type Platform } from "@/stores/platforms";
+import type { SimpleRom } from "@/stores/roms";
+import storeGalleryRoms from "@/v2/stores/galleryRoms";
+import PlatformView from "./Platform.vue";
+
+const {
+  getRandomRom,
+  getRoms,
+  getPlatform,
+  push,
+  snackbarError,
+  snackbarInfo,
+} = vi.hoisted(() => ({
+  getRandomRom: vi.fn(),
+  getRoms: vi.fn(),
+  getPlatform: vi.fn(),
+  push: vi.fn(),
+  snackbarError: vi.fn(),
+  snackbarInfo: vi.fn(),
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const { routeState } = vi.hoisted(() => ({
+  routeState: {
+    name: "platform",
+    path: "/platform/1",
+    params: { platform: "1" } as Record<string, string>,
+    query: {} as Record<string, string>,
+  },
+}));
+
+vi.mock("vue-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-router")>()),
+  useRoute: () => routeState,
+  useRouter: () => ({ push, replace: vi.fn() }),
+  onBeforeRouteUpdate: vi.fn(),
+}));
+
+vi.mock("@/plugins/router", () => ({
+  ROUTES: { ROM: "rom", UPLOAD: "upload" },
+}));
+
+vi.mock("@/services/api/rom", () => ({
+  default: { getRandomRom, getRoms, bulkDownloadRoms: vi.fn() },
+}));
+
+vi.mock("@/services/api/platform", () => ({
+  default: { getPlatform, deletePlatform: vi.fn() },
+}));
+
+vi.mock("@v2/lib", () => ({
+  RDivider: defineComponent({ template: "<hr />" }),
+}));
+
+vi.mock("@/v2/components/Gallery/GalleryShell.vue", () => ({
+  default: defineComponent({
+    setup(_props, { expose }) {
+      expose({ applyRestoredScroll: vi.fn() });
+    },
+    template: "<main><slot name='header' /></main>",
+  }),
+}));
+
+vi.mock("@/v2/components/Gallery/PlatformHead.vue", () => ({
+  default: defineComponent({
+    emits: ["random"],
+    template: `<header><button class="random" @click="$emit('random')" /></header>`,
+  }),
+}));
+
+vi.mock("@/v2/components/Gallery/FirmwareTab.vue", () => ({
+  default: defineComponent({ template: "<div />" }),
+}));
+
+vi.mock("@/v2/components/Gallery/ScanPlatformDialog.vue", () => ({
+  default: defineComponent({ template: "<div />" }),
+}));
+
+vi.mock("@/v2/components/Gallery/SettingsTab.vue", () => ({
+  default: defineComponent({ template: "<div />" }),
+}));
+
+vi.mock("@/v2/composables/useCan", () => ({
+  useCan: () => ref(true),
+}));
+
+vi.mock("@/v2/composables/useConfirm", () => ({
+  useConfirm: () => vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("@/v2/composables/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+vi.mock("@/v2/composables/useSnackbar", () => ({
+  useSnackbar: () => ({ error: snackbarError, info: snackbarInfo }),
+}));
+
+function platform(id: number): Platform {
+  return {
+    id,
+    name: "Super Nintendo",
+    display_name: "Super Nintendo",
+    slug: "snes",
+    fs_slug: "snes",
+    rom_count: 83000,
+  } as Platform;
+}
+
+function rom(id: number): SimpleRom {
+  return { id, name: "Chrono Trigger" } as SimpleRom;
+}
+
+async function mountView() {
+  const platforms = storePlatforms();
+  platforms.set([platform(1)]);
+  const galleryRoms = storeGalleryRoms();
+  vi.spyOn(galleryRoms, "fetchInitialMetadata").mockResolvedValue();
+
+  const wrapper = mount(PlatformView);
+  await flushPromises();
+  // Only what the button does is under test, not the view's own load flow.
+  getRoms.mockClear();
+  return wrapper;
+}
+
+describe("Platform view random rom", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    getPlatform.mockResolvedValue({ data: platform(1) });
+    getRoms.mockResolvedValue({ data: { items: [], total: 0 } });
+  });
+
+  it("resolves a pick with a single scoped request", async () => {
+    // Issue #4068: the pick used to cost a count request plus a fetch at a
+    // random offset, each of them also building the char index, the filter
+    // values and the rom id index for the whole platform.
+    getRandomRom.mockResolvedValue({ data: rom(42) });
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+    await flushPromises();
+
+    expect(getRandomRom).toHaveBeenCalledTimes(1);
+    expect(getRandomRom).toHaveBeenCalledWith({ platformIds: [1] });
+    expect(getRoms).not.toHaveBeenCalled();
+    expect(push).toHaveBeenCalledWith({ name: "rom", params: { rom: 42 } });
+  });
+
+  it("reports an empty platform without navigating", async () => {
+    getRandomRom.mockResolvedValue({ data: null });
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+    await flushPromises();
+
+    expect(snackbarInfo).toHaveBeenCalledWith("platform.random-rom-empty");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed pick without navigating", async () => {
+    getRandomRom.mockRejectedValue(new Error("boom"));
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+    await flushPromises();
+
+    expect(snackbarError).toHaveBeenCalledWith("platform.random-rom-error");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("ignores a click while a pick is in flight", async () => {
+    let resolvePick: (value: { data: SimpleRom }) => void = () => {};
+    getRandomRom.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePick = resolve;
+      }),
+    );
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+    await wrapper.get("button.random").trigger("click");
+
+    expect(getRandomRom).toHaveBeenCalledTimes(1);
+
+    resolvePick({ data: rom(42) });
+    await flushPromises();
+    expect(push).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/v2/views/Gallery/Platform.vue
+++ b/frontend/src/v2/views/Gallery/Platform.vue
@@ -326,36 +326,20 @@ function onScan() {
 }
 
 // Random ROM — pick one game from this platform and jump to its
-// details. Mirrors the Home RandomPickWidget approach: a cheap
-// count-only fetch gives the `total`, then a single-item fetch at a
-// random offset resolves the ROM. Scoped to the current platform via
-// `platformIds`.
+// details. Mirrors the Home RandomPickWidget: `/roms/random` samples the
+// pick server-side, so one request resolves it whatever the platform
+// holds. `null` means the platform holds no roms.
 async function onRandomGame() {
   const p = currentPlatform.value;
   if (!p || randomLoading.value) return;
   randomLoading.value = true;
   try {
-    const { data: head } = await romApi.getRoms({
-      platformIds: [p.id],
-      limit: 1,
-      offset: 0,
-    });
-    if (!head.total) {
+    const { data } = await romApi.getRandomRom({ platformIds: [p.id] });
+    if (!data) {
       snackbar.info(t("platform.random-rom-empty"));
       return;
     }
-    const randomOffset = Math.floor(Math.random() * head.total);
-    const { data } = await romApi.getRoms({
-      platformIds: [p.id],
-      limit: 1,
-      offset: randomOffset,
-    });
-    const pick = data.items[0];
-    if (!pick) {
-      snackbar.info(t("platform.random-rom-empty"));
-      return;
-    }
-    router.push({ name: ROUTES.ROM, params: { rom: pick.id } });
+    router.push({ name: ROUTES.ROM, params: { rom: data.id } });
   } catch {
     snackbar.error(t("platform.random-rom-error"));
   } finally {


### PR DESCRIPTION
### Description

**Description**

The v2 gallery "Random ROM" button (platform and collection pages) resolved a pick with two `/api/roms` list requests: one with `limit=1` to read `total`, then a second one at a random offset. Both are scoped requests, which are never served from the filter cache, and each one additionally builds the A-Z character index, the filter values and the full ROM id index for the entire scope. That cost is paid on every click and grows with the library.

Reported in #4068, measured on a platform holding ~83k games:

|        | requests | payload  | time   |
| ------ | -------- | -------- | ------ |
| before | 2        | 878 KB   | 7.19 s |
| after  | 1        | 16.9 KB  | 0.27 s |

#4071 added `GET /api/roms/random`, which samples the pick on the primary key server-side and returns `SimpleRomSchema | None` in constant time. Both gallery buttons now go through `romApi.getRandomRom()`, so a pick is one small request whatever the scope holds, and `null` means the scope is empty. No API change and no component signature change.

`Collection.vue` keeps its `randomScope()` split, so regular / virtual / smart collections still map to `collection_id` / `virtual_collection_id` / `smart_collection_id`, and keeps its guard against a pick that lands after the user moved to another collection (now one check instead of two, since there is only one await).

The v1 `RandomBtn.vue` and `ContextualRandomBtn.vue` still hold the old two-call shape and are deliberately untouched: v1 is frozen, and editing them would trip `check-v1-frozen`.

**Files changed**

- `frontend/src/v2/views/Gallery/Platform.vue` - `onRandomGame()` issues a single `romApi.getRandomRom({ platformIds: [p.id] })`; `null` drives the existing "no ROMs in this platform" snackbar.
- `frontend/src/v2/views/Gallery/Collection.vue` - same rewire, scoped through the existing `randomScope()`; the two stale-collection checks collapse into one.
- `frontend/src/v2/views/Gallery/Platform.test.ts` (new) - 4 tests: one scoped request with no `getRoms` call and navigation to the pick, empty platform, failed pick, click ignored while a pick is in flight.
- `frontend/src/v2/views/Gallery/Collection.test.ts` (new) - 7 tests: the same four plus the virtual and smart scope shapes, and a pick that resolves after the view moved to another collection.

**Testing**

- `npm run test`: 647 tests across 54 files pass, 11 of them new.
- `vue-tsc` clean over `src/` (the remaining `e2e/*.spec.ts` errors are pre-existing locally: `@playwright/test` is not installed on this machine, and no e2e file was touched).
- `trunk fmt && trunk check` clean on all four files.
- Browser-verified headlessly against a dev stack, on a platform gallery and on a genre virtual collection: exactly one `/api/roms/random` per click, zero `limit=1` list requests, and the router lands on the picked ROM.
- No backend change; the backend suite was run anyway and is green (2731 passed, 2 skipped).

**Anything a reviewer should look at**

1. `Platform.vue` still has no stale-scope guard, while `Collection.vue` does. That asymmetry predates this PR and the race window shrank from seconds to milliseconds, so I left it alone rather than widen the diff. Happy to add it here or open a follow-up, whichever you prefer.
2. The empty-scope message is now driven by `data === null`. The endpoint also returns `null` when the sampled ROM fails its post-fetch `can_see_rom()` re-check, so in a rare race (a ROM moving to a hidden platform mid-request) a user could see the "empty" copy on a non-empty scope. That is the endpoint's deliberate choice from #4071, where `null` keeps a hidden ROM indistinguishable from an empty scope.
3. These are the first view-level tests for `Platform.vue` and `Collection.vue`, so the mock surface is wide: `GalleryShell` has to `expose({ applyRestoredScroll })` because the views call it through a template ref, and the head components are stubbed down to a button that emits `random`. If you would rather see thinner coverage, say so and I will trim.
4. `Collection.vue` reports failures with the `platform.random-rom-error` key. That cross-namespace reuse is pre-existing and out of scope here.

> AI assistance disclosure: this PR was written primarily by Claude Code (Opus 5), including the code, the unit tests and this description. I reviewed the diff, ran the suites and verified the behaviour in a browser before opening it.

Fixes #4068

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

Not applicable: no visual change, the button behaves identically and only resolves faster.
