### PR TITLE
fix(v2): show a running scan on pages loaded mid-scan

### DIFF
--- a/frontend/src/v2/composables/useScanLifecycle/index.test.ts
+++ b/frontend/src/v2/composables/useScanLifecycle/index.test.ts
@@ -1,7 +1,7 @@
 import { mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { defineComponent, nextTick } from "vue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, reactive } from "vue";
 import type { ScanStats } from "@/__generated__";
 import taskApi from "@/services/api/task";
 import storeScanning from "@/stores/scanning";
@@ -34,17 +34,23 @@ vi.mock("@/services/api/platform", () => ({
   },
 }));
 
-const authState = {
+// Reactive so the composable's `watch` on `authStore.user` fires when the
+// user arrives after install, which is the real flow: AppLayout installs
+// while /users/me is still in flight.
+const authState = reactive({
   user: { id: 1, oauth_scopes: ["tasks.run"] } as {
     id: number;
     oauth_scopes: string[];
   } | null,
-};
+});
 vi.mock("@/stores/auth", () => ({
   default: () => authState,
 }));
 
 const getTaskStatus = vi.mocked(taskApi.getTaskStatus);
+
+/** Drain pending microtasks so the reconcile's promise chain has settled. */
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 function makeStats(overrides: Partial<ScanStats> = {}): ScanStats {
   return {
@@ -77,9 +83,13 @@ function runningScanTask(stats: ScanStats | null) {
 }
 
 // The lifecycle uses `inject` and `onScopeDispose`, so it needs a host
-// component instance.
+// component instance. Tracked so `afterEach` can unmount it: the auth state
+// is reactive and shared, so a leaked host would keep watching it and
+// reconcile again during later tests.
+let host: ReturnType<typeof mount> | null = null;
+
 function install() {
-  mount(
+  host = mount(
     defineComponent({
       setup() {
         installScanLifecycle();
@@ -102,6 +112,11 @@ describe("installScanLifecycle", () => {
     authState.user = { id: 1, oauth_scopes: ["tasks.run"] };
   });
 
+  afterEach(() => {
+    host?.unmount();
+    host = null;
+  });
+
   it("treats a stats event as proof a scan is running", () => {
     install();
     const scanning = storeScanning();
@@ -119,13 +134,33 @@ describe("installScanLifecycle", () => {
     } as never);
 
     install();
-    await nextTick();
-    await nextTick();
+    await flushPromises();
 
     const scanning = storeScanning();
     expect(scanning.scanning).toBe(true);
     expect(scanning.scanStats.scanned_roms).toBe(40);
     expect(scanning.scanStats.total_roms).toBe(100);
+  });
+
+  it("reconciles once the user arrives after install", async () => {
+    // The real flow: AppLayout installs while /users/me is still in flight,
+    // so `user` is null at install and the watch has to catch the arrival.
+    authState.user = null;
+    getTaskStatus.mockResolvedValue({
+      data: [runningScanTask(makeStats({ scanned_roms: 7 }))],
+    } as never);
+
+    install();
+    await flushPromises();
+    expect(getTaskStatus).not.toHaveBeenCalled();
+
+    authState.user = { id: 1, oauth_scopes: ["tasks.run"] };
+    await flushPromises();
+
+    expect(getTaskStatus).toHaveBeenCalledTimes(1);
+    const scanning = storeScanning();
+    expect(scanning.scanning).toBe(true);
+    expect(scanning.scanStats.scanned_roms).toBe(7);
   });
 
   it("stays idle when no scan job is running", async () => {
@@ -134,8 +169,7 @@ describe("installScanLifecycle", () => {
     } as never);
 
     install();
-    await nextTick();
-    await nextTick();
+    await flushPromises();
 
     expect(storeScanning().scanning).toBe(false);
   });
@@ -144,7 +178,7 @@ describe("installScanLifecycle", () => {
     authState.user = { id: 1, oauth_scopes: ["platforms.write"] };
 
     install();
-    await nextTick();
+    await flushPromises();
 
     expect(getTaskStatus).not.toHaveBeenCalled();
     expect(storeScanning().scanning).toBe(false);
@@ -161,8 +195,7 @@ describe("installScanLifecycle", () => {
     install();
     fire("scan:done", makeStats({ scanned_roms: 100 }));
     resolveStatus({ data: [runningScanTask(makeStats({ scanned_roms: 40 }))] });
-    await nextTick();
-    await nextTick();
+    await flushPromises();
 
     const scanning = storeScanning();
     expect(scanning.scanning).toBe(false);
@@ -180,8 +213,7 @@ describe("installScanLifecycle", () => {
     install();
     fire("scan:update_stats", makeStats({ scanned_roms: 90 }));
     resolveStatus({ data: [runningScanTask(makeStats({ scanned_roms: 40 }))] });
-    await nextTick();
-    await nextTick();
+    await flushPromises();
 
     expect(storeScanning().scanStats.scanned_roms).toBe(90);
   });

--- a/frontend/src/v2/composables/useScanLifecycle/index.test.ts
+++ b/frontend/src/v2/composables/useScanLifecycle/index.test.ts
@@ -1,0 +1,188 @@
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, nextTick } from "vue";
+import type { ScanStats } from "@/__generated__";
+import taskApi from "@/services/api/task";
+import storeScanning from "@/stores/scanning";
+import { installScanLifecycle } from "./index";
+
+// Minimal socket stand-in: records handlers so tests can fire events, and
+// stays "connected" so `useSocketEvent` never tries to dial out.
+const handlers = new Map<string, (payload: unknown) => void>();
+vi.mock("@/services/socket", () => ({
+  default: {
+    connected: true,
+    connect: vi.fn(),
+    on: (event: string, handler: (payload: unknown) => void) => {
+      handlers.set(event, handler);
+    },
+    off: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/api/task", () => ({
+  default: { getTaskStatus: vi.fn() },
+}));
+
+// Platform lookups are incidental here: `getPlatform` for platforms the
+// scanning store doesn't know yet, `getPlatforms` for the post-scan reconcile.
+vi.mock("@/services/api/platform", () => ({
+  default: {
+    getPlatform: vi.fn(() => Promise.resolve({ data: { id: 1 } })),
+    getPlatforms: vi.fn(() => Promise.resolve({ data: [] })),
+  },
+}));
+
+const authState = {
+  user: { id: 1, oauth_scopes: ["tasks.run"] } as {
+    id: number;
+    oauth_scopes: string[];
+  } | null,
+};
+vi.mock("@/stores/auth", () => ({
+  default: () => authState,
+}));
+
+const getTaskStatus = vi.mocked(taskApi.getTaskStatus);
+
+function makeStats(overrides: Partial<ScanStats> = {}): ScanStats {
+  return {
+    total_platforms: 0,
+    total_roms: 0,
+    scanned_platforms: 0,
+    new_platforms: 0,
+    identified_platforms: 0,
+    scanned_roms: 0,
+    new_roms: 0,
+    identified_roms: 0,
+    scanned_firmware: 0,
+    new_firmware: 0,
+    ...overrides,
+  };
+}
+
+function runningScanTask(stats: ScanStats | null) {
+  return {
+    task_name: "scan_platforms",
+    task_id: "job-1",
+    status: "started",
+    task_type: "scan",
+    created_at: null,
+    enqueued_at: null,
+    started_at: null,
+    ended_at: null,
+    meta: { scan_stats: stats },
+  };
+}
+
+// The lifecycle uses `inject` and `onScopeDispose`, so it needs a host
+// component instance.
+function install() {
+  mount(
+    defineComponent({
+      setup() {
+        installScanLifecycle();
+        return () => null;
+      },
+    }),
+  );
+}
+
+function fire(event: string, payload: unknown) {
+  handlers.get(event)?.(payload);
+}
+
+describe("installScanLifecycle", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    handlers.clear();
+    getTaskStatus.mockReset();
+    getTaskStatus.mockResolvedValue({ data: [] } as never);
+    authState.user = { id: 1, oauth_scopes: ["tasks.run"] };
+  });
+
+  it("treats a stats event as proof a scan is running", () => {
+    install();
+    const scanning = storeScanning();
+    expect(scanning.scanning).toBe(false);
+
+    fire("scan:update_stats", makeStats({ scanned_roms: 12 }));
+
+    expect(scanning.scanning).toBe(true);
+    expect(scanning.scanStats.scanned_roms).toBe(12);
+  });
+
+  it("reconciles with a running scan job on install", async () => {
+    getTaskStatus.mockResolvedValue({
+      data: [runningScanTask(makeStats({ scanned_roms: 40, total_roms: 100 }))],
+    } as never);
+
+    install();
+    await nextTick();
+    await nextTick();
+
+    const scanning = storeScanning();
+    expect(scanning.scanning).toBe(true);
+    expect(scanning.scanStats.scanned_roms).toBe(40);
+    expect(scanning.scanStats.total_roms).toBe(100);
+  });
+
+  it("stays idle when no scan job is running", async () => {
+    getTaskStatus.mockResolvedValue({
+      data: [{ ...runningScanTask(makeStats()), status: "finished" }],
+    } as never);
+
+    install();
+    await nextTick();
+    await nextTick();
+
+    expect(storeScanning().scanning).toBe(false);
+  });
+
+  it("skips the reconcile without the tasks.run scope", async () => {
+    authState.user = { id: 1, oauth_scopes: ["platforms.write"] };
+
+    install();
+    await nextTick();
+
+    expect(getTaskStatus).not.toHaveBeenCalled();
+    expect(storeScanning().scanning).toBe(false);
+  });
+
+  it("does not resurrect a scan that ended while the reconcile was in flight", async () => {
+    let resolveStatus!: (value: unknown) => void;
+    getTaskStatus.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStatus = resolve;
+      }) as never,
+    );
+
+    install();
+    fire("scan:done", makeStats({ scanned_roms: 100 }));
+    resolveStatus({ data: [runningScanTask(makeStats({ scanned_roms: 40 }))] });
+    await nextTick();
+    await nextTick();
+
+    const scanning = storeScanning();
+    expect(scanning.scanning).toBe(false);
+    expect(scanning.scanStats.scanned_roms).toBe(100);
+  });
+
+  it("lets live stats win over the job's snapshot", async () => {
+    let resolveStatus!: (value: unknown) => void;
+    getTaskStatus.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStatus = resolve;
+      }) as never,
+    );
+
+    install();
+    fire("scan:update_stats", makeStats({ scanned_roms: 90 }));
+    resolveStatus({ data: [runningScanTask(makeStats({ scanned_roms: 40 }))] });
+    await nextTick();
+    await nextTick();
+
+    expect(storeScanning().scanStats.scanned_roms).toBe(90);
+  });
+});

--- a/frontend/src/v2/composables/useScanLifecycle/index.ts
+++ b/frontend/src/v2/composables/useScanLifecycle/index.ts
@@ -18,14 +18,20 @@
 //   * `scan:done_ko`           — scan errored; surface the message as a
 //                                snackbar and flip `scanning` off.
 //
+// Events alone can't tell a tab that loads mid-scan what's going on, so
+// install also reconciles against the running RQ job — see
+// `reconcileWithRunningScan` below.
+//
 // `useSocketEvent` is the typed subscription wrapper that auto-cleans up
 // on unmount; since AppLayout never unmounts during normal use the
 // listeners effectively live for the session.
 import { debounce } from "lodash";
 import type { Emitter } from "mitt";
-import { inject } from "vue";
-import type { ScanStats } from "@/__generated__";
+import { inject, watch } from "vue";
+import type { ScanStats, ScanTaskStatusResponse } from "@/__generated__";
 import platformApi from "@/services/api/platform";
+import taskApi from "@/services/api/task";
+import storeAuth from "@/stores/auth";
 import storePlatforms from "@/stores/platforms";
 import storeRoms, { type SimpleRom } from "@/stores/roms";
 import storeScanning, { type ScanningPlatform } from "@/stores/scanning";
@@ -38,7 +44,12 @@ export function installScanLifecycle() {
   const romsStore = storeRoms();
   const platformsStore = storePlatforms();
   const galleryRomsStore = storeGalleryRoms();
+  const authStore = storeAuth();
   const emitter = inject<Emitter<Events>>("emitter");
+
+  // Guards for `reconcileWithRunningScan` below.
+  let sawScanEnd = false;
+  let reconciledForUserId: number | null = null;
 
   useSocketEvent<ScanningPlatform>(
     "scan:scanning_platform",
@@ -162,11 +173,18 @@ export function installScanLifecycle() {
     processRomUpdates();
   });
 
+  // Stats are the only event a scan emits continuously: `scanning_platform`
+  // fires once per platform, and `scanning_rom` only for ROMs the scan
+  // actually adds, so an update scan over a settled library can go a long
+  // while emitting nothing else. Flipping `scanning` here is what lets a tab
+  // that missed the start of the scan catch up on the next tick.
   useSocketEvent<ScanStats>("scan:update_stats", (stats) => {
+    scanningStore.setScanning(true);
     scanningStore.setScanStats(stats);
   });
 
   useSocketEvent<ScanStats>("scan:done", (stats) => {
+    sawScanEnd = true;
     scanningStore.setScanStats(stats);
     scanningStore.setScanning(false);
     // Reconcile against the backend once the scan settles: pick up anything
@@ -181,6 +199,7 @@ export function installScanLifecycle() {
   });
 
   useSocketEvent<string>("scan:done_ko", (msg) => {
+    sawScanEnd = true;
     scanningStore.setScanning(false);
     emitter?.emit("snackbarShow", {
       msg: `Scan failed: ${msg}`,
@@ -189,4 +208,51 @@ export function installScanLifecycle() {
       timeout: 6000,
     });
   });
+
+  // Reconcile with the scan the server is actually running. Without this a
+  // tab that loads mid-scan (refresh, second tab, another device) shows the
+  // /scan empty state and an armed "Start scan" button until an event lands.
+  //
+  // `/tasks/status` needs `tasks.run`, the same scope the `scan` socket
+  // handler gates on, so anyone who could have started this scan can read it
+  // back. Users without it stay purely event-driven.
+  watch(
+    () => authStore.user,
+    (user) => {
+      if (!user) {
+        reconciledForUserId = null;
+        return;
+      }
+      // Once per login — the watch also fires when the user object is
+      // replaced by an unrelated profile update.
+      if (reconciledForUserId === user.id) return;
+      if (!user.oauth_scopes.includes("tasks.run")) return;
+      reconciledForUserId = user.id;
+      sawScanEnd = false;
+      reconcileWithRunningScan();
+    },
+    { immediate: true },
+  );
+
+  function reconcileWithRunningScan() {
+    taskApi
+      .getTaskStatus()
+      .then(({ data }) => {
+        // A terminal event that landed while the request was in flight means
+        // the job we asked about is already over; don't resurrect it. Same for
+        // stats already streaming in, which are fresher than the job's meta.
+        if (sawScanEnd || scanningStore.scanning) return;
+        const running = data.find(
+          (task): task is ScanTaskStatusResponse =>
+            task.task_type === "scan" && task.status === "started",
+        );
+        if (!running) return;
+        scanningStore.setScanning(true);
+        // The per-platform live log only ever lived in the originating tab's
+        // memory, so the panel list fills in from the next platform onward.
+        if (running.meta.scan_stats)
+          scanningStore.setScanStats(running.meta.scan_stats);
+      })
+      .catch((error) => console.error(error));
+  }
 }

--- a/frontend/src/v2/composables/useScanLifecycle/index.ts
+++ b/frontend/src/v2/composables/useScanLifecycle/index.ts
@@ -47,10 +47,6 @@ export function installScanLifecycle() {
   const authStore = storeAuth();
   const emitter = inject<Emitter<Events>>("emitter");
 
-  // Guards for `reconcileWithRunningScan` below.
-  let sawScanEnd = false;
-  let reconciledForUserId: number | null = null;
-
   useSocketEvent<ScanningPlatform>(
     "scan:scanning_platform",
     ({
@@ -184,7 +180,7 @@ export function installScanLifecycle() {
   });
 
   useSocketEvent<ScanStats>("scan:done", (stats) => {
-    sawScanEnd = true;
+    markScanEnded();
     scanningStore.setScanStats(stats);
     scanningStore.setScanning(false);
     // Reconcile against the backend once the scan settles: pick up anything
@@ -199,7 +195,7 @@ export function installScanLifecycle() {
   });
 
   useSocketEvent<string>("scan:done_ko", (msg) => {
-    sawScanEnd = true;
+    markScanEnded();
     scanningStore.setScanning(false);
     emitter?.emit("snackbarShow", {
       msg: `Scan failed: ${msg}`,
@@ -216,18 +212,21 @@ export function installScanLifecycle() {
   // `/tasks/status` needs `tasks.run`, the same scope the `scan` socket
   // handler gates on, so anyone who could have started this scan can read it
   // back. Users without it stay purely event-driven.
+  let sawScanEnd = false;
+  function markScanEnded() {
+    sawScanEnd = true;
+  }
+
+  // Reconciles once per eligible user: collapsing the source to an id keeps
+  // unrelated profile updates from re-firing it, and re-arms if the scope
+  // shows up later.
   watch(
-    () => authStore.user,
-    (user) => {
-      if (!user) {
-        reconciledForUserId = null;
-        return;
-      }
-      // Once per login — the watch also fires when the user object is
-      // replaced by an unrelated profile update.
-      if (reconciledForUserId === user.id) return;
-      if (!user.oauth_scopes.includes("tasks.run")) return;
-      reconciledForUserId = user.id;
+    () =>
+      authStore.user?.oauth_scopes.includes("tasks.run")
+        ? authStore.user.id
+        : null,
+    (userId) => {
+      if (userId === null) return;
       sawScanEnd = false;
       reconcileWithRunningScan();
     },

--- a/frontend/src/v2/composables/useScanLifecycle/index.ts
+++ b/frontend/src/v2/composables/useScanLifecycle/index.ts
@@ -250,7 +250,9 @@ export function installScanLifecycle() {
         scanningStore.setScanning(true);
         // The per-platform live log only ever lived in the originating tab's
         // memory, so the panel list fills in from the next platform onward.
-        if (running.meta.scan_stats)
+        // `meta` is typed as required but this is a JSON boundary: a missing
+        // snapshot just means no counters yet, not "no scan".
+        if (running.meta?.scan_stats)
           scanningStore.setScanStats(running.meta.scan_stats);
       })
       .catch((error) => console.error(error));


### PR DESCRIPTION
**Description**

Fixes #4141 — a page loaded while a scan is running now shows the scan instead of its empty state.

Scan state was built up purely from socket events, so a tab that loaded mid-scan (hard refresh, second tab, another device) started at `scanning: false`: `/scan` rendered "no scan started" with an armed **Start scan** button, and the navbar pill stayed hidden while the server was scanning.

Two independent causes, both in `useScanLifecycle`:

**1. `scan:update_stats` didn't flip `scanning` on.** `scanning_platform` and `scanning_rom` both called `setScanning(true)`; `update_stats` only stored the stats. That matters because it's the one event a scan emits continuously — `scanning_platform` fires once per platform, and `scanning_rom` only for ROMs the scan actually adds, so a quick/update scan over a settled library emits nothing else for long stretches. One line, and it closes the recovery window for the common case.

**2. Nothing reconciled with the server.** New `reconcileWithRunningScan()` reads `GET /api/tasks/status` on install and, if a task with `task_type: "scan"` and `status: "started"` is there, seeds `scanning` and `scanStats` from its `meta.scan_stats`. That makes a refresh correct immediately rather than eventually.

Details:

- Gated on the `tasks.run` scope — the same scope `reject_unauthorized_scan` requires of the `scan` socket handler — so anyone who could have started this scan can read it back, and users without it don't eat a 403 on every page load.
- Runs once per login, keyed on user id, since the watch also fires when the user object is replaced by an unrelated profile update.
- Two races guarded: a `scan:done`/`done_ko` landing while the request is in flight won't resurrect a finished scan, and live stats already in the store win over the job's staler snapshot.
- `Scan.vue` needed no change — it already gates the config lock, the CTA, the abort button and the live panel on `scanning`.

**Not fixed here:** the per-platform live log (`scanningPlatforms`) only ever exists in the originating tab's memory — the job meta carries stats, not the platform/ROM list. A reconciled page gets the correct status bar, counters, progress bar and abort button, with the panel list filling in from the next `scan:scanning_platform` onward. Preserving the full log across reloads would need the backend to persist it, which felt out of scope.

> [!IMPORTANT]
> **Don't verify this with `DEV_MODE=true`.** Under `DEV_MODE` the scan handler short-circuits and runs the scan inline in the web process, so there's no RQ job, `/api/tasks/status` reports nothing, and the reconcile correctly finds nothing to reconcile with. Since `DEVELOPER_SETUP.md` tells contributors to set `DEV_MODE=true`, it's easy to test there and wrongly conclude the reconcile is broken. The `update_stats` fix still works in DEV_MODE; the reconcile needs `DEV_MODE=false` plus a real RQ worker.

**Testing**

Unit tests (6 new cases) cover: stats-event-implies-scanning, reconcile from a running job, staying idle when no scan is running, skipping without the scope, and both races.

Manually verified against a production-shaped stack — `DEV_MODE=false`, real RQ worker, MariaDB + Valkey, 4500-ROM library — with a scan running in the worker and `/api/tasks/status` confirmed reporting `task_type: scan, status: started`:

- Hard reload on `/scan` mid-scan → "Scanning" with pulse, live counters (1/3 platforms, 230/4500 ROMs), abort button, config locked, Start button showing its spinner, log streaming.
- Hard reload on `/` (Home) mid-scan → navbar pill present: "Scanning 221 / 4500", `aria-label="Scanning library. Click to view"`, links to `/scan`, keyboard-focusable.
- Both `r-v2-light` and `r-v2-dark`.

Full frontend suite green: typecheck, 673 tests / 57 files, build, Trunk.

Two gaps worth naming: I didn't exercise the skip-path scan (only `update_stats` firing) in the browser — the scan I tested was all-new ROMs, where `scanning_rom` fires constantly — nor did I do an A/B revert to attribute the behaviour change visually. Both are covered by the unit tests. No touch/gamepad or responsive sweep either, since the change adds no markup or CSS; it only makes existing components render in a case where they previously didn't.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### AI assistance disclosure

Written with AI assistance (Claude Code, Opus 5), and substantially so: the diagnosis, both code changes, the unit tests, the local verification stack, and this description were all produced by the agent under my direction and review.
