### PR TITLE
fix(ss): store the ScreenScraper box-2D front locally

### DIFF
--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -720,9 +720,9 @@ class FSResourcesHandler(FSHandler):
                     return False
 
         # Drop ScreenScraper's green "missing art" placeholder so a box face
-        # (box-2D-back / box-2D-side) falls back to the dark placeholder rather
-        # than rendering bright green. Runs for pre-existing files too, cleaning
-        # them up on rescan.
+        # (box-2D / box-2D-back / box-2D-side) falls back to the dark placeholder
+        # rather than rendering bright green. Runs for pre-existing files too,
+        # cleaning them up on rescan.
         if await self._discard_if_chroma_key(dest_path):
             return False
 

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -292,6 +292,7 @@ class SSMetadataMedia(TypedDict):
 
     # Resources stored in filesystem
     bezel_path: str | None
+    box2d_path: str | None
     box2d_back_path: str | None
     box2d_side_path: str | None
     box3d_path: str | None
@@ -354,6 +355,7 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
         video_url=None,
         video_normalized_url=None,
         bezel_path=None,
+        box2d_path=None,
         box2d_back_path=None,
         box2d_side_path=None,
         box3d_path=None,
@@ -393,6 +395,12 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
                 ss_media["box2d_url"] = strip_sensitive_query_params(
                     media["url"], SENSITIVE_KEYS
                 )
+                # Stored locally as well as feeding url_cover, so the box front
+                # stays reachable when another provider wins the cover.
+                if MetadataMediaType.BOX2D in preferred_media_types:
+                    ss_media["box2d_path"] = (
+                        f"{fs_resource_handler.get_media_resources_path(rom.platform_id, rom.id, MetadataMediaType.BOX2D)}/box2d.png"
+                    )
             elif media.get("type") == "fanart" and not ss_media["fanart_url"]:
                 ss_media["fanart_url"] = strip_sensitive_query_params(
                     media["url"], SENSITIVE_KEYS

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -351,6 +351,44 @@ class TestExtractMediaFromSsGame:
             },
         )
 
+    def test_box2d_path_set_when_in_config(self):
+        """When 'box2d' is in SCAN_MEDIA the box front is persisted locally, so it
+        stays reachable when another provider wins the cover."""
+        config = _make_config(scan_media=["box2d"])
+        rom = self._make_rom()
+        game = self._make_game_with_box_faces()
+
+        with (
+            patch("handler.metadata.ss_handler.cm.get_config", return_value=config),
+            patch(
+                "handler.metadata.ss_handler.fs_resource_handler.get_media_resources_path",
+                side_effect=lambda pid, rid, mt: f"roms/{pid}/{rid}/{mt.value}",
+            ),
+        ):
+            result = extract_media_from_ss_game(rom, game)
+
+        assert result["box2d_url"] is not None
+        assert "box-2D" in result["box2d_url"]
+        assert result["box2d_path"] == "roms/1/100/box2d/box2d.png"
+
+    def test_box2d_path_not_set_when_absent_from_config(self):
+        """Without 'box2d' in SCAN_MEDIA the front URL is kept but not stored."""
+        config = _make_config(scan_media=["box2d_back"])
+        rom = self._make_rom()
+        game = self._make_game_with_box_faces()
+
+        with (
+            patch("handler.metadata.ss_handler.cm.get_config", return_value=config),
+            patch(
+                "handler.metadata.ss_handler.fs_resource_handler.get_media_resources_path",
+                side_effect=lambda pid, rid, mt: f"roms/{pid}/{rid}/{mt.value}",
+            ),
+        ):
+            result = extract_media_from_ss_game(rom, game)
+
+        assert result["box2d_url"] is not None
+        assert result["box2d_path"] is None
+
     def test_box2d_side_path_set_when_in_config(self):
         """When 'box2d_side' is in SCAN_MEDIA the spine is persisted locally."""
         config = _make_config(scan_media=["box2d", "box2d_back", "box2d_side"])

--- a/frontend/src/__generated__/models/RomSSMetadata.ts
+++ b/frontend/src/__generated__/models/RomSSMetadata.ts
@@ -23,6 +23,7 @@ export type RomSSMetadata = {
     video_url?: (string | null);
     video_normalized_url?: (string | null);
     bezel_path?: (string | null);
+    box2d_path?: (string | null);
     box2d_back_path?: (string | null);
     box2d_side_path?: (string | null);
     box3d_path?: (string | null);

--- a/frontend/src/locales/bg_BG/rom.json
+++ b/frontend/src/locales/bg_BG/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "Разпознай тази игра",
   "media": "Media",
   "media-bezel": "Рамка",
+  "media-box2d": "Кутия (2D, лице)",
   "media-box2d-back": "Кутия (2D, гръб)",
   "media-box2d-side": "Кутия (2D, страна)",
   "media-box3d": "Кутия (3D)",

--- a/frontend/src/locales/cs_CZ/rom.json
+++ b/frontend/src/locales/cs_CZ/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "Spárovat tuto hru",
   "media": "Media",
   "media-bezel": "Rámeček",
+  "media-box2d": "Krabice (2D, přední)",
   "media-box2d-back": "Krabice (2D, zadní)",
   "media-box2d-side": "Krabice (2D, boční)",
   "media-box3d": "Krabice (3D)",

--- a/frontend/src/locales/de_DE/rom.json
+++ b/frontend/src/locales/de_DE/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "Dieses Spiel zuordnen",
   "media": "Media",
   "media-bezel": "Rahmen",
+  "media-box2d": "Box (2D, Vorderseite)",
   "media-box2d-back": "Box (2D, Rückseite)",
   "media-box2d-side": "Box (2D, Seite)",
   "media-box3d": "Box (3D)",

--- a/frontend/src/locales/en_GB/rom.json
+++ b/frontend/src/locales/en_GB/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "Match this game",
   "media": "Media",
   "media-bezel": "Bezel",
+  "media-box2d": "Box (2D, front)",
   "media-box2d-back": "Box (2D, back)",
   "media-box2d-side": "Box (2D, side)",
   "media-box3d": "Box (3D)",

--- a/frontend/src/locales/en_US/rom.json
+++ b/frontend/src/locales/en_US/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "Match this game",
   "media": "Media",
   "media-bezel": "Bezel",
+  "media-box2d": "Box (2D, front)",
   "media-box2d-back": "Box (2D, back)",
   "media-box2d-side": "Box (2D, side)",
   "media-box3d": "Box (3D)",

--- a/frontend/src/locales/es_ES/rom.json
+++ b/frontend/src/locales/es_ES/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "Emparejar este juego",
   "media": "Media",
   "media-bezel": "Marco",
+  "media-box2d": "Caja (2D, frontal)",
   "media-box2d-back": "Caja (2D, trasera)",
   "media-box2d-side": "Caja (2D, lateral)",
   "media-box3d": "Caja (3D)",

--- a/frontend/src/locales/fr_FR/rom.json
+++ b/frontend/src/locales/fr_FR/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "Associer ce jeu",
   "media": "Media",
   "media-bezel": "Cadre",
+  "media-box2d": "Boîte (2D, face)",
   "media-box2d-back": "Boîte (2D, dos)",
   "media-box2d-side": "Boîte (2D, tranche)",
   "media-box3d": "Boîte (3D)",

--- a/frontend/src/locales/hu_HU/rom.json
+++ b/frontend/src/locales/hu_HU/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "Játék egyeztetése",
   "media": "Media",
   "media-bezel": "Keret",
+  "media-box2d": "Doboz (2D, előlap)",
   "media-box2d-back": "Doboz (2D, hátlap)",
   "media-box2d-side": "Doboz (2D, oldal)",
   "media-box3d": "Doboz (3D)",

--- a/frontend/src/locales/it_IT/rom.json
+++ b/frontend/src/locales/it_IT/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "Associa questo gioco",
   "media": "Media",
   "media-bezel": "Cornice",
+  "media-box2d": "Confezione (2D, fronte)",
   "media-box2d-back": "Confezione (2D, retro)",
   "media-box2d-side": "Confezione (2D, lato)",
   "media-box3d": "Confezione (3D)",

--- a/frontend/src/locales/ja_JP/rom.json
+++ b/frontend/src/locales/ja_JP/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "このゲームをマッチ",
   "media": "Media",
   "media-bezel": "ベゼル",
+  "media-box2d": "パッケージ（2D、表面）",
   "media-box2d-back": "パッケージ（2D、裏面）",
   "media-box2d-side": "パッケージ（2D、側面）",
   "media-box3d": "パッケージ（3D）",

--- a/frontend/src/locales/ko_KR/rom.json
+++ b/frontend/src/locales/ko_KR/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "이 게임 일치",
   "media": "Media",
   "media-bezel": "베젤",
+  "media-box2d": "박스 (2D, 앞면)",
   "media-box2d-back": "박스 (2D, 뒷면)",
   "media-box2d-side": "박스 (2D, 측면)",
   "media-box3d": "박스 (3D)",

--- a/frontend/src/locales/pl_PL/rom.json
+++ b/frontend/src/locales/pl_PL/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "Dopasuj tę grę",
   "media": "Media",
   "media-bezel": "Ramka",
+  "media-box2d": "Pudełko (2D, przód)",
   "media-box2d-back": "Pudełko (2D, tył)",
   "media-box2d-side": "Pudełko (2D, bok)",
   "media-box3d": "Pudełko (3D)",

--- a/frontend/src/locales/pt_BR/rom.json
+++ b/frontend/src/locales/pt_BR/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "Vincular este jogo",
   "media": "Media",
   "media-bezel": "Moldura",
+  "media-box2d": "Caixa (2D, frente)",
   "media-box2d-back": "Caixa (2D, verso)",
   "media-box2d-side": "Caixa (2D, lateral)",
   "media-box3d": "Caixa (3D)",

--- a/frontend/src/locales/ro_RO/rom.json
+++ b/frontend/src/locales/ro_RO/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "Asociază acest joc",
   "media": "Media",
   "media-bezel": "Ramă",
+  "media-box2d": "Cutie (2D, față)",
   "media-box2d-back": "Cutie (2D, spate)",
   "media-box2d-side": "Cutie (2D, lateral)",
   "media-box3d": "Cutie (3D)",

--- a/frontend/src/locales/ru_RU/rom.json
+++ b/frontend/src/locales/ru_RU/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "Сопоставить эту игру",
   "media": "Media",
   "media-bezel": "Рамка",
+  "media-box2d": "Коробка (2D, лицевая сторона)",
   "media-box2d-back": "Коробка (2D, обратная сторона)",
   "media-box2d-side": "Коробка (2D, боковая сторона)",
   "media-box3d": "Коробка (3D)",

--- a/frontend/src/locales/tr_TR/rom.json
+++ b/frontend/src/locales/tr_TR/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "Bu oyunu eşleştir",
   "media": "Medya",
   "media-bezel": "Çerçeve",
+  "media-box2d": "Kutu (2D, ön)",
   "media-box2d-back": "Kutu (2D, arka)",
   "media-box2d-side": "Kutu (2D, yan)",
   "media-box3d": "Kutu (3D)",

--- a/frontend/src/locales/zh_CN/rom.json
+++ b/frontend/src/locales/zh_CN/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "匹配此游戏",
   "media": "Media",
   "media-bezel": "边框",
+  "media-box2d": "包装盒（2D，正面）",
   "media-box2d-back": "包装盒（2D，背面）",
   "media-box2d-side": "包装盒（2D，侧面）",
   "media-box3d": "包装盒（3D）",

--- a/frontend/src/locales/zh_TW/rom.json
+++ b/frontend/src/locales/zh_TW/rom.json
@@ -204,6 +204,7 @@
   "match-this-game": "匹配此遊戲",
   "media": "Media",
   "media-bezel": "邊框",
+  "media-box2d": "包裝盒（2D，正面）",
   "media-box2d-back": "包裝盒（2D，背面）",
   "media-box2d-side": "包裝盒（2D，側面）",
   "media-box3d": "包裝盒（3D）",

--- a/frontend/src/v2/composables/useBoxFaces/index.ts
+++ b/frontend/src/v2/composables/useBoxFaces/index.ts
@@ -2,17 +2,19 @@
 // (front / back / spine) for a rom, and reports whether the full set is
 // available.
 //
-//   * front  — the rom's own cover chain (the ScreenScraper box-2D front
-//              becomes the cover on match), webp-rewritten like everywhere
-//              else.
+//   * front  — ss_metadata.box2d_path, falling back to the rom's own cover
+//              chain (webp-rewritten like everywhere else). The stored SS
+//              front comes from the same scan set as the back and spine, so
+//              preferring it keeps the three faces visually consistent even
+//              when another provider won the cover.
 //   * back   — ss_metadata.box2d_back_path
 //   * spine  — ss_metadata.box2d_side_path
 //
-// Back and spine are persisted locally only when the user enabled the
-// `box2d_back` / `box2d_side` media types in `scan.media`, so `complete`
-// is false for most libraries until they opt in and re-scan. RBox3D is
-// only mounted when `complete` is true; otherwise the surface keeps the
-// flat cover.
+// Each face is persisted locally only when the user enabled the matching
+// `box2d` / `box2d_back` / `box2d_side` media type in `scan.media`, so
+// `complete` is false for most libraries until they opt in and re-scan.
+// RBox3D is only mounted when `complete` is true; otherwise the surface
+// keeps the flat cover.
 import {
   computed,
   toValue,
@@ -50,11 +52,12 @@ export function computeBoxFaces(
   supportsWebp: boolean,
 ): BoxFaces {
   const localCover = rom.path_cover_large ?? rom.path_cover_small ?? null;
-  const front =
+  const cover =
     localCover && supportsWebp
       ? localCover.replace(RASTER_EXT, ".webp")
       : localCover;
 
+  const front = resourceUrl(rom.ss_metadata?.box2d_path) ?? cover;
   const back = resourceUrl(rom.ss_metadata?.box2d_back_path);
   const spine = resourceUrl(rom.ss_metadata?.box2d_side_path);
 

--- a/frontend/src/v2/composables/useBoxFaces/useBoxFaces.test.ts
+++ b/frontend/src/v2/composables/useBoxFaces/useBoxFaces.test.ts
@@ -5,7 +5,7 @@ import { computeBoxFaces, type BoxFacesRom } from "./index";
 const RES = "/assets/romm/resources";
 
 // Minimal rom factory — computeBoxFaces only reads the cover chain and the
-// two ss_metadata path fields. Single cast scoped to the test.
+// three ss_metadata box-face path fields. Single cast scoped to the test.
 function rom(over: Partial<SimpleRom>): BoxFacesRom {
   const base: Partial<SimpleRom> = {
     path_cover_large: null,
@@ -69,6 +69,38 @@ describe("computeBoxFaces", () => {
     );
     expect(faces.front).toBe("roms/1/1/cover/l.webp");
     expect(faces.back).toBe(`${RES}/roms/1/1/box2d_back/box2d_back.png`);
+  });
+
+  it("prefers the stored ScreenScraper front over the rom cover", () => {
+    const faces = computeBoxFaces(
+      rom({
+        path_cover_large: "roms/1/1/cover/l.png",
+        ss_metadata: {
+          box2d_path: "roms/1/1/box2d/box2d.png",
+          box2d_back_path: "roms/1/1/box2d_back/box2d_back.png",
+          box2d_side_path: "roms/1/1/box2d_side/box2d_side.png",
+        },
+      }),
+      true,
+    );
+    // No webp rewrite: only the cover chain has webp variants on disk.
+    expect(faces.front).toBe(`${RES}/roms/1/1/box2d/box2d.png`);
+    expect(faces.complete).toBe(true);
+  });
+
+  it("resolves the front from the box front alone, without a cover", () => {
+    const faces = computeBoxFaces(
+      rom({
+        ss_metadata: {
+          box2d_path: "roms/1/1/box2d/box2d.png",
+          box2d_back_path: "roms/1/1/box2d_back/box2d_back.png",
+          box2d_side_path: "roms/1/1/box2d_side/box2d_side.png",
+        },
+      }),
+      false,
+    );
+    expect(faces.front).toBe(`${RES}/roms/1/1/box2d/box2d.png`);
+    expect(faces.complete).toBe(true);
   });
 
   it("falls back to the small cover when the large one is absent", () => {

--- a/frontend/src/v2/utils/romArtwork.test.ts
+++ b/frontend/src/v2/utils/romArtwork.test.ts
@@ -26,15 +26,42 @@ function makeFile(overrides: Partial<RomFileSchema>): RomFileSchema {
   };
 }
 
-function makeRom(files: RomFileSchema[]): DetailedRom {
+function makeRom(
+  files: RomFileSchema[],
+  overrides: Partial<DetailedRom> = {},
+): DetailedRom {
   return {
     updated_at: "2024-01-01T00:00:00Z",
     ss_metadata: null,
     gamelist_metadata: null,
     path_video: null,
     files,
+    ...overrides,
   } as DetailedRom;
 }
+
+describe("resolveRomArtwork — scraped resources", () => {
+  it("includes the ScreenScraper box front, which no other surface shows", () => {
+    const rom = makeRom([], {
+      ss_metadata: {
+        box2d_path: "roms/1/1/box2d/box2d.png",
+        box2d_back_path: "roms/1/1/box2d_back/box2d_back.png",
+      },
+    });
+    const entries = resolveRomArtwork(rom);
+
+    expect(entries.map((e) => e.key)).toEqual(["box2d", "box2d_back"]);
+    expect(entries[0].url).toContain("roms/1/1/box2d/box2d.png");
+  });
+
+  it("omits the box front when it was not stored locally", () => {
+    const rom = makeRom([], {
+      ss_metadata: { box2d_url: "https://screenscraper.example.com/box-2D" },
+    });
+
+    expect(resolveRomArtwork(rom)).toHaveLength(0);
+  });
+});
 
 describe("resolveRomArtwork — library media files", () => {
   it("includes image files as non-video entries pointing at the content endpoint", () => {

--- a/frontend/src/v2/utils/romArtwork.ts
+++ b/frontend/src/v2/utils/romArtwork.ts
@@ -11,7 +11,9 @@
 //      to the ROM shows up here too.
 //
 // Covers, screenshots, the manual and the soundtrack are intentionally left
-// out: they each have their own surface elsewhere in the details view.
+// out: they each have their own surface elsewhere in the details view. The
+// ScreenScraper box front is listed, though: it is a specific scan that any
+// other provider's cover can outrank, so it needs a home of its own.
 import i18n from "@/locales";
 import type { DetailedRom } from "@/stores/roms";
 import { FRONTEND_RESOURCES_PATH } from "@/utils";
@@ -80,6 +82,11 @@ export function resolveRomArtwork(rom: DetailedRom): RomArtworkEntry[] {
         key: "box3d",
         label: i18n.global.t("rom.media-box3d"),
         url: ss?.box3d_path ?? gl?.box3d_path ?? null,
+      },
+      {
+        key: "box2d",
+        label: i18n.global.t("rom.media-box2d"),
+        url: ss?.box2d_path ?? null,
       },
       {
         key: "box2d_back",


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

Fixes #4127.

ScreenScraper's `box-2D` was the only media type that never got a local file. Every sibling branch in `extract_media_from_ss_game` records a `*_path` when its type is listed in `scan.media`; `box-2D` only fed `url_cover`. That works while ScreenScraper wins the cover, but `SCAN_ARTWORK_PRIORITY` defaults to `sgdb, igdb, moby, ss, ...`, so usually it doesn't — and then the box front is recorded as a URL, never downloaded, and unreachable from the UI. Symptoms: no box front in Media → Artwork (only back and spine), and a 3D box whose front is a digital cover from another provider glued to two ScreenScraper photographs.

Backend:

- `box2d_path` added to `SSMetadataMedia`, set to `roms/<platform>/<rom>/box2d/box2d.png` when `box2d` is in `scan.media`. Everything downstream was already generic (`store_metadata_media` derives its keys from `MetadataMediaType`), so the download, the clear-path-on-failed-download behaviour, chroma-key placeholder rejection and cleanup on `ss_id` change all work without new wiring. No migration: `ss_metadata` is a JSON column.
- Comment fix in `store_media_file`, which listed only the back/side faces as chroma-key candidates.

Frontend:

- `useBoxFaces` takes the front face from `ss_metadata.box2d_path`, falling back to the rom's cover chain. The webp rewrite stays scoped to the cover chain, as `box2d.png` has no webp sibling. The 3D box is now independent of cover priority.
- `resolveRomArtwork` lists the box front ahead of the back and spine, with a new `rom.media-box2d` key in all 18 locales.
- `RomSSMetadata.ts` regenerated from the backend OpenAPI schema (one added field, no other drift).

Two behaviours worth flagging for review:

1. `box2d` is already in the **default** `SCAN_MEDIA`, so this turns on one extra image download per ScreenScraper-matched ROM by default, and that file is byte-identical to `cover/big.png` whenever ScreenScraper won the cover. I kept it consistent with every sibling media type rather than special-casing, since "did another provider win the cover" isn't knowable at extraction time and would go stale when priority changes — but it is a disk/bandwidth increase on upgrade. Happy to gate it differently if you'd rather it stay opt-in.
2. For the same reason the Artwork subtab can show a box-front tile that duplicates the cover. `box3d` already behaves this way, so I left it alone rather than adding source detection.

Existing libraries need a ScreenScraper metadata refresh to populate the field; until then the front falls back to the cover exactly as it does today (covered by a test). Note #4002 (update scans not refreshing stale ScreenScraper data) may mean a forced refresh is needed.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Verification: full backend suite (2748 passed), full frontend suite (671 passed), `vue-tsc`, `trunk fmt && trunk check`, and both i18n scripts are clean. I also ran a local instance with a ROM seeded with three labelled box-face images and confirmed in the browser, in light and dark: the box front tile appears first in Media → Artwork, the 3D box resolves all three faces to ScreenScraper scans (previously the front was the unrelated cover), and removing `box2d_path` reverts the front to the cover.

#### Screenshots (if applicable)

N/A — verified locally with placeholder scans, which wouldn't be informative here.

---

This PR was written with AI assistance (Claude Code): the investigation, the code changes, the tests and this description were all produced with AI, and reviewed by me before submitting.
