### PR TITLE
fix(v2): drop a random pick after leaving the platform

### DIFF
--- a/frontend/src/v2/views/Gallery/Collection.test.ts
+++ b/frontend/src/v2/views/Gallery/Collection.test.ts
@@ -237,6 +237,37 @@ describe("Collection view random rom", () => {
     expect(push).not.toHaveBeenCalled();
   });
 
+  it("stays quiet when a pick fails after the view moved to another collection", async () => {
+    let failPick: (reason: Error) => void = () => {};
+    getRandomRom.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        failPick = reject;
+      }),
+    );
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+
+    routeState.params = { collection: "2" };
+    routeGuards.forEach((guard) =>
+      guard({ name: "collection", params: { collection: "2" } }),
+    );
+    await flushPromises();
+
+    failPick(new Error("boom"));
+    await flushPromises();
+
+    expect(snackbarError).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+
+    // The button still works on the collection the user landed on.
+    getRandomRom.mockResolvedValue({ data: rom(7) });
+    await wrapper.get("button.random").trigger("click");
+    await flushPromises();
+
+    expect(push).toHaveBeenCalledWith({ name: "rom", params: { rom: 7 } });
+  });
+
   it("ignores a click while a pick is in flight", async () => {
     let resolvePick: (value: { data: SimpleRom }) => void = () => {};
     getRandomRom.mockReturnValue(

--- a/frontend/src/v2/views/Gallery/Collection.vue
+++ b/frontend/src/v2/views/Gallery/Collection.vue
@@ -288,17 +288,18 @@ async function onRandomGame() {
   if (!c || randomLoading.value) return;
   randomLoading.value = true;
   const scopeId = c.id;
+  // A pick from the collection the user just left leads nowhere useful.
+  const stale = () => currentCollection.value?.id !== scopeId;
   try {
     const { data } = await romApi.getRandomRom(randomScope());
-    // A pick from the collection the user just left leads nowhere useful.
-    if (currentCollection.value?.id !== scopeId) return;
+    if (stale()) return;
     if (!data) {
       snackbar.info(t("collection.empty"));
       return;
     }
     router.push({ name: ROUTES.ROM, params: { rom: data.id } });
   } catch {
-    snackbar.error(t("platform.random-rom-error"));
+    if (!stale()) snackbar.error(t("platform.random-rom-error"));
   } finally {
     randomLoading.value = false;
   }

--- a/frontend/src/v2/views/Gallery/Platform.test.ts
+++ b/frontend/src/v2/views/Gallery/Platform.test.ts
@@ -137,6 +137,17 @@ function deferRandomRom() {
   return (pick: SimpleRom | null) => settle({ data: pick });
 }
 
+/** Rejects the promise the next `getRandomRom` call returns, on demand. */
+function deferRandomRomFailure() {
+  let fail: (reason: Error) => void = () => {};
+  getRandomRom.mockReturnValueOnce(
+    new Promise((_resolve, reject) => {
+      fail = reject;
+    }),
+  );
+  return () => fail(new Error("boom"));
+}
+
 /** Moves the view to another platform the way the router would. */
 async function navigateTo(platformId: number) {
   routeState.params = { platform: String(platformId) };
@@ -227,6 +238,28 @@ describe("Platform view random rom", () => {
     await flushPromises();
 
     expect(push).not.toHaveBeenCalled();
+  });
+
+  it("stays quiet when a pick fails after the view moved to another platform", async () => {
+    const failPick = deferRandomRomFailure();
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+
+    await navigateTo(2);
+
+    failPick();
+    await flushPromises();
+
+    expect(snackbarError).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+
+    // The button still works on the platform the user landed on.
+    getRandomRom.mockResolvedValue({ data: rom(7) });
+    await wrapper.get("button.random").trigger("click");
+    await flushPromises();
+
+    expect(push).toHaveBeenCalledWith({ name: "rom", params: { rom: 7 } });
   });
 
   // A same-platform reload swaps in a fresh `Platform` record, so the check

--- a/frontend/src/v2/views/Gallery/Platform.test.ts
+++ b/frontend/src/v2/views/Gallery/Platform.test.ts
@@ -13,6 +13,7 @@ const {
   getRoms,
   getPlatform,
   push,
+  routeGuards,
   snackbarError,
   snackbarInfo,
 } = vi.hoisted(() => ({
@@ -20,6 +21,10 @@ const {
   getRoms: vi.fn(),
   getPlatform: vi.fn(),
   push: vi.fn(),
+  routeGuards: [] as ((to: {
+    name: string;
+    params: Record<string, string>;
+  }) => unknown)[],
   snackbarError: vi.fn(),
   snackbarInfo: vi.fn(),
 }));
@@ -41,7 +46,9 @@ vi.mock("vue-router", async (importOriginal) => ({
   ...(await importOriginal<typeof import("vue-router")>()),
   useRoute: () => routeState,
   useRouter: () => ({ push, replace: vi.fn() }),
-  onBeforeRouteUpdate: vi.fn(),
+  // Captured rather than dropped: calling the guard is how a test moves
+  // the view to another platform, which is what the stale check watches.
+  onBeforeRouteUpdate: vi.fn((guard) => routeGuards.push(guard)),
 }));
 
 vi.mock("@/plugins/router", () => ({
@@ -104,13 +111,13 @@ vi.mock("@/v2/composables/useSnackbar", () => ({
   useSnackbar: () => ({ error: snackbarError, info: snackbarInfo }),
 }));
 
-function platform(id: number): Platform {
+function platform(id: number, name = "Super Nintendo"): Platform {
   return {
     id,
-    name: "Super Nintendo",
-    display_name: "Super Nintendo",
-    slug: "snes",
-    fs_slug: "snes",
+    name,
+    display_name: name,
+    slug: `platform-${id}`,
+    fs_slug: `platform-${id}`,
     rom_count: 83000,
   } as Platform;
 }
@@ -119,9 +126,30 @@ function rom(id: number): SimpleRom {
   return { id, name: "Chrono Trigger" } as SimpleRom;
 }
 
+/** Resolves the promise the next `getRandomRom` call returns, on demand. */
+function deferRandomRom() {
+  let settle: (value: { data: SimpleRom | null }) => void = () => {};
+  getRandomRom.mockReturnValueOnce(
+    new Promise((resolve) => {
+      settle = resolve;
+    }),
+  );
+  return (pick: SimpleRom | null) => settle({ data: pick });
+}
+
+/** Moves the view to another platform the way the router would. */
+async function navigateTo(platformId: number) {
+  routeState.params = { platform: String(platformId) };
+  routeState.path = `/platform/${platformId}`;
+  routeGuards.forEach((guard) =>
+    guard({ name: "platform", params: { platform: String(platformId) } }),
+  );
+  await flushPromises();
+}
+
 async function mountView() {
   const platforms = storePlatforms();
-  platforms.set([platform(1)]);
+  platforms.set([platform(1), platform(2, "Mega Drive")]);
   const galleryRoms = storeGalleryRoms();
   vi.spyOn(galleryRoms, "fetchInitialMetadata").mockResolvedValue();
 
@@ -136,7 +164,13 @@ describe("Platform view random rom", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
-    getPlatform.mockResolvedValue({ data: platform(1) });
+    routeState.name = "platform";
+    routeState.path = "/platform/1";
+    routeState.params = { platform: "1" };
+    routeGuards.length = 0;
+    getPlatform.mockImplementation((id: number) =>
+      Promise.resolve({ data: platform(id) }),
+    );
     getRoms.mockResolvedValue({ data: { items: [], total: 0 } });
   });
 
@@ -176,6 +210,39 @@ describe("Platform view random rom", () => {
 
     expect(snackbarError).toHaveBeenCalledWith("platform.random-rom-error");
     expect(push).not.toHaveBeenCalled();
+  });
+
+  // Issue #4104: the pick is scoped to the platform that was on screen when
+  // the button was clicked, so following it after the user moved on drops
+  // them into a game from a gallery they already left.
+  it("drops a pick that lands after the view moved to another platform", async () => {
+    const resolvePick = deferRandomRom();
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+
+    await navigateTo(2);
+
+    resolvePick(rom(42));
+    await flushPromises();
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  // A same-platform reload swaps in a fresh `Platform` record, so the check
+  // has to compare ids rather than object identity.
+  it("still navigates when the view reloaded the same platform", async () => {
+    const resolvePick = deferRandomRom();
+
+    const wrapper = await mountView();
+    await wrapper.get("button.random").trigger("click");
+
+    await navigateTo(1);
+
+    resolvePick(rom(42));
+    await flushPromises();
+
+    expect(push).toHaveBeenCalledWith({ name: "rom", params: { rom: 42 } });
   });
 
   it("ignores a click while a pick is in flight", async () => {

--- a/frontend/src/v2/views/Gallery/Platform.vue
+++ b/frontend/src/v2/views/Gallery/Platform.vue
@@ -333,8 +333,14 @@ async function onRandomGame() {
   const p = currentPlatform.value;
   if (!p || randomLoading.value) return;
   randomLoading.value = true;
+  const scopeId = p.id;
+  // The pick belongs to the platform that was on screen when the button was
+  // clicked; following it after the user moved on would drop them into a
+  // game from a gallery they already left.
+  const stale = () => currentPlatform.value?.id !== scopeId;
   try {
-    const { data } = await romApi.getRandomRom({ platformIds: [p.id] });
+    const { data } = await romApi.getRandomRom({ platformIds: [scopeId] });
+    if (stale()) return;
     if (!data) {
       snackbar.info(t("platform.random-rom-empty"));
       return;

--- a/frontend/src/v2/views/Gallery/Platform.vue
+++ b/frontend/src/v2/views/Gallery/Platform.vue
@@ -347,7 +347,7 @@ async function onRandomGame() {
     }
     router.push({ name: ROUTES.ROM, params: { rom: data.id } });
   } catch {
-    snackbar.error(t("platform.random-rom-error"));
+    if (!stale()) snackbar.error(t("platform.random-rom-error"));
   } finally {
     randomLoading.value = false;
   }


### PR DESCRIPTION
**Description**

The v2 platform gallery resolves "Random ROM" over two requests: a count-only
fetch for `total`, then a single-item fetch at a random offset. Neither result
was re-checked against the platform still on screen, so on a large library the
pick could land after the user had already switched platforms and navigate them
into a game from the gallery they just left.

`onRandomGame()` now captures the platform id at click time and compares it
against `currentPlatform` after each await, discarding a stale pick silently.
Because the first check sits between the two requests, leaving the platform now
also skips the second request instead of firing it and throwing the result away.

The same staleness check also gates the error handler: these requests are issued
without an abort `signal`, so navigating away never cancels them, and one that
failed afterwards still raised "Couldn't pick a random ROM" for the platform the
user had left. Thanks to Greptile for catching that path.

The collection gallery already carried the scope capture and the post-await
checks, but had the same unconditional error handler, so it gets the one-line
mirror here to keep the two galleries behaving identically.

Fixes #4104

**Files changed**

- `frontend/src/v2/views/Gallery/Platform.vue`: capture `scopeId` at click time,
  add a `stale()` check after both awaits, and scope both requests to `scopeId`
  rather than re-reading the live platform. The `catch` is gated on the same
  check. Every early return sits inside the existing `try`, so `finally` still
  clears `randomLoading` and the button never wedges.
- `frontend/src/v2/views/Gallery/Platform.test.ts` (new): 8 mount-level cases for
  the random pick. Two hold a request in flight and move the view to another
  platform (one per await point) and assert no navigation happens, one rejects an
  in-flight request after the move and asserts no snackbar, one pins that a
  same-platform reload still navigates, and the rest cover the scoped happy path
  plus the empty, failed, and already-in-flight branches.
- `frontend/src/v2/views/Gallery/Collection.vue`: mirror of the same error-path
  guard. It already captured the collection id and checked both awaits, so the
  unconditional `catch` was the only piece out of step.
- `frontend/src/v2/views/Gallery/Collection.test.ts` (new): three cases for the
  collection random pick, covering the scoped happy path, a stale resolved pick,
  and a stale rejection.

**Testing**

- `npx vitest run src/v2/views/Gallery/`: 11/11. Each new guard was written
  test-first, so every stale case fails against the unpatched view and passes
  after. The two stale-rejection cases also click again afterwards to prove
  `finally` still cleared the loading flag.
- Full frontend suite: 647 passed, 54 files. `vue-tsc` clean. `trunk fmt` and
  `trunk check` clean. Backend suite unaffected and green (2731 passed, 2
  skipped).
- Browser-verified against a local dev stack with Playwright stalling only the
  two `limit=1` `/api/roms` requests to widen the window, then navigating in-app
  (platform 1, platforms index, platform 2) rather than reloading. Before the
  fix the run ended on `/rom/2`, a platform 1 game, while sitting on
  `/platform/2`. After the fix it stays on `/platform/2` and the second request
  is never issued.

**Anything a reviewer should look at**

- The check compares ids, not object identity, on purpose: the view's background
  `platformApi.getPlatform` refresh swaps in a fresh `Platform` record for the
  same platform, and an identity check would wrongly discard a valid pick after
  a same-platform reload. There is a test for exactly that.
- A stale pick is dropped without a snackbar, on both the success and the failure
  path. The user has already moved on, so feedback about a gallery they left
  would be noise.
- Known residual, deliberately out of scope: `stale()` keys off the loaded
  gallery scope, which is only cleared when another gallery view mounts, so
  navigating to a non-gallery route (Home, Settings) with a pick in flight can
  still navigate. Both galleries share that behaviour.
- Overlaps open PR #4097, which rewrites the platform function onto a single
  `getRandomRom` call. Whichever lands second needs a small rebase: on the
  single-request shape this collapses to one `stale()` check, and the two
  `Platform.test.ts` files need merging. Happy to rebase this one on top if
  #4097 goes first.

**AI Assistance**

This PR (code, tests, and description) was written primarily by Claude Code,
reviewed and verified by me locally.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

Not applicable, no visual change. The fix is the absence of an unwanted
navigation and of an unwanted error snackbar.
