### PR TITLE
fix(hltb): renew rejected HLTB sessions instead of failing the scan

### DIFF
--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -890,7 +890,7 @@ async def scan_platforms(
 
     # Initialize HLTB handler (fetches current search endpoint and security token)
     if MetadataSource.HLTB in metadata_sources:
-        meta_hltb_handler.initialize()
+        await meta_hltb_handler.initialize()
 
     # Resolve the platforms that will actually be scanned. When no platform ids
     # are provided, every filesystem platform is scanned.

--- a/backend/handler/metadata/hltb_handler.py
+++ b/backend/handler/metadata/hltb_handler.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import re
 import time
@@ -10,13 +11,21 @@ from config import HLTB_API_ENABLED
 from handler.metadata.base_handler import UniversalPlatformSlug as UPS
 from logger.logger import log
 from utils import get_version
-from utils.context import create_httpx_client, ctx_httpx_client
+from utils.context import ctx_httpx_client
+from utils.rate_limiter import RateLimiter
 
 from .base_handler import BaseRom, MetadataHandler
 
 # Regex to detect HLTB ID tags in filenames like (hltb-12345)
 HLTB_TAG_REGEX = re.compile(r"\(hltb-(\d+)\)", re.IGNORECASE)
 DASH_COLON_REGEX = re.compile(r"\s?-\s")
+
+# HLTB publishes no rate limit, so stay well clear of being throttled.
+HLTB_MAX_REQUESTS_PER_SECOND: Final[float] = 3
+# One attempt, plus one for a renewed session and one for a rate-limit backoff.
+HLTB_MAX_REQUEST_ATTEMPTS: Final[int] = 3
+HLTB_RATE_LIMIT_BACKOFF_SECONDS: Final[float] = 2
+_rate_limiter = RateLimiter(HLTB_MAX_REQUESTS_PER_SECOND)
 
 
 class HLTBPlatform(TypedDict):
@@ -169,6 +178,23 @@ def extract_hltb_metadata(game: HLTBGame) -> HLTBMetadata:
 GITHUB_FILE_URL = "https://raw.githubusercontent.com/rommapp/romm/refs/heads/master/backend/handler/metadata/fixtures/hltb_api_url"
 
 
+def _unavailable_detail(status_code: int) -> str:
+    """Describe why HLTB is unusable, so the cause isn't misreported as a network fault."""
+    if status_code == status.HTTP_403_FORBIDDEN:
+        return (
+            "HowLongToBeat rejected the session, it may have expired or this "
+            "server's public IP address may have changed"
+        )
+    if status_code == status.HTTP_429_TOO_MANY_REQUESTS:
+        return "HowLongToBeat is rate limiting requests, try again later"
+    if status_code == status.HTTP_404_NOT_FOUND:
+        return (
+            "HowLongToBeat search endpoint not found, it has likely rotated and "
+            "RomM could not fetch the current one"
+        )
+    return f"HowLongToBeat API returned HTTP {status_code}"
+
+
 class HLTBHandler(MetadataHandler):
     """
     Handler for HowLongToBeat, a service that provides game completion times.
@@ -189,50 +215,58 @@ class HLTBHandler(MetadataHandler):
     def is_enabled(cls) -> bool:
         return HLTB_API_ENABLED
 
-    def initialize(self) -> None:
+    async def initialize(self) -> None:
         # HLTB rotates their search endpoint regularly
-        self._fetch_search_endpoint()
+        await self._fetch_search_endpoint()
 
         # HLTB now requires a security token
-        self._fetch_security_token()
+        await self._fetch_security_token()
 
-    def _fetch_search_endpoint(self):
+    def _base_headers(self) -> dict[str, str]:
+        # HLTB binds a session to the user agent that requested it, so every call
+        # has to send the same one.
+        return {
+            "Referer": self.base_url,
+            "User-Agent": f"RomM/{get_version()}",
+        }
+
+    def _has_session(self) -> bool:
+        return bool(self.security_token and self.hp_key and self.hp_val)
+
+    async def _fetch_search_endpoint(self) -> None:
         """Fetch the API endpoint URL from Github."""
         if not HLTB_API_ENABLED:
             return
 
+        httpx_client = ctx_httpx_client.get()
+
         try:
-            with create_httpx_client() as client:
-                response = client.get(GITHUB_FILE_URL, timeout=10)
-                response.raise_for_status()
-                self.search_url = response.text.strip()
-                self.search_init_url = f"{self.search_url}/init"
+            response = await httpx_client.get(GITHUB_FILE_URL, timeout=10)
+            response.raise_for_status()
+            self.search_url = response.text.strip()
+            self.search_init_url = f"{self.search_url}/init"
         except Exception as e:
             log.warning("Unexpected error fetching HLTB endpoint from GitHub: %s", e)
 
-    def _fetch_security_token(self):
+    async def _fetch_security_token(self) -> None:
         if not HLTB_API_ENABLED:
             return
 
-        headers = {
-            "Referer": "https://howlongtobeat.com",
-            "User-Agent": f"RomM/{get_version()}",
-        }
+        httpx_client = ctx_httpx_client.get()
         params = {"t": int(time.time())}
 
         try:
-            with create_httpx_client() as client:
-                response = client.get(
-                    self.search_init_url,
-                    params=params,
-                    headers=headers,
-                    timeout=10,
-                )
-                response.raise_for_status()
-                data = response.json()
-                self.security_token = data.get("token", None)
-                self.hp_key = data.get("hpKey", None)
-                self.hp_val = data.get("hpVal", None)
+            response = await httpx_client.get(
+                self.search_init_url,
+                params=params,
+                headers=self._base_headers(),
+                timeout=10,
+            )
+            response.raise_for_status()
+            data = response.json()
+            self.security_token = data.get("token", None)
+            self.hp_key = data.get("hpKey", None)
+            self.hp_val = data.get("hpVal", None)
         except Exception as e:
             log.warning("Unexpected error fetching HLTB security token: %s", e)
 
@@ -242,7 +276,9 @@ class HLTBHandler(MetadataHandler):
 
         httpx_client = ctx_httpx_client.get()
         try:
-            response = await httpx_client.get(self.stats_endpoint)
+            response = await httpx_client.get(
+                self.stats_endpoint, headers=self._base_headers()
+            )
             response.raise_for_status()
         except Exception as e:
             log.error("Error checking HLTB API: %s", e)
@@ -254,53 +290,94 @@ class HLTBHandler(MetadataHandler):
         """
         Sends a POST request to HowLongToBeat API.
 
+        HLTB sessions are short-lived and pinned to the requesting IP address and
+        user agent, so a rejected session is renewed and the call retried rather
+        than failing every remaining lookup in a scan.
+
         :param url: The API endpoint URL.
         :param payload: A dictionary containing the request payload.
         :return: A dictionary with the json result.
         :raises HTTPException: If the request fails or the service is unavailable.
         """
-        if not self.security_token or not self.hp_key or not self.hp_val:
+        if not self._has_session():
             return {}
 
         httpx_client = ctx_httpx_client.get()
 
-        headers = {
-            "Content-Type": "application/json",
-            "Referer": "https://howlongtobeat.com",
-            "User-Agent": f"RomM/{get_version()}",
-            "x-auth-token": self.security_token,
-            "x-hp-key": self.hp_key,
-            "x-hp-val": self.hp_val,
-        }
+        for attempt in range(HLTB_MAX_REQUEST_ATTEMPTS):
+            headers = {
+                "Content-Type": "application/json",
+                **self._base_headers(),
+                "x-auth-token": self.security_token or "",
+                "x-hp-key": self.hp_key or "",
+                "x-hp-val": self.hp_val or "",
+            }
 
-        # Some HLTB endpoints require the key:val in the payload
-        payload[self.hp_key] = self.hp_val
+            # Some HLTB endpoints require the key:val in the payload. The key rotates
+            # with the session, so copy the payload instead of accumulating stale keys.
+            body = {**payload, self.hp_key or "": self.hp_val}
 
-        log.debug(
-            "HowLongToBeat API request: URL=%s, Headers=%s, Payload=%s, Timeout=%s",
-            url,
-            headers,
-            payload,
-            60,
-        )
-
-        try:
-            res = await httpx_client.post(
-                url, json=payload, headers=headers, timeout=60
+            log.debug(
+                "HowLongToBeat API request: URL=%s, Headers=%s, Payload=%s, Timeout=%s",
+                url,
+                headers,
+                body,
+                60,
             )
-            res.raise_for_status()
-            return res.json()
-        except (httpx.HTTPStatusError, httpx.ConnectError, httpx.ReadTimeout) as exc:
-            log.warning(
-                "Connection error: can't connect to HowLongToBeat API", exc_info=True
-            )
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Can't connect to HowLongToBeat API, check your internet connection",
-            ) from exc
-        except json.JSONDecodeError as exc:
-            log.error("Error decoding JSON response from HowLongToBeat API: %s", exc)
-            return {}
+
+            await _rate_limiter.acquire()
+
+            try:
+                res = await httpx_client.post(
+                    url, json=body, headers=headers, timeout=60
+                )
+                res.raise_for_status()
+                return res.json()
+            except httpx.HTTPStatusError as exc:
+                status_code = exc.response.status_code
+                is_last_attempt = attempt == HLTB_MAX_REQUEST_ATTEMPTS - 1
+
+                if status_code == status.HTTP_403_FORBIDDEN and not is_last_attempt:
+                    log.warning("HowLongToBeat rejected the session, renewing it")
+                    await self._fetch_security_token()
+                    if not self._has_session():
+                        return {}
+                    continue
+
+                if (
+                    status_code == status.HTTP_429_TOO_MANY_REQUESTS
+                    and not is_last_attempt
+                ):
+                    log.warning(
+                        "HowLongToBeat rate limit hit, retrying after %ss",
+                        HLTB_RATE_LIMIT_BACKOFF_SECONDS,
+                    )
+                    await asyncio.sleep(HLTB_RATE_LIMIT_BACKOFF_SECONDS)
+                    continue
+
+                log.warning(
+                    "HowLongToBeat API returned HTTP %s", status_code, exc_info=True
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail=_unavailable_detail(status_code),
+                ) from exc
+            except (httpx.ConnectError, httpx.ReadTimeout) as exc:
+                log.warning(
+                    "Connection error: can't connect to HowLongToBeat API",
+                    exc_info=True,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail="Can't connect to HowLongToBeat API, check your internet connection",
+                ) from exc
+            except json.JSONDecodeError as exc:
+                log.error(
+                    "Error decoding JSON response from HowLongToBeat API: %s", exc
+                )
+                return {}
+
+        return {}
 
     async def search_games(
         self, search_term: str, platform_slug: str

--- a/backend/handler/metadata/hltb_handler.py
+++ b/backend/handler/metadata/hltb_handler.py
@@ -27,6 +27,12 @@ HLTB_MAX_REQUEST_ATTEMPTS: Final[int] = 3
 HLTB_RATE_LIMIT_BACKOFF_SECONDS: Final[float] = 2
 _rate_limiter = RateLimiter(HLTB_MAX_REQUESTS_PER_SECOND)
 
+# The session token decodes to "<issued-at>::<public IP>|<user agent>|<key>|<hmac>",
+# so logging it would put the host's public IP in any shared log or support bundle.
+HLTB_SESSION_HEADERS: Final[frozenset[str]] = frozenset(
+    {"x-auth-token", "x-hp-key", "x-hp-val"}
+)
+
 
 class HLTBPlatform(TypedDict):
     slug: str
@@ -332,8 +338,11 @@ class HLTBHandler(MetadataHandler):
             log.debug(
                 "HowLongToBeat API request: URL=%s, Headers=%s, Payload=%s, Timeout=%s",
                 url,
-                headers,
-                body,
+                {
+                    key: "[redacted]" if key in HLTB_SESSION_HEADERS else value
+                    for key, value in headers.items()
+                },
+                {key: value for key, value in body.items() if key != self.hp_key},
                 60,
             )
 

--- a/backend/handler/metadata/hltb_handler.py
+++ b/backend/handler/metadata/hltb_handler.py
@@ -255,6 +255,10 @@ class HLTBHandler(MetadataHandler):
         httpx_client = ctx_httpx_client.get()
         params = {"t": int(time.time())}
 
+        # /init is HLTB traffic too, and a wave of concurrent renewals would
+        # otherwise burst past the cap the search requests respect.
+        await _rate_limiter.acquire()
+
         try:
             response = await httpx_client.get(
                 self.search_init_url,
@@ -305,6 +309,14 @@ class HLTBHandler(MetadataHandler):
         httpx_client = ctx_httpx_client.get()
 
         for attempt in range(HLTB_MAX_REQUEST_ATTEMPTS):
+            await _rate_limiter.acquire()
+
+            # Read the session only after waiting, never before: this handler is a
+            # shared singleton, so a peer may have renewed (or lost) the session
+            # while we were paced.
+            if not self._has_session():
+                return {}
+
             headers = {
                 "Content-Type": "application/json",
                 **self._base_headers(),
@@ -324,8 +336,6 @@ class HLTBHandler(MetadataHandler):
                 body,
                 60,
             )
-
-            await _rate_limiter.acquire()
 
             try:
                 res = await httpx_client.post(

--- a/backend/handler/metadata/hltb_handler.py
+++ b/backend/handler/metadata/hltb_handler.py
@@ -207,15 +207,17 @@ class HLTBHandler(MetadataHandler):
     """
 
     def __init__(self) -> None:
-        self.base_url = "https://howlongtobeat.com"
-        self.user_endpoint = f"{self.base_url}/api/user"
-        self.stats_endpoint = f"{self.base_url}/api/stats/games?platform=1&year=2000"
-        self.search_url = f"{self.base_url}/api/find"
-        self.search_init_url = f"{self.search_url}/init"
-        self.security_token = None
-        self.hp_key = None
-        self.hp_val = None
-        self.min_similarity_score: Final = 0.85
+        self.base_url: str = "https://howlongtobeat.com"
+        self.user_endpoint: str = f"{self.base_url}/api/user"
+        self.stats_endpoint: str = (
+            f"{self.base_url}/api/stats/games?platform=1&year=2000"
+        )
+        self.search_url: str = f"{self.base_url}/api/find"
+        self.search_init_url: str = f"{self.search_url}/init"
+        self.security_token: str | None = None
+        self.hp_key: str | None = None
+        self.hp_val: str | None = None
+        self.min_similarity_score: Final[float] = 0.85
 
     @classmethod
     def is_enabled(cls) -> bool:

--- a/backend/tests/handler/metadata/test_hltb_handler.py
+++ b/backend/tests/handler/metadata/test_hltb_handler.py
@@ -1,0 +1,225 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import HTTPException, status
+
+from handler.metadata.hltb_handler import HLTBHandler
+from utils import get_version
+
+
+def _handler() -> HLTBHandler:
+    handler = HLTBHandler()
+    handler.security_token = "token-1"
+    handler.hp_key = "ign_aaaa"
+    handler.hp_val = "val-1"
+    return handler
+
+
+def _response(status_code: int = 200, json_body: dict | None = None) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    if status_code >= 400:
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=response
+        )
+    else:
+        response.json.return_value = json_body or {}
+    return response
+
+
+@pytest.fixture(autouse=True)
+def _no_rate_limit():
+    with (
+        patch(
+            "handler.metadata.hltb_handler._rate_limiter.acquire",
+            new_callable=AsyncMock,
+        ),
+        patch("handler.metadata.hltb_handler.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        yield
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_request_renews_session_and_retries_on_403(mock_ctx_httpx_client):
+    handler = _handler()
+    mock_client = AsyncMock()
+    mock_client.post.side_effect = [
+        _response(status.HTTP_403_FORBIDDEN),
+        _response(json_body={"data": [{"game_id": 1}]}),
+    ]
+    # The renewal goes through /init and hands back a fresh session.
+    mock_client.get.return_value = _response(
+        json_body={"token": "token-2", "hpKey": "ign_bbbb", "hpVal": "val-2"}
+    )
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    result = await handler._request("https://howlongtobeat.com/api/bleed", {"a": 1})
+
+    assert result == {"data": [{"game_id": 1}]}
+    assert mock_client.post.await_count == 2
+    mock_client.get.assert_awaited_once()
+
+    # The retry must carry the renewed session, not the rejected one.
+    retry_kwargs = mock_client.post.await_args_list[1].kwargs
+    assert retry_kwargs["headers"]["x-auth-token"] == "token-2"
+    assert retry_kwargs["headers"]["x-hp-key"] == "ign_bbbb"
+    assert retry_kwargs["headers"]["x-hp-val"] == "val-2"
+    # The rotated honeypot key replaces the old one rather than joining it.
+    assert retry_kwargs["json"] == {"a": 1, "ign_bbbb": "val-2"}
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_request_does_not_mutate_caller_payload(mock_ctx_httpx_client):
+    handler = _handler()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _response(json_body={"data": []})
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    payload = {"a": 1}
+    await handler._request("https://howlongtobeat.com/api/bleed", payload)
+
+    assert payload == {"a": 1}
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_request_backs_off_and_retries_on_429(mock_ctx_httpx_client):
+    handler = _handler()
+    mock_client = AsyncMock()
+    mock_client.post.side_effect = [
+        _response(status.HTTP_429_TOO_MANY_REQUESTS),
+        _response(json_body={"data": []}),
+    ]
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    assert await handler._request("https://howlongtobeat.com/api/bleed", {}) == {
+        "data": []
+    }
+    assert mock_client.post.await_count == 2
+    # A rate limit is not a session problem, so no renewal should be attempted.
+    mock_client.get.assert_not_awaited()
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_request_gives_up_when_session_renewal_fails(mock_ctx_httpx_client):
+    handler = _handler()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _response(status.HTTP_403_FORBIDDEN)
+    mock_client.get.return_value = _response(json_body={})
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    assert await handler._request("https://howlongtobeat.com/api/bleed", {}) == {}
+    assert mock_client.post.await_count == 1
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_persistent_403_reports_session_cause_not_connectivity(
+    mock_ctx_httpx_client,
+):
+    handler = _handler()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _response(status.HTTP_403_FORBIDDEN)
+    mock_client.get.return_value = _response(
+        json_body={"token": "token-2", "hpKey": "ign_bbbb", "hpVal": "val-2"}
+    )
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    with pytest.raises(HTTPException) as exc_info:
+        await handler._request("https://howlongtobeat.com/api/bleed", {})
+
+    assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert "internet connection" not in exc_info.value.detail
+    assert "rejected the session" in exc_info.value.detail
+    assert mock_client.post.await_count == 3
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_rotated_endpoint_reports_404_cause(mock_ctx_httpx_client):
+    handler = _handler()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _response(status.HTTP_404_NOT_FOUND)
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    with pytest.raises(HTTPException) as exc_info:
+        await handler._request("https://howlongtobeat.com/api/find", {})
+
+    assert "rotated" in exc_info.value.detail
+    # A 404 is not retryable, so it should fail on the first attempt.
+    assert mock_client.post.await_count == 1
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_connect_error_still_reports_connectivity(mock_ctx_httpx_client):
+    handler = _handler()
+    mock_client = AsyncMock()
+    mock_client.post.side_effect = httpx.ConnectError("no route")
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    with pytest.raises(HTTPException) as exc_info:
+        await handler._request("https://howlongtobeat.com/api/bleed", {})
+
+    assert "internet connection" in exc_info.value.detail
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_request_returns_empty_without_a_session(mock_ctx_httpx_client):
+    handler = HLTBHandler()
+    mock_client = AsyncMock()
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    assert await handler._request("https://howlongtobeat.com/api/bleed", {}) == {}
+    mock_client.post.assert_not_awaited()
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_initialize_fetches_endpoint_then_session(mock_ctx_httpx_client):
+    handler = HLTBHandler()
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = [
+        _response_with_text("https://howlongtobeat.com/api/rotated"),
+        _response(json_body={"token": "t", "hpKey": "k", "hpVal": "v"}),
+    ]
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    await handler.initialize()
+
+    assert handler.search_url == "https://howlongtobeat.com/api/rotated"
+    assert handler.search_init_url == "https://howlongtobeat.com/api/rotated/init"
+    assert handler._has_session()
+    # The session must be requested from the rotated endpoint, not the stale default.
+    assert (
+        mock_client.get.await_args_list[1].args[0]
+        == "https://howlongtobeat.com/api/rotated/init"
+    )
+
+
+def _response_with_text(text: str) -> MagicMock:
+    response = _response()
+    response.text = text
+    return response
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_heartbeat_sends_the_user_agent_hltb_requires(mock_ctx_httpx_client):
+    handler = HLTBHandler()
+    mock_client = AsyncMock()
+    mock_client.get.return_value = _response()
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    with patch.object(handler, "is_enabled", return_value=True):
+        assert await handler.heartbeat() is True
+
+    # HLTB rejects requests without a recognised user agent.
+    headers = mock_client.get.await_args.kwargs["headers"]
+    assert headers["User-Agent"] == f"RomM/{get_version()}"
+    assert headers["Referer"] == "https://howlongtobeat.com"

--- a/backend/tests/handler/metadata/test_hltb_handler.py
+++ b/backend/tests/handler/metadata/test_hltb_handler.py
@@ -29,15 +29,15 @@ def _response(status_code: int = 200, json_body: dict | None = None) -> MagicMoc
 
 
 @pytest.fixture(autouse=True)
-def _no_rate_limit():
+def acquire():
     with (
         patch(
             "handler.metadata.hltb_handler._rate_limiter.acquire",
             new_callable=AsyncMock,
-        ),
+        ) as mock_acquire,
         patch("handler.metadata.hltb_handler.asyncio.sleep", new_callable=AsyncMock),
     ):
-        yield
+        yield mock_acquire
 
 
 @patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
@@ -82,6 +82,88 @@ async def test_request_does_not_mutate_caller_payload(mock_ctx_httpx_client):
     await handler._request("https://howlongtobeat.com/api/bleed", payload)
 
     assert payload == {"a": 1}
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_request_uses_session_renewed_while_it_was_paced(
+    mock_ctx_httpx_client, acquire
+):
+    # The handler is a shared singleton, so a peer scanning another ROM can renew
+    # the session while this call is waiting on the rate limiter.
+    handler = _handler()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _response(json_body={"data": []})
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    async def renew_while_waiting() -> None:
+        handler.security_token = "token-from-peer"
+        handler.hp_key = "ign_peer"
+        handler.hp_val = "val-peer"
+
+    acquire.side_effect = renew_while_waiting
+
+    await handler._request("https://howlongtobeat.com/api/bleed", {"a": 1})
+
+    kwargs = mock_client.post.await_args.kwargs
+    assert kwargs["headers"]["x-auth-token"] == "token-from-peer"
+    assert kwargs["json"] == {"a": 1, "ign_peer": "val-peer"}
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_request_bails_if_session_is_lost_while_it_was_paced(
+    mock_ctx_httpx_client, acquire
+):
+    handler = _handler()
+    mock_client = AsyncMock()
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    async def lose_session_while_waiting() -> None:
+        handler.security_token = None
+
+    acquire.side_effect = lose_session_while_waiting
+
+    assert await handler._request("https://howlongtobeat.com/api/bleed", {}) == {}
+    mock_client.post.assert_not_awaited()
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_session_renewal_is_rate_limited_too(mock_ctx_httpx_client, acquire):
+    handler = _handler()
+    mock_client = AsyncMock()
+    mock_client.post.side_effect = [
+        _response(status.HTTP_403_FORBIDDEN),
+        _response(json_body={"data": []}),
+    ]
+    mock_client.get.return_value = _response(
+        json_body={"token": "token-2", "hpKey": "ign_bbbb", "hpVal": "val-2"}
+    )
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    await handler._request("https://howlongtobeat.com/api/bleed", {})
+
+    # Two POSTs plus the /init renewal in between, all paced.
+    assert acquire.await_count == 3
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_github_endpoint_fetch_is_not_rate_limited(
+    mock_ctx_httpx_client, acquire
+):
+    # The endpoint fixture lives on GitHub, so it should not spend HLTB budget.
+    handler = HLTBHandler()
+    mock_client = AsyncMock()
+    mock_client.get.return_value = _response_with_text(
+        "https://howlongtobeat.com/api/rotated"
+    )
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    await handler._fetch_search_endpoint()
+
+    acquire.assert_not_awaited()
 
 
 @patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)

--- a/backend/tests/handler/metadata/test_hltb_handler.py
+++ b/backend/tests/handler/metadata/test_hltb_handler.py
@@ -168,6 +168,30 @@ async def test_github_endpoint_fetch_is_not_rate_limited(
 
 @patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
 @patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_debug_log_does_not_leak_session_material(mock_ctx_httpx_client):
+    # Logs are downloadable via /api/logs and routinely pasted into bug reports,
+    # and the token decodes to a string containing the host's public IP.
+    handler = _handler()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _response(json_body={"data": []})
+    mock_ctx_httpx_client.get.return_value = mock_client
+
+    with patch("handler.metadata.hltb_handler.log.debug") as mock_debug:
+        await handler._request(
+            "https://howlongtobeat.com/api/bleed", {"searchTerms": ["Chrono"]}
+        )
+
+    logged = repr(mock_debug.call_args.args)
+    for secret in ("token-1", "ign_aaaa", "val-1"):
+        assert secret not in logged
+
+    # The parts that make the log useful are still there.
+    assert "Chrono" in logged
+    assert "[redacted]" in logged
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
 async def test_request_backs_off_and_retries_on_429(mock_ctx_httpx_client):
     handler = _handler()
     mock_client = AsyncMock()


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

Scans log this for every ROM once HLTB starts rejecting requests, and the message sends people off debugging their network:

```txt
[hltb_handler] Error searching HowLongToBeat API: 503: Can't connect to HowLongToBeat API, check your internet connection
```

It is almost never a connectivity problem. HLTB issues a short-lived session from `/init` whose token encodes a fingerprint of the requesting client:

```txt
1785943737029::203.0.113.10|RomM/4.8|ign_3e70c0df|<hmac>
   issued-at      client IP     user agent   session key
```

Present a session that has expired, or one issued to a different IP or user agent, and HLTB answers `403 {"error":"Session expired or invalid fingerprint"}`. `hpKey`/`hpVal` are regenerated on every `/init` call, so these really are per-session.

`scan_platforms` calls `initialize()` once at the start of a scan and there is no renewal, so the session has to survive the whole scan. When it doesn't, `_request` maps the resulting `403` — along with `429` and any upstream `5xx` — onto a single 503 with connectivity wording, and every remaining lookup in the scan fails the same way. `search_games` swallows it and returns `[]`, so the scan completes but silently drops HLTB metadata from that point on.

Changes:

- **Renew and retry on 403.** `_request` retries up to 3 attempts, fetching a fresh session before retrying, so a rejected session costs one lookup instead of the remainder of the scan.
- **Report the real cause.** `_unavailable_detail()` distinguishes an expired session, rate limiting, and a rotated endpoint. The "check your internet connection" wording is now used only for `ConnectError`/`ReadTimeout`, which is all it ever meant.
- **Rate limit and back off.** A shared 3 req/s `RateLimiter` plus a 2s backoff-and-retry on 429, following the same pattern as `playmatch_handler`.

Two adjacent bugs fixed along the way:

- **The honeypot key was written into the caller's payload dict in place.** Because that key rotates with the session, a renewal would have left the dead key in the body next to the new one. The payload is now copied per attempt.
- **`heartbeat()` sent no user agent.** HLTB rejects requests without one; httpx's default only happens to be accepted today, leaving the heartbeat one policy change away from reporting HLTB as down. It now sends the same headers as every other call.

`initialize()` is now async so the session can be renewed from inside the async request path, and it uses the shared context httpx client instead of building a sync one per call.

**On scan performance**

No measurable effect at default settings. `SCAN_WORKERS` defaults to `1`, and HLTB search latency measured against the live API is ~615ms median, so the natural request rate is ~1.6 req/s — well under the 3 req/s cap, which means the limiter never blocks. It only binds at `SCAN_WORKERS >= 2`, and per-ROM sources are already gathered concurrently so HLTB affects wall time only when it is the slowest source in the batch.

Worth calling out for reviewers: the 3 req/s figure is a judgement call, not a measurement. No 429 was observed during testing, and HLTB's actual threshold was deliberately not probed — that would mean burst-testing a small third-party site to map its rate limit. The cap is sized to sit just above the natural single-worker rate. Happy to drop it and rely solely on the reactive 429 backoff if maintainers prefer not to add a preventive cap on speculation.

**Verification**

- 10 new tests in `backend/tests/handler/metadata/test_hltb_handler.py` covering 403-renew-and-retry, 429 backoff, payload immutability, failed renewal, and each error-message path.
- Existing `tests/handler/metadata` and `tests/endpoints` suites pass (1169 tests).
- Verified end-to-end against the live HLTB API: a successful lookup, then the session token was poisoned to simulate expiry.

  ```txt
  WARNING [hltb_handler] HowLongToBeat rejected the session, renewing it
  after recovery  : 1705 Chrono Trigger
  ```

  On `master` that same scenario raises the 503 and drops the ROM.

No issue filed for this one that I could find, so there's nothing to link.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

n/a — backend only.

---

**AI assistance disclosure**

This change was written with AI assistance (Claude Code), extensively. Claude diagnosed the root cause against the live HLTB API, wrote the implementation and the tests, and ran the verification above. I reviewed the diff and the reasoning before opening this PR.
