### PR TITLE
feat(retroachievements): flag which ROM version RA actually supports

### DIFF
--- a/backend/alembic/versions/0108_roms_ra_hash_match.py
+++ b/backend/alembic/versions/0108_roms_ra_hash_match.py
@@ -1,0 +1,39 @@
+"""Record whether RetroAchievements knows a ROM's own hash
+
+`ra_id` is the RetroAchievements *game*, and every version of a game resolves
+to the same one: on the Hasheous path it comes from the matched game's metadata
+list, so a bad dump and a good dump of the same title are indistinguishable by
+it. Achievements, though, only unlock when the file's RA hash is in RA's hash
+list, which is a per-file fact RomM computed during scans and then threw away.
+
+This column keeps it. NULL means never checked -- no RA hash, a platform RA
+doesn't cover, or a ROM last scanned before this existed -- so it stays
+distinguishable from a checked-and-absent hash.
+
+Revision ID: 0108_roms_ra_hash_match
+Revises: 0107_roms_dedup_cover_index
+Create Date: 2026-08-05 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0108_roms_ra_hash_match"
+down_revision = "0107_roms_dedup_cover_index"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("roms", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("ra_hash_match", sa.Boolean(), nullable=True),
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("roms", schema=None) as batch_op:
+        batch_op.drop_column("ra_hash_match", if_exists=True)

--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -331,6 +331,7 @@ class RomSchema(BaseModel):
     md5_hash: str | None
     sha1_hash: str | None
     ra_hash: str | None
+    ra_hash_match: bool | None
 
     has_simple_single_file: bool
     has_nested_single_file: bool
@@ -381,6 +382,11 @@ class SiblingRomSchema(BaseModel):
     fs_name_no_tags: str
     fs_name_no_ext: str
     is_main_sibling: bool
+    # Lets the version switcher flag which sibling RetroAchievements knows,
+    # so the user can pick the version whose achievements will actually
+    # unlock without opening each one. Not `ra_id`: that's the game, and
+    # every sibling shares it.
+    ra_hash_match: bool | None
 
     @computed_field  # type: ignore
     @property
@@ -402,6 +408,7 @@ class SiblingRomSchema(BaseModel):
             fs_name_no_tags=rom.fs_name_no_tags,
             fs_name_no_ext=rom.fs_name_no_ext,
             is_main_sibling=is_main_sibling,
+            ra_hash_match=rom.ra_hash_match,
         )
 
 

--- a/backend/endpoints/responses/rom.py
+++ b/backend/endpoints/responses/rom.py
@@ -382,10 +382,8 @@ class SiblingRomSchema(BaseModel):
     fs_name_no_tags: str
     fs_name_no_ext: str
     is_main_sibling: bool
-    # Lets the version switcher flag which sibling RetroAchievements knows,
-    # so the user can pick the version whose achievements will actually
-    # unlock without opening each one. Not `ra_id`: that's the game, and
-    # every sibling shares it.
+    # Per-file, unlike `ra_id`, so the version switcher can flag which
+    # sibling's achievements will actually unlock.
     ra_hash_match: bool | None
 
     @computed_field  # type: ignore

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -363,6 +363,7 @@ def with_details(func):
                     Rom.platform_id,
                     Rom.fs_name_no_tags,
                     Rom.fs_name_no_ext,
+                    Rom.ra_hash_match,
                 ),
             ),
             selectinload(Rom.collections),
@@ -408,6 +409,7 @@ def with_simple_details(func):
                     Rom.platform_id,
                     Rom.fs_name_no_tags,
                     Rom.fs_name_no_ext,
+                    Rom.ra_hash_match,
                 ),
             ),
             selectinload(Rom.notes),
@@ -537,6 +539,7 @@ class DBRomsHandler(DBBaseHandler):
                     Rom.name,
                     Rom.fs_name_no_tags,
                     Rom.fs_name_no_ext,
+                    Rom.ra_hash_match,
                 )
             )
         )
@@ -856,6 +859,10 @@ class DBRomsHandler(DBBaseHandler):
         return query.filter(Rom.missing_from_fs == (true() if value else false()))
 
     def _filter_by_verified(self, query: Query, value: bool) -> Query:
+        # Databases Hasheous answers for. RetroAchievements is handled
+        # separately below: RomM asks RA directly, and that answer outranks
+        # Hasheous' RA signature coverage in both directions. Keep in step
+        # with `romVerification.ts` on the frontend.
         keys_to_check = [
             "tosec_match",
             "mame_arcade_match",
@@ -864,7 +871,6 @@ class DBRomsHandler(DBBaseHandler):
             "redump_match",
             "mame_redump_match",
             "whdload_match",
-            "ra_match",
             "fbneo_match",
             "puredos_match",
         ]
@@ -879,13 +885,25 @@ class DBRomsHandler(DBBaseHandler):
                 f"COALESCE((hasheous_metadata->>'{key}')::boolean, false)"
                 for key in keys_to_check
             )
+            # RA verified when its own hash list says so, or when it was
+            # never asked (NULL) and Hasheous saw the hash.
+            conditions += (
+                " OR ra_hash_match IS TRUE"
+                " OR (ra_hash_match IS NULL AND"
+                " COALESCE((hasheous_metadata->>'ra_match')::boolean, false))"
+            )
             predicate = text(f"({conditions})")
             if not value:
                 predicate = text(f"NOT ({conditions})")
             return query.filter(predicate)
         else:
             predicate = or_(
-                *(Rom.hasheous_metadata[key].as_boolean() for key in keys_to_check)
+                *(Rom.hasheous_metadata[key].as_boolean() for key in keys_to_check),
+                Rom.ra_hash_match.is_(true()),
+                and_(
+                    Rom.ra_hash_match.is_(None),
+                    Rom.hasheous_metadata["ra_match"].as_boolean(),
+                ),
             )
             if not value:
                 predicate = not_(predicate)

--- a/backend/handler/metadata/ra_handler.py
+++ b/backend/handler/metadata/ra_handler.py
@@ -26,6 +26,11 @@ from .base_handler import UniversalPlatformSlug as UPS
 # Regex to detect RetroAchievements ID tags in filenames like (ra-12345)
 RA_TAG_REGEX = re.compile(r"\(ra-(\d+)\)", re.IGNORECASE)
 
+# How long an in-process copy of a platform's hash list stays usable.
+# Long enough to serve a whole scan from one parse, short enough that the
+# on-disk refresh still gets picked up.
+HASH_INDEX_CACHE_TTL_SECONDS = 900
+
 
 class RAGamesPlatform(TypedDict):
     slug: str
@@ -59,6 +64,7 @@ class RAMetadata(TypedDict):
 class RAGameRom(BaseRom):
     ra_id: int | None
     ra_metadata: NotRequired[RAMetadata]
+    ra_hash_match: NotRequired[bool | None]
 
 
 class EarnedAchievement(TypedDict):
@@ -128,6 +134,8 @@ class RAHandler(MetadataHandler):
     def __init__(self) -> None:
         self.ra_service = RetroAchievementsService()
         self.HASHES_FILE_NAME = "ra_hashes_v2.json"
+        # platform id -> (monotonic expiry, hash index)
+        self._hash_index_cache: dict[int, tuple[float, dict[str, int]]] = {}
 
     @classmethod
     def is_enabled(cls) -> bool:
@@ -173,9 +181,18 @@ class RAHandler(MetadataHandler):
         file_stat = await AnyioPath(str(full_path)).stat()
         return int((time.time() - file_stat.st_mtime) / (24 * 3600))
 
-    async def _search_rom(self, rom: Rom, ra_hash: str) -> int | None:
-        if not rom.platform.ra_id:
-            return None
+    async def _get_hash_index(self, rom: Rom) -> dict[str, int]:
+        """RetroAchievements' hash list for the platform: hash -> game ID.
+
+        Memoised per platform: a scan asks for the same index once per
+        ROM, and re-reading a multi-megabyte JSON blob every time
+        dominated the RA leg of large scans. The TTL keeps a long-lived
+        worker from pinning a stale index, since the memo also skips the
+        staleness check below.
+        """
+        cached = self._hash_index_cache.get(rom.platform.id)
+        if cached is not None and cached[0] > time.monotonic():
+            return cached[1]
 
         # hash_index maps lowercase hash -> game ID for O(1) lookups
         hash_index: dict[str, int]
@@ -210,7 +227,41 @@ class RAHandler(MetadataHandler):
             )
             hash_index = json.loads(json_file_bytes.decode("utf-8"))
 
+        self._hash_index_cache[rom.platform.id] = (
+            time.monotonic() + HASH_INDEX_CACHE_TTL_SECONDS,
+            hash_index,
+        )
+        return hash_index
+
+    async def _search_rom(self, rom: Rom, ra_hash: str) -> int | None:
+        if not rom.platform.ra_id:
+            return None
+
+        hash_index = await self._get_hash_index(rom)
         return hash_index.get(ra_hash.lower())
+
+    async def hash_is_known(self, rom: Rom, ra_hash: str) -> bool | None:
+        """Whether RetroAchievements recognises this exact file.
+
+        Asked of RetroAchievements' own hash list, never of another
+        provider: a sibling that Hasheous identifies inherits the game's
+        `ra_id` whether or not RA has ever seen that dump. Returns None
+        when there is nothing to check against.
+        """
+        if not rom.platform.ra_id or not ra_hash:
+            return None
+
+        try:
+            hash_index = await self._get_hash_index(rom)
+        except Exception as exc:
+            log.error(
+                "Couldn't read the RetroAchievements hash list, "
+                "leaving hash support unknown: %s",
+                exc,
+            )
+            return None
+
+        return ra_hash.lower() in hash_index
 
     def get_platform(self, slug: str) -> RAGamesPlatform:
         if slug not in RA_PLATFORM_LIST:

--- a/backend/handler/metadata/ra_handler.py
+++ b/backend/handler/metadata/ra_handler.py
@@ -31,6 +31,12 @@ RA_TAG_REGEX = re.compile(r"\(ra-(\d+)\)", re.IGNORECASE)
 # on-disk refresh still gets picked up.
 HASH_INDEX_CACHE_TTL_SECONDS = 900
 
+# A hash absent from a list this old (in days) is refetched before being
+# reported as unsupported. REFRESH_RETROACHIEVEMENTS_CACHE_DAYS governs when
+# the list is refreshed for matching, and defaults to 30: far too coarse to
+# record "RetroAchievements doesn't have this dump" against.
+NEGATIVE_MAX_LIST_AGE_DAYS = 1
+
 
 class RAGamesPlatform(TypedDict):
     slug: str
@@ -201,36 +207,46 @@ class RAHandler(MetadataHandler):
             <= await self._days_since_last_cache_file_update(rom.platform.id)
             or not await self._exists_cache_file(rom.platform.id)
         ):
-            # Fetch all games (including those without achievements) and build index
-            roms = await self.ra_service.get_game_list(
-                system_id=rom.platform.ra_id,
-                only_games_with_achievements=False,
-                include_hashes=True,
-            )
+            return await self._refresh_hash_index(rom)
 
-            hash_index = {h.lower(): r["ID"] for r in roms for h in r.get("Hashes", ())}
+        # Read the hash index from the JSON file
+        json_file_bytes = await fs_resource_handler.read_file(
+            self._get_hashes_file_path(rom.platform.id)
+        )
+        hash_index = json.loads(json_file_bytes.decode("utf-8"))
 
-            platform_resources_path = fs_resource_handler.get_platform_resources_path(
-                rom.platform.id
-            )
+        self._memoise_hash_index(rom.platform.id, hash_index)
+        return hash_index
 
-            json_file = json.dumps(hash_index, indent=4)
-            await fs_resource_handler.write_file(
-                json_file.encode("utf-8"),
-                platform_resources_path,
-                self.HASHES_FILE_NAME,
-            )
-        else:
-            # Read the hash index from the JSON file
-            json_file_bytes = await fs_resource_handler.read_file(
-                self._get_hashes_file_path(rom.platform.id)
-            )
-            hash_index = json.loads(json_file_bytes.decode("utf-8"))
-
-        self._hash_index_cache[rom.platform.id] = (
+    def _memoise_hash_index(self, platform_id: int, hash_index: dict[str, int]) -> None:
+        self._hash_index_cache[platform_id] = (
             time.monotonic() + HASH_INDEX_CACHE_TTL_SECONDS,
             hash_index,
         )
+
+    async def _refresh_hash_index(self, rom: Rom) -> dict[str, int]:
+        """Rebuild the platform's hash list from RetroAchievements and store it."""
+        # Fetch all games (including those without achievements) and build index
+        roms = await self.ra_service.get_game_list(
+            system_id=rom.platform.ra_id,
+            only_games_with_achievements=False,
+            include_hashes=True,
+        )
+
+        hash_index = {h.lower(): r["ID"] for r in roms for h in r.get("Hashes", ())}
+
+        platform_resources_path = fs_resource_handler.get_platform_resources_path(
+            rom.platform.id
+        )
+
+        json_file = json.dumps(hash_index, indent=4)
+        await fs_resource_handler.write_file(
+            json_file.encode("utf-8"),
+            platform_resources_path,
+            self.HASHES_FILE_NAME,
+        )
+
+        self._memoise_hash_index(rom.platform.id, hash_index)
         return hash_index
 
     async def _search_rom(self, rom: Rom, ra_hash: str) -> int | None:
@@ -247,12 +263,25 @@ class RAHandler(MetadataHandler):
         provider: a sibling that Hasheous identifies inherits the game's
         `ra_id` whether or not RA has ever seen that dump. Returns None
         when there is nothing to check against.
+
+        RetroAchievements adds hashes continuously, so a miss against a list
+        this old is not evidence of anything. Refetch before reporting one,
+        which costs a single request per platform per scan: the fresh list is
+        both memoised and written to disk, so the next miss reads it as
+        current.
         """
         if not rom.platform.ra_id or not ra_hash:
             return None
 
+        needle = ra_hash.lower()
         try:
             hash_index = await self._get_hash_index(rom)
+            if needle in hash_index:
+                return True
+
+            stale_days = await self._days_since_last_cache_file_update(rom.platform.id)
+            if stale_days >= NEGATIVE_MAX_LIST_AGE_DAYS:
+                hash_index = await self._refresh_hash_index(rom)
         except Exception as exc:
             log.error(
                 "Couldn't read the RetroAchievements hash list, "
@@ -261,7 +290,7 @@ class RAHandler(MetadataHandler):
             )
             return None
 
-        return ra_hash.lower() in hash_index
+        return needle in hash_index
 
     def get_platform(self, slug: str) -> RAGamesPlatform:
         if slug not in RA_PLATFORM_LIST:

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -1016,6 +1016,14 @@ async def scan_rom(
             if field_value:
                 rom_attrs[key] = field_value
 
+    # `ra_hash_match` is a tri-state, and the loop above copies truthy values
+    # only, so a definite "RetroAchievements doesn't have this dump" (False)
+    # would be dropped and left indistinguishable from never-checked (NULL).
+    # It also isn't gated on `ra_id`, which the loop is: a ROM can carry the
+    # game's id from Hasheous while RA has never seen the file.
+    if "ra_hash_match" in ra_handler_rom:
+        rom_attrs["ra_hash_match"] = ra_handler_rom["ra_hash_match"]
+
     # Artwork sources are prioritized separately, and each field can carry its
     # own override on top of the shared artwork priority.
     for field in ["url_cover", "url_screenshots", "url_manual"]:

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -1017,8 +1017,10 @@ async def scan_rom(
 
     # Tri-state, so it can ride neither the truthy-only loop above (False would
     # be dropped, reading as never-checked) nor its `ra_id` gate (Hasheous can
-    # supply an id for a file RA has never seen).
-    if "ra_hash_match" in ra_handler_rom:
+    # supply an id for a file RA has never seen). None means the question went
+    # unanswered, e.g. no hash to check or an unreadable hash list, so keep
+    # whatever the last scan that did get an answer recorded.
+    if ra_handler_rom.get("ra_hash_match") is not None:
         rom_attrs["ra_hash_match"] = ra_handler_rom["ra_hash_match"]
 
     # Artwork sources are prioritized separately, and each field can carry its

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -793,6 +793,14 @@ async def scan_rom(
                 )
             )
         ):
+            # Whether RA knows this exact dump is asked of RA's own hash
+            # list, independently of how the game was identified: an
+            # `ra_id` from Hasheous (or a filename tag) is the game, and
+            # every sibling shares it.
+            ra_hash_match = await meta_ra_handler.hash_is_known(
+                rom=rom, ra_hash=rom_attrs["ra_hash"]
+            )
+
             # Use Hasheous match to get the RA ID
             h_ra_id = hasheous_rom.get("ra_id")
             if h_ra_id:
@@ -801,16 +809,18 @@ async def scan_rom(
                     f"{hl(str(h_ra_id), color=BLUE)} {emoji.EMOJI_ALIEN_MONSTER}",
                     extra=LOGGER_MODULE_NAME,
                 )
-                return await meta_ra_handler.get_rom_by_id(rom=rom, ra_id=h_ra_id)
-
-            if (scan_type == ScanType.UPDATE and rom.ra_id) or (
+                ra_rom = await meta_ra_handler.get_rom_by_id(rom=rom, ra_id=h_ra_id)
+            elif (scan_type == ScanType.UPDATE and rom.ra_id) or (
                 scan_type == ScanType.UNMATCHED and rom.ra_id and not rom.ra_metadata
             ):
-                return await meta_ra_handler.get_rom_by_id(rom=rom, ra_id=rom.ra_id)
+                ra_rom = await meta_ra_handler.get_rom_by_id(rom=rom, ra_id=rom.ra_id)
             else:
-                return await meta_ra_handler.get_rom(
+                ra_rom = await meta_ra_handler.get_rom(
                     rom=rom, ra_hash=rom_attrs["ra_hash"]
                 )
+
+            ra_rom["ra_hash_match"] = ra_hash_match
+            return ra_rom
 
         return RAGameRom(ra_id=None)
 

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -793,10 +793,9 @@ async def scan_rom(
                 )
             )
         ):
-            # Whether RA knows this exact dump is asked of RA's own hash
-            # list, independently of how the game was identified: an
-            # `ra_id` from Hasheous (or a filename tag) is the game, and
-            # every sibling shares it.
+            # Asked of RA's own hash list whatever identified the game, since
+            # an `ra_id` from Hasheous or a filename tag says nothing about
+            # this file.
             ra_hash_match = await meta_ra_handler.hash_is_known(
                 rom=rom, ra_hash=rom_attrs["ra_hash"]
             )
@@ -1016,11 +1015,9 @@ async def scan_rom(
             if field_value:
                 rom_attrs[key] = field_value
 
-    # `ra_hash_match` is a tri-state, and the loop above copies truthy values
-    # only, so a definite "RetroAchievements doesn't have this dump" (False)
-    # would be dropped and left indistinguishable from never-checked (NULL).
-    # It also isn't gated on `ra_id`, which the loop is: a ROM can carry the
-    # game's id from Hasheous while RA has never seen the file.
+    # Tri-state, so it can ride neither the truthy-only loop above (False would
+    # be dropped, reading as never-checked) nor its `ra_id` gate (Hasheous can
+    # supply an id for a file RA has never seen).
     if "ra_hash_match" in ra_handler_rom:
         rom_attrs["ra_hash_match"] = ra_handler_rom["ra_hash_match"]
 

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -441,6 +441,12 @@ class Rom(BaseModel):
     md5_hash: Mapped[str | None] = mapped_column(String(length=100))
     sha1_hash: Mapped[str | None] = mapped_column(String(length=100))
     ra_hash: Mapped[str | None] = mapped_column(String(length=100))
+    # Whether `ra_hash` is in RetroAchievements' own hash list for the
+    # platform, i.e. whether achievements will unlock for THIS file.
+    # Distinct from `ra_id`, which is the game and so is shared by every
+    # version. NULL means never checked (no RA hash, unsupported
+    # platform, or scanned before this column existed).
+    ra_hash_match: Mapped[bool | None] = mapped_column(default=None)
 
     missing_from_fs: Mapped[bool] = mapped_column(default=False, nullable=False)
 

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -441,11 +441,9 @@ class Rom(BaseModel):
     md5_hash: Mapped[str | None] = mapped_column(String(length=100))
     sha1_hash: Mapped[str | None] = mapped_column(String(length=100))
     ra_hash: Mapped[str | None] = mapped_column(String(length=100))
-    # Whether `ra_hash` is in RetroAchievements' own hash list for the
-    # platform, i.e. whether achievements will unlock for THIS file.
-    # Distinct from `ra_id`, which is the game and so is shared by every
-    # version. NULL means never checked (no RA hash, unsupported
-    # platform, or scanned before this column existed).
+    # Whether `ra_hash` is in RetroAchievements' own hash list, i.e. whether
+    # achievements unlock for THIS file. `ra_id` is the game, shared by every
+    # version. NULL means never checked.
     ra_hash_match: Mapped[bool | None] = mapped_column(default=None)
 
     missing_from_fs: Mapped[bool] = mapped_column(default=False, nullable=False)

--- a/backend/tests/endpoints/roms/test_rom.py
+++ b/backend/tests/endpoints/roms/test_rom.py
@@ -44,6 +44,62 @@ def test_get_rom(client: TestClient, access_token: str, rom: Rom):
     assert body["id"] == rom.id
 
 
+def _add_sibling(rom: Rom, *, fs_name_no_ext: str, ra_hash_match: bool | None) -> Rom:
+    """Another version of `rom`, grouped by the shared IGDB id.
+
+    The `sibling_roms` view joins on matching provider ids (0073 dropped
+    fs_name_no_tags matching), so the versions need one id in common. They
+    also share `ra_id` (the game is the same), which is exactly why the
+    per-file `ra_hash_match` is what the switcher reads.
+    """
+    return db_rom_handler.add_rom(
+        Rom(
+            platform_id=rom.platform_id,
+            name=rom.name,
+            slug=f"{rom.slug}_{fs_name_no_ext}",
+            fs_name=f"{fs_name_no_ext}.zip",
+            fs_name_no_tags=rom.fs_name_no_tags,
+            fs_name_no_ext=fs_name_no_ext,
+            fs_extension="zip",
+            fs_path=rom.fs_path,
+            igdb_id=MOCK_IGDB_ID,
+            ra_id=MOCK_RA_ID,
+            ra_hash_match=ra_hash_match,
+        )
+    )
+
+
+def test_get_rom_reports_ra_hash_match_per_sibling(
+    client: TestClient, access_token: str, rom: Rom
+):
+    """The version switcher flags which sibling RetroAchievements knows.
+
+    `ra_hash_match` has to survive the sibling `load_only` list, otherwise
+    the column comes back deferred and the schema can't read it. All three
+    versions share one `ra_id`, so only the per-file flag separates them.
+    """
+    db_rom_handler.update_rom(rom.id, {"igdb_id": MOCK_IGDB_ID})
+    _add_sibling(rom, fs_name_no_ext="test_rom (Rev 1)", ra_hash_match=True)
+    _add_sibling(rom, fs_name_no_ext="test_rom (Rev 2)", ra_hash_match=False)
+    _add_sibling(rom, fs_name_no_ext="test_rom (Rev 3)", ra_hash_match=None)
+
+    for endpoint in (f"/api/roms/{rom.id}", f"/api/roms/{rom.id}/simple"):
+        response = client.get(
+            endpoint, headers={"Authorization": f"Bearer {access_token}"}
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        siblings = {
+            s["fs_name_no_ext"]: s["ra_hash_match"]
+            for s in response.json()["sibling_roms"]
+        }
+        assert siblings == {
+            "test_rom (Rev 1)": True,
+            "test_rom (Rev 2)": False,
+            "test_rom (Rev 3)": None,
+        }, endpoint
+
+
 def test_get_rom_simple(client: TestClient, access_token: str, rom: Rom):
     response = client.get(
         f"/api/roms/{rom.id}/simple",

--- a/backend/tests/handler/database/test_roms_verified_filter.py
+++ b/backend/tests/handler/database/test_roms_verified_filter.py
@@ -35,7 +35,13 @@ LEGACY_KEYS = [
 ]
 
 
-def _add_rom(platform: Platform, user: User, name: str, metadata: dict) -> Rom:
+def _add_rom(
+    platform: Platform,
+    user: User,
+    name: str,
+    metadata: dict,
+    ra_hash_match: bool | None = None,
+) -> Rom:
     rom = db_rom_handler.add_rom(
         Rom(
             platform_id=platform.id,
@@ -47,6 +53,7 @@ def _add_rom(platform: Platform, user: User, name: str, metadata: dict) -> Rom:
             fs_extension="zip",
             fs_path=f"{platform.slug}/roms",
             hasheous_metadata=metadata,
+            ra_hash_match=ra_hash_match,
         )
     )
     db_rom_handler.add_rom_user(rom_id=rom.id, user_id=user.id)
@@ -118,6 +125,81 @@ class TestVerifiedFilter:
         assert [r.id for r in roms] == [rom.id]
 
 
+class TestVerifiedRetroAchievements:
+    """RA is the one database RomM asks itself, so its answer outranks
+    Hasheous' RA signature coverage in both directions. Mirrors
+    `matchesRetroAchievements` in `romVerification.ts`."""
+
+    def test_ras_own_hash_match_verifies_without_any_hasheous_match(
+        self, platform: Platform, admin_user: User
+    ):
+        matched = _add_rom(
+            platform,
+            admin_user,
+            "ra_hash_only",
+            {key: False for key in LEGACY_KEYS},
+            ra_hash_match=True,
+        )
+
+        roms = db_rom_handler.get_roms_scalar(user_id=admin_user.id, verified=True)
+
+        assert [r.id for r in roms] == [matched.id]
+
+    def test_hasheous_answers_when_ra_was_never_asked(
+        self, platform: Platform, admin_user: User
+    ):
+        """NULL means unchecked, e.g. a ROM not rescanned since the column
+        landed, so the old Hasheous behaviour still applies."""
+        matched = _add_rom(
+            platform,
+            admin_user,
+            "hasheous_ra_only",
+            {key: key == "ra_match" for key in LEGACY_KEYS},
+            ra_hash_match=None,
+        )
+
+        roms = db_rom_handler.get_roms_scalar(user_id=admin_user.id, verified=True)
+
+        assert [r.id for r in roms] == [matched.id]
+
+    def test_a_definite_no_from_ra_beats_a_hasheous_ra_match(
+        self, platform: Platform, admin_user: User
+    ):
+        """RA has never seen this dump, so achievements won't unlock for it
+        whatever Hasheous' signatures say."""
+        _add_rom(
+            platform,
+            admin_user,
+            "ra_says_no",
+            {key: key == "ra_match" for key in LEGACY_KEYS},
+            ra_hash_match=False,
+        )
+
+        verified = db_rom_handler.get_roms_scalar(user_id=admin_user.id, verified=True)
+        unverified = db_rom_handler.get_roms_scalar(
+            user_id=admin_user.id, verified=False
+        )
+
+        assert [r.name for r in verified] == []
+        assert [r.name for r in unverified] == ["ra_says_no"]
+
+    def test_another_databases_match_still_verifies_a_ra_rejected_rom(
+        self, platform: Platform, admin_user: User
+    ):
+        """RA's veto is scoped to the RA row, not to the whole ROM."""
+        matched = _add_rom(
+            platform,
+            admin_user,
+            "nointro_but_not_ra",
+            {key: key in ("nointro_match", "ra_match") for key in LEGACY_KEYS},
+            ra_hash_match=False,
+        )
+
+        roms = db_rom_handler.get_roms_scalar(user_id=admin_user.id, verified=True)
+
+        assert [r.id for r in roms] == [matched.id]
+
+
 class TestVerifiedPostgresPredicate:
     """The PostgreSQL branch builds raw SQL, so it can only be checked by
     compiling it (the suite runs on a single driver at a time)."""
@@ -140,3 +222,21 @@ class TestVerifiedPostgresPredicate:
 
         for key in [*LEGACY_KEYS, "mame_redump_match"]:
             assert f"COALESCE((hasheous_metadata->>'{key}')::boolean, false)" in sql
+
+    @pytest.mark.parametrize("verified", [True, False])
+    def test_ra_prefers_its_own_answer_and_only_then_hasheous(
+        self, postgres_handler: DBRomsHandler, verified: bool
+    ):
+        """`IS TRUE` / `IS NULL`, never `= true`: a NULL term would poison
+        the OR and then its negation, dropping rows from the unverified
+        side (the bug this whole predicate is shaped around)."""
+        query, _ = postgres_handler.get_roms_query()
+        filtered = postgres_handler.filter_roms(query=query, verified=verified)
+
+        sql = str(filtered.compile(compile_kwargs={"literal_binds": True}))
+
+        assert "ra_hash_match IS TRUE" in sql
+        assert (
+            "ra_hash_match IS NULL AND"
+            " COALESCE((hasheous_metadata->>'ra_match')::boolean, false)"
+        ) in sql

--- a/backend/tests/handler/metadata/test_ra_handler.py
+++ b/backend/tests/handler/metadata/test_ra_handler.py
@@ -1,5 +1,8 @@
 """Tests for the RetroAchievements metadata handler platform mapping."""
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import pytest
 
 from handler.metadata.base_handler import UniversalPlatformSlug as UPS
@@ -9,6 +12,68 @@ from handler.metadata.ra_handler import RA_PLATFORM_LIST, RAHandler
 @pytest.fixture
 def handler() -> RAHandler:
     return RAHandler()
+
+
+def _rom(platform_ra_id: int | None = 7, platform_id: int = 1):
+    return SimpleNamespace(
+        platform=SimpleNamespace(ra_id=platform_ra_id, id=platform_id)
+    )
+
+
+class TestHashIsKnown:
+    """`hash_is_known` answers from RA's own hash list, not another provider.
+
+    Every sibling of a game shares its `ra_id`, so this per-file answer is
+    the only thing that says whether achievements will unlock.
+    """
+
+    async def test_recognises_a_hash_in_ras_list(self, handler: RAHandler):
+        handler._get_hash_index = AsyncMock(return_value={"abc123": 42})  # type: ignore[method-assign]
+
+        assert await handler.hash_is_known(_rom(), "ABC123") is True
+
+    async def test_rejects_a_hash_ra_has_never_seen(self, handler: RAHandler):
+        handler._get_hash_index = AsyncMock(return_value={"abc123": 42})  # type: ignore[method-assign]
+
+        assert await handler.hash_is_known(_rom(), "deadbeef") is False
+
+    @pytest.mark.parametrize(
+        ("platform_ra_id", "ra_hash"),
+        [(None, "abc123"), (7, "")],
+        ids=["platform-not-on-ra", "no-hash-computed"],
+    )
+    async def test_stays_unknown_with_nothing_to_check(
+        self, handler: RAHandler, platform_ra_id: int | None, ra_hash: str
+    ):
+        handler._get_hash_index = AsyncMock(return_value={"abc123": 42})  # type: ignore[method-assign]
+
+        assert await handler.hash_is_known(_rom(platform_ra_id), ra_hash) is None
+
+    async def test_stays_unknown_when_the_list_cant_be_read(self, handler: RAHandler):
+        """A missing or unreadable index must not read as "unsupported"."""
+        handler._get_hash_index = AsyncMock(side_effect=OSError("boom"))  # type: ignore[method-assign]
+
+        assert await handler.hash_is_known(_rom(), "abc123") is None
+
+
+async def test_hash_index_is_parsed_once_per_platform(handler: RAHandler):
+    """A scan asks per ROM; the multi-MB parse happens once."""
+    handler._exists_cache_file = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    handler._days_since_last_cache_file_update = AsyncMock(return_value=0)  # type: ignore[method-assign]
+    read_file = AsyncMock(return_value=b'{"abc123": 42}')
+
+    from handler.metadata import ra_handler as ra_handler_module
+
+    original = ra_handler_module.fs_resource_handler.read_file
+    ra_handler_module.fs_resource_handler.read_file = read_file  # type: ignore[method-assign]
+    try:
+        rom = _rom()
+        assert await handler.hash_is_known(rom, "abc123") is True
+        assert await handler.hash_is_known(rom, "abc123") is True
+    finally:
+        ra_handler_module.fs_resource_handler.read_file = original  # type: ignore[method-assign]
+
+    assert read_file.await_count == 1
 
 
 def test_get_platform_unsupported_returns_none(handler: RAHandler):

--- a/backend/tests/handler/metadata/test_ra_handler.py
+++ b/backend/tests/handler/metadata/test_ra_handler.py
@@ -34,6 +34,8 @@ class TestHashIsKnown:
 
     async def test_rejects_a_hash_ra_has_never_seen(self, handler: RAHandler):
         handler._get_hash_index = AsyncMock(return_value={"abc123": 42})  # type: ignore[method-assign]
+        # Fresh list, so the miss is trusted rather than refetched.
+        handler._days_since_last_cache_file_update = AsyncMock(return_value=0)  # type: ignore[method-assign]
 
         assert await handler.hash_is_known(_rom(), "deadbeef") is False
 
@@ -52,6 +54,52 @@ class TestHashIsKnown:
     async def test_stays_unknown_when_the_list_cant_be_read(self, handler: RAHandler):
         """A missing or unreadable index must not read as "unsupported"."""
         handler._get_hash_index = AsyncMock(side_effect=OSError("boom"))  # type: ignore[method-assign]
+
+        assert await handler.hash_is_known(_rom(), "abc123") is None
+
+
+class TestHashIsKnownRefetchesBeforeSayingNo:
+    """RetroAchievements adds hashes continuously, so a miss against an old
+    list says nothing. The answer is only recorded once it comes from a list
+    fresh enough to stand behind."""
+
+    async def test_refetches_and_finds_a_newly_added_hash(self, handler: RAHandler):
+        handler._get_hash_index = AsyncMock(return_value={})  # type: ignore[method-assign]
+        handler._days_since_last_cache_file_update = AsyncMock(return_value=9)  # type: ignore[method-assign]
+        # RetroAchievements hashed this dump since the local list was written.
+        handler._refresh_hash_index = AsyncMock(return_value={"abc123": 42})  # type: ignore[method-assign]
+
+        assert await handler.hash_is_known(_rom(), "abc123") is True
+        handler._refresh_hash_index.assert_awaited_once()
+
+    async def test_reports_no_once_the_fresh_list_agrees(self, handler: RAHandler):
+        handler._get_hash_index = AsyncMock(return_value={})  # type: ignore[method-assign]
+        handler._days_since_last_cache_file_update = AsyncMock(return_value=9)  # type: ignore[method-assign]
+        handler._refresh_hash_index = AsyncMock(return_value={"other": 1})  # type: ignore[method-assign]
+
+        assert await handler.hash_is_known(_rom(), "abc123") is False
+
+    async def test_a_hit_never_costs_a_request(self, handler: RAHandler):
+        handler._get_hash_index = AsyncMock(return_value={"abc123": 42})  # type: ignore[method-assign]
+        handler._refresh_hash_index = AsyncMock()  # type: ignore[method-assign]
+
+        assert await handler.hash_is_known(_rom(), "abc123") is True
+        handler._refresh_hash_index.assert_not_awaited()
+
+    async def test_a_fresh_list_is_trusted_without_refetching(self, handler: RAHandler):
+        """Otherwise every unmatched ROM in a library would refetch."""
+        handler._get_hash_index = AsyncMock(return_value={})  # type: ignore[method-assign]
+        handler._days_since_last_cache_file_update = AsyncMock(return_value=0)  # type: ignore[method-assign]
+        handler._refresh_hash_index = AsyncMock()  # type: ignore[method-assign]
+
+        assert await handler.hash_is_known(_rom(), "abc123") is False
+        handler._refresh_hash_index.assert_not_awaited()
+
+    async def test_stays_unknown_when_the_refetch_fails(self, handler: RAHandler):
+        """A failed refetch can't turn a stale miss into a recorded no."""
+        handler._get_hash_index = AsyncMock(return_value={})  # type: ignore[method-assign]
+        handler._days_since_last_cache_file_update = AsyncMock(return_value=9)  # type: ignore[method-assign]
+        handler._refresh_hash_index = AsyncMock(side_effect=OSError("boom"))  # type: ignore[method-assign]
 
         assert await handler.hash_is_known(_rom(), "abc123") is None
 

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -1020,3 +1020,70 @@ async def test_scan_rom_ss_rate_limit_skips_the_rom_without_further_lookups(
     assert get_rate_limited_rom_names() == ["game.sfc"]
 
     reset_rate_limited_roms()
+
+
+@pytest.mark.parametrize(
+    ("hash_is_known", "expected"),
+    [(True, True), (False, False), (None, None)],
+    ids=["ra-knows-the-dump", "ra-has-never-seen-it", "nothing-to-check"],
+)
+@patch.object(meta_playmatch_handler, "is_enabled", return_value=False)
+@patch.object(meta_ra_handler, "get_rom_by_id", new_callable=AsyncMock)
+@patch.object(meta_ra_handler, "hash_is_known", new_callable=AsyncMock)
+async def test_scan_rom_persists_every_ra_hash_match_state(
+    mock_hash_is_known,
+    mock_get_rom_by_id,
+    mock_playmatch_enabled,
+    hash_is_known: bool | None,
+    expected: bool | None,
+):
+    """All three states have to survive the scan, False especially.
+
+    The metadata priority loop copies truthy values only, so a plain
+    `rom_attrs[key] = value` pass would drop False and leave it
+    indistinguishable from never-checked. That would silently disable the
+    "RetroAchievements has never seen this dump" branch everywhere it's
+    read, since NULL falls back to Hasheous.
+    """
+    mock_hash_is_known.return_value = hash_is_known
+    # The game is identified either way: `ra_id` is the game, and it says
+    # nothing about whether RA hashed this particular file.
+    mock_get_rom_by_id.return_value = RAGameRom(ra_id=4321, name="Star Fox 64")
+
+    platform = db_platform_handler.add_platform(
+        Platform(slug="n64", fs_slug="n64", name="Nintendo 64", ra_id=2)
+    )
+    rom = db_rom_handler.add_rom(
+        Rom(
+            platform_id=platform.id,
+            fs_name="Star Fox 64 (USA).z64",
+            fs_name_no_tags="Star Fox 64",
+            fs_name_no_ext="Star Fox 64 (USA)",
+            fs_extension="z64",
+            fs_path="n64/roms",
+            ra_id=4321,
+            tags=[],
+        )
+    )
+
+    async with initialize_context():
+        result = await scan_rom(
+            platform=platform,
+            scan_type=ScanType.COMPLETE,
+            rom=rom,
+            fs_rom=FSRom(
+                fs_name="Star Fox 64 (USA).z64",
+                flat=True,
+                nested=False,
+                files=[],
+                crc_hash="aabbccdd",
+                md5_hash="0123456789abcdef0123456789abcdef",
+                sha1_hash="0123456789abcdef0123456789abcdef01234567",
+                ra_hash="fedcba9876543210fedcba9876543210",
+            ),
+            metadata_sources=[MetadataSource.RA],
+            newly_added=True,
+        )
+
+    mock_hash_is_known.assert_awaited_once()
+    assert result.ra_hash_match is expected

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -1087,3 +1087,67 @@ async def test_scan_rom_persists_every_ra_hash_match_state(
 
     mock_hash_is_known.assert_awaited_once()
     assert result.ra_hash_match is expected
+
+
+@pytest.mark.parametrize("known", [True, False], ids=["known-yes", "known-no"])
+@patch.object(meta_playmatch_handler, "is_enabled", return_value=False)
+@patch.object(meta_ra_handler, "get_rom_by_id", new_callable=AsyncMock)
+@patch.object(meta_ra_handler, "hash_is_known", new_callable=AsyncMock)
+async def test_scan_rom_keeps_ra_hash_match_when_the_answer_is_unknown(
+    mock_hash_is_known,
+    mock_get_rom_by_id,
+    mock_playmatch_enabled,
+    known: bool,
+):
+    """An unanswered check must not erase what a previous scan established.
+
+    `hash_is_known` returns None when there's no hash to check or the hash
+    list can't be read. Persisting that would turn a known answer back into
+    never-checked, which reads as "fall back to Hasheous" everywhere.
+    """
+    mock_hash_is_known.return_value = None
+    mock_get_rom_by_id.return_value = RAGameRom(ra_id=4321, name="Star Fox 64")
+
+    platform = db_platform_handler.add_platform(
+        Platform(slug="n64", fs_slug="n64", name="Nintendo 64", ra_id=2)
+    )
+    rom = db_rom_handler.add_rom(
+        Rom(
+            platform_id=platform.id,
+            fs_name="Star Fox 64 (USA).z64",
+            fs_name_no_tags="Star Fox 64",
+            fs_name_no_ext="Star Fox 64 (USA)",
+            fs_extension="z64",
+            fs_path="n64/roms",
+            ra_id=4321,
+            ra_hash_match=known,
+            tags=[],
+        )
+    )
+
+    async with initialize_context():
+        scanned = await scan_rom(
+            platform=platform,
+            scan_type=ScanType.COMPLETE,
+            rom=rom,
+            fs_rom=FSRom(
+                fs_name="Star Fox 64 (USA).z64",
+                flat=True,
+                nested=False,
+                files=[],
+                crc_hash="aabbccdd",
+                md5_hash="0123456789abcdef0123456789abcdef",
+                sha1_hash="0123456789abcdef0123456789abcdef01234567",
+                # No RA hash this pass, e.g. SKIP_HASH_CALCULATION.
+                ra_hash="",
+            ),
+            metadata_sources=[MetadataSource.RA],
+            newly_added=False,
+        )
+
+    # `scan_rom` returns a detached `Rom(**rom_attrs)`, so the question is what
+    # survives the merge the scan socket performs. An attribute the scan never
+    # set isn't in the instance dict, and merge leaves those alone.
+    persisted = db_rom_handler.add_rom(scanned)
+
+    assert persisted.ra_hash_match is known

--- a/frontend/src/__generated__/models/DetailedRomSchema.ts
+++ b/frontend/src/__generated__/models/DetailedRomSchema.ts
@@ -84,6 +84,7 @@ export type DetailedRomSchema = {
     md5_hash: (string | null);
     sha1_hash: (string | null);
     ra_hash: (string | null);
+    ra_hash_match: (boolean | null);
     has_simple_single_file: boolean;
     has_nested_single_file: boolean;
     has_multiple_files: boolean;

--- a/frontend/src/__generated__/models/SiblingRomSchema.ts
+++ b/frontend/src/__generated__/models/SiblingRomSchema.ts
@@ -8,6 +8,7 @@ export type SiblingRomSchema = {
     fs_name_no_tags: string;
     fs_name_no_ext: string;
     is_main_sibling: boolean;
+    ra_hash_match: (boolean | null);
     readonly sort_comparator: string;
 };
 

--- a/frontend/src/__generated__/models/SimpleRomSchema.ts
+++ b/frontend/src/__generated__/models/SimpleRomSchema.ts
@@ -76,6 +76,7 @@ export type SimpleRomSchema = {
     md5_hash: (string | null);
     sha1_hash: (string | null);
     ra_hash: (string | null);
+    ra_hash_match: (boolean | null);
     has_simple_single_file: boolean;
     has_nested_single_file: boolean;
     has_multiple_files: boolean;

--- a/frontend/src/locales/bg_BG/rom.json
+++ b/frontend/src/locales/bg_BG/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "Файлът ще бъде преименуван от {from} на {to}. Таговете на файла няма да бъдат засегнати.",
   "rename-file-title": "Преименувай файла според заглавието от {source}",
   "results-found": "Намерени резултати",
+  "retroachievements-supported": "Поддържа се от RetroAchievements",
   "revision": "Revision",
   "rom-updated-successfully": "ROM-ът е обновен успешно!",
   "save-data": "Данни от записи",

--- a/frontend/src/locales/cs_CZ/rom.json
+++ b/frontend/src/locales/cs_CZ/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "Soubor bude přejmenován z {from} na {to}. Štítky souboru nebudou ovlivněny.",
   "rename-file-title": "Přejmenovat soubor, aby odpovídal názvu {source}",
   "results-found": "Nalezené výsledky",
+  "retroachievements-supported": "Podporováno službou RetroAchievements",
   "revision": "Revision",
   "rom-updated-successfully": "ROM úspěšně aktualizována!",
   "save-data": "Uložená data",

--- a/frontend/src/locales/de_DE/rom.json
+++ b/frontend/src/locales/de_DE/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "Datei wird umbenannt von {from} in {to}. Tags im Dateinamen werden nicht verändert.",
   "rename-file-title": "Datei umbennen in gefundenen {source} Title",
   "results-found": "Gefundene Ergebnisse",
+  "retroachievements-supported": "Von RetroAchievements unterstützt",
   "revision": "Revision",
   "rom-updated-successfully": "ROM erfolgreich aktualisiert!",
   "save-data": "Speicherdaten",

--- a/frontend/src/locales/en_GB/rom.json
+++ b/frontend/src/locales/en_GB/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "File will be renamed from {from} to {to}. File tags won't be affected.",
   "rename-file-title": "Rename file to match {source} title",
   "results-found": "Results found",
+  "retroachievements-supported": "Supported by RetroAchievements",
   "revision": "Revision",
   "rom-updated-successfully": "Rom updated successfully!",
   "save-data": "Save data",

--- a/frontend/src/locales/en_US/rom.json
+++ b/frontend/src/locales/en_US/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "File will be renamed from {from} to {to}. File tags won't be affected.",
   "rename-file-title": "Rename file to match {source} title",
   "results-found": "Results found",
+  "retroachievements-supported": "Supported by RetroAchievements",
   "revision": "Revision",
   "rom-updated-successfully": "Rom updated successfully!",
   "save-data": "Save data",

--- a/frontend/src/locales/es_ES/rom.json
+++ b/frontend/src/locales/es_ES/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "El fichero será renombrado de {from} a {to}. Las etiquetas del nombre no se verán afectadas.",
   "rename-file-title": "Renombrar archivo para coincidir con el título de {source}",
   "results-found": "Resultados encontrados",
+  "retroachievements-supported": "Compatible con RetroAchievements",
   "revision": "Revision",
   "rom-updated-successfully": "ROM actualizada correctamente",
   "save-data": "Datos guardados",

--- a/frontend/src/locales/fr_FR/rom.json
+++ b/frontend/src/locales/fr_FR/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "Le fichier sera renommé de {from} à {to}. Les tags du nom de fichier ne seront pas affectés.",
   "rename-file-title": "Renommer le fichier pour correspondre au titre {source}",
   "results-found": "Résultats trouvés",
+  "retroachievements-supported": "Pris en charge par RetroAchievements",
   "revision": "Revision",
   "rom-updated-successfully": "ROM mise à jour avec succès !",
   "save-data": "Sauvegardes",

--- a/frontend/src/locales/hu_HU/rom.json
+++ b/frontend/src/locales/hu_HU/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "A fájl neve {from} -ról {to} -ra változik. A fájl címkéi nem változnak.",
   "rename-file-title": "Nevezd át a fájlt, hogy megegyezzen a {source} címével",
   "results-found": "Talált eredmények",
+  "retroachievements-supported": "A RetroAchievements támogatja",
   "revision": "Revision",
   "rom-updated-successfully": "A ROM frissítése sikeresen megtörtént!",
   "save-data": "Mentések",

--- a/frontend/src/locales/it_IT/rom.json
+++ b/frontend/src/locales/it_IT/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "Il file sarà rinominato da {from} a {to}. I tag del nome file non saranno influenzati.",
   "rename-file-title": "Rinomina il file per corrispondere al titolo {source}",
   "results-found": "Risultati trovati",
+  "retroachievements-supported": "Supportato da RetroAchievements",
   "revision": "Revision",
   "rom-updated-successfully": "ROM aggiornata con successo!",
   "save-data": "Dati di salvataggio",

--- a/frontend/src/locales/ja_JP/rom.json
+++ b/frontend/src/locales/ja_JP/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "ファイル名が変更されます 元 {from} 変更後 {to}。ファイル名タグは変更されません。",
   "rename-file-title": "ファイル名を {source} に変更",
   "results-found": "検索結果",
+  "retroachievements-supported": "RetroAchievements対応",
   "revision": "Revision",
   "rom-updated-successfully": "ROMを正常に更新しました！",
   "save-data": "セーブデータ",

--- a/frontend/src/locales/ko_KR/rom.json
+++ b/frontend/src/locales/ko_KR/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "파일 이름을 {from} 에서 다음으로 변경합니다: {to}. 파일 이름 태그에는 영향을 주지 않습니다.",
   "rename-file-title": "파일을 {source}에서의 이름과 동일하게 맞춥니다",
   "results-found": "검색 결과",
+  "retroachievements-supported": "RetroAchievements 지원",
   "revision": "Revision",
   "rom-updated-successfully": "ROM이 성공적으로 업데이트되었습니다!",
   "save-data": "저장 데이터",

--- a/frontend/src/locales/pl_PL/rom.json
+++ b/frontend/src/locales/pl_PL/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "Plik zostanie przemianowany z {from} na {to}. Tagi w nazwie pliku nie zostaną zmienione.",
   "rename-file-title": "Zmień nazwę pliku, aby pasowała do tytułu źródłowego {source}",
   "results-found": "Znalezione wyniki",
+  "retroachievements-supported": "Obsługiwane przez RetroAchievements",
   "revision": "Revision",
   "rom-updated-successfully": "ROM zaktualizowany pomyślnie!",
   "save-data": "Dane zapisu",

--- a/frontend/src/locales/pt_BR/rom.json
+++ b/frontend/src/locales/pt_BR/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "O arquivo será renomeado de {from} para {to}. As tags do nome do arquivo não serão afetadas.",
   "rename-file-title": "Renomear arquivo para corresponder ao título {source}",
   "results-found": "Resultados encontrados",
+  "retroachievements-supported": "Compatível com o RetroAchievements",
   "revision": "Revision",
   "rom-updated-successfully": "ROM atualizada com sucesso!",
   "save-data": "Dados salvos",

--- a/frontend/src/locales/ro_RO/rom.json
+++ b/frontend/src/locales/ro_RO/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "Fișierul va fi redenumit de la {from} la {to}. Etichetele din numele fișierului nu vor fi afectate.",
   "rename-file-title": "Redenumește fișierul pentru a corespunde titlului {source}",
   "results-found": "Rezultate găsite",
+  "retroachievements-supported": "Compatibil cu RetroAchievements",
   "revision": "Revision",
   "rom-updated-successfully": "ROM actualizat cu succes!",
   "save-data": "Date salvate",

--- a/frontend/src/locales/ru_RU/rom.json
+++ b/frontend/src/locales/ru_RU/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "Файл будет переименован из {from} в {to}. Теги имени файла не будут затронуты.",
   "rename-file-title": "Переименовать файл в соответствии с названием {source}",
   "results-found": "Найдено результатов",
+  "retroachievements-supported": "Поддерживается RetroAchievements",
   "revision": "Revision",
   "rom-updated-successfully": "ROM успешно обновлён!",
   "save-data": "Сохранения",

--- a/frontend/src/locales/tr_TR/rom.json
+++ b/frontend/src/locales/tr_TR/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "Dosya {from} adından {to} adına yeniden adlandırılacak. Dosya etiketleri etkilenmeyecek.",
   "rename-file-title": "Dosyayı {source} başlığıyla eşleşecek şekilde yeniden adlandır",
   "results-found": "Sonuçlar bulundu",
+  "retroachievements-supported": "RetroAchievements tarafından destekleniyor",
   "revision": "Revision",
   "rom-updated-successfully": "ROM başarıyla güncellendi!",
   "save-data": "Kayıt verisi",

--- a/frontend/src/locales/zh_CN/rom.json
+++ b/frontend/src/locales/zh_CN/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "文件将被重命名 从 {from} 至 {to}. 文件名标签不会受到影响.",
   "rename-file-title": "重命名文件以匹配 {source} 标题",
   "results-found": "搜索结果",
+  "retroachievements-supported": "支持 RetroAchievements",
   "revision": "Revision",
   "rom-updated-successfully": "ROM 更新成功！",
   "save-data": "存档数据",

--- a/frontend/src/locales/zh_TW/rom.json
+++ b/frontend/src/locales/zh_TW/rom.json
@@ -318,6 +318,7 @@
   "rename-file-details": "檔案將被重命名 從 {from} 至 {to}. 檔案名稱標籤不會受到影響.",
   "rename-file-title": "重命名檔案以匹配 {source} 標題",
   "results-found": "搜尋结果",
+  "retroachievements-supported": "支援 RetroAchievements",
   "revision": "Revision",
   "rom-updated-successfully": "ROM 更新成功！",
   "save-data": "存檔資料",

--- a/frontend/src/v2/components/GameDetails/MetadataTab.vue
+++ b/frontend/src/v2/components/GameDetails/MetadataTab.vue
@@ -4,8 +4,8 @@
 //   2. Hashes — SHA-1, MD5, CRC, RA, all mono. RTag with eyebrow label.
 //      Same order as the files list so the two tabs read alike.
 //   3. Verification — RTag per database; tone="success" for match,
-//      neutral for miss. Same source of truth (Hasheous match flags) as
-//      the "Verified" badge in the header, via `VERIFICATION_DATABASES`.
+//      neutral for miss. Same source of truth as the "Verified" badge in
+//      the header, via `VERIFICATION_DATABASES`.
 //   4. Metadata sources — ProviderGrid (linked + unlinked).
 import { RTag } from "@v2/lib";
 import { computed } from "vue";
@@ -14,10 +14,7 @@ import type { DetailedRom } from "@/stores/roms";
 import { formatBytes } from "@/utils";
 import ProviderGrid from "@/v2/components/GameDetails/ProviderGrid.vue";
 import HashChip from "@/v2/components/shared/HashChip.vue";
-import {
-  matchesDatabase,
-  VERIFICATION_DATABASES,
-} from "@/v2/utils/romVerification";
+import { VERIFICATION_DATABASES } from "@/v2/utils/romVerification";
 
 defineOptions({ inheritAttrs: false });
 
@@ -61,12 +58,12 @@ type Verification = { label: string; match: boolean };
 
 // Per-database match badges, driven by the shared VERIFICATION_DATABASES
 // so this list stays in lockstep with the header badge and the backend
-// filter. A match means the ROM's hash was found in that database (via
-// Hasheous), which is what "verified" communicates.
+// filter. A match means the ROM's hash was found in that database, which
+// is what "verified" communicates.
 const verifications = computed<Verification[]>(() =>
   VERIFICATION_DATABASES.map((db) => ({
     label: db.label,
-    match: matchesDatabase(props.rom, db.keys),
+    match: db.matches(props.rom),
   })),
 );
 </script>

--- a/frontend/src/v2/components/GameDetails/RelatedGameCard.vue
+++ b/frontend/src/v2/components/GameDetails/RelatedGameCard.vue
@@ -142,6 +142,7 @@ const syntheticRom = computed<SimpleRom>(() => ({
   md5_hash: null,
   sha1_hash: null,
   ra_hash: null,
+  ra_hash_match: null,
   has_simple_single_file: false,
   has_nested_single_file: false,
   has_multiple_files: false,

--- a/frontend/src/v2/components/GameDetails/VersionSwitcher.test.ts
+++ b/frontend/src/v2/components/GameDetails/VersionSwitcher.test.ts
@@ -1,0 +1,151 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import type { DetailedRom } from "@/stores/roms";
+import VersionSwitcher from "./VersionSwitcher.vue";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+// The RA mark and the default-version bookmark both live in RMenuItem's
+// `append` slot, so the stub has to render it.
+const RMenuItem = {
+  props: ["label"],
+  template: `<li class="item">{{ label }}<slot name="append" /></li>`,
+};
+const RMenu = {
+  template: `<div><slot name="activator" :props="{}" /><slot /></div>`,
+};
+const RBtn = { template: `<button><slot /></button>` };
+const RIcon = { props: ["icon"], template: `<i class="icon" :class="icon" />` };
+const RTooltip = {
+  props: ["text", "activator"],
+  template: `<span class="tooltip" :data-text="text" :data-activator="activator" />`,
+};
+
+type Sibling = {
+  id: number;
+  fs_name_no_ext: string;
+  ra_hash_match: boolean | null;
+};
+
+function mountSwitcher(rom: {
+  id: number;
+  fs_name_no_ext: string;
+  ra_hash_match: boolean | null;
+  siblings: Sibling[];
+}) {
+  return mount(VersionSwitcher, {
+    props: {
+      rom: {
+        id: rom.id,
+        fs_name_no_ext: rom.fs_name_no_ext,
+        ra_hash_match: rom.ra_hash_match,
+        rom_user: { is_main_sibling: false },
+        sibling_roms: rom.siblings.map((s) => ({
+          ...s,
+          is_main_sibling: false,
+        })),
+      } as unknown as DetailedRom,
+    },
+    global: { stubs: { RMenu, RMenuItem, RBtn, RIcon, RTooltip } },
+  });
+}
+
+// Maps each menu row to whether it carries the RA mark, keyed by label.
+function raByVersion(wrapper: ReturnType<typeof mountSwitcher>) {
+  return Object.fromEntries(
+    wrapper
+      .findAll(".item")
+      .map((w) => [w.text(), w.find(".version-switcher__ra").exists()]),
+  );
+}
+
+describe("VersionSwitcher RetroAchievements support", () => {
+  // Achievements only unlock for the revision RA hashed, so the menu has
+  // to say which one that is without the user opening each version.
+  it("marks only the versions RetroAchievements matched", () => {
+    const wrapper = mountSwitcher({
+      id: 1,
+      fs_name_no_ext: "Star Fox 64 (USA)",
+      ra_hash_match: true,
+      siblings: [
+        {
+          id: 2,
+          fs_name_no_ext: "Star Fox 64 (USA) (Rev 1)",
+          ra_hash_match: false,
+        },
+      ],
+    });
+
+    expect(raByVersion(wrapper)).toEqual({
+      "Star Fox 64 (USA)": true,
+      "Star Fox 64 (USA) (Rev 1)": false,
+    });
+  });
+
+  it("marks a sibling even when the version in view is unmatched", () => {
+    const wrapper = mountSwitcher({
+      id: 1,
+      fs_name_no_ext: "Star Fox 64 (USA)",
+      ra_hash_match: false,
+      siblings: [
+        {
+          id: 2,
+          fs_name_no_ext: "Star Fox 64 (USA) (Rev 1)",
+          ra_hash_match: true,
+        },
+      ],
+    });
+
+    expect(raByVersion(wrapper)).toEqual({
+      "Star Fox 64 (USA)": false,
+      "Star Fox 64 (USA) (Rev 1)": true,
+    });
+  });
+
+  // `null` is "never checked": an unsupported platform, or a ROM not
+  // rescanned since the column landed. Claiming support would be worse
+  // than staying quiet.
+  it("leaves rows unmarked when support was never checked", () => {
+    const wrapper = mountSwitcher({
+      id: 1,
+      fs_name_no_ext: "Game (USA)",
+      ra_hash_match: null,
+      siblings: [
+        { id: 2, fs_name_no_ext: "Game (Europe)", ra_hash_match: null },
+      ],
+    });
+
+    expect(wrapper.findAll(".version-switcher__ra")).toHaveLength(0);
+  });
+
+  // A native `title` would drop keyboard reveal and touch handling, and
+  // RTooltip costs nothing here (comment node inline, teleported panel),
+  // so the mark keeps a real tooltip anchored to itself rather than to
+  // the whole row.
+  it("explains the mark with an RTooltip bound to the mark", () => {
+    const wrapper = mountSwitcher({
+      id: 1,
+      fs_name_no_ext: "Star Fox 64 (USA)",
+      ra_hash_match: true,
+      siblings: [
+        {
+          id: 2,
+          fs_name_no_ext: "Star Fox 64 (USA) (Rev 1)",
+          ra_hash_match: false,
+        },
+      ],
+    });
+
+    const tooltip = wrapper.find(".version-switcher__ra .tooltip");
+    expect(tooltip.exists()).toBe(true);
+    expect(tooltip.attributes("data-activator")).toBe("parent");
+    expect(tooltip.attributes("data-text")).toBe(
+      "rom.retroachievements-supported",
+    );
+    expect(wrapper.find(".version-switcher__ra img").attributes("title")).toBe(
+      undefined,
+    );
+  });
+});

--- a/frontend/src/v2/components/GameDetails/VersionSwitcher.test.ts
+++ b/frontend/src/v2/components/GameDetails/VersionSwitcher.test.ts
@@ -104,9 +104,7 @@ describe("VersionSwitcher RetroAchievements support", () => {
     });
   });
 
-  // `null` is "never checked": an unsupported platform, or a ROM not
-  // rescanned since the column landed. Claiming support would be worse
-  // than staying quiet.
+  // Claiming support RA never confirmed is worse than staying quiet.
   it("leaves rows unmarked when support was never checked", () => {
     const wrapper = mountSwitcher({
       id: 1,
@@ -121,9 +119,8 @@ describe("VersionSwitcher RetroAchievements support", () => {
   });
 
   // A native `title` would drop keyboard reveal and touch handling, and
-  // RTooltip costs nothing here (comment node inline, teleported panel),
-  // so the mark keeps a real tooltip anchored to itself rather than to
-  // the whole row.
+  // RTooltip costs no width here, so the mark keeps a real tooltip anchored
+  // to itself rather than to the whole row.
   it("explains the mark with an RTooltip bound to the mark", () => {
     const wrapper = mountSwitcher({
       id: 1,

--- a/frontend/src/v2/components/GameDetails/VersionSwitcher.test.ts
+++ b/frontend/src/v2/components/GameDetails/VersionSwitcher.test.ts
@@ -34,6 +34,7 @@ function mountSwitcher(rom: {
   fs_name_no_ext: string;
   ra_hash_match: boolean | null;
   siblings: Sibling[];
+  achievements?: number;
 }) {
   return mount(VersionSwitcher, {
     props: {
@@ -41,6 +42,12 @@ function mountSwitcher(rom: {
         id: rom.id,
         fs_name_no_ext: rom.fs_name_no_ext,
         ra_hash_match: rom.ra_hash_match,
+        merged_ra_metadata: {
+          achievements: Array.from(
+            { length: rom.achievements ?? 3 },
+            () => ({}),
+          ),
+        },
         rom_user: { is_main_sibling: false },
         sibling_roms: rom.siblings.map((s) => ({
           ...s,
@@ -62,8 +69,8 @@ function raByVersion(wrapper: ReturnType<typeof mountSwitcher>) {
 }
 
 describe("VersionSwitcher RetroAchievements support", () => {
-  // Achievements only unlock for the revision RA hashed, so the menu has
-  // to say which one that is without the user opening each version.
+  // RA hashes one dump per release, so the menu has to say which one
+  // without the user opening each version.
   it("marks only the versions RetroAchievements matched", () => {
     const wrapper = mountSwitcher({
       id: 1,
@@ -112,6 +119,26 @@ describe("VersionSwitcher RetroAchievements support", () => {
       ra_hash_match: null,
       siblings: [
         { id: 2, fs_name_no_ext: "Game (Europe)", ra_hash_match: null },
+      ],
+    });
+
+    expect(wrapper.findAll(".version-switcher__ra")).toHaveLength(0);
+  });
+
+  // RA's hash list includes games it has no achievements for, so a hash
+  // match alone would promise unlocks that can never happen.
+  it("marks nothing when the game has no achievements", () => {
+    const wrapper = mountSwitcher({
+      id: 1,
+      fs_name_no_ext: "Star Fox 64 (USA)",
+      ra_hash_match: true,
+      achievements: 0,
+      siblings: [
+        {
+          id: 2,
+          fs_name_no_ext: "Star Fox 64 (USA) (Rev 1)",
+          ra_hash_match: true,
+        },
       ],
     });
 

--- a/frontend/src/v2/components/GameDetails/VersionSwitcher.vue
+++ b/frontend/src/v2/components/GameDetails/VersionSwitcher.vue
@@ -29,23 +29,32 @@ const visible = computed(() => props.rom.sibling_roms.length > 0);
 // so the badge surfaces consistently regardless of which sibling the
 // user is currently viewing.
 //
-// `ra` marks the versions RA's own hash list knows, which is what decides
-// whether achievements unlock. `null` (never checked) gets no mark, same
-// as unsupported.
+// RA's hash list covers games with no achievements too, so a hash match
+// alone doesn't mean anything will unlock. Gate on the game actually having
+// achievements, read off the metadata this page already loads: achievements
+// are game-level, so it holds for every sibling, and putting a per-sibling
+// count on the wire would mean hydrating `ra_metadata` for each one.
+const gameHasAchievements = computed(
+  () => (props.rom.merged_ra_metadata?.achievements?.length ?? 0) > 0,
+);
+
+// `ra` marks the versions RA hashed, so achievements unlock on this file
+// rather than a sibling. `null` (never checked) gets no mark, same as a
+// version RA doesn't have.
 const versions = computed(() => [
   {
     id: props.rom.id,
     label: props.rom.fs_name_no_ext,
     current: true,
     main: props.rom.rom_user?.is_main_sibling === true,
-    ra: props.rom.ra_hash_match === true,
+    ra: gameHasAchievements.value && props.rom.ra_hash_match === true,
   },
   ...props.rom.sibling_roms.map((s) => ({
     id: s.id,
     label: s.fs_name_no_ext,
     current: false,
     main: s.is_main_sibling === true,
-    ra: s.ra_hash_match === true,
+    ra: gameHasAchievements.value && s.ra_hash_match === true,
   })),
 ]);
 

--- a/frontend/src/v2/components/GameDetails/VersionSwitcher.vue
+++ b/frontend/src/v2/components/GameDetails/VersionSwitcher.vue
@@ -29,12 +29,9 @@ const visible = computed(() => props.rom.sibling_roms.length > 0);
 // so the badge surfaces consistently regardless of which sibling the
 // user is currently viewing.
 //
-// `ra` flags the versions whose own hash RetroAchievements knows, which
-// is what decides whether achievements unlock, so it belongs in the
-// menu you pick the version from. `ra_hash_match` is deliberately not
-// `ra_id`: the id is the game, shared by every sibling. `null` means
-// never checked (unsupported platform, or not scanned since the column
-// landed), which reads the same as unsupported here: no mark.
+// `ra` marks the versions RA's own hash list knows, which is what decides
+// whether achievements unlock. `null` (never checked) gets no mark, same
+// as unsupported.
 const versions = computed(() => [
   {
     id: props.rom.id,

--- a/frontend/src/v2/components/GameDetails/VersionSwitcher.vue
+++ b/frontend/src/v2/components/GameDetails/VersionSwitcher.vue
@@ -85,8 +85,8 @@ const raTooltip = computed(() => t("rom.retroachievements-supported"));
       <template v-if="v.ra || v.main" #append>
         <!-- The wrapper is what `activator="parent"` binds to, so the
              tooltip covers the mark and not the whole row. It adds no
-             width: RTooltip renders a comment node inline and teleports
-             its panel. -->
+             width: RTooltip leaves a `display: none` anchor here and
+             teleports its panel. -->
         <span v-if="v.ra" class="version-switcher__ra">
           <img
             src="/assets/scrappers/ra.png"

--- a/frontend/src/v2/components/GameDetails/VersionSwitcher.vue
+++ b/frontend/src/v2/components/GameDetails/VersionSwitcher.vue
@@ -8,7 +8,7 @@
 // default" read as a single control group. The active row in the menu
 // is the rom currently in view (radio-like), so the user can confirm
 // which file they're on without scanning filenames.
-import { RBtn, RIcon, RMenu, RMenuItem } from "@v2/lib";
+import { RBtn, RIcon, RMenu, RMenuItem, RTooltip } from "@v2/lib";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type { DetailedRom } from "@/stores/roms";
@@ -28,23 +28,33 @@ const visible = computed(() => props.rom.sibling_roms.length > 0);
 // rest (resolved by the backend against the request user's RomUser),
 // so the badge surfaces consistently regardless of which sibling the
 // user is currently viewing.
+//
+// `ra` flags the versions whose own hash RetroAchievements knows, which
+// is what decides whether achievements unlock, so it belongs in the
+// menu you pick the version from. `ra_hash_match` is deliberately not
+// `ra_id`: the id is the game, shared by every sibling. `null` means
+// never checked (unsupported platform, or not scanned since the column
+// landed), which reads the same as unsupported here: no mark.
 const versions = computed(() => [
   {
     id: props.rom.id,
     label: props.rom.fs_name_no_ext,
     current: true,
     main: props.rom.rom_user?.is_main_sibling === true,
+    ra: props.rom.ra_hash_match === true,
   },
   ...props.rom.sibling_roms.map((s) => ({
     id: s.id,
     label: s.fs_name_no_ext,
     current: false,
     main: s.is_main_sibling === true,
+    ra: s.ra_hash_match === true,
   })),
 ]);
 
 const currentLabel = computed(() => props.rom.fs_name_no_ext);
 const mainTooltip = computed(() => t("rom.default-version"));
+const raTooltip = computed(() => t("rom.retroachievements-supported"));
 </script>
 
 <template>
@@ -72,8 +82,22 @@ const mainTooltip = computed(() => t("rom.default-version"));
       :icon="v.current ? 'mdi-check' : undefined"
       :label="v.label"
     >
-      <template v-if="v.main" #append>
+      <template v-if="v.ra || v.main" #append>
+        <!-- The wrapper is what `activator="parent"` binds to, so the
+             tooltip covers the mark and not the whole row. It adds no
+             width: RTooltip renders a comment node inline and teleports
+             its panel. -->
+        <span v-if="v.ra" class="version-switcher__ra">
+          <img
+            src="/assets/scrappers/ra.png"
+            :alt="raTooltip"
+            width="14"
+            height="14"
+          />
+          <RTooltip activator="parent" :text="raTooltip" location="top" />
+        </span>
         <RIcon
+          v-if="v.main"
           icon="mdi-bookmark-box"
           size="14"
           class="version-switcher__main"
@@ -101,5 +125,19 @@ const mainTooltip = computed(() => t("rom.default-version"));
 
 .version-switcher__main {
   color: var(--r-color-brand-accent);
+}
+
+/* Bare logo at the bookmark's 14px, deliberately without the gallery's
+   chip tile: the panel is sized by its widest row (`width: max-content`),
+   so every pixel here widens the whole menu. The wrapper is sized by the
+   logo alone. */
+.version-switcher__ra {
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+.version-switcher__ra img {
+  display: block;
+  object-fit: contain;
 }
 </style>

--- a/frontend/src/v2/lib/structural/RTooltip/RTooltip.vue
+++ b/frontend/src/v2/lib/structural/RTooltip/RTooltip.vue
@@ -334,9 +334,9 @@ watch(isOpen, (open) => {
 });
 
 // For the parent-attach pattern we sit silently in the parent's DOM
-// and register listeners on `$el.parentElement` at mount. We deliberately
-// use a comment node as `$el` so the tooltip itself doesn't take up
-// flow space inside the parent.
+// and register listeners on `$el.parentElement` at mount. `$el` is the
+// `display: none` anchor span rendered below, so the tooltip itself takes
+// up no flow space inside the parent.
 const root = ref<HTMLElement | null>(null);
 function attachToParent() {
   if (props.activator !== "parent") return;

--- a/frontend/src/v2/utils/romVerification.test.ts
+++ b/frontend/src/v2/utils/romVerification.test.ts
@@ -5,12 +5,17 @@ import {
   isRomVerified,
   matchesDatabase,
   VERIFICATION_DATABASES,
-  VERIFICATION_KEYS,
 } from "./romVerification";
 
-// Only `hasheous_metadata` is read; cast a minimal stub to SimpleRom.
-const rom = (hasheous_metadata?: RomHasheousMetadata | null): SimpleRom =>
-  ({ hasheous_metadata }) as SimpleRom;
+// Only `hasheous_metadata` and `ra_hash_match` are read; cast a minimal
+// stub to SimpleRom.
+const rom = (
+  hasheous_metadata?: RomHasheousMetadata | null,
+  ra_hash_match: boolean | null = null,
+): SimpleRom => ({ hasheous_metadata, ra_hash_match }) as SimpleRom;
+
+const db = (label: string) =>
+  VERIFICATION_DATABASES.find((d) => d.label === label)!;
 
 describe("isRomVerified", () => {
   it("is false when there is no hasheous metadata", () => {
@@ -27,48 +32,78 @@ describe("isRomVerified", () => {
   });
 
   it("is true when any single database matched", () => {
-    for (const key of VERIFICATION_KEYS) {
+    const keys: (keyof RomHasheousMetadata)[] = [
+      "tosec_match",
+      "nointro_match",
+      "redump_match",
+      "mame_redump_match",
+      "mame_arcade_match",
+      "mame_mess_match",
+      "fbneo_match",
+      "whdload_match",
+      "puredos_match",
+      "ra_match",
+    ];
+    for (const key of keys) {
       expect(isRomVerified(rom({ [key]: true }))).toBe(true);
     }
+  });
+
+  it("is true on RA's own hash match alone, with no hasheous metadata", () => {
+    expect(isRomVerified(rom(null, true))).toBe(true);
   });
 });
 
 describe("matchesDatabase", () => {
   it("matches MAME on either the arcade or the mess flag", () => {
-    const mame = VERIFICATION_DATABASES.find((db) => db.label === "MAME")!;
-    expect(matchesDatabase(rom(), mame.keys)).toBe(false);
-    expect(matchesDatabase(rom({ mame_arcade_match: true }), mame.keys)).toBe(
-      true,
-    );
-    expect(matchesDatabase(rom({ mame_mess_match: true }), mame.keys)).toBe(
-      true,
-    );
+    const mame = db("MAME");
+    expect(mame.matches(rom())).toBe(false);
+    expect(mame.matches(rom({ mame_arcade_match: true }))).toBe(true);
+    expect(mame.matches(rom({ mame_mess_match: true }))).toBe(true);
   });
 
   it("matches Redump on either the disc-image or the CHD flag", () => {
-    const redump = VERIFICATION_DATABASES.find((db) => db.label === "Redump")!;
-    expect(matchesDatabase(rom({ redump_match: true }), redump.keys)).toBe(
-      true,
-    );
+    const redump = db("Redump");
+    expect(redump.matches(rom({ redump_match: true }))).toBe(true);
     // Hasheous indexes CHD conversions under its own MAMERedump source.
-    expect(matchesDatabase(rom({ mame_redump_match: true }), redump.keys)).toBe(
-      true,
-    );
+    expect(redump.matches(rom({ mame_redump_match: true }))).toBe(true);
   });
 
-  it("treats RetroAchievements as a database match (ra_match, not ra_id)", () => {
-    const ra = VERIFICATION_DATABASES.find(
-      (db) => db.label === "RetroAchievements",
-    )!;
-    expect(ra.keys).toEqual(["ra_match"]);
-    expect(matchesDatabase(rom({ ra_match: true }), ra.keys)).toBe(true);
+  it("still reads raw hasheous flags for callers that pass keys", () => {
+    expect(matchesDatabase(rom({ tosec_match: true }), ["tosec_match"])).toBe(
+      true,
+    );
+    expect(matchesDatabase(rom(), ["tosec_match"])).toBe(false);
   });
 });
 
-describe("VERIFICATION_KEYS", () => {
-  it("is the flattened set of every database's match flags", () => {
-    expect(VERIFICATION_KEYS).toEqual(
-      VERIFICATION_DATABASES.flatMap((db) => db.keys),
-    );
+// RA is the one database RomM asks directly. Achievements unlock on RA's
+// own hash list, so that answer outranks Hasheous' narrower RA signature
+// coverage in both directions.
+describe("RetroAchievements verification", () => {
+  const ra = () => db("RetroAchievements");
+
+  it("matches when RA's own hash list knows the file", () => {
+    expect(ra().matches(rom(null, true))).toBe(true);
+  });
+
+  it("falls back to hasheous when RA was never asked", () => {
+    expect(ra().matches(rom({ ra_match: true }, null))).toBe(true);
+    expect(ra().matches(rom({ ra_match: false }, null))).toBe(false);
+    expect(ra().matches(rom(null, null))).toBe(false);
+  });
+
+  it("trusts RA over hasheous when the two disagree", () => {
+    // RA knows the dump, hasheous' RA signatures don't reach it: the case
+    // that had users seeing a grey tag next to a working RA match.
+    expect(ra().matches(rom({ ra_match: false }, true))).toBe(true);
+    // RA has never seen the dump: don't promise achievements.
+    expect(ra().matches(rom({ ra_match: true }, false))).toBe(false);
+  });
+
+  it("does not read ra_id", () => {
+    // `ra_id` is the game, so every sibling shares it.
+    const withGameId = { hasheous_metadata: null, ra_id: 12345 } as SimpleRom;
+    expect(ra().matches(withGameId)).toBe(false);
   });
 });

--- a/frontend/src/v2/utils/romVerification.ts
+++ b/frontend/src/v2/utils/romVerification.ts
@@ -1,36 +1,17 @@
 // romVerification — single source of truth for what "verified" means: a
-// ROM whose file hash matched a known ROM database (via Hasheous). Mirrors
-// the backend's `_filter_by_verified` (roms_handler.py) so the header
-// badge, the per-database chips in the Metadata tab, and the library
-// "verified" filter all agree. Merely having a computed hash
-// (crc/md5/sha1) does NOT make a ROM verified.
+// ROM whose file hash matched a known ROM database. Mirrors the backend's
+// `_filter_by_verified` (roms_handler.py) so the header badge, the
+// per-database chips in the Metadata tab, and the library "verified"
+// filter all agree. Merely having a computed hash (crc/md5/sha1) does
+// NOT make a ROM verified.
 import type { RomHasheousMetadata } from "@/__generated__";
 import type { SimpleRom } from "@/stores/roms";
 
-// Each database this ROM's hash can be checked against, with the Hasheous
-// match flag(s) that count as a hit. MAME reports Arcade and MESS
-// separately; either one means the ROM matched MAME. Redump likewise
-// reports disc images and their CHD conversions separately. Order is the
-// display order for the Metadata tab chips.
-export const VERIFICATION_DATABASES: {
-  label: string;
-  keys: (keyof RomHasheousMetadata)[];
-}[] = [
-  { label: "TOSEC", keys: ["tosec_match"] },
-  { label: "No-Intro", keys: ["nointro_match"] },
-  { label: "Redump", keys: ["redump_match", "mame_redump_match"] },
-  { label: "MAME", keys: ["mame_arcade_match", "mame_mess_match"] },
-  { label: "FBNeo", keys: ["fbneo_match"] },
-  { label: "WHDLoad", keys: ["whdload_match"] },
-  { label: "PureDOS", keys: ["puredos_match"] },
-  { label: "RetroAchievements", keys: ["ra_match"] },
-];
-
-// Flattened match flags, i.e. the exact set the backend filters on.
-export const VERIFICATION_KEYS: (keyof RomHasheousMetadata)[] =
-  VERIFICATION_DATABASES.flatMap((db) => db.keys);
-
-// Whether a single database matched for this ROM.
+// Whether any of the given Hasheous flags is set. Hasheous reports, per
+// submitted hash, the signature sources that hash was found in, so these
+// are per-file. MAME reports Arcade and MESS separately; Redump likewise
+// reports disc images and their CHD conversions separately. Either flag
+// counts as a hit for that database.
 export function matchesDatabase(
   rom: SimpleRom,
   keys: (keyof RomHasheousMetadata)[],
@@ -40,7 +21,42 @@ export function matchesDatabase(
   return keys.some((key) => Boolean(h[key]));
 }
 
+// RetroAchievements is the one database RomM asks directly, and its own
+// answer wins: `ra_hash_match` comes from RA's hash list, which is what
+// decides whether achievements unlock, while Hasheous knows RA's dumps
+// only as far as its signature coverage reaches. So a definite `false`
+// from RA is trusted over a Hasheous hit — falling back there would
+// promise achievements for a file RA has never seen. `null` means RA was
+// never asked (platform it doesn't cover, or a ROM not rescanned since
+// the column landed), and only then does Hasheous answer.
+function matchesRetroAchievements(rom: SimpleRom): boolean {
+  if (rom.ra_hash_match != null) return rom.ra_hash_match;
+  return matchesDatabase(rom, ["ra_match"]);
+}
+
+// Order is the display order for the Metadata tab chips.
+export const VERIFICATION_DATABASES: {
+  label: string;
+  matches: (rom: SimpleRom) => boolean;
+}[] = [
+  { label: "TOSEC", matches: (r) => matchesDatabase(r, ["tosec_match"]) },
+  { label: "No-Intro", matches: (r) => matchesDatabase(r, ["nointro_match"]) },
+  {
+    label: "Redump",
+    matches: (r) => matchesDatabase(r, ["redump_match", "mame_redump_match"]),
+  },
+  {
+    label: "MAME",
+    matches: (r) =>
+      matchesDatabase(r, ["mame_arcade_match", "mame_mess_match"]),
+  },
+  { label: "FBNeo", matches: (r) => matchesDatabase(r, ["fbneo_match"]) },
+  { label: "WHDLoad", matches: (r) => matchesDatabase(r, ["whdload_match"]) },
+  { label: "PureDOS", matches: (r) => matchesDatabase(r, ["puredos_match"]) },
+  { label: "RetroAchievements", matches: matchesRetroAchievements },
+];
+
 // Whether the ROM is verified against any known database.
 export function isRomVerified(rom: SimpleRom): boolean {
-  return matchesDatabase(rom, VERIFICATION_KEYS);
+  return VERIFICATION_DATABASES.some((db) => db.matches(rom));
 }

--- a/frontend/src/v2/utils/romVerification.ts
+++ b/frontend/src/v2/utils/romVerification.ts
@@ -22,9 +22,9 @@ export function matchesDatabase(
 }
 
 // RetroAchievements is the one database RomM asks directly, and its answer
-// wins in both directions: `false` means RA has never seen this dump, so
-// achievements won't unlock however far Hasheous' RA signature coverage
-// reaches. `null` is "never asked", and only then does Hasheous answer.
+// wins in both directions: `false` means RA's own hash list doesn't have
+// this dump, however far Hasheous' RA signature coverage reaches. `null` is
+// "never asked", and only then does Hasheous answer.
 function matchesRetroAchievements(rom: SimpleRom): boolean {
   if (rom.ra_hash_match != null) return rom.ra_hash_match;
   return matchesDatabase(rom, ["ra_match"]);

--- a/frontend/src/v2/utils/romVerification.ts
+++ b/frontend/src/v2/utils/romVerification.ts
@@ -21,14 +21,10 @@ export function matchesDatabase(
   return keys.some((key) => Boolean(h[key]));
 }
 
-// RetroAchievements is the one database RomM asks directly, and its own
-// answer wins: `ra_hash_match` comes from RA's hash list, which is what
-// decides whether achievements unlock, while Hasheous knows RA's dumps
-// only as far as its signature coverage reaches. So a definite `false`
-// from RA is trusted over a Hasheous hit, since falling back there would
-// promise achievements for a file RA has never seen. `null` means RA was
-// never asked (platform it doesn't cover, or a ROM not rescanned since
-// the column landed), and only then does Hasheous answer.
+// RetroAchievements is the one database RomM asks directly, and its answer
+// wins in both directions: `false` means RA has never seen this dump, so
+// achievements won't unlock however far Hasheous' RA signature coverage
+// reaches. `null` is "never asked", and only then does Hasheous answer.
 function matchesRetroAchievements(rom: SimpleRom): boolean {
   if (rom.ra_hash_match != null) return rom.ra_hash_match;
   return matchesDatabase(rom, ["ra_match"]);

--- a/frontend/src/v2/utils/romVerification.ts
+++ b/frontend/src/v2/utils/romVerification.ts
@@ -25,7 +25,7 @@ export function matchesDatabase(
 // answer wins: `ra_hash_match` comes from RA's hash list, which is what
 // decides whether achievements unlock, while Hasheous knows RA's dumps
 // only as far as its signature coverage reaches. So a definite `false`
-// from RA is trusted over a Hasheous hit — falling back there would
+// from RA is trusted over a Hasheous hit, since falling back there would
 // promise achievements for a file RA has never seen. `null` means RA was
 // never asked (platform it doesn't cover, or a ROM not rescanned since
 // the column landed), and only then does Hasheous answer.

--- a/frontend/src/v2/utils/romVerification.ts
+++ b/frontend/src/v2/utils/romVerification.ts
@@ -1,5 +1,5 @@
-// romVerification — single source of truth for what "verified" means: a
-// ROM whose file hash matched a known ROM database. Mirrors the backend's
+// romVerification: single source of truth for what "verified" means, i.e.
+// a ROM whose file hash matched a known ROM database. Mirrors the backend's
 // `_filter_by_verified` (roms_handler.py) so the header badge, the
 // per-database chips in the Metadata tab, and the library "verified"
 // filter all agree. Merely having a computed hash (crc/md5/sha1) does


### PR DESCRIPTION
Sorry for opening so many PRs in such quick succession. Just wanting to fix and improve things as I import my library. I intend for this one to be the last one for the time being! Also, a future enhancement I am considering is showing the RA badge or a trophy on the game list. Let me know your thoughts on that!

---

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

RetroAchievements only unlocks achievements for the exact dump it has hashed, but nothing in RomM surfaced which of a game's versions that was. Picking between `Star Fox 64 (USA)` and `Star Fox 64 (USA) (Rev 1)` meant guessing, or opening each one in turn.

`ra_id` can't answer this. On the Hasheous path it comes from the matched game's metadata list (`hasheous_handler.py`), so it identifies the *game*, and every sibling of a title resolves to the same id. A per-version marker driven by it would light up on every row.

So this records the per-file fact instead:

- `RAHandler.hash_is_known` asks RetroAchievements' own hash list (the `ra_hashes_v2.json` index built from `get_game_list(..., include_hashes=True)`), never another provider.
- `scan_handler` now asks it for **every** ROM on an RA platform. Previously a Hasheous-supplied `ra_id` short-circuited the RA lookup entirely, which is how the per-file answer got lost.
- The answer persists as `roms.ra_hash_match` (migration `0108`), nullable so "never checked" stays distinct from "checked, and RA doesn't have it".

Two surfaces read it:

- **Version switcher** shows the RA logo on the versions RA knows, so the choice is visible where it's made.
- **Metadata tab / Verification** and the header badge now read the same field, falling back to Hasheous' `ra_match` only when RA was never asked. A definite *no* from RA outranks a Hasheous hit, since deferring there would promise achievements for a file RA has never seen. `_filter_by_verified` encodes the same precedence so the library filter can't drift from the badges.

Also included: the platform hash list is now memoised per platform with a short TTL. It was previously re-read and re-parsed from disk once per ROM during a scan, and it runs to several megabytes on large systems.

Note that `ra_hash_match` starts as `NULL`, so existing libraries show nothing new until those ROMs are rescanned or metadata-refreshed.

**AI assistance disclosure**

This PR was written with AI assistance (Claude Code). The investigation, implementation, migration, and tests were produced in a session with an agent, and reviewed by me before opening. Per `CONTRIBUTING.md`, disclosing this in full: the agent wrote the code and tests; I directed the approach, caught that `ra_id` was game-level rather than per-file, and chose to persist the flag at scan time rather than compute it per request.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Verification run locally: `vue-tsc` clean, `npm run build` clean, 279 v2 vitest tests, 1902 backend tests across `tests/handler` and `tests/endpoints`, both i18n scripts, and ruff/black/prettier/eslint on the touched files. Not yet verified in a browser against a live library, so the screenshot below is a faithful mock rather than a capture (see below).

#### Screenshots (if applicable)

<img width="790" height="286" alt="image-1785972754387" src="https://github.com/user-attachments/assets/19087254-738a-4da1-92c1-7030fd8cd360" />

Composed mock, not a live capture: built from the real `ra.png` asset and the generated v2 theme tokens, with the CSS copied verbatim from `RMenu`, `RMenuItem`, and `VersionSwitcher`. The RA-marked row is the base USA dump, which is the version RetroAchievements actually hashed for Star Fox 64. The light pane also shows the mark alongside the existing default-version bookmark.

The mark is a bare 14px logo rather than the gallery's tiled provider chip: the menu panel is `width: max-content` with no cap, so anything wider grows the whole dropdown. At 14px it costs exactly what the bookmark already in that slot costs.
