### PR TITLE
fix(v2): keep Playmatch selectable when providers are set to All

### DIFF
--- a/frontend/src/v2/components/Dialogs/RefreshMetadataDialog.vue
+++ b/frontend/src/v2/components/Dialogs/RefreshMetadataDialog.vue
@@ -15,45 +15,17 @@ import {
   RSwitch,
   RTooltip,
 } from "@v2/lib";
-import { useLocalStorage } from "@vueuse/core";
 import type { Emitter } from "mitt";
-import { storeToRefs } from "pinia";
 import { computed, inject, onBeforeUnmount, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import socket from "@/services/socket";
-import storeConfig from "@/stores/config";
-import storeHeartbeat, { type MetadataOption } from "@/stores/heartbeat";
 import { type SimpleRom } from "@/stores/roms";
 import storeScanning from "@/stores/scanning";
 import type { Events } from "@/types/emitter";
+import { useScanProviders } from "@/v2/composables/useScanProviders";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
 
 defineOptions({ inheritAttrs: false });
-
-const LOCAL_STORAGE_METADATA_SOURCES_KEY = "scan.metadataSources";
-const LOCAL_STORAGE_LAUNCHBOX_REMOTE_ENABLED_KEY =
-  "scan.launchboxRemoteEnabled";
-const LOCAL_STORAGE_HASHEOUS_ENABLED_KEY = "scan.hasheousEnabled";
-const LOCAL_STORAGE_PLAYMATCH_ENABLED_KEY = "scan.playmatchEnabled";
-
-// Hash-matcher providers — proxies that match files by hash and feed
-// IDs into the primary catalogs. Filtered out of the main provider
-// select and rendered as switch pills so users don't read them as
-// standalone sources.
-const HASH_MATCHER_KEYS = ["hasheous", "playmatch"] as const;
-
-// Provider categorisation — mirrors the Scan view's split so this
-// dialog reads as a sibling surface, not a parallel vocabulary.
-const GENERAL_PROVIDER_KEYS = new Set([
-  "igdb",
-  "ss",
-  "moby",
-  "launchbox",
-  "flashpoint",
-  "gamelist",
-  "libretro",
-]);
-const SPECIFIC_PROVIDER_KEYS = new Set(["ra", "sgdb", "hltb"]);
 
 const { t } = useI18n();
 const emitter = inject<Emitter<Events>>("emitter");
@@ -64,138 +36,24 @@ const show = ref(false);
 // normalise to an array so the scan emit groups by platform without
 // branching on the input shape.
 const roms = ref<SimpleRom[]>([]);
-const heartbeat = storeHeartbeat();
 const scanningStore = storeScanning();
-const configStore = storeConfig();
-const { config } = storeToRefs(configStore);
 
-const calculateHashes = computed(() => !config.value.SKIP_HASH_CALCULATION);
-
-const metadataOptions = computed(() =>
-  heartbeat
-    .getMetadataOptionsByPriority()
-    .filter(
-      (option) =>
-        !(HASH_MATCHER_KEYS as readonly string[]).includes(option.value),
-    )
-    .map((option) => {
-      const requiresHashes = option.value === "ra";
-      const hashingDisabled = !calculateHashes.value;
-      let disabled = option.disabled;
-      if (hashingDisabled && requiresHashes) {
-        disabled = t("scan.requires-hashes", { source: option.name });
-      }
-      const name = option.value === "igdb" ? "IGDB" : option.name;
-      return { ...option, name, disabled };
-    }),
-);
-
-const generalProviders = computed<MetadataOption[]>(() =>
-  metadataOptions.value.filter((o) => GENERAL_PROVIDER_KEYS.has(o.value)),
-);
-const specificProviders = computed<MetadataOption[]>(() =>
-  metadataOptions.value.filter((o) => SPECIFIC_PROVIDER_KEYS.has(o.value)),
-);
-
-const storedMetadataSources = useLocalStorage(
-  LOCAL_STORAGE_METADATA_SOURCES_KEY,
-  [] as string[],
-);
-const launchboxRemoteEnabled = useLocalStorage(
-  LOCAL_STORAGE_LAUNCHBOX_REMOTE_ENABLED_KEY,
-  true,
-);
-const hasheousEnabled = useLocalStorage(
-  LOCAL_STORAGE_HASHEOUS_ENABLED_KEY,
-  true,
-);
-const playmatchEnabled = useLocalStorage(
-  LOCAL_STORAGE_PLAYMATCH_ENABLED_KEY,
-  true,
-);
-
-const metadataSources = ref<MetadataOption[]>([]);
-const isLaunchboxSelected = computed(() =>
-  metadataSources.value.some((s) => s.value === "launchbox"),
-);
-
-watch(
-  [metadataOptions, storedMetadataSources],
-  ([newOptions, newStoredMetadataSources]) => {
-    const filteredMetadataSources = newOptions.filter(
-      (option) =>
-        newStoredMetadataSources.includes(option.value) && !option.disabled,
-    );
-    metadataSources.value =
-      filteredMetadataSources.length > 0
-        ? filteredMetadataSources
-        : heartbeat
-            .getEnabledMetadataOptions()
-            .filter(
-              (o) =>
-                !(HASH_MATCHER_KEYS as readonly string[]).includes(o.value),
-            );
-  },
-  { immediate: true },
-);
-
-interface HashMatcher {
-  value: "hasheous" | "playmatch";
-  name: string;
-  logo: string;
-  /** Reason the switch is forced off — surfaced in the hover tooltip.
-   *  null when the switch is interactable. */
-  blockedReason: string | null;
-  switchEnabled: boolean;
-}
-
-const hashMatchers = computed<HashMatcher[]>(() => {
-  const sources = heartbeat.value.METADATA_SOURCES;
-  const igdbSelected = metadataSources.value.some((s) => s.value === "igdb");
-  const noHashes = !calculateHashes.value;
-
-  const hasheousAdmin = Boolean(sources?.HASHEOUS_API_ENABLED);
-  const playmatchAdmin = Boolean(sources?.PLAYMATCH_API_ENABLED);
-
-  return [
-    {
-      value: "hasheous",
-      name: "Hasheous",
-      logo: "/assets/scrappers/hasheous.png",
-      blockedReason: !hasheousAdmin
-        ? t("scan.disabled-by-admin")
-        : noHashes
-          ? t("scan.requires-hashes", { source: "Hasheous" })
-          : null,
-      switchEnabled: hasheousAdmin && !noHashes,
-    },
-    {
-      value: "playmatch",
-      name: "Playmatch",
-      logo: "/assets/scrappers/playmatch.png",
-      blockedReason: !playmatchAdmin
-        ? t("scan.disabled-by-admin")
-        : noHashes
-          ? t("scan.requires-hashes", { source: "Playmatch" })
-          : !igdbSelected
-            ? t("scan.playmatch-requires-igdb")
-            : null,
-      switchEnabled: playmatchAdmin && !noHashes && igdbSelected,
-    },
-  ];
-});
-
-function setHashMatcher(value: HashMatcher["value"], next: boolean) {
-  if (value === "hasheous") hasheousEnabled.value = next;
-  else playmatchEnabled.value = next;
-}
-
-function isHashMatcherOn(matcher: HashMatcher): boolean {
-  if (!matcher.switchEnabled) return false;
-  return matcher.value === "hasheous"
-    ? hasheousEnabled.value
-    : playmatchEnabled.value;
-}
+const {
+  calculateHashes,
+  generalProviders,
+  specificProviders,
+  metadataSources,
+  effectiveMetadataSources,
+  generalAllSelected,
+  specificAllSelected,
+  isLaunchboxSelected,
+  launchboxRemoteEnabled,
+  hashMatchers,
+  setHashMatcher,
+  isHashMatcherOn,
+  buildScanPayload,
+  persistSelection,
+} = useScanProviders();
 
 // Per-ROM scan types — the Scan view's "new platforms" / "quick"
 // options don't apply to an already-ingested ROM. We keep `update`
@@ -280,7 +138,7 @@ function onScan() {
   if (roms.value.length === 0) return;
 
   scanningStore.setScanning(true);
-  storedMetadataSources.value = metadataSources.value.map((s) => s.value);
+  persistSelection();
 
   // Group rom ids by platform — the scan socket event accepts one
   // platform list + one rom-id list, so a selection that spans
@@ -305,31 +163,13 @@ function onScan() {
 
   if (!socket.connected) socket.connect();
 
-  // Build the apis payload — providers + hasheous (when its switch is
-  // on; the backend accepts it as a MetadataSource enum value).
-  // Playmatch has no enum entry; the backend gates it via the separate
-  // `playmatch_enabled` flag below.
-  const apis = metadataSources.value.map((s) => s.value);
-  const hasheousMatcher = hashMatchers.value.find(
-    (m) => m.value === "hasheous",
-  );
-  if (hasheousMatcher && isHashMatcherOn(hasheousMatcher)) {
-    apis.push("hasheous");
-  }
-  const playmatchMatcher = hashMatchers.value.find(
-    (m) => m.value === "playmatch",
-  );
-
+  const payload = buildScanPayload();
   for (const [platformId, romIds] of byPlatform) {
     socket.emit("scan", {
       platforms: [platformId],
       roms_ids: romIds,
       type: scanType.value,
-      apis,
-      launchbox_remote_enabled: launchboxRemoteEnabled.value,
-      playmatch_enabled: playmatchMatcher
-        ? isHashMatcherOn(playmatchMatcher)
-        : false,
+      ...payload,
     });
   }
 
@@ -413,6 +253,7 @@ function closeDialog() {
               chips
               chip-tone="plain"
               show-all-option
+              @update:all-selected="generalAllSelected = $event"
             >
               <template #chip="{ item }">
                 <RTooltip :text="item.raw.name" location="bottom">
@@ -503,6 +344,7 @@ function closeDialog() {
               chips
               chip-tone="plain"
               show-all-option
+              @update:all-selected="specificAllSelected = $event"
             >
               <template #chip="{ item }">
                 <RTooltip :text="item.raw.name" location="bottom">
@@ -640,7 +482,7 @@ function closeDialog() {
         variant="translucent"
         color="primary"
         prepend-icon="mdi-magnify-scan"
-        :disabled="metadataSources.length === 0"
+        :disabled="effectiveMetadataSources.length === 0"
         @click="onScan"
       >
         {{ t("rom.refresh-metadata") }}

--- a/frontend/src/v2/components/Gallery/ScanPlatformDialog.vue
+++ b/frontend/src/v2/components/Gallery/ScanPlatformDialog.vue
@@ -19,15 +19,12 @@ import {
   RSwitch,
   RTooltip,
 } from "@v2/lib";
-import { useLocalStorage } from "@vueuse/core";
-import { storeToRefs } from "pinia";
-import { computed, ref, watch } from "vue";
+import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import socket from "@/services/socket";
-import storeConfig from "@/stores/config";
-import storeHeartbeat, { type MetadataOption } from "@/stores/heartbeat";
 import type { Platform } from "@/stores/platforms";
 import storeScanning from "@/stores/scanning";
+import { useScanProviders } from "@/v2/composables/useScanProviders";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
 
 defineOptions({ inheritAttrs: false });
@@ -41,164 +38,26 @@ const emit = defineEmits<{
   (e: "update:modelValue", v: boolean): void;
 }>();
 
-const LOCAL_STORAGE_METADATA_SOURCES_KEY = "scan.metadataSources";
-const LOCAL_STORAGE_LAUNCHBOX_REMOTE_ENABLED_KEY =
-  "scan.launchboxRemoteEnabled";
-const LOCAL_STORAGE_HASHEOUS_ENABLED_KEY = "scan.hasheousEnabled";
-const LOCAL_STORAGE_PLAYMATCH_ENABLED_KEY = "scan.playmatchEnabled";
-
-// Hash-matcher providers — proxies that match files by hash and feed
-// IDs into the primary catalogs. Filtered out of the main provider
-// select and rendered as switch pills so users don't read them as
-// standalone sources.
-const HASH_MATCHER_KEYS = ["hasheous", "playmatch"] as const;
-
-const GENERAL_PROVIDER_KEYS = new Set([
-  "igdb",
-  "ss",
-  "moby",
-  "launchbox",
-  "flashpoint",
-  "gamelist",
-  "libretro",
-]);
-const SPECIFIC_PROVIDER_KEYS = new Set(["ra", "sgdb", "hltb"]);
-
 const { t } = useI18n();
 const snackbar = useSnackbar();
-const heartbeat = storeHeartbeat();
 const scanningStore = storeScanning();
-const configStore = storeConfig();
-const { config } = storeToRefs(configStore);
 
-const calculateHashes = computed(() => !config.value.SKIP_HASH_CALCULATION);
-
-const metadataOptions = computed(() =>
-  heartbeat
-    .getMetadataOptionsByPriority()
-    .filter(
-      (option) =>
-        !(HASH_MATCHER_KEYS as readonly string[]).includes(option.value),
-    )
-    .map((option) => {
-      const requiresHashes = option.value === "ra";
-      const hashingDisabled = !calculateHashes.value;
-      let disabled = option.disabled;
-      if (hashingDisabled && requiresHashes) {
-        disabled = t("scan.requires-hashes", { source: option.name });
-      }
-      const name = option.value === "igdb" ? "IGDB" : option.name;
-      return { ...option, name, disabled };
-    }),
-);
-
-const generalProviders = computed<MetadataOption[]>(() =>
-  metadataOptions.value.filter((o) => GENERAL_PROVIDER_KEYS.has(o.value)),
-);
-const specificProviders = computed<MetadataOption[]>(() =>
-  metadataOptions.value.filter((o) => SPECIFIC_PROVIDER_KEYS.has(o.value)),
-);
-
-const storedMetadataSources = useLocalStorage(
-  LOCAL_STORAGE_METADATA_SOURCES_KEY,
-  [] as string[],
-);
-const launchboxRemoteEnabled = useLocalStorage(
-  LOCAL_STORAGE_LAUNCHBOX_REMOTE_ENABLED_KEY,
-  true,
-);
-const hasheousEnabled = useLocalStorage(
-  LOCAL_STORAGE_HASHEOUS_ENABLED_KEY,
-  true,
-);
-const playmatchEnabled = useLocalStorage(
-  LOCAL_STORAGE_PLAYMATCH_ENABLED_KEY,
-  true,
-);
-
-const metadataSources = ref<MetadataOption[]>([]);
-const isLaunchboxSelected = computed(() =>
-  metadataSources.value.some((s) => s.value === "launchbox"),
-);
-
-watch(
-  [metadataOptions, storedMetadataSources],
-  ([newOptions, newStoredMetadataSources]) => {
-    const filteredMetadataSources = newOptions.filter(
-      (option) =>
-        newStoredMetadataSources.includes(option.value) && !option.disabled,
-    );
-    metadataSources.value =
-      filteredMetadataSources.length > 0
-        ? filteredMetadataSources
-        : heartbeat
-            .getEnabledMetadataOptions()
-            .filter(
-              (o) =>
-                !(HASH_MATCHER_KEYS as readonly string[]).includes(o.value),
-            );
-  },
-  { immediate: true },
-);
-
-interface HashMatcher {
-  value: "hasheous" | "playmatch";
-  name: string;
-  logo: string;
-  blockedReason: string | null;
-  switchEnabled: boolean;
-}
-
-const hashMatchers = computed<HashMatcher[]>(() => {
-  const sources = heartbeat.value.METADATA_SOURCES;
-  const igdbSelected = metadataSources.value.some((s) => s.value === "igdb");
-  const noHashes = !calculateHashes.value;
-
-  const hasheousAdmin = Boolean(sources?.HASHEOUS_API_ENABLED);
-  const playmatchAdmin = Boolean(sources?.PLAYMATCH_API_ENABLED);
-
-  return [
-    {
-      value: "hasheous",
-      name: "Hasheous",
-      logo: "/assets/scrappers/hasheous.png",
-      blockedReason: !hasheousAdmin
-        ? t("scan.disabled-by-admin")
-        : noHashes
-          ? t("scan.requires-hashes", { source: "Hasheous" })
-          : null,
-      switchEnabled: hasheousAdmin && !noHashes,
-    },
-    {
-      value: "playmatch",
-      name: "Playmatch",
-      logo: "/assets/scrappers/playmatch.png",
-      blockedReason: !playmatchAdmin
-        ? t("scan.disabled-by-admin")
-        : noHashes
-          ? t("scan.requires-hashes", { source: "Playmatch" })
-          : !igdbSelected
-            ? t(
-                "scan.playmatch-requires-igdb",
-                "Select IGDB to enable Playmatch.",
-              )
-            : null,
-      switchEnabled: playmatchAdmin && !noHashes && igdbSelected,
-    },
-  ];
-});
-
-function setHashMatcher(value: HashMatcher["value"], next: boolean) {
-  if (value === "hasheous") hasheousEnabled.value = next;
-  else playmatchEnabled.value = next;
-}
-
-function isHashMatcherOn(matcher: HashMatcher): boolean {
-  if (!matcher.switchEnabled) return false;
-  return matcher.value === "hasheous"
-    ? hasheousEnabled.value
-    : playmatchEnabled.value;
-}
+const {
+  calculateHashes,
+  generalProviders,
+  specificProviders,
+  metadataSources,
+  effectiveMetadataSources,
+  generalAllSelected,
+  specificAllSelected,
+  isLaunchboxSelected,
+  launchboxRemoteEnabled,
+  hashMatchers,
+  setHashMatcher,
+  isHashMatcherOn,
+  buildScanPayload,
+  persistSelection,
+} = useScanProviders();
 
 // Per-platform scan types — the full Scan-view list minus
 // `new_platforms` (a discovery scan against fs_slugs not yet in the
@@ -242,28 +101,13 @@ function closeDialog() {
 
 function onScan() {
   scanningStore.setScanning(true);
-  storedMetadataSources.value = metadataSources.value.map((s) => s.value);
-
-  const apis = metadataSources.value.map((s) => s.value);
-  const hasheousMatcher = hashMatchers.value.find(
-    (m) => m.value === "hasheous",
-  );
-  if (hasheousMatcher && isHashMatcherOn(hasheousMatcher)) {
-    apis.push("hasheous");
-  }
-  const playmatchMatcher = hashMatchers.value.find(
-    (m) => m.value === "playmatch",
-  );
+  persistSelection();
 
   if (!socket.connected) socket.connect();
   socket.emit("scan", {
     platforms: [props.platform.id],
     type: scanType.value,
-    apis,
-    launchbox_remote_enabled: launchboxRemoteEnabled.value,
-    playmatch_enabled: playmatchMatcher
-      ? isHashMatcherOn(playmatchMatcher)
-      : false,
+    ...buildScanPayload(),
   });
 
   snackbar.info(`Scanning ${props.platform.display_name}…`, {
@@ -334,6 +178,7 @@ function onScan() {
               chips
               chip-tone="plain"
               show-all-option
+              @update:all-selected="generalAllSelected = $event"
             >
               <template #chip="{ item }">
                 <RTooltip :text="item.raw.name" location="bottom">
@@ -421,6 +266,7 @@ function onScan() {
               chips
               chip-tone="plain"
               show-all-option
+              @update:all-selected="specificAllSelected = $event"
             >
               <template #chip="{ item }">
                 <RTooltip :text="item.raw.name" location="bottom">
@@ -557,7 +403,7 @@ function onScan() {
         variant="translucent"
         color="primary"
         prepend-icon="mdi-magnify-scan"
-        :disabled="metadataSources.length === 0"
+        :disabled="effectiveMetadataSources.length === 0"
         @click="onScan"
       >
         {{ t("scan.scan", "Scan") }}

--- a/frontend/src/v2/composables/useScanProviders/index.test.ts
+++ b/frontend/src/v2/composables/useScanProviders/index.test.ts
@@ -5,7 +5,7 @@ import { useScanProviders, type HashMatcher } from "./index";
 
 // Provider list the heartbeat would expose with every source enabled.
 const OPTIONS: MetadataOption[] = [
-  { value: "igdb", name: "IGDB + Playmatch", logo_path: "", disabled: "" },
+  { value: "igdb", name: "IGDB", logo_path: "", disabled: "" },
   { value: "ss", name: "ScreenScraper", logo_path: "", disabled: "" },
   { value: "moby", name: "MobyGames", logo_path: "", disabled: "" },
   { value: "ra", name: "RetroAchievements", logo_path: "", disabled: "" },

--- a/frontend/src/v2/composables/useScanProviders/index.test.ts
+++ b/frontend/src/v2/composables/useScanProviders/index.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick, ref } from "vue";
+import type { MetadataOption } from "@/stores/heartbeat";
+import { useScanProviders, type HashMatcher } from "./index";
+
+// Provider list the heartbeat would expose with every source enabled.
+const OPTIONS: MetadataOption[] = [
+  { value: "igdb", name: "IGDB + Playmatch", logo_path: "", disabled: "" },
+  { value: "ss", name: "ScreenScraper", logo_path: "", disabled: "" },
+  { value: "moby", name: "MobyGames", logo_path: "", disabled: "" },
+  { value: "ra", name: "RetroAchievements", logo_path: "", disabled: "" },
+  { value: "hasheous", name: "Hasheous", logo_path: "", disabled: "" },
+  { value: "playmatch", name: "Playmatch", logo_path: "", disabled: "" },
+];
+
+const heartbeat = {
+  value: {
+    METADATA_SOURCES: {
+      HASHEOUS_API_ENABLED: true,
+      PLAYMATCH_API_ENABLED: true,
+    },
+  },
+  getMetadataOptionsByPriority: () => OPTIONS,
+};
+const config = ref({ SKIP_HASH_CALCULATION: false });
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+vi.mock("pinia", () => ({
+  storeToRefs: () => ({ config }),
+}));
+vi.mock("@/stores/config", () => ({ default: () => ({}) }));
+vi.mock("@/stores/heartbeat", () => ({ default: () => heartbeat }));
+
+beforeEach(() => {
+  localStorage.clear();
+  config.value.SKIP_HASH_CALCULATION = false;
+});
+
+describe("useScanProviders — effective sources", () => {
+  it("expands an All-mode group to its enabled providers", () => {
+    const { effectiveMetadataSources } = useScanProviders();
+    // Nothing stored ⇒ both selects boot in All-mode with an empty model.
+    expect(effectiveMetadataSources.value.map((s) => s.value)).toEqual([
+      "igdb",
+      "ss",
+      "moby",
+      "ra",
+    ]);
+  });
+
+  it("uses the explicit picks once a group has a selection", () => {
+    const { metadataSources, generalAllSelected, effectiveMetadataSources } =
+      useScanProviders();
+    generalAllSelected.value = false;
+    metadataSources.value = [OPTIONS[1]];
+    expect(effectiveMetadataSources.value.map((s) => s.value)).toEqual([
+      "ss",
+      "ra",
+    ]);
+  });
+
+  it("restores the stored picks once the provider list arrives", async () => {
+    localStorage.setItem("scan.metadataSources", JSON.stringify(["moby"]));
+    const { metadataSources } = useScanProviders();
+    await nextTick();
+    expect(metadataSources.value.map((s) => s.value)).toEqual(["moby"]);
+  });
+
+  it("keeps in-progress picks when only the option list changes", async () => {
+    const { metadataSources, generalAllSelected } = useScanProviders();
+    generalAllSelected.value = false;
+    metadataSources.value = [OPTIONS[1]];
+    // A heartbeat refresh re-emits the option list with fresh identities.
+    config.value.SKIP_HASH_CALCULATION = true;
+    await nextTick();
+    expect(metadataSources.value.map((s) => s.value)).toEqual(["ss"]);
+  });
+
+  it("keeps hash matchers out of the provider selects", () => {
+    const { generalProviders, specificProviders } = useScanProviders();
+    const listed = [...generalProviders.value, ...specificProviders.value].map(
+      (o) => o.value,
+    );
+    expect(listed).not.toContain("hasheous");
+    expect(listed).not.toContain("playmatch");
+  });
+});
+
+describe("useScanProviders — Playmatch gate", () => {
+  function playmatch(matchers: HashMatcher[]) {
+    return matchers.find((m) => m.value === "playmatch")!;
+  }
+
+  it("is enabled when the general group is in All-mode (IGDB included)", () => {
+    const { hashMatchers } = useScanProviders();
+    expect(playmatch(hashMatchers.value).switchEnabled).toBe(true);
+  });
+
+  it("is enabled when IGDB is picked explicitly", () => {
+    const { metadataSources, generalAllSelected, hashMatchers } =
+      useScanProviders();
+    generalAllSelected.value = false;
+    metadataSources.value = [OPTIONS[0]];
+    expect(playmatch(hashMatchers.value).switchEnabled).toBe(true);
+  });
+
+  it("is blocked when the picked providers exclude IGDB", () => {
+    const { metadataSources, generalAllSelected, hashMatchers } =
+      useScanProviders();
+    generalAllSelected.value = false;
+    metadataSources.value = [OPTIONS[1]];
+    const matcher = playmatch(hashMatchers.value);
+    expect(matcher.switchEnabled).toBe(false);
+    expect(matcher.blockedReason).toBe("scan.playmatch-requires-igdb");
+  });
+
+  it("is blocked when hash calculation is off", () => {
+    config.value.SKIP_HASH_CALCULATION = true;
+    const { hashMatchers } = useScanProviders();
+    const matcher = playmatch(hashMatchers.value);
+    expect(matcher.switchEnabled).toBe(false);
+    expect(matcher.blockedReason).toBe("scan.requires-hashes");
+  });
+});
+
+describe("useScanProviders — scan payload", () => {
+  it("sends the expanded provider list and the playmatch flag", () => {
+    const { buildScanPayload } = useScanProviders();
+    expect(buildScanPayload()).toEqual({
+      apis: ["igdb", "ss", "moby", "ra", "hasheous"],
+      launchbox_remote_enabled: true,
+      playmatch_enabled: true,
+    });
+  });
+
+  it("drops both hash matchers when hashing is disabled", () => {
+    config.value.SKIP_HASH_CALCULATION = true;
+    const { buildScanPayload } = useScanProviders();
+    const payload = buildScanPayload();
+    expect(payload.apis).not.toContain("hasheous");
+    expect(payload.playmatch_enabled).toBe(false);
+  });
+
+  it("persists the explicit picks, leaving All-mode groups empty", async () => {
+    const { metadataSources, generalAllSelected, persistSelection } =
+      useScanProviders();
+    generalAllSelected.value = false;
+    metadataSources.value = [OPTIONS[0]];
+    persistSelection();
+    await nextTick();
+    expect(
+      JSON.parse(localStorage.getItem("scan.metadataSources") ?? "[]"),
+    ).toEqual(["igdb"]);
+  });
+});

--- a/frontend/src/v2/composables/useScanProviders/index.test.ts
+++ b/frontend/src/v2/composables/useScanProviders/index.test.ts
@@ -38,7 +38,7 @@ beforeEach(() => {
   config.value.SKIP_HASH_CALCULATION = false;
 });
 
-describe("useScanProviders — effective sources", () => {
+describe("useScanProviders effective sources", () => {
   it("expands an All-mode group to its enabled providers", () => {
     const { effectiveMetadataSources } = useScanProviders();
     // Nothing stored ⇒ both selects boot in All-mode with an empty model.
@@ -88,7 +88,7 @@ describe("useScanProviders — effective sources", () => {
   });
 });
 
-describe("useScanProviders — Playmatch gate", () => {
+describe("useScanProviders Playmatch gate", () => {
   function playmatch(matchers: HashMatcher[]) {
     return matchers.find((m) => m.value === "playmatch")!;
   }
@@ -125,7 +125,7 @@ describe("useScanProviders — Playmatch gate", () => {
   });
 });
 
-describe("useScanProviders — scan payload", () => {
+describe("useScanProviders scan payload", () => {
   it("sends the expanded provider list and the playmatch flag", () => {
     const { buildScanPayload } = useScanProviders();
     expect(buildScanPayload()).toEqual({

--- a/frontend/src/v2/composables/useScanProviders/index.ts
+++ b/frontend/src/v2/composables/useScanProviders/index.ts
@@ -1,4 +1,4 @@
-// useScanProviders — the provider + hash-matcher model shared by every
+// useScanProviders: the provider + hash-matcher model shared by every
 // surface that launches a scan (the /scan view, the per-platform scan
 // dialog, the per-ROM refresh dialog), so all three send the backend the
 // same payload for the same choices.
@@ -10,7 +10,7 @@
 // `playmatch_enabled and IGDB in apis`), hence its IGDB requirement.
 //
 // A group's RSelect treats an empty model as "All", so an All-mode group
-// contributes nothing to `metadataSources` — while the backend reads an
+// contributes nothing to `metadataSources`, while the backend reads an
 // empty `apis` list as "no sources". `effectiveMetadataSources` bridges
 // that by expanding an All-mode group to its enabled providers.
 import { useLocalStorage, type RemovableRef } from "@vueuse/core";
@@ -28,10 +28,8 @@ const LOCAL_STORAGE_PLAYMATCH_ENABLED_KEY = "scan.playmatchEnabled";
 
 const HASH_MATCHER_KEYS = ["hasheous", "playmatch"] as const;
 
-// Provider categorisation — mirrors the split used by the setup wizard's
-// metadata step. General catalogs ship a full game record (title, artwork,
-// descriptions); specific sources add a single domain dimension
-// (achievements, completion times, custom art).
+// Mirrors the split used by the setup wizard's metadata step: general
+// catalogs ship a full game record, specific sources add one dimension.
 const GENERAL_PROVIDER_KEYS = new Set([
   "igdb",
   "ss",
@@ -67,7 +65,7 @@ export interface UseScanProviders {
   specificProviders: ComputedRef<MetadataOption[]>;
   /** Explicit picks, shared as the v-model of both provider selects. */
   metadataSources: Ref<MetadataOption[]>;
-  /** Picks with All-mode groups expanded — what the scan actually uses. */
+  /** Picks with All-mode groups expanded, i.e. what the scan uses. */
   effectiveMetadataSources: ComputedRef<MetadataOption[]>;
   /** Bind to each select's `@update:all-selected`. */
   generalAllSelected: Ref<boolean>;
@@ -89,7 +87,7 @@ export function useScanProviders(): UseScanProviders {
 
   const calculateHashes = computed(() => !config.value.SKIP_HASH_CALCULATION);
 
-  // Catalog options — main metadata sources, minus the hash matchers.
+  // Catalog options: main metadata sources, minus the hash matchers.
   const metadataOptions = computed(() =>
     heartbeat
       .getMetadataOptionsByPriority()
@@ -143,9 +141,9 @@ export function useScanProviders(): UseScanProviders {
     [metadataOptions, storedMetadataSources],
     ([options, stored], previous) => {
       // A new stored list (written by whichever surface last scanned)
-      // replaces the picks. When only the option list moved — a heartbeat
-      // refresh, an admin toggle — keep the current picks and just drop
-      // the ones that went away, so an in-progress selection survives.
+      // replaces the picks. When only the option list moved (a heartbeat
+      // refresh, an admin toggle), keep the current picks and just drop the
+      // ones that went away, so an in-progress selection survives.
       const storedChanged = !previous || previous[1] !== stored;
       metadataSources.value = storedChanged
         ? options.filter((o) => stored.includes(o.value) && !o.disabled)

--- a/frontend/src/v2/composables/useScanProviders/index.ts
+++ b/frontend/src/v2/composables/useScanProviders/index.ts
@@ -1,0 +1,289 @@
+// useScanProviders — the provider + hash-matcher model shared by every
+// surface that launches a scan (the /scan view, the per-platform scan
+// dialog, the per-ROM refresh dialog), so all three send the backend the
+// same payload for the same choices.
+//
+// Hash matchers are proxies, not catalogs: they match files by hash and
+// feed IDs into the primary catalogs. Hasheous rides along in `apis`
+// (backend gate: `MetadataSource.HASHEOUS in apis`); Playmatch has no enum
+// entry and uses the separate `playmatch_enabled` flag (backend gate:
+// `playmatch_enabled and IGDB in apis`), hence its IGDB requirement.
+//
+// A group's RSelect treats an empty model as "All", so an All-mode group
+// contributes nothing to `metadataSources` — while the backend reads an
+// empty `apis` list as "no sources". `effectiveMetadataSources` bridges
+// that by expanding an All-mode group to its enabled providers.
+import { useLocalStorage, type RemovableRef } from "@vueuse/core";
+import { storeToRefs } from "pinia";
+import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
+import { useI18n } from "vue-i18n";
+import storeConfig from "@/stores/config";
+import storeHeartbeat, { type MetadataOption } from "@/stores/heartbeat";
+
+const LOCAL_STORAGE_METADATA_SOURCES_KEY = "scan.metadataSources";
+const LOCAL_STORAGE_LAUNCHBOX_REMOTE_ENABLED_KEY =
+  "scan.launchboxRemoteEnabled";
+const LOCAL_STORAGE_HASHEOUS_ENABLED_KEY = "scan.hasheousEnabled";
+const LOCAL_STORAGE_PLAYMATCH_ENABLED_KEY = "scan.playmatchEnabled";
+
+const HASH_MATCHER_KEYS = ["hasheous", "playmatch"] as const;
+
+// Provider categorisation — mirrors the split used by the setup wizard's
+// metadata step. General catalogs ship a full game record (title, artwork,
+// descriptions); specific sources add a single domain dimension
+// (achievements, completion times, custom art).
+const GENERAL_PROVIDER_KEYS = new Set([
+  "igdb",
+  "ss",
+  "moby",
+  "launchbox",
+  "flashpoint",
+  "gamelist",
+  "libretro",
+]);
+const SPECIFIC_PROVIDER_KEYS = new Set(["ra", "sgdb", "hltb"]);
+
+export type HashMatcherKey = (typeof HASH_MATCHER_KEYS)[number];
+
+export interface HashMatcher {
+  value: HashMatcherKey;
+  name: string;
+  logo: string;
+  /** Reason the switch is forced off, surfaced in the hover tooltip.
+   *  null when the switch is interactable. */
+  blockedReason: string | null;
+  switchEnabled: boolean;
+}
+
+export interface ScanPayload {
+  apis: string[];
+  launchbox_remote_enabled: boolean;
+  playmatch_enabled: boolean;
+}
+
+export interface UseScanProviders {
+  calculateHashes: ComputedRef<boolean>;
+  generalProviders: ComputedRef<MetadataOption[]>;
+  specificProviders: ComputedRef<MetadataOption[]>;
+  /** Explicit picks, shared as the v-model of both provider selects. */
+  metadataSources: Ref<MetadataOption[]>;
+  /** Picks with All-mode groups expanded — what the scan actually uses. */
+  effectiveMetadataSources: ComputedRef<MetadataOption[]>;
+  /** Bind to each select's `@update:all-selected`. */
+  generalAllSelected: Ref<boolean>;
+  specificAllSelected: Ref<boolean>;
+  isLaunchboxSelected: ComputedRef<boolean>;
+  launchboxRemoteEnabled: RemovableRef<boolean>;
+  hashMatchers: ComputedRef<HashMatcher[]>;
+  setHashMatcher: (value: HashMatcherKey, next: boolean) => void;
+  isHashMatcherOn: (matcher: HashMatcher) => boolean;
+  buildScanPayload: () => ScanPayload;
+  persistSelection: () => void;
+}
+
+export function useScanProviders(): UseScanProviders {
+  const { t } = useI18n();
+  const heartbeat = storeHeartbeat();
+  const configStore = storeConfig();
+  const { config } = storeToRefs(configStore);
+
+  const calculateHashes = computed(() => !config.value.SKIP_HASH_CALCULATION);
+
+  // Catalog options — main metadata sources. IGDB's heartbeat label flips
+  // to "IGDB + Playmatch" when Playmatch is admin-enabled; strip the suffix
+  // since Playmatch has its own pill.
+  const metadataOptions = computed(() =>
+    heartbeat
+      .getMetadataOptionsByPriority()
+      .filter(
+        (option) =>
+          !(HASH_MATCHER_KEYS as readonly string[]).includes(option.value),
+      )
+      .map((option) => {
+        const requiresHashes = option.value === "ra";
+        let disabled = option.disabled;
+        if (!calculateHashes.value && requiresHashes) {
+          disabled = t("scan.requires-hashes", { source: option.name });
+        }
+        const name = option.value === "igdb" ? "IGDB" : option.name;
+        return { ...option, name, disabled };
+      }),
+  );
+
+  const generalProviders = computed<MetadataOption[]>(() =>
+    metadataOptions.value.filter((o) => GENERAL_PROVIDER_KEYS.has(o.value)),
+  );
+  const specificProviders = computed<MetadataOption[]>(() =>
+    metadataOptions.value.filter((o) => SPECIFIC_PROVIDER_KEYS.has(o.value)),
+  );
+  const enabledGeneralProviders = computed(() =>
+    generalProviders.value.filter((o) => !o.disabled),
+  );
+  const enabledSpecificProviders = computed(() =>
+    specificProviders.value.filter((o) => !o.disabled),
+  );
+
+  const storedMetadataSources = useLocalStorage(
+    LOCAL_STORAGE_METADATA_SOURCES_KEY,
+    [] as string[],
+  );
+  const launchboxRemoteEnabled = useLocalStorage(
+    LOCAL_STORAGE_LAUNCHBOX_REMOTE_ENABLED_KEY,
+    true,
+  );
+  const hasheousEnabled = useLocalStorage(
+    LOCAL_STORAGE_HASHEOUS_ENABLED_KEY,
+    true,
+  );
+  const playmatchEnabled = useLocalStorage(
+    LOCAL_STORAGE_PLAYMATCH_ENABLED_KEY,
+    true,
+  );
+
+  // A group with no pick stays empty, which the selects read as All.
+  const metadataSources = ref<MetadataOption[]>([]);
+  watch(
+    [metadataOptions, storedMetadataSources],
+    ([options, stored], previous) => {
+      // A new stored list (written by whichever surface last scanned)
+      // replaces the picks. When only the option list moved — a heartbeat
+      // refresh, an admin toggle — keep the current picks and just drop
+      // the ones that went away, so an in-progress selection survives.
+      const storedChanged = !previous || previous[1] !== stored;
+      metadataSources.value = storedChanged
+        ? options.filter((o) => stored.includes(o.value) && !o.disabled)
+        : metadataSources.value
+            .map((s) => options.find((o) => o.value === s.value && !o.disabled))
+            .filter((o): o is MetadataOption => Boolean(o));
+    },
+    { immediate: true },
+  );
+
+  function hasGroupSelection(keys: Set<string>): boolean {
+    return metadataSources.value.some((s) => keys.has(s.value));
+  }
+
+  // All-mode mirrors of each select, initialised the way the primitive does
+  // (no own selection ⇒ All) and kept in sync via `@update:all-selected`.
+  const generalAllSelected = ref(!hasGroupSelection(GENERAL_PROVIDER_KEYS));
+  const specificAllSelected = ref(!hasGroupSelection(SPECIFIC_PROVIDER_KEYS));
+
+  // An explicit pick always wins over the All flag: the two are mutually
+  // exclusive in the select, and reading the model keeps us right even
+  // before a select has mounted to emit its initial state.
+  function resolveGroup(
+    keys: Set<string>,
+    allSelected: boolean,
+    enabled: MetadataOption[],
+  ): MetadataOption[] {
+    const picked = metadataSources.value.filter((s) => keys.has(s.value));
+    if (picked.length > 0) return picked;
+    return allSelected ? enabled : [];
+  }
+
+  const effectiveMetadataSources = computed<MetadataOption[]>(() => [
+    ...resolveGroup(
+      GENERAL_PROVIDER_KEYS,
+      generalAllSelected.value,
+      enabledGeneralProviders.value,
+    ),
+    ...resolveGroup(
+      SPECIFIC_PROVIDER_KEYS,
+      specificAllSelected.value,
+      enabledSpecificProviders.value,
+    ),
+  ]);
+
+  const isLaunchboxSelected = computed(() =>
+    effectiveMetadataSources.value.some((s) => s.value === "launchbox"),
+  );
+
+  const hashMatchers = computed<HashMatcher[]>(() => {
+    const sources = heartbeat.value.METADATA_SOURCES;
+    const igdbSelected = effectiveMetadataSources.value.some(
+      (s) => s.value === "igdb",
+    );
+    const noHashes = !calculateHashes.value;
+
+    const hasheousAdmin = Boolean(sources?.HASHEOUS_API_ENABLED);
+    const playmatchAdmin = Boolean(sources?.PLAYMATCH_API_ENABLED);
+
+    return [
+      {
+        value: "hasheous",
+        name: "Hasheous",
+        logo: "/assets/scrappers/hasheous.png",
+        blockedReason: !hasheousAdmin
+          ? t("scan.disabled-by-admin")
+          : noHashes
+            ? t("scan.requires-hashes", { source: "Hasheous" })
+            : null,
+        switchEnabled: hasheousAdmin && !noHashes,
+      },
+      {
+        value: "playmatch",
+        name: "Playmatch",
+        logo: "/assets/scrappers/playmatch.png",
+        blockedReason: !playmatchAdmin
+          ? t("scan.disabled-by-admin")
+          : noHashes
+            ? t("scan.requires-hashes", { source: "Playmatch" })
+            : !igdbSelected
+              ? t("scan.playmatch-requires-igdb")
+              : null,
+        switchEnabled: playmatchAdmin && !noHashes && igdbSelected,
+      },
+    ];
+  });
+
+  function setHashMatcher(value: HashMatcherKey, next: boolean) {
+    if (value === "hasheous") hasheousEnabled.value = next;
+    else playmatchEnabled.value = next;
+  }
+
+  function isHashMatcherOn(matcher: HashMatcher): boolean {
+    if (!matcher.switchEnabled) return false;
+    return matcher.value === "hasheous"
+      ? hasheousEnabled.value
+      : playmatchEnabled.value;
+  }
+
+  function isOn(value: HashMatcherKey): boolean {
+    const matcher = hashMatchers.value.find((m) => m.value === value);
+    return matcher ? isHashMatcherOn(matcher) : false;
+  }
+
+  function buildScanPayload(): ScanPayload {
+    const apis = effectiveMetadataSources.value.map((s) => s.value);
+    if (isOn("hasheous")) apis.push("hasheous");
+    return {
+      apis,
+      launchbox_remote_enabled: launchboxRemoteEnabled.value,
+      playmatch_enabled: isOn("playmatch"),
+    };
+  }
+
+  // Persist the explicit picks, not the expanded list: an All-mode group
+  // stores nothing so it keeps meaning "everything", including providers
+  // enabled later.
+  function persistSelection() {
+    storedMetadataSources.value = metadataSources.value.map((s) => s.value);
+  }
+
+  return {
+    calculateHashes,
+    generalProviders,
+    specificProviders,
+    metadataSources,
+    effectiveMetadataSources,
+    generalAllSelected,
+    specificAllSelected,
+    isLaunchboxSelected,
+    launchboxRemoteEnabled,
+    hashMatchers,
+    setHashMatcher,
+    isHashMatcherOn,
+    buildScanPayload,
+    persistSelection,
+  };
+}

--- a/frontend/src/v2/composables/useScanProviders/index.ts
+++ b/frontend/src/v2/composables/useScanProviders/index.ts
@@ -89,9 +89,7 @@ export function useScanProviders(): UseScanProviders {
 
   const calculateHashes = computed(() => !config.value.SKIP_HASH_CALCULATION);
 
-  // Catalog options — main metadata sources. IGDB's heartbeat label flips
-  // to "IGDB + Playmatch" when Playmatch is admin-enabled; strip the suffix
-  // since Playmatch has its own pill.
+  // Catalog options — main metadata sources, minus the hash matchers.
   const metadataOptions = computed(() =>
     heartbeat
       .getMetadataOptionsByPriority()
@@ -105,8 +103,7 @@ export function useScanProviders(): UseScanProviders {
         if (!calculateHashes.value && requiresHashes) {
           disabled = t("scan.requires-hashes", { source: option.name });
         }
-        const name = option.value === "igdb" ? "IGDB" : option.name;
-        return { ...option, name, disabled };
+        return { ...option, disabled };
       }),
   );
 

--- a/frontend/src/v2/views/Scan.vue
+++ b/frontend/src/v2/views/Scan.vue
@@ -24,13 +24,8 @@
 // `scan:update_stats`, `scan:done`, `scan:done_ko`) is wired globally
 // by `installScanLifecycle` in AppLayout; this view is pure UI.
 //
-// Hash matchers (Hasheous, Playmatch) sit between the provider select
-// and the scan-type select as two compact switch pills. They're
-// proxies — not standalone catalogs — and treating them as regular
-// providers obscured that. Hasheous toggles its presence in the `apis`
-// array (backend gate is `MetadataSource.HASHEOUS in apis`); Playmatch
-// toggles a separate `playmatch_enabled` flag (it has no enum entry;
-// backend gate is `playmatch_enabled and IGDB in apis`).
+// The provider selects and the hash-matcher pills are driven by
+// `useScanProviders`, shared with the two scan dialogs.
 import {
   RAlert,
   RAvatar,
@@ -41,40 +36,23 @@ import {
   RSwitch,
   RTooltip,
 } from "@v2/lib";
-import { useLocalStorage } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { computed, nextTick, onMounted, ref, useTemplateRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { ROUTES } from "@/plugins/router";
 import socket from "@/services/socket";
-import storeConfig from "@/stores/config";
-import storeHeartbeat, { type MetadataOption } from "@/stores/heartbeat";
 import storePlatforms from "@/stores/platforms";
 import storeScanning from "@/stores/scanning";
 import ScanInfoDialog from "@/v2/components/Scan/ScanInfoDialog.vue";
 import ScanPlatform from "@/v2/components/Scan/ScanPlatform.vue";
 import PlatformSelect from "@/v2/components/shared/PlatformSelect.vue";
-
-const LOCAL_STORAGE_METADATA_SOURCES_KEY = "scan.metadataSources";
-const LOCAL_STORAGE_LAUNCHBOX_REMOTE_ENABLED_KEY =
-  "scan.launchboxRemoteEnabled";
-const LOCAL_STORAGE_HASHEOUS_ENABLED_KEY = "scan.hasheousEnabled";
-const LOCAL_STORAGE_PLAYMATCH_ENABLED_KEY = "scan.playmatchEnabled";
-
-// Hash-matcher providers — proxies that match files by hash and feed
-// IDs into the primary catalogs (IGDB, RetroAchievements). Kept out of
-// the main provider select so users don't read them as standalone
-// sources.
-const HASH_MATCHER_KEYS = ["hasheous", "playmatch"] as const;
+import { useScanProviders } from "@/v2/composables/useScanProviders";
 
 const { t } = useI18n();
 const scanningStore = storeScanning();
 const { scanning, scanningPlatforms, scanStats } = storeToRefs(scanningStore);
 const platformsStore = storePlatforms();
 const { scannablePlatforms } = storeToRefs(platformsStore);
-const configStore = storeConfig();
-const { config } = storeToRefs(configStore);
-const heartbeat = storeHeartbeat();
 const platformsToScan = ref<string[]>([]);
 
 // Never-scanned folders are fetched on demand.
@@ -100,187 +78,22 @@ const sortedPlatforms = computed(() =>
   ),
 );
 
-const calculateHashes = computed(
-  () => !config.value.SKIP_HASH_CALCULATION || false,
-);
-
-// Catalog options — main metadata sources. Hash matchers (hasheous,
-// playmatch) are filtered out and rendered as switch pills. IGDB's
-// heartbeat label flips to "IGDB + Playmatch" when Playmatch is
-// admin-enabled — strip the suffix since Playmatch has its own tile.
-const metadataOptions = computed(() =>
-  heartbeat
-    .getMetadataOptionsByPriority()
-    .filter(
-      (option) =>
-        !(HASH_MATCHER_KEYS as readonly string[]).includes(option.value),
-    )
-    .map((option) => {
-      const requiresHashes = option.value === "ra";
-      const hashingDisabled = !calculateHashes.value;
-      let disabled = option.disabled;
-      if (hashingDisabled && requiresHashes) {
-        disabled = t("scan.requires-hashes", { source: option.name });
-      }
-      const name = option.value === "igdb" ? "IGDB" : option.name;
-      return { ...option, name, disabled };
-    }),
-);
-
-interface HashMatcher {
-  value: "hasheous" | "playmatch";
-  name: string;
-  logo: string;
-  /** Reason the switch is forced off, surfaced in the hover tooltip.
-   *  null when the switch is interactable. */
-  blockedReason: string | null;
-  switchEnabled: boolean;
-}
-
-const hashMatchers = computed<HashMatcher[]>(() => {
-  const sources = heartbeat.value.METADATA_SOURCES;
-  const igdbSelected = effectiveMetadataSources.value.some(
-    (s) => s.value === "igdb",
-  );
-  const noHashes = !calculateHashes.value;
-
-  const hasheousAdmin = Boolean(sources?.HASHEOUS_API_ENABLED);
-  const playmatchAdmin = Boolean(sources?.PLAYMATCH_API_ENABLED);
-
-  return [
-    {
-      value: "hasheous",
-      name: "Hasheous",
-      logo: "/assets/scrappers/hasheous.png",
-      blockedReason: !hasheousAdmin
-        ? t("scan.disabled-by-admin")
-        : noHashes
-          ? t("scan.requires-hashes", { source: "Hasheous" })
-          : null,
-      switchEnabled: hasheousAdmin && !noHashes,
-    },
-    {
-      value: "playmatch",
-      name: "Playmatch",
-      logo: "/assets/scrappers/playmatch.png",
-      // Playmatch is hash-based — same gate as Hasheous — plus the
-      // backend requires IGDB in `apis` for its server-side join, so
-      // we surface that as a secondary gate.
-      blockedReason: !playmatchAdmin
-        ? t("scan.disabled-by-admin")
-        : noHashes
-          ? t("scan.requires-hashes", { source: "Playmatch" })
-          : !igdbSelected
-            ? t("scan.playmatch-requires-igdb")
-            : null,
-      switchEnabled: playmatchAdmin && !noHashes && igdbSelected,
-    },
-  ];
-});
-
-const storedMetadataSources = useLocalStorage(
-  LOCAL_STORAGE_METADATA_SOURCES_KEY,
-  [] as string[],
-);
-const launchboxRemoteEnabled = useLocalStorage(
-  LOCAL_STORAGE_LAUNCHBOX_REMOTE_ENABLED_KEY,
-  true,
-);
-const hasheousEnabled = useLocalStorage(
-  LOCAL_STORAGE_HASHEOUS_ENABLED_KEY,
-  true,
-);
-const playmatchEnabled = useLocalStorage(
-  LOCAL_STORAGE_PLAYMATCH_ENABLED_KEY,
-  true,
-);
-
-const metadataSources = ref<MetadataOption[]>(
-  metadataOptions.value.filter(
-    (m) => storedMetadataSources.value.includes(m.value) && !m.disabled,
-  ) || heartbeat.getEnabledMetadataOptions(),
-);
-
-const isLaunchboxSelected = computed(() =>
-  effectiveMetadataSources.value.some((s) => s.value === "launchbox"),
-);
-
-watch(metadataOptions, (newOptions) => {
-  metadataSources.value = metadataSources.value.filter((s) =>
-    newOptions.some((opt) => opt.value === s.value && !opt.disabled),
-  );
-});
-
-function setHashMatcher(value: HashMatcher["value"], next: boolean) {
-  if (value === "hasheous") hasheousEnabled.value = next;
-  else playmatchEnabled.value = next;
-}
-
-function isHashMatcherOn(matcher: HashMatcher): boolean {
-  if (!matcher.switchEnabled) return false;
-  return matcher.value === "hasheous"
-    ? hasheousEnabled.value
-    : playmatchEnabled.value;
-}
-
-// Provider categorisation — mirrors the split used by the setup
-// wizard's metadata step. General catalogs ship a full game record
-// (title, artwork, descriptions); specific sources add a single
-// domain dimension (achievements, completion times, custom art).
-// Each group renders its own RSelect; both share `metadataSources`
-// as the model. RSelect's `show-all-option` is subset-safe — toggling
-// All in one group doesn't touch the other.
-const GENERAL_PROVIDER_KEYS = new Set([
-  "igdb",
-  "ss",
-  "moby",
-  "launchbox",
-  "flashpoint",
-  "gamelist",
-  "libretro",
-]);
-const SPECIFIC_PROVIDER_KEYS = new Set(["ra", "sgdb", "hltb"]);
-
-const generalProviders = computed<MetadataOption[]>(() =>
-  metadataOptions.value.filter((o) => GENERAL_PROVIDER_KEYS.has(o.value)),
-);
-const specificProviders = computed<MetadataOption[]>(() =>
-  metadataOptions.value.filter((o) => SPECIFIC_PROVIDER_KEYS.has(o.value)),
-);
-
-// Each group's RSelect uses empty-model-as-"All", but the scan backend
-// reads an empty `apis` list as "no sources", not "all". So when a group
-// is in All-mode we materialise its full enabled provider list — both to
-// drive the UI gates (IGDB present? any source picked?) and to build the
-// `apis` payload the backend actually understands.
-const enabledGeneralProviders = computed(() =>
-  generalProviders.value.filter((o) => !o.disabled),
-);
-const enabledSpecificProviders = computed(() =>
-  specificProviders.value.filter((o) => !o.disabled),
-);
-
-function hasGroupSelection(keys: Set<string>): boolean {
-  return metadataSources.value.some((s) => keys.has(s.value));
-}
-
-// All-mode mirrors of each RSelect. Initialised the same way the
-// primitive does (no own selection ⇒ All) and kept in sync afterwards
-// via each select's `@update:all-selected`.
-const generalAllSelected = ref(!hasGroupSelection(GENERAL_PROVIDER_KEYS));
-const specificAllSelected = ref(!hasGroupSelection(SPECIFIC_PROVIDER_KEYS));
-
-// Concrete providers the scan will actually use: each group contributes
-// its explicit selection, or every enabled provider when in All-mode.
-const effectiveMetadataSources = computed<MetadataOption[]>(() => {
-  const general = generalAllSelected.value
-    ? enabledGeneralProviders.value
-    : metadataSources.value.filter((s) => GENERAL_PROVIDER_KEYS.has(s.value));
-  const specific = specificAllSelected.value
-    ? enabledSpecificProviders.value
-    : metadataSources.value.filter((s) => SPECIFIC_PROVIDER_KEYS.has(s.value));
-  return [...general, ...specific];
-});
+const {
+  calculateHashes,
+  generalProviders,
+  specificProviders,
+  metadataSources,
+  effectiveMetadataSources,
+  generalAllSelected,
+  specificAllSelected,
+  isLaunchboxSelected,
+  launchboxRemoteEnabled,
+  hashMatchers,
+  setHashMatcher,
+  isHashMatcherOn,
+  buildScanPayload,
+  persistSelection,
+} = useScanProviders();
 
 // Auto-expand a platform's panel the moment it starts reporting roms. The
 // panel body only lists ROMs, so firmware alone leaves nothing to show. We
@@ -429,33 +242,12 @@ function scan() {
 
   if (!socket.connected) socket.connect();
 
-  storedMetadataSources.value = metadataSources.value.map((s) => s.value);
-
-  // Build the apis payload from the effective sources (All-mode groups
-  // expanded to their full provider list — the backend treats an empty
-  // list as "no sources", not "all") plus hasheous (when its switch is
-  // on and the backend accepts it as a MetadataSource enum value).
-  // Playmatch has no enum entry — it's gated server-side via the
-  // separate `playmatch_enabled` flag below.
-  const apis = effectiveMetadataSources.value.map((s) => s.value);
-  const hasheousMatcher = hashMatchers.value.find(
-    (m) => m.value === "hasheous",
-  );
-  if (hasheousMatcher && isHashMatcherOn(hasheousMatcher)) {
-    apis.push("hasheous");
-  }
-  const playmatchMatcher = hashMatchers.value.find(
-    (m) => m.value === "playmatch",
-  );
+  persistSelection();
 
   socket.emit("scan", {
     platform_fs_slugs: platformsToScan.value,
     type: scanType.value,
-    apis,
-    launchbox_remote_enabled: launchboxRemoteEnabled.value,
-    playmatch_enabled: playmatchMatcher
-      ? isHashMatcherOn(playmatchMatcher)
-      : false,
+    ...buildScanPayload(),
   });
 }
 


### PR DESCRIPTION
**Description**

In the v2 provider selects, "All" is represented by an **empty model**: `RSelect`'s
All-mode strips its own items from the `v-model` rather than listing them. The
Playmatch gate in both scan dialogs read that raw model:

```ts
const igdbSelected = metadataSources.value.some((s) => s.value === "igdb");
```

So with Providers set to All, `igdbSelected` was `false` and the Playmatch switch
stayed disabled with "Select IGDB to enable Playmatch" — even though the scan was
about to run IGDB.

The same read fed the payload, so the bug was not only cosmetic. An All-mode group
contributed nothing to `apis`, and the backend reads an empty `apis` list as *no
sources*, not "all". Setting both provider groups to All in either dialog would
have scanned with no providers at all, and the submit button greyed out because it
gated on `metadataSources.length`.

`Scan.vue` already had the fix — `effectiveMetadataSources` expands an All-mode
group to its enabled providers — but the two dialogs never got it. They each
carried their own copy of the provider list, the localStorage keys, the hash-matcher
definitions and the payload builder, which is how they drifted in the first place.
Rather than add a third copy of the expansion, this moves the whole model into a
shared `useScanProviders` composable and points all three surfaces at it.

**Reproduction**

1. Open any ROM's ⋮ menu → Refresh metadata (or a platform's Scan dialog).
2. In Providers → General, choose **All**.
3. Playmatch under Proxies is disabled, tooltipped "Select IGDB to enable Playmatch".

Picking IGDB explicitly instead of All enabled it, which is what made this look
like a display bug rather than an empty-payload bug.

**Files changed**

- `frontend/src/v2/composables/useScanProviders/index.ts` (new): the shared model —
  provider categorisation, the four `scan.*` localStorage keys, `metadataOptions`,
  `effectiveMetadataSources`, the Hasheous/Playmatch matchers, `buildScanPayload()`
  and `persistSelection()`. Two behavioural notes versus the code it replaces: an
  explicit pick now always wins over the All flag, so the gate is correct even
  before a select has mounted and emitted its initial All state; and the restore
  watch only re-derives the selection when the *stored* list changes, so a heartbeat
  refresh or an admin toggle no longer discards an in-progress selection (it just
  prunes providers that went away). The three surfaces lose 587 lines between them.
- `frontend/src/v2/composables/useScanProviders/index.test.ts` (new): 12 cases. The
  load-bearing one asserts Playmatch is enabled with the general group in All-mode,
  which fails against the old logic. The rest cover explicit picks winning over All,
  the hash-matcher exclusions, the `SKIP_HASH_CALCULATION` gate, the expanded `apis`
  payload, and both restore paths.
- `frontend/src/v2/components/Dialogs/RefreshMetadataDialog.vue`,
  `frontend/src/v2/components/Gallery/ScanPlatformDialog.vue`: consume the composable.
  This is where the reported bug lives. Both also had the empty-`apis` and
  disabled-submit consequences described above.
- `frontend/src/v2/views/Scan.vue`: consume the composable. No behaviour change — it
  already resolved All-mode correctly; this just removes the copy it was resolving with.
- Dropped a stray inline i18n fallback in `ScanPlatformDialog`
  (`t("scan.playmatch-requires-igdb", "Select IGDB to enable Playmatch.")`); the key
  exists in every locale, and the hardcoded default shadowed the translated string
  with English.

**Verification**

`npm run typecheck` clean, eslint and prettier clean on the changed files, and the
full suite passes at 667 (655 before, +12 here). I have not exercised this in a
browser — there is no RomM instance running against this worktree — so the
theme/input pass is unverified and a maintainer may want to eyeball the two dialogs.
The logic is covered by the unit tests above.

**AI Assistance Disclosure**

AI assistance (Claude Code) was used for this contribution: the root-cause analysis,
the implementation, the unit tests and this description were AI-generated, then
reviewed by me before submission. Any replies I post on this PR are written by me
unless stated otherwise.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
