### PR TITLE
fix(hashing): extract CHD SHA-1 for folder-based ROMs

### DIFF
--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -430,9 +430,7 @@ class FSRomsHandler(FSHandler):
                         crc_c,
                         md5_h,
                         sha1_h,
-                        chd_sha1_hash=await asyncio.to_thread(
-                            _chd_sha1_hash, abs_file_path
-                        ),
+                        chd_sha1_hash=_chd_sha1_hash(abs_file_path),
                     )
                 else:
                     file_hash = FileHash(
@@ -572,7 +570,7 @@ class FSRomsHandler(FSHandler):
                 crc_c,
                 md5_h,
                 sha1_h,
-                chd_sha1_hash=await asyncio.to_thread(_chd_sha1_hash, rom_dir),
+                chd_sha1_hash=_chd_sha1_hash(rom_dir),
             )
             rom_files.append(
                 self._build_rom_file(

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -129,7 +129,7 @@ ARCHIVE_READERS = {
 
 
 def _chd_sha1_hash(file_path: Path) -> str:
-    """Return the disc-data SHA1 embedded in a CHD v5 header, or "" for non-CHD files."""
+    """Return the embedded CHD v5 raw+meta SHA-1, or "" for non-CHD files."""
     return extract_chd_hash(file_path) if is_chd_file(file_path) else ""
 
 

--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -128,6 +128,11 @@ ARCHIVE_READERS = {
 }
 
 
+def _chd_sha1_hash(file_path: Path) -> str:
+    """Return the disc-data SHA1 embedded in a CHD v5 header, or "" for non-CHD files."""
+    return extract_chd_hash(file_path) if is_chd_file(file_path) else ""
+
+
 def _make_file_hash(
     crc_c: int, md5_h: Any, sha1_h: Any, chd_sha1_hash: str = ""
 ) -> FileHash:
@@ -379,7 +384,6 @@ class FSRomsHandler(FSHandler):
                 f"{abs_fs_path}/{rom.fs_name}", recursive=True
             ):
                 # Check if file is excluded by extension.
-                f_rom_dir = Path(f_path, rom.fs_name)
                 file_name_lower = file_name.lower()
                 if any(
                     file_name_lower.endswith("." + ext) for ext in excluded_file_exts
@@ -396,6 +400,8 @@ class FSRomsHandler(FSHandler):
                 # Check if this is a top-level file (not in a subdirectory)
                 is_top_level = f_path.samefile(Path(abs_fs_path, rom.fs_name))
 
+                abs_file_path = Path(f_path, file_name)
+
                 if hashable_platform:
                     try:
                         if is_top_level:
@@ -403,7 +409,7 @@ class FSRomsHandler(FSHandler):
                             crc_c, rom_crc_c, md5_h, rom_md5_h, sha1_h, rom_sha1_h = (
                                 await asyncio.to_thread(
                                     self._calculate_rom_hashes,
-                                    Path(f_path, file_name),
+                                    abs_file_path,
                                     rom_crc_c,
                                     rom_md5_h,
                                     rom_sha1_h,
@@ -413,7 +419,7 @@ class FSRomsHandler(FSHandler):
                             # Calculate individual file hash only
                             crc_c, _, md5_h, _, sha1_h, _ = await asyncio.to_thread(
                                 self._calculate_rom_hashes,
-                                Path(f_path, file_name),
+                                abs_file_path,
                             )
                     except zlib.error:
                         crc_c = 0
@@ -424,10 +430,8 @@ class FSRomsHandler(FSHandler):
                         crc_c,
                         md5_h,
                         sha1_h,
-                        chd_sha1_hash=(
-                            extract_chd_hash(f_rom_dir)
-                            if is_chd_file(f_rom_dir)
-                            else ""
+                        chd_sha1_hash=await asyncio.to_thread(
+                            _chd_sha1_hash, abs_file_path
                         ),
                     )
                 else:
@@ -568,9 +572,7 @@ class FSRomsHandler(FSHandler):
                 crc_c,
                 md5_h,
                 sha1_h,
-                chd_sha1_hash=(
-                    extract_chd_hash(rom_dir) if is_chd_file(rom_dir) else ""
-                ),
+                chd_sha1_hash=await asyncio.to_thread(_chd_sha1_hash, rom_dir),
             )
             rom_files.append(
                 self._build_rom_file(

--- a/backend/tests/handler/filesystem/test_roms_handler.py
+++ b/backend/tests/handler/filesystem/test_roms_handler.py
@@ -914,6 +914,55 @@ class TestFSRomsHandler:
         # Header SHA1 stored separately in chd_sha1_hash
         assert parsed_rom_files.rom_files[0].chd_sha1_hash == internal_sha1
 
+    @pytest.mark.asyncio
+    async def test_get_rom_files_folder_extracts_chd_hash_per_file(
+        self, tmp_path: Path
+    ):
+        """Every CHD in a folder-based ROM keeps its own header SHA1."""
+        disc_platform = Platform(name="PlayStation", slug="psx", fs_slug="psx")
+        roms_path = tmp_path / disc_platform.fs_slug / "roms"
+        game_dir = roms_path / "Final Fantasy VII"
+        game_dir.mkdir(parents=True)
+
+        sha1_by_disc = {
+            "Final Fantasy VII (Disc 1).chd": "0123456789abcdef0123456789abcdef01234567",
+            "Final Fantasy VII (Disc 2).chd": "89abcdef0123456789abcdef0123456789abcdef",
+        }
+        for file_name, internal_sha1 in sha1_by_disc.items():
+            header = bytearray(124)
+            header[0:8] = b"MComprHD"
+            header[12:16] = int(5).to_bytes(4, "big")
+            header[84:104] = bytes.fromhex(internal_sha1)
+            (game_dir / file_name).write_bytes(header + file_name.encode())
+
+        (game_dir / "Final Fantasy VII.m3u").write_text("\n".join(sha1_by_disc) + "\n")
+
+        test_handler = FSRomsHandler()
+        test_handler.base_path = tmp_path
+
+        rom = Rom(
+            id=1,
+            fs_name="Final Fantasy VII",
+            fs_extension="",
+            fs_path=str(roms_path.relative_to(tmp_path)),
+            platform=disc_platform,
+        )
+
+        with patch(
+            "adapters.services.rahasher.RAHasherService.calculate_hash",
+            return_value="",
+        ):
+            parsed_rom_files = await test_handler.get_rom_files(rom)
+
+        chd_hash_by_file = {
+            rom_file.file_name: rom_file.chd_sha1_hash
+            for rom_file in parsed_rom_files.rom_files
+        }
+        assert chd_hash_by_file == {
+            **sha1_by_disc,
+            "Final Fantasy VII.m3u": "",
+        }
+
     @staticmethod
     def _setup_archive_rom(
         tmp_path: Path, platform: Platform, fs_name: str, fs_extension: str, data: bytes


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

Fixes #4126.

The CHD disc-data SHA-1 was never extracted for ROMs stored in a per-game folder. In the folder branch of `FSRomsHandler.get_rom_files`, the path handed to `is_chd_file()` / `extract_chd_hash()` was built from the ROM's folder name instead of the file being walked:

```python
for f_path, file_name in iter_files(f"{abs_fs_path}/{rom.fs_name}", recursive=True):
    f_rom_dir = Path(f_path, rom.fs_name)   # .../psx/Final Fantasy VII/Final Fantasy VII
```

`f_path` is the directory holding the file and `file_name` is the file, so the probed path pointed at a file that doesn't exist. `is_chd_file()` found no `.chd` suffix, libmagic raised `OSError` on the missing path and returned `False`, and `chd_sha1_hash` came out empty for every file of every folder-based ROM. This is not specific to multi-disc sets or `(Disc N)` naming; single-disc games in a folder were affected too. Single files sitting directly in the platform folder always used the correct path, which is why those worked.

Beyond the missing column in the UI, this also degraded metadata matching: `HasheousHandler` sends only the CHD disc-data SHA-1 when it is present, because a CHD's raw MD5/SHA-1/CRC are hashes of the container and match nothing in the database. With the field blank, folder-based CHDs were looked up by those container hashes instead.

Changes:

- Resolve the walked file's real path once (`abs_file_path`) and use it for both the raw hashes and the CHD header probe.
- Extract the probe into a `_chd_sha1_hash()` helper shared by the folder and single-file branches, and run it via `asyncio.to_thread` like the surrounding hashing calls, since it now performs real I/O per file.
- Add a regression test covering a two-disc CHD folder plus an `.m3u`: each disc keeps its own header SHA-1, the playlist stays empty.

Note for existing libraries: `_should_get_rom_files` only rebuilds ROM files for newly added ROMs or a **Complete**/**Hashes** scan, so already-scanned folder ROMs need a hashes rescan to backfill the value.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A — backend only, no UI change.

---

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The AI performed the investigation, wrote the fix and the regression test, and drafted this description; all of it was reviewed by me before submitting. Verification run locally: the new test fails on `master` and passes with the fix, `uv run pytest` green across the backend suite, and ruff/mypy clean on the changed files.
