### PR TITLE
fix(media): stop recording paths for media that never landed

### DIFF
--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -1932,17 +1932,11 @@ async def update_rom(
                     media_type,
                 )
 
-            media_path = cleaned_data.get("ss_metadata", {}).get(
-                f"{media_type.value}_path"
+        ss_metadata = cleaned_data.get("ss_metadata")
+        if ss_metadata:
+            await fs_resource_handler.store_metadata_media(
+                ss_metadata, preferred_media_types, add_ss_auth_to_url
             )
-            media_url = cleaned_data.get("ss_metadata", {}).get(
-                f"{media_type.value}_url"
-            )
-            if media_path and media_url:
-                await fs_resource_handler.store_media_file(
-                    add_ss_auth_to_url(media_url),
-                    media_path,
-                )
 
     # Handle local media files from LaunchBox when the ID has changed
     if (
@@ -1962,17 +1956,11 @@ async def update_rom(
                     media_type,
                 )
 
-            media_path = cleaned_data.get("launchbox_metadata", {}).get(
-                f"{media_type.value}_path"
+        launchbox_metadata = cleaned_data.get("launchbox_metadata")
+        if launchbox_metadata:
+            await fs_resource_handler.store_metadata_media(
+                launchbox_metadata, preferred_media_types
             )
-            media_url = cleaned_data.get("launchbox_metadata", {}).get(
-                f"{media_type.value}_url"
-            )
-            if media_path and media_url:
-                await fs_resource_handler.store_media_file(
-                    media_url,
-                    media_path,
-                )
 
     log.debug(
         f"Updating {hl(cleaned_data.get('name', ''), color=BLUE)} [{hl(cleaned_data.get('fs_name', ''))}] with data {cleaned_data}"

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -555,37 +555,32 @@ async def _identify_rom(
         },
     )
 
-    # Handle special media files from Screenscraper
+    # Handle special media files from Screenscraper, ES-DE gamelist.xml and
+    # LaunchBox. Media that didn't land on disk has its recorded path cleared, so
+    # write those dicts back when that happens.
+    preferred_media_types = get_preferred_media_types()
+    media_updates: dict[str, Any] = {}
+
     if _added_rom.ss_metadata and MetadataSource.SS in metadata_sources:
-        preferred_media_types = get_preferred_media_types()
-        for media_type in preferred_media_types:
-            media_path = _added_rom.ss_metadata.get(f"{media_type.value}_path")
-            media_url = _added_rom.ss_metadata.get(f"{media_type.value}_url")
-            if media_path and media_url:
-                await fs_resource_handler.store_media_file(
-                    add_ss_auth_to_url(media_url),
-                    media_path,
-                )
+        if await fs_resource_handler.store_metadata_media(
+            _added_rom.ss_metadata, preferred_media_types, add_ss_auth_to_url
+        ):
+            media_updates["ss_metadata"] = _added_rom.ss_metadata
 
-    # Handle special media files from ES-DE gamelist.xml
     if _added_rom.gamelist_metadata and MetadataSource.GAMELIST in metadata_sources:
-        preferred_media_types = get_preferred_media_types()
-        for media_type in preferred_media_types:
-            if _added_rom.gamelist_metadata.get(f"{media_type.value}_path"):
-                await fs_resource_handler.store_media_file(
-                    _added_rom.gamelist_metadata[f"{media_type.value}_url"],
-                    _added_rom.gamelist_metadata[f"{media_type.value}_path"],
-                )
+        if await fs_resource_handler.store_metadata_media(
+            _added_rom.gamelist_metadata, preferred_media_types
+        ):
+            media_updates["gamelist_metadata"] = _added_rom.gamelist_metadata
 
-    # Handle special media files from LaunchBox
     if _added_rom.launchbox_metadata and MetadataSource.LAUNCHBOX in metadata_sources:
-        preferred_media_types = get_preferred_media_types()
-        for media_type in preferred_media_types:
-            if _added_rom.launchbox_metadata.get(f"{media_type.value}_path"):
-                await fs_resource_handler.store_media_file(
-                    _added_rom.launchbox_metadata[f"{media_type.value}_url"],
-                    _added_rom.launchbox_metadata[f"{media_type.value}_path"],
-                )
+        if await fs_resource_handler.store_metadata_media(
+            _added_rom.launchbox_metadata, preferred_media_types
+        ):
+            media_updates["launchbox_metadata"] = _added_rom.launchbox_metadata
+
+    if media_updates:
+        db_rom_handler.update_rom(_added_rom.id, media_updates)
 
     # Store normal and locked badges
     if _added_rom.ra_metadata and MetadataSource.RA in metadata_sources:

--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -1,7 +1,9 @@
 import gzip
 import os
+from collections.abc import Callable, Iterable
 from io import BytesIO
 from pathlib import Path
+from typing import Any
 
 import httpx
 from anyio import Path as AnyioPath
@@ -661,7 +663,12 @@ class FSResourcesHandler(FSHandler):
     ) -> str:
         return os.path.join("roms", str(platform_id), str(rom_id), media_type.value)
 
-    async def store_media_file(self, url_media: str, dest_path: str) -> None:
+    async def store_media_file(self, url_media: str, dest_path: str) -> bool:
+        """Fetch a media file into ``dest_path``.
+
+        Returns whether the file is on disk afterwards, so callers can stop
+        recording a path for media that never landed.
+        """
         directory, filename = os.path.split(dest_path)
 
         if await self.file_exists(dest_path):
@@ -679,7 +686,7 @@ class FSResourcesHandler(FSHandler):
                 except Exception as exc:
                     log.error(f"Unable to copy media file {url_media}: {str(exc)}")
                     await self._discard_partial_file(dest_path)
-                    return None
+                    return False
             else:
                 # Handle HTTP URLs
                 httpx_client = ctx_httpx_client.get()
@@ -696,7 +703,7 @@ class FSResourcesHandler(FSHandler):
                                 ("image/", "video/", "application/pdf"),
                                 "media",
                             ):
-                                return None
+                                return False
 
                             async with await self.write_file_streamed(
                                 path=directory, filename=filename
@@ -706,17 +713,54 @@ class FSResourcesHandler(FSHandler):
                 except httpx.TransportError as exc:
                     log.error(f"Unable to fetch media file at {url_media}: {str(exc)}")
                     await self._discard_partial_file(dest_path)
-                    return None
+                    return False
                 except OSError as exc:
                     log.error(f"Unable to write media file for {url_media}: {str(exc)}")
                     await self._discard_partial_file(dest_path)
-                    return None
+                    return False
 
         # Drop ScreenScraper's green "missing art" placeholder so a box face
         # (box-2D-back / box-2D-side) falls back to the dark placeholder rather
         # than rendering bright green. Runs for pre-existing files too, cleaning
         # them up on rescan.
-        await self._discard_if_chroma_key(dest_path)
+        if await self._discard_if_chroma_key(dest_path):
+            return False
+
+        # A non-200 response, or a local URI that resolved to nothing, leaves no
+        # file behind without raising.
+        return await self.file_exists(dest_path)
+
+    async def store_metadata_media(
+        self,
+        metadata: dict[str, Any],
+        media_types: Iterable[MetadataMediaType],
+        url_transform: Callable[[str], str] | None = None,
+    ) -> bool:
+        """Fetch every recorded media file of a provider metadata dict.
+
+        Providers record where each media file should live before it's fetched,
+        so a failed download (or discarded placeholder art) would otherwise leave
+        the dict pointing at a file that isn't there. Clears those ``*_path``
+        entries and returns whether the dict was modified.
+        """
+        changed = False
+
+        for media_type in media_types:
+            path_key = f"{media_type.value}_path"
+            media_path = metadata.get(path_key)
+            media_url = metadata.get(f"{media_type.value}_url")
+            if not media_path or not media_url:
+                continue
+
+            stored = await self.store_media_file(
+                url_transform(media_url) if url_transform else media_url,
+                media_path,
+            )
+            if not stored:
+                metadata[path_key] = None
+                changed = True
+
+        return changed
 
     async def remove_media_resources_path(
         self,

--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -740,22 +740,30 @@ class FSResourcesHandler(FSHandler):
 
         Providers record where each media file should live before it's fetched,
         so a failed download (or discarded placeholder art) would otherwise leave
-        the dict pointing at a file that isn't there. Clears those ``*_path``
-        entries and returns whether the dict was modified.
+        the dict pointing at a file that isn't there. Every ``*_path`` left in the
+        dict afterwards points at a file that exists; the rest are cleared, and
+        the ``*_url`` is kept so a later scan can retry. Returns whether the dict
+        was modified.
         """
         changed = False
 
         for media_type in media_types:
             path_key = f"{media_type.value}_path"
             media_path = metadata.get(path_key)
-            media_url = metadata.get(f"{media_type.value}_url")
-            if not media_path or not media_url:
+            if not media_path:
                 continue
 
-            stored = await self.store_media_file(
-                url_transform(media_url) if url_transform else media_url,
-                media_path,
-            )
+            media_url = metadata.get(f"{media_type.value}_url")
+            if media_url:
+                stored = await self.store_media_file(
+                    url_transform(media_url) if url_transform else media_url,
+                    media_path,
+                )
+            else:
+                # Nothing to fetch from, so the path only holds if an earlier
+                # scan already stored the file.
+                stored = await self.file_exists(media_path)
+
             if not stored:
                 metadata[path_key] = None
                 changed = True

--- a/backend/tests/handler/filesystem/test_resources_handler.py
+++ b/backend/tests/handler/filesystem/test_resources_handler.py
@@ -13,6 +13,7 @@ from adapters.services.screenscraper import (
     SS_DEFAULT_MEDIA_TIMEOUT,
 )
 from config import RESOURCES_BASE_PATH
+from config.config_manager import MetadataMediaType
 from handler.filesystem.base_handler import CoverSize
 from handler.filesystem.resources_handler import (
     FSResourcesHandler,
@@ -769,6 +770,194 @@ class TestChromaKeyDetection:
         await handler.store_media_file("http://example.com/x.png", rel)
 
         assert (tmp_path / rel).exists()
+
+
+class TestStoreMediaFileResult:
+    """store_media_file reports whether the media actually landed on disk, so
+    callers can drop the recorded path instead of pointing at a missing file."""
+
+    @pytest.fixture
+    def handler(self):
+        return FSResourcesHandler()
+
+    @pytest.mark.asyncio
+    async def test_returns_true_for_downloaded_file(
+        self, handler: FSResourcesHandler, tmp_path
+    ):
+        handler.base_path = tmp_path
+        rel = "roms/1/1/box2d_back/box2d_back.png"
+
+        with patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx:
+            mock_ctx.get.return_value = _FakeHttpxClient(_FakeResponse())
+            assert await handler.store_media_file("http://example.com/x.png", rel)
+
+        assert (tmp_path / rel).exists()
+
+    @pytest.mark.asyncio
+    async def test_returns_true_for_pre_existing_file(
+        self, handler: FSResourcesHandler, tmp_path
+    ):
+        handler.base_path = tmp_path
+        rel = "roms/1/1/box2d_back/box2d_back.png"
+        (tmp_path / rel).parent.mkdir(parents=True)
+        (tmp_path / rel).write_bytes(b"art")
+
+        assert await handler.store_media_file("http://example.com/x.png", rel)
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_error_response(
+        self, handler: FSResourcesHandler, tmp_path
+    ):
+        handler.base_path = tmp_path
+        response = _FakeResponse()
+        response.status_code = 404
+
+        with patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx:
+            mock_ctx.get.return_value = _FakeHttpxClient(response)
+            stored = await handler.store_media_file(
+                "http://example.com/x.png", "roms/1/1/box2d_back/box2d_back.png"
+            )
+
+        assert stored is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_unexpected_content_type(
+        self, handler: FSResourcesHandler, tmp_path
+    ):
+        handler.base_path = tmp_path
+        response = _FakeResponse()
+        response.headers = {"content-type": "text/html"}
+
+        with patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx:
+            mock_ctx.get.return_value = _FakeHttpxClient(response)
+            stored = await handler.store_media_file(
+                "http://example.com/x.png", "roms/1/1/box2d_back/box2d_back.png"
+            )
+
+        assert stored is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_transport_error(
+        self, handler: FSResourcesHandler, tmp_path
+    ):
+        handler.base_path = tmp_path
+
+        with patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx:
+            client = Mock()
+            client.stream.side_effect = httpx.ConnectError("no route")
+            mock_ctx.get.return_value = client
+            stored = await handler.store_media_file(
+                "http://example.com/x.png", "roms/1/1/box2d_back/box2d_back.png"
+            )
+
+        assert stored is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_for_discarded_chroma_key(
+        self, handler: FSResourcesHandler, tmp_path
+    ):
+        handler.base_path = tmp_path
+        rel = "roms/1/1/box2d_back/box2d_back.png"
+        (tmp_path / rel).parent.mkdir(parents=True)
+        Image.new("RGB", (64, 64), (0, 255, 0)).save(tmp_path / rel)
+
+        assert await handler.store_media_file("http://example.com/x.png", rel) is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_for_unresolvable_local_uri(
+        self, handler: FSResourcesHandler, tmp_path
+    ):
+        handler.base_path = tmp_path
+        stored = await handler.store_media_file(
+            "launchbox-file://Videos/NES/missing.mp4", "roms/1/1/video/video.mp4"
+        )
+
+        assert stored is False
+
+
+class TestStoreMetadataMedia:
+    """Recorded media paths must not survive a download that didn't produce a
+    file, or exports and artwork URLs would point at nothing."""
+
+    @pytest.fixture
+    def handler(self):
+        return FSResourcesHandler()
+
+    @pytest.mark.asyncio
+    async def test_clears_paths_for_media_that_did_not_land(
+        self, handler: FSResourcesHandler
+    ):
+        metadata = {
+            "box2d_back_url": "http://example.com/back.png",
+            "box2d_back_path": "roms/1/1/box2d_back/box2d_back.png",
+            "fanart_url": "http://example.com/fanart.png",
+            "fanart_path": "roms/1/1/fanart/fanart.png",
+        }
+
+        async def fake_store(_url: str, dest_path: str) -> bool:
+            return "fanart" in dest_path
+
+        with patch.object(handler, "store_media_file", side_effect=fake_store):
+            changed = await handler.store_metadata_media(
+                metadata,
+                [MetadataMediaType.BOX2D_BACK, MetadataMediaType.FANART],
+            )
+
+        assert changed is True
+        assert metadata["box2d_back_path"] is None
+        assert metadata["fanart_path"] == "roms/1/1/fanart/fanart.png"
+        # The URL is kept so a later scan can retry the download
+        assert metadata["box2d_back_url"] == "http://example.com/back.png"
+
+    @pytest.mark.asyncio
+    async def test_leaves_metadata_untouched_when_all_media_lands(
+        self, handler: FSResourcesHandler
+    ):
+        metadata = {
+            "fanart_url": "http://example.com/fanart.png",
+            "fanart_path": "roms/1/1/fanart/fanart.png",
+        }
+
+        with patch.object(handler, "store_media_file", return_value=True):
+            changed = await handler.store_metadata_media(
+                metadata, [MetadataMediaType.FANART]
+            )
+
+        assert changed is False
+        assert metadata["fanart_path"] == "roms/1/1/fanart/fanart.png"
+
+    @pytest.mark.asyncio
+    async def test_skips_media_types_without_a_url_or_path(
+        self, handler: FSResourcesHandler
+    ):
+        metadata = {"fanart_url": "http://example.com/fanart.png"}
+
+        with patch.object(handler, "store_media_file") as store_mock:
+            changed = await handler.store_metadata_media(
+                metadata,
+                [MetadataMediaType.FANART, MetadataMediaType.BOX2D_BACK],
+            )
+
+        assert changed is False
+        store_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_applies_the_url_transform(self, handler: FSResourcesHandler):
+        metadata = {
+            "fanart_url": "http://example.com/fanart.png",
+            "fanart_path": "roms/1/1/fanart/fanart.png",
+        }
+
+        with patch.object(handler, "store_media_file", return_value=True) as store_mock:
+            await handler.store_metadata_media(
+                metadata,
+                [MetadataMediaType.FANART],
+                lambda url: f"{url}?ssid=user",
+            )
+
+        store_mock.assert_awaited_once_with(
+            "http://example.com/fanart.png?ssid=user", "roms/1/1/fanart/fanart.png"
+        )
 
 
 class _FakeResponse:

--- a/backend/tests/handler/filesystem/test_resources_handler.py
+++ b/backend/tests/handler/filesystem/test_resources_handler.py
@@ -927,9 +927,7 @@ class TestStoreMetadataMedia:
         assert metadata["fanart_path"] == "roms/1/1/fanart/fanart.png"
 
     @pytest.mark.asyncio
-    async def test_skips_media_types_without_a_url_or_path(
-        self, handler: FSResourcesHandler
-    ):
+    async def test_skips_media_types_without_a_path(self, handler: FSResourcesHandler):
         metadata = {"fanart_url": "http://example.com/fanart.png"}
 
         with patch.object(handler, "store_media_file") as store_mock:
@@ -940,6 +938,39 @@ class TestStoreMetadataMedia:
 
         assert changed is False
         store_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_clears_a_urlless_path_when_the_file_is_missing(
+        self, handler: FSResourcesHandler, tmp_path
+    ):
+        # A path with no URL can never be fetched, so it must not survive when
+        # the file it names isn't there.
+        handler.base_path = tmp_path
+        metadata = {"fanart_path": "roms/1/1/fanart/fanart.png"}
+
+        changed = await handler.store_metadata_media(
+            metadata, [MetadataMediaType.FANART]
+        )
+
+        assert changed is True
+        assert metadata["fanart_path"] is None
+
+    @pytest.mark.asyncio
+    async def test_keeps_a_urlless_path_when_the_file_exists(
+        self, handler: FSResourcesHandler, tmp_path
+    ):
+        handler.base_path = tmp_path
+        rel = "roms/1/1/fanart/fanart.png"
+        (tmp_path / rel).parent.mkdir(parents=True)
+        (tmp_path / rel).write_bytes(b"art")
+        metadata = {"fanart_path": rel}
+
+        changed = await handler.store_metadata_media(
+            metadata, [MetadataMediaType.FANART]
+        )
+
+        assert changed is False
+        assert metadata["fanart_path"] == rel
 
     @pytest.mark.asyncio
     async def test_applies_the_url_transform(self, handler: FSResourcesHandler):

--- a/backend/tests/utils/test_gamelist_exporter.py
+++ b/backend/tests/utils/test_gamelist_exporter.py
@@ -397,10 +397,9 @@ async def test_export_platform_to_file_omits_tags_when_copy_fails(
     # Successful copies present
     assert (platform_dir / "assets/covers/Super Mario World (USA).jpg").is_file()
     assert (platform_dir / "assets/screenshots/Super Mario World (USA).jpg").is_file()
-    # Failed copies don't produce destination files (an empty subdir may be
-    # left behind because _copy_asset mkdirs before opening the source).
-    assert not (platform_dir / "assets/manuals/Super Mario World (USA).pdf").exists()
-    assert not (platform_dir / "assets/videos/Super Mario World (USA).mp4").exists()
+    # A missing source produces neither a destination file nor an empty subdir
+    assert not (platform_dir / "assets/manuals").exists()
+    assert not (platform_dir / "assets/videos").exists()
 
     game = fromstring((platform_dir / "gamelist.xml").read_text()).findall("game")[0]
     assert game.find("manual") is None

--- a/backend/utils/gamelist_exporter.py
+++ b/backend/utils/gamelist_exporter.py
@@ -158,7 +158,7 @@ class GamelistExporter:
         if dest.exists():
             return True
 
-        # Metadata scanned before RomM cleared unfetched media paths can still
+        # Metadata scanned before unfetched media paths were cleared can still
         # point at files that were never downloaded.
         if not source.is_file():
             log.debug(f"Skipping asset {source}: source file is missing")

--- a/backend/utils/gamelist_exporter.py
+++ b/backend/utils/gamelist_exporter.py
@@ -155,9 +155,16 @@ class GamelistExporter:
     def _copy_asset(self, source: Path, dest: Path) -> bool:
         """Place ``source`` at ``dest`` via hardlink (same filesystem) or copy
         (otherwise). Returns True on success."""
-        dest.parent.mkdir(parents=True, exist_ok=True)
         if dest.exists():
             return True
+
+        # Metadata scanned before RomM cleared unfetched media paths can still
+        # point at files that were never downloaded.
+        if not source.is_file():
+            log.debug(f"Skipping asset {source}: source file is missing")
+            return False
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
 
         try:
             link_or_copy_file(source, dest)

--- a/backend/utils/pegasus_exporter.py
+++ b/backend/utils/pegasus_exporter.py
@@ -292,9 +292,16 @@ class PegasusExporter:
     def _copy_asset(self, source: Path, dest: Path) -> bool:
         """Place ``source`` at ``dest`` via hardlink (same filesystem) or copy
         (otherwise). Returns True on success."""
-        dest.parent.mkdir(parents=True, exist_ok=True)
         if dest.exists():
             return True
+
+        # Metadata scanned before RomM cleared unfetched media paths can still
+        # point at files that were never downloaded.
+        if not source.is_file():
+            log.debug(f"Skipping asset {source}: source file is missing")
+            return False
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
 
         try:
             link_or_copy_file(source, dest)

--- a/backend/utils/pegasus_exporter.py
+++ b/backend/utils/pegasus_exporter.py
@@ -295,7 +295,7 @@ class PegasusExporter:
         if dest.exists():
             return True
 
-        # Metadata scanned before RomM cleared unfetched media paths can still
+        # Metadata scanned before unfetched media paths were cleared can still
         # point at files that were never downloaded.
         if not source.is_file():
             log.debug(f"Skipping asset {source}: source file is missing")


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

Local gamelist/Pegasus exports log one of these per ROM, per missing asset:

```txt
Failed to copy /romm/resources/roms/10/4099/box2d_back/box2d_back.png -> /romm/library/roms/gb/assets/backcovers/RoboCop Versus The Terminator (USA).png: [Errno 2] No such file or directory
```

The source file really isn't there, but `ss_metadata.box2d_back_path` says it is.

Providers record where each media file *should* live at match time, before it is fetched (`extract_media_from_ss_game`), and that path is persisted regardless of what the download does next. `store_media_file` has four ways to leave nothing on disk without raising:

- a non-200 response
- an unexpected content type
- an `httpx.TransportError` (the partial file is discarded)
- `_discard_if_chroma_key` deleting the download — this is the likely one here, since it exists specifically to drop ScreenScraper's green "missing art" placeholder for `box-2D-back` / `box-2D-side` faces

All four return without touching the metadata, so the ROM keeps a path to a file that was never kept. Two visible consequences: exports warn on every run and leave an empty `assets/backcovers/` behind, and the frontend builds box-face URLs (`useBoxFaces`, `romArtwork`) that 404.

Changes:

- **`store_media_file` returns whether the media landed.** `False` on each bail-out path, on a discarded chroma-key placeholder, and on a local URI that resolved to nothing — the last case previously fell through silently, so the final check is actual file existence rather than the absence of an error.
- **New `store_metadata_media` clears phantom paths.** It walks the preferred media types of a provider metadata dict, and nulls `*_path` for anything that didn't land while keeping `*_url`, so a later scan can retry the download. Returns whether the dict changed. Every `*_path` it leaves behind points at a file that exists — including the (currently unreachable) case of a path recorded without a URL, which can't be fetched and so is cleared when its file is missing.
- **Scan writes the corrected dicts back.** The three near-identical SS / gamelist / LaunchBox blocks in `_identify_rom` collapse onto the helper, and the metadata is re-persisted when paths were cleared. The gamelist and LaunchBox blocks also stop indexing `*_url` unconditionally, which would have raised on a path recorded without a URL.
- **The manual `PUT /api/roms/{id}` path gets the same treatment**, for a changed `ss_id` or `launchbox_id`. `cleaned_data` is persisted immediately after, so the cleared paths land without an extra write.
- **Both exporters tolerate a stale path.** A missing source is now skipped at debug level instead of warned, and `dest.parent.mkdir` moved after that check so a failure no longer leaves an empty asset subdir. Asset refs were already omitted when a copy failed, so exported `gamelist.xml` / `metadata.pegasus.txt` content is unchanged.

The exporter change is what makes this quiet for libraries that already have phantom paths in the DB. Those clear on the next scan of each ROM; there's no backfill in this PR. Happy to add a cleanup task that nulls `*_path` entries whose file is missing if maintainers would rather not wait for a rescan.

**Verification**

- 17 new tests in `backend/tests/handler/filesystem/test_resources_handler.py`: `store_media_file`'s return value across each failure mode (error response, bad content type, transport error, discarded chroma key, unresolvable local URI, pre-existing file, successful download), and `store_metadata_media`'s clearing, no-op, skip, URL-transform, and URL-less-path behavior.
- Tightened `test_export_platform_to_file_omits_tags_when_copy_fails`, which previously asserted an empty subdir "may be left behind"; it now asserts the subdir isn't created at all.
- Full backend suite passes: 2744 passed, 2 skipped.
- `ruff@0.15.22`, `black`, `isort` and `mypy` clean on the changed files. (`trunk` wasn't available in my worktree, so I ran the pinned linters directly; mypy's remaining errors in these files are pre-existing and none fall in the changed ranges.)

I couldn't find an existing issue for this one, so there's nothing to link. It's adjacent to #4127 and #4128 (both about media that is recorded but unreachable) but distinct: this is about paths recorded for media that was never stored.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

n/a — backend only.

---

**AI assistance disclosure**

This change was written with AI assistance (Claude Code), extensively. Claude traced the root cause from the log line through the scan and export paths, wrote the implementation and the tests, and ran the verification above. I reviewed the diff and the reasoning before opening this PR.

