### PR TITLE
perf(home): stop counting the whole library for the two home rows

### DIFF
--- a/frontend/src/services/api/rom.ts
+++ b/frontend/src/services/api/rom.ts
@@ -373,6 +373,7 @@ async function getRecentRoms() {
       with_char_index: false,
       with_filter_values: false,
       with_rom_id_index: false,
+      with_total: false,
     },
   });
 }
@@ -386,6 +387,7 @@ async function getRecentPlayedRoms() {
       with_char_index: false,
       with_filter_values: false,
       with_rom_id_index: false,
+      with_total: false,
       last_played: true,
     },
   });

--- a/frontend/src/services/cache/api.test.ts
+++ b/frontend/src/services/cache/api.test.ts
@@ -1,0 +1,82 @@
+import type { AxiosRequestConfig, AxiosResponse } from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  RECENT_PLAYED_ROMS_LIMIT,
+  RECENT_ROMS_LIMIT,
+} from "@/services/api/rom";
+import cacheService from "@/services/cache";
+import cachedApiService from "@/services/cache/api";
+
+vi.mock("@/services/cache", () => ({
+  default: {
+    request: vi.fn(),
+    clearCacheForPattern: vi.fn(),
+    clearCache: vi.fn(),
+    getCacheSize: vi.fn(),
+  },
+}));
+
+const noop = () => undefined;
+
+// Mirrors CacheService.generateCacheKey, so the assertions below exercise the
+// same string the real cache stores entries under.
+function cacheKeyFor(params: AxiosRequestConfig["params"]): string {
+  const queryString = params ? new URLSearchParams(params).toString() : "";
+  return `${window.location.origin}/roms${queryString ? `?${queryString}` : ""}`;
+}
+
+function requestParams(callIndex = 0): AxiosRequestConfig["params"] {
+  return vi.mocked(cacheService.request).mock.calls[callIndex][0].params;
+}
+
+function clearedPattern(callIndex = 0): string {
+  return vi.mocked(cacheService.clearCacheForPattern).mock.calls[callIndex][0];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(cacheService.request).mockResolvedValue({
+    data: { items: [] },
+  } as AxiosResponse);
+  vi.mocked(cacheService.clearCacheForPattern).mockResolvedValue(undefined);
+});
+
+describe("home row requests", () => {
+  it("does not make the server count the library for recently added", async () => {
+    await cachedApiService.getRecentRoms(noop);
+
+    expect(requestParams()).toMatchObject({
+      limit: RECENT_ROMS_LIMIT,
+      with_total: false,
+    });
+  });
+
+  it("does not make the server count the library for recently played", async () => {
+    await cachedApiService.getRecentPlayedRoms(noop);
+
+    expect(requestParams()).toMatchObject({
+      limit: RECENT_PLAYED_ROMS_LIMIT,
+      with_total: false,
+    });
+  });
+});
+
+describe("home row cache invalidation", () => {
+  // The clear patterns repeat the request's parameter map, and
+  // clearCacheForPattern matches by substring. Any parameter added to one side
+  // but not the other, or added in a different position, silently stops the row
+  // from ever being invalidated.
+  it("clears the entry recently added actually wrote", async () => {
+    await cachedApiService.getRecentRoms(noop);
+    await cachedApiService.clearRecentRomsCache();
+
+    expect(cacheKeyFor(requestParams())).toContain(clearedPattern());
+  });
+
+  it("clears the entry recently played actually wrote", async () => {
+    await cachedApiService.getRecentPlayedRoms(noop);
+    await cachedApiService.clearRecentPlayedRomsCache();
+
+    expect(cacheKeyFor(requestParams())).toContain(clearedPattern());
+  });
+});

--- a/frontend/src/services/cache/api.ts
+++ b/frontend/src/services/cache/api.ts
@@ -9,6 +9,32 @@ import type { CustomLimitOffsetPage_SimpleRomSchema_ as GetRomsResponse } from "
 import type { GetRomsParams } from "@/services/api/rom";
 import cacheService from "@/services/cache";
 
+// The home rows render a fixed number of covers and never show a total, so they
+// opt out of the whole-library count. Each map is shared by the request and its
+// cache-clear pattern: the pattern is matched against the cache key by
+// substring, so a parameter present on one side but not the other would leave
+// the row permanently stale.
+const RECENT_ROMS_PARAMS = {
+  order_by: "id",
+  order_dir: "desc",
+  limit: 15,
+  with_char_index: false,
+  with_filter_values: false,
+  with_rom_id_index: false,
+  with_total: false,
+} as const;
+
+const RECENT_PLAYED_ROMS_PARAMS = {
+  order_by: "last_played",
+  order_dir: "desc",
+  limit: 15,
+  with_char_index: false,
+  with_filter_values: false,
+  with_rom_id_index: false,
+  with_total: false,
+  last_played: true,
+} as const;
+
 class CachedApiService {
   private createRequestConfig(
     method: Method,
@@ -164,14 +190,7 @@ class CachedApiService {
   async getRecentRoms(
     onBackgroundUpdate: (data: GetRomsResponse) => void,
   ): Promise<AxiosResponse<GetRomsResponse>> {
-    const config = this.createRequestConfig("GET", "/roms", {
-      order_by: "id",
-      order_dir: "desc",
-      limit: 15,
-      with_char_index: false,
-      with_filter_values: false,
-      with_rom_id_index: false,
-    });
+    const config = this.createRequestConfig("GET", "/roms", RECENT_ROMS_PARAMS);
 
     return cacheService.request<GetRomsResponse>(config, onBackgroundUpdate);
   }
@@ -179,15 +198,11 @@ class CachedApiService {
   async getRecentPlayedRoms(
     onBackgroundUpdate: (data: GetRomsResponse) => void,
   ): Promise<AxiosResponse<GetRomsResponse>> {
-    const config = this.createRequestConfig("GET", "/roms", {
-      order_by: "last_played",
-      order_dir: "desc",
-      limit: 15,
-      with_char_index: false,
-      with_filter_values: false,
-      with_rom_id_index: false,
-      last_played: true,
-    });
+    const config = this.createRequestConfig(
+      "GET",
+      "/roms",
+      RECENT_PLAYED_ROMS_PARAMS,
+    );
 
     return cacheService.request<GetRomsResponse>(config, onBackgroundUpdate);
   }
@@ -198,26 +213,11 @@ class CachedApiService {
   }
 
   async clearRecentRomsCache() {
-    await this.clearRomsCache({
-      order_by: "id",
-      order_dir: "desc",
-      limit: 15,
-      with_char_index: false,
-      with_filter_values: false,
-      with_rom_id_index: false,
-    });
+    await this.clearRomsCache(RECENT_ROMS_PARAMS);
   }
 
   async clearRecentPlayedRomsCache() {
-    await this.clearRomsCache({
-      order_by: "last_played",
-      order_dir: "desc",
-      limit: 15,
-      with_char_index: false,
-      with_filter_values: false,
-      with_rom_id_index: false,
-      last_played: true,
-    });
+    await this.clearRomsCache(RECENT_PLAYED_ROMS_PARAMS);
   }
 
   // Cache management methods


### PR DESCRIPTION
**Description**

Fixes #4099

The home page renders two fixed rows, "Recently added" and "Continue playing", each requesting 15 games. Both also asked the server to count the result set and then discarded the number, since the rows only ever draw 15 covers.

`GET /api/roms` already accepts `with_total` (added for the gallery in #4062). This passes `with_total=false` on both home requests.

Measured against a real 83,130-game library (RomM 5.1.1-beta.1), median of 8 alternated runs:

| Home row | count ON | count OFF | saved |
| --- | --- | --- | --- |
| Recently added | 0.299s | 0.163s | 0.137s (~46%) |
| Continue playing | 0.675s | 0.689s | none (within noise) |

The win is concentrated in "Recently added", whose count spans the whole library. "Continue playing" carries `last_played=true`, so its count covers only the played subset (90 rows here) and was never expensive. The flag is applied there too for symmetry and because the saving scales with a user's played library, but it is not where the time goes: with the count already off, that request measures 0.168s unfiltered, 0.477s once the `last_played` filter is applied, and 0.692s once sorted by `last_played`. That cost belongs to #4067, not here.

#4062 deliberately left these two alone. The home rows go through the client-side Cache API layer, where `clearCacheForPattern` does a **substring** match against a cache key built as `new URLSearchParams(params).toString()`. The request params and the cache-clear pattern were two independent copies of the same literal map, so adding a parameter to one side and not the other, or at a different position, would silently stop those rows from ever being invalidated again.

So rather than introduce a fourth copy of the literal, each row's params now live in a single `const` that both the request and its clear pattern read from, which makes the desync unrepresentable rather than merely avoided.

**Testing**

- `npm run test` - 53 files, 640 tests passing (up 4, all additive; no existing test changed).
- `npm run typecheck` - clean. `trunk fmt && trunk check` - no issues.
- The two invalidation tests were checked for vacuousness rather than assumed to work: injecting the exact half-done change the issue warns about (adding `with_total` to the clear pattern only) makes both fail, and they pass again once reverted.
- Verified against a live 83,130-game 5.1.1-beta.1 instance using the exact query strings the branch emits. `with_total=false` returns `total: null` with the same 15 items in the same order; the response envelope keys and every per-item field are otherwise unchanged. Timings above.
- Not exercised through the browser UI. There is no visual change and both rows already ignore `total`, but end-to-end confirmation would be watching the two home `/api/roms` requests carry `with_total=false`.

**Anything a reviewer should pay attention to**

1. **The parameter maps are the contract.** Anything added to these two rows must be added to the `const`, never at a call site. A parameter present on the request but not the clear pattern (or in a different order) makes the cache key stop matching the clear pattern, and the row goes permanently stale with no error. That hazard is exactly why this was carved out of #4062, and the two invariant tests exist to catch it.
2. **`total` is now `null` for these two responses.** Verified nothing consumes it: `stores/roms.ts` destructures only `items`, and both home views read the resulting store arrays. `CustomLimitOffsetPage_SimpleRomSchema_.total` is already typed `number | null`, so no regeneration is needed.
3. **No backend change.** `resolve_total()` already returns `None` when `with_total` is false and the ROM id index is not being built, which is what both rows send.
4. **The shared maps are safe to share.** Both consumers treat `config.params` as read-only: the axios `paramsSerializer` and `CacheService.generateCacheKey` each construct a fresh `URLSearchParams`. Nothing mutates the object, so the request and the clear pattern cannot diverge at runtime.
5. **Not a frozen path.** The change is confined to `src/services/**`; the v1 freeze gate covers `frontend/src/{views,components,console,layouts}/**`. Both the v1 and v2 home pages benefit, since they share `stores/roms.ts`.

**AI Assistance Disclosure**

AI assistance (Claude Code) was used for this contribution, covering code generation, the unit tests, and this pull request description. All changes were reviewed and verified locally by me before submission. Any replies I post on this PR are written by me unless stated otherwise.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes