### PR TITLE
fix(v2): compute game-card cover width instead of deriving it

### DIFF
--- a/frontend/src/v2/components/GameCard/GameCard.vue
+++ b/frontend/src/v2/components/GameCard/GameCard.vue
@@ -576,9 +576,14 @@ function onStaticKeydown(e: KeyboardEvent) {
   display: flex;
   flex-direction: column;
 }
-/* Width follows the cover (overrides GameCover's base `width: 100%`). */
+/* Width follows the cover (overrides GameCover's base `width: 100%`).
+   Multiplied out instead of leaning on GameCover's `aspect-ratio`: a
+   width derived from the aspect-ratio alone is circular inside a
+   shrink-to-fit ancestor (the match-dialog cell), and WebKit collapses
+   that to a few pixels. `--r-cover-ratio` is set inline on this element
+   with the cover's measured ratio, so it wins over the card-level one. */
 .r-gc:not(.r-gc--hero) .r-gc__art {
-  width: auto;
+  width: calc(var(--r-card-art-h) * var(--r-cover-ratio, 0.6667));
 }
 /* Label fills the cover's width and ellipsises, without widening the card. */
 .r-gc:not(.r-gc--hero) .r-gc__label {

--- a/frontend/src/v2/components/MatchRom/MatchRomBodyGrid.vue
+++ b/frontend/src/v2/components/MatchRom/MatchRomBodyGrid.vue
@@ -301,11 +301,8 @@ watch(
   /* Shrink-wrap the card's natural width and never shrink below it (a fixed
      -height card shrunk on the cross axis would crop its cover). */
   flex: 0 0 auto;
-  /* Lay the card out as a flex item (not a block child). GameCard derives its
-     width from a fixed height via the cover's `aspect-ratio`; as a block child
-     of a shrink-to-fit cell that width resolution is circular, and WebKit
-     (Safari) collapses it to a thin sliver. Flex intrinsic sizing resolves it
-     correctly, the same path the gallery row already relies on. */
+  /* Lay the card out as a flex item (not a block child), the same path the
+     gallery row uses. */
   display: flex;
   /* …but never wider than the grid: a wide cover (landscape provider art, or
      a card wider than a narrow phone) draws its width from the cover aspect


### PR DESCRIPTION
**Description**

The Match ROM dialog renders every result cover as a thin vertical sliver in Safari (Chromium is fine). Reported in #3761.

Non-hero `GameCard`s render at a fixed height with a natural width, and `.r-gc__art` took that width from `GameCover`'s `aspect-ratio` via `width: auto`. The width therefore depends on the aspect-ratio transferred size, and inside a shrink-to-fit ancestor (the dialog's `.match-grid__card-cell`) that resolution is circular. WebKit gives up and collapses the box to a few pixels, so `object-fit: cover` paints a one-pixel-wide slice of the cover.

The fix multiplies the height by the cover ratio instead:

```css
.r-gc:not(.r-gc--hero) .r-gc__art {
  width: calc(var(--r-card-art-h) * var(--r-cover-ratio, 0.6667));
}
```

Both values are already CSS variables on that element (`--r-cover-ratio` is set inline with the cover's measured ratio), so the width lands on the same number with nothing left for the engine to resolve.

Note on the earlier fix: 44ef5cf5 addressed this same report by making the grid cell a flex container. That changed *where* the width was resolved but left the aspect-ratio transfer in place, so the covers still collapse on 5.1.0. This PR removes the transfer, and I've reverted the now-inaccurate comment on `.match-grid__card-cell` (the `display: flex` itself stays, since that matches the gallery row).

**Verification**

- Confirmed against the failing case: injecting the new rule into a live 5.1.0 instance in Safari renders the covers correctly.
- No layout regression: I measured old vs. new width resolution across 5 cover ratios x 5 size tiers in 3 layout contexts (gallery row, match-dialog cell, list row with its `max-width` cap), in both WebKit and Chromium. All 110 boxes agree except 16 that differ by <= 0.02px, in the default tier where `--r-card-art-h` is itself fractional (236.98px). That is rounding order, not a layout change. WebKit and Chromium produce identical geometry under the new rule.
- Worth flagging for reviewers: headless WebKit does **not** reproduce this bug (the pre-44ef5cf5 markup renders correctly there), so the automated comparison above can only show equivalence. The fix itself was confirmed manually in Safari.

**AI assistance disclosure**

This PR was written primarily by Claude Code (Claude Opus 5): the diagnosis, the code change, the cross-engine comparison harness, and this description. The failing case and the confirmation that the fix resolves it in Safari were done by me manually.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

<sup>No unit test: this is a CSS-only layout fix whose failure mode reproduces only in real Safari, which is not in the test matrix (`playwright.config.ts` runs Chromium only).</sup>

#### Screenshots (if applicable)

<!-- before / after -->
