### PR TITLE
fix(resources): fetch each cover once instead of once per size

### DIFF
--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -175,18 +175,20 @@ class FSResourcesHandler(FSHandler):
         except OSError as exc:
             log.error(f"Unable to remove partial file {relative_path}: {str(exc)}")
 
-    async def _store_cover(
-        self, entity: Rom | Collection, url_cover: str, size: CoverSize
-    ) -> None:
-        """Store roms resources in filesystem
+    async def _store_cover(self, entity: Rom | Collection, url_cover: str) -> None:
+        """Fetch a cover once and write both sizes.
+
+        The small cover is a downscale of the large one, so fetching the same
+        URL a second time would only re-retrieve bytes we already hold, and on
+        ScreenScraper would spend a second request from the account's quota.
 
         Args:
-            fs_slug: short name of the platform
-            rom_name: name of rom file
+            entity: Rom or Collection object
             url_cover: url to get the cover
-            size: size of the cover
         """
         cover_file = f"{entity.fs_resources_path}/cover"
+        big_path = f"{cover_file}/{CoverSize.BIG.value}.png"
+        small_path = f"{cover_file}/{CoverSize.SMALL.value}.png"
         await self.make_directory(cover_file)
 
         # Handle local-file URIs from metadata handlers (gamelist, LaunchBox)
@@ -196,22 +198,12 @@ class FSResourcesHandler(FSHandler):
                 if resolved is None or not await AnyioPath(resolved).exists():
                     log.warning(f"Cover file not found: {url_cover}")
                     return None
-                dest_path = f"{cover_file}/{size.value}.png"
-                # Small-size covers get resized in place, which would mutate
-                # the user's source image if the destination were a hardlink.
-                await self.copy_file(resolved, dest_path, allow_link=False)
-
-                if await self._discard_if_chroma_key(dest_path):
-                    return None
-
-                if ENABLE_SCHEDULED_CONVERT_IMAGES_TO_WEBP:
-                    self.image_converter.convert_to_webp(
-                        self.validate_path(f"{cover_file}/{size.value}.png"),
-                        force=True,
-                    )
+                # Covers are rewritten in place by later scans, which would
+                # mutate the user's source image through a hardlink.
+                await self.copy_file(resolved, big_path, allow_link=False)
             except Exception as exc:
                 log.error(f"Unable to copy cover file {url_cover}: {str(exc)}")
-                await self._discard_partial_file(f"{cover_file}/{size.value}.png")
+                await self._discard_partial_file(big_path)
                 return None
         else:
             # Handle HTTP URLs
@@ -233,7 +225,7 @@ class FSResourcesHandler(FSHandler):
                             )
 
                             async with await self.write_file_streamed(
-                                path=cover_file, filename=f"{size.value}.png"
+                                path=cover_file, filename=f"{CoverSize.BIG.value}.png"
                             ) as f:
                                 if is_gzipped:
                                     # Content is gzipped, decompress it
@@ -249,42 +241,83 @@ class FSResourcesHandler(FSHandler):
                                         await f.write(chunk)
 
                             downloaded = True
-
-                # Inspecting and re-encoding the file is local work, so it runs
-                # once the provider's request slot has been handed back.
-                if downloaded:
-                    if await self._discard_if_chroma_key(
-                        f"{cover_file}/{size.value}.png"
-                    ):
-                        return None
-
-                    if ENABLE_SCHEDULED_CONVERT_IMAGES_TO_WEBP:
-                        self.image_converter.convert_to_webp(
-                            self.validate_path(f"{cover_file}/{size.value}.png"),
-                            force=True,
-                        )
             except httpx.TransportError as exc:
                 log.error(f"Unable to fetch cover at {url_cover}: {str(exc)}")
-                await self._discard_partial_file(f"{cover_file}/{size.value}.png")
+                await self._discard_partial_file(big_path)
                 return None
             except OSError as exc:
                 log.error(f"Unable to write cover for {url_cover}: {str(exc)}")
-                await self._discard_partial_file(f"{cover_file}/{size.value}.png")
+                await self._discard_partial_file(big_path)
                 return None
 
-        if size == CoverSize.SMALL:
-            try:
-                image_path = self.validate_path(f"{cover_file}/{size.value}.png")
-                with Image.open(image_path) as img:
-                    self.resize_cover_to_small(img, save_path=str(image_path))
-
-                if ENABLE_SCHEDULED_CONVERT_IMAGES_TO_WEBP:
-                    self.image_converter.convert_to_webp(
-                        self.validate_path(f"{cover_file}/{size.value}.png"), force=True
-                    )
-            except UnidentifiedImageError as exc:
-                log.error(f"Unable to identify image {cover_file}: {str(exc)}")
+            if not downloaded:
                 return None
+
+        # Inspecting and re-encoding the file is local work, so it runs once the
+        # provider's request slot has been handed back.
+        try:
+            if await self._discard_if_chroma_key(big_path):
+                # A small cover left by an earlier scan would outlive the large
+                # one it was derived from.
+                await self._discard_partial_file(small_path)
+                return None
+
+            with Image.open(self.validate_path(big_path)) as img:
+                self.resize_cover_to_small(
+                    img, save_path=str(self.validate_path(small_path))
+                )
+
+            if ENABLE_SCHEDULED_CONVERT_IMAGES_TO_WEBP:
+                self.image_converter.convert_to_webp(
+                    self.validate_path(big_path), force=True
+                )
+                self.image_converter.convert_to_webp(
+                    self.validate_path(small_path), force=True
+                )
+        except UnidentifiedImageError as exc:
+            # Undecodable bytes still satisfy cover_exists(), so keeping them
+            # would stop every later scan from refetching a working cover.
+            log.error(f"Unable to identify image {big_path}: {str(exc)}")
+            for path in (big_path, small_path):
+                await self._discard_partial_file(path)
+        except OSError as exc:
+            log.error(f"Unable to write cover for {url_cover}: {str(exc)}")
+            for path in (big_path, small_path):
+                await self._discard_partial_file(path)
+
+    async def _derive_small_cover(self, entity: Rom | Collection) -> None:
+        """Rebuild a missing small cover from the large one already on disk.
+
+        The small cover is a downscale of the large one, so a half-written pair
+        is repaired locally instead of spending a request on bytes we hold.
+
+        Args:
+            entity: Rom or Collection object
+        """
+        path_cover_l = self._get_cover_path(entity, CoverSize.BIG)
+        if not path_cover_l:
+            return
+
+        path_cover_s = (
+            f"{entity.fs_resources_path}/cover/"
+            f"{CoverSize.SMALL.value}{Path(path_cover_l).suffix}"
+        )
+
+        try:
+            with Image.open(self.validate_path(path_cover_l)) as img:
+                self.resize_cover_to_small(
+                    img, save_path=str(self.validate_path(path_cover_s))
+                )
+
+            if ENABLE_SCHEDULED_CONVERT_IMAGES_TO_WEBP:
+                self.image_converter.convert_to_webp(
+                    self.validate_path(path_cover_s), force=True
+                )
+        except (UnidentifiedImageError, OSError) as exc:
+            # Unlike a fresh download, these bytes weren't written here, so the
+            # large cover stays put and only the partial small one is dropped.
+            log.error(f"Unable to resize cover {path_cover_l}: {str(exc)}")
+            await self._discard_partial_file(path_cover_s)
 
     def _get_cover_path(self, entity: Rom | Collection, size: CoverSize) -> str | None:
         """Returns rom cover filesystem path adapted to frontend folder structure
@@ -305,12 +338,16 @@ class FSResourcesHandler(FSHandler):
         if not entity:
             return None, None
 
-        # Download covers if URL provided and (overwriting or covers don't exist)
-        if url_cover:
-            if overwrite or not self.cover_exists(entity, CoverSize.SMALL):
-                await self._store_cover(entity, url_cover, CoverSize.SMALL)
-            if overwrite or not self.cover_exists(entity, CoverSize.BIG):
-                await self._store_cover(entity, url_cover, CoverSize.BIG)
+        has_cover_l = self.cover_exists(entity, CoverSize.BIG)
+        has_cover_s = self.cover_exists(entity, CoverSize.SMALL)
+
+        # A single fetch writes both sizes
+        if url_cover and (overwrite or not has_cover_l):
+            await self._store_cover(entity, url_cover)
+        elif has_cover_l and not has_cover_s:
+            # Refetching to recover the small cover would overwrite a large one
+            # that is already good, and lose it if the fetch fails.
+            await self._derive_small_cover(entity)
 
         # Return paths for existing covers
         path_cover_s = (

--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -178,10 +178,6 @@ class FSResourcesHandler(FSHandler):
     async def _store_cover(self, entity: Rom | Collection, url_cover: str) -> None:
         """Fetch a cover once and write both sizes.
 
-        The small cover is a downscale of the large one, so fetching the same
-        URL a second time would only re-retrieve bytes we already hold, and on
-        ScreenScraper would spend a second request from the account's quota.
-
         Args:
             entity: Rom or Collection object
             url_cover: url to get the cover
@@ -253,8 +249,6 @@ class FSResourcesHandler(FSHandler):
             if not downloaded:
                 return None
 
-        # Inspecting and re-encoding the file is local work, so it runs once the
-        # provider's request slot has been handed back.
         try:
             if await self._discard_if_chroma_key(big_path):
                 # A small cover left by an earlier scan would outlive the large
@@ -287,9 +281,6 @@ class FSResourcesHandler(FSHandler):
 
     async def _derive_small_cover(self, entity: Rom | Collection) -> None:
         """Rebuild a missing small cover from the large one already on disk.
-
-        The small cover is a downscale of the large one, so a half-written pair
-        is repaired locally instead of spending a request on bytes we hold.
 
         Args:
             entity: Rom or Collection object

--- a/backend/tests/handler/filesystem/test_resources_handler.py
+++ b/backend/tests/handler/filesystem/test_resources_handler.py
@@ -1,5 +1,6 @@
 import errno
 import os
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -303,39 +304,6 @@ class TestFSResourcesHandler:
         result = await handler.get_cover(rom, False, None)
         # Should return empty strings since no covers exist and no URL provided
         assert result == (None, None)
-
-    @pytest.mark.asyncio
-    async def test_get_cover_with_url_no_overwrite(
-        self, handler: FSResourcesHandler, rom
-    ):
-        """Test get_cover with URL but no overwrite when covers don't exist"""
-        url = "http://example.com/cover.png"
-
-        with patch.object(handler, "_store_cover") as mock_store:
-            with patch.object(handler, "cover_exists") as mock_exists:
-                mock_exists.return_value = False
-
-                await handler.get_cover(rom, False, url)
-
-                # Should call _store_cover for both sizes since covers don't exist
-                assert mock_store.call_count == 2
-                mock_store.assert_any_call(rom, url, CoverSize.SMALL)
-                mock_store.assert_any_call(rom, url, CoverSize.BIG)
-
-    @pytest.mark.asyncio
-    async def test_get_cover_with_overwrite(
-        self, handler: FSResourcesHandler, rom: Rom
-    ):
-        """Test get_cover with overwrite enabled"""
-        url = "http://example.com/cover.png"
-
-        with patch.object(handler, "_store_cover") as mock_store:
-            await handler.get_cover(rom, True, url)
-
-            # Should call _store_cover for both sizes regardless of existence
-            assert mock_store.call_count == 2
-            mock_store.assert_any_call(rom, url, CoverSize.SMALL)
-            mock_store.assert_any_call(rom, url, CoverSize.BIG)
 
     async def test_remove_cover_no_entity(self, handler: FSResourcesHandler):
         """Test remove_cover with no entity"""
@@ -1122,9 +1090,7 @@ class TestDiskFullHandling:
         ):
             mock_ctx.get.return_value = _FakeHttpxClient(_FakeResponse())
 
-            await handler._store_cover(
-                rom, "http://example.com/cover.png", CoverSize.BIG
-            )
+            await handler._store_cover(rom, "http://example.com/cover.png")
 
         assert not target.exists()
 
@@ -1140,9 +1106,7 @@ class TestDiskFullHandling:
         with patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx:
             mock_ctx.get.return_value = _FakeHttpxClient(_DroppedResponse())
 
-            await handler._store_cover(
-                rom, "http://example.com/cover.png", CoverSize.BIG
-            )
+            await handler._store_cover(rom, "http://example.com/cover.png")
 
         assert not target.exists()
 
@@ -1245,7 +1209,7 @@ class TestScreenScraperMediaThrottling:
         with patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx:
             mock_ctx.get.return_value = client
             await handler._store_cover(
-                rom, "https://www.screenscraper.fr/image.php?gameid=1", CoverSize.BIG
+                rom, "https://www.screenscraper.fr/image.php?gameid=1"
             )
 
         assert client.calls[0]["in_flight"] == 1
@@ -1299,3 +1263,333 @@ class TestScreenScraperMediaThrottling:
         assert client.calls == [
             {"timeout": SS_DEFAULT_MEDIA_TIMEOUT, "in_flight": 0},
         ]
+
+
+COVER_URL = "http://example.com/cover.png"
+
+
+def _png_bytes(
+    size: tuple[int, int] = (900, 1200), color: tuple[int, int, int] = (85, 62, 152)
+) -> bytes:
+    buffer = BytesIO()
+    Image.new("RGB", size, color).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+class _CountingResponse:
+    def __init__(self, payload: bytes):
+        self.status_code = 200
+        self.headers = {"content-type": "image/png"}
+        self._payload = payload
+
+    async def aiter_raw(self):
+        yield self._payload
+
+
+class _CountingClient:
+    """Records every request, so a redundant refetch of a cover is visible."""
+
+    def __init__(self, payload: bytes):
+        self._payload = payload
+        self.requests: list[str] = []
+
+    def stream(self, _method: str, url: str, **_kwargs):
+        self.requests.append(url)
+        return _FakeStreamContext(_CountingResponse(self._payload))
+
+
+class TestCoverSingleFetch:
+    """A cover must be fetched exactly once.
+
+    `small` is a downscale of `big`, so a second request for the same URL only
+    re-downloads bytes RomM already holds. That doubles cover bandwidth, and on
+    ScreenScraper burns a second billable api2 request per cover.
+    """
+
+    @pytest.fixture
+    def handler(self, tmp_path):
+        handler = FSResourcesHandler()
+        handler.base_path = tmp_path
+        return handler
+
+    @pytest.fixture
+    def rom(self):
+        rom = Mock(spec=Rom)
+        rom.id = 1
+        rom.platform_id = 1
+        rom.fs_resources_path = "roms/1/1"
+        return rom
+
+    @staticmethod
+    def _cover_dir(handler: FSResourcesHandler, entity) -> Path:
+        return handler.base_path / entity.fs_resources_path / "cover"
+
+    @staticmethod
+    def _image_size(path: Path) -> tuple[int, int]:
+        with Image.open(path) as img:
+            return img.size
+
+    @staticmethod
+    def _write_cover(
+        path: Path,
+        color: tuple[int, int, int] = (10, 20, 30),
+        size: tuple[int, int] = (16, 16),
+    ) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        Image.new("RGB", size, color).save(path)
+
+    @staticmethod
+    async def _get_cover(
+        handler: FSResourcesHandler,
+        entity,
+        overwrite: bool,
+        client,
+        url: str | None = COVER_URL,
+    ) -> tuple[str | None, str | None]:
+        with patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx:
+            mock_ctx.get.return_value = client
+            return await handler.get_cover(entity, overwrite, url)
+
+    async def test_fetches_the_cover_once_when_no_covers_exist(
+        self, handler: FSResourcesHandler, rom: Rom
+    ):
+        client = _CountingClient(_png_bytes())
+
+        path_small, path_big = await self._get_cover(handler, rom, False, client)
+
+        assert client.requests == [COVER_URL]
+        cover_dir = self._cover_dir(handler, rom)
+        assert self._image_size(cover_dir / "big.png") == (900, 1200)
+        assert self._image_size(cover_dir / "small.png") == (180, 240)
+        assert path_big == "roms/1/1/cover/big.png"
+        assert path_small == "roms/1/1/cover/small.png"
+
+    async def test_fetches_the_cover_once_when_overwriting(
+        self, handler: FSResourcesHandler, rom: Rom
+    ):
+        cover_dir = self._cover_dir(handler, rom)
+        self._write_cover(cover_dir / "big.png")
+        self._write_cover(cover_dir / "small.png")
+        client = _CountingClient(_png_bytes())
+
+        await self._get_cover(handler, rom, True, client)
+
+        assert client.requests == [COVER_URL]
+        assert self._image_size(cover_dir / "big.png") == (900, 1200)
+        assert self._image_size(cover_dir / "small.png") == (180, 240)
+
+    async def test_does_not_fetch_when_both_covers_exist(
+        self, handler: FSResourcesHandler, rom: Rom
+    ):
+        cover_dir = self._cover_dir(handler, rom)
+        self._write_cover(cover_dir / "big.png")
+        self._write_cover(cover_dir / "small.png")
+        client = _CountingClient(_png_bytes())
+
+        path_small, path_big = await self._get_cover(handler, rom, False, client)
+
+        assert client.requests == []
+        assert path_small == "roms/1/1/cover/small.png"
+        assert path_big == "roms/1/1/cover/big.png"
+
+    async def test_fetches_once_when_only_the_small_cover_exists(
+        self, handler: FSResourcesHandler, rom: Rom
+    ):
+        cover_dir = self._cover_dir(handler, rom)
+        self._write_cover(cover_dir / "small.png")
+        client = _CountingClient(_png_bytes())
+
+        await self._get_cover(handler, rom, False, client)
+
+        assert client.requests == [COVER_URL]
+        assert self._image_size(cover_dir / "big.png") == (900, 1200)
+        assert self._image_size(cover_dir / "small.png") == (180, 240)
+
+    async def test_rebuilds_a_missing_small_cover_without_fetching(
+        self, handler: FSResourcesHandler, rom: Rom
+    ):
+        cover_dir = self._cover_dir(handler, rom)
+        self._write_cover(cover_dir / "big.png", size=(900, 1200))
+        before = (cover_dir / "big.png").read_bytes()
+        client = _CountingClient(_png_bytes())
+
+        path_small, path_big = await self._get_cover(handler, rom, False, client)
+
+        assert client.requests == []
+        assert (cover_dir / "big.png").read_bytes() == before
+        assert self._image_size(cover_dir / "small.png") == (180, 240)
+        assert path_big == "roms/1/1/cover/big.png"
+        assert path_small == "roms/1/1/cover/small.png"
+
+    async def test_a_broken_provider_cannot_destroy_an_existing_large_cover(
+        self, handler: FSResourcesHandler, rom: Rom
+    ):
+        # Fetching into big.png to recover a missing small.png would put a good
+        # large cover at the mercy of the download.
+        cover_dir = self._cover_dir(handler, rom)
+        self._write_cover(cover_dir / "big.png", size=(900, 1200))
+        before = (cover_dir / "big.png").read_bytes()
+
+        path_small, path_big = await self._get_cover(
+            handler, rom, False, _FakeHttpxClient(_DroppedResponse())
+        )
+
+        assert (cover_dir / "big.png").read_bytes() == before
+        assert path_big == "roms/1/1/cover/big.png"
+        assert path_small == "roms/1/1/cover/small.png"
+
+    async def test_rebuilds_the_small_cover_with_the_large_covers_extension(
+        self, handler: FSResourcesHandler, rom: Rom
+    ):
+        cover_dir = self._cover_dir(handler, rom)
+        self._write_cover(cover_dir / "big.jpg", size=(900, 1200))
+        client = _CountingClient(_png_bytes())
+
+        path_small, _ = await self._get_cover(handler, rom, False, client)
+
+        assert client.requests == []
+        assert self._image_size(cover_dir / "small.jpg") == (180, 240)
+        assert path_small == "roms/1/1/cover/small.jpg"
+
+    async def test_leaves_an_unreadable_large_cover_in_place(
+        self, handler: FSResourcesHandler, rom: Rom
+    ):
+        cover_dir = self._cover_dir(handler, rom)
+        cover_dir.mkdir(parents=True)
+        (cover_dir / "big.png").write_bytes(b"not an image")
+        client = _CountingClient(_png_bytes())
+
+        path_small, path_big = await self._get_cover(handler, rom, False, client)
+
+        assert client.requests == []
+        assert (cover_dir / "big.png").exists()
+        assert not (cover_dir / "small.png").exists()
+        assert path_big == "roms/1/1/cover/big.png"
+        assert path_small is None
+
+    async def test_does_not_fetch_without_a_url(
+        self, handler: FSResourcesHandler, rom: Rom
+    ):
+        cover_dir = self._cover_dir(handler, rom)
+        self._write_cover(cover_dir / "big.png")
+        self._write_cover(cover_dir / "small.png")
+        client = _CountingClient(_png_bytes())
+
+        path_small, path_big = await self._get_cover(handler, rom, True, client, None)
+
+        assert client.requests == []
+        assert path_small == "roms/1/1/cover/small.png"
+        assert path_big == "roms/1/1/cover/big.png"
+
+    async def test_copies_a_local_cover_once(
+        self, handler: FSResourcesHandler, rom: Rom, tmp_path
+    ):
+        source = tmp_path / "library" / "art.png"
+        source.parent.mkdir(parents=True)
+        Image.new("RGB", (900, 1200), (85, 62, 152)).save(source)
+
+        copied_to: list[str] = []
+        original_copy = handler.copy_file
+
+        async def counting_copy(src, dest, allow_link=False):
+            copied_to.append(dest)
+            await original_copy(src, dest, allow_link=allow_link)
+
+        with (
+            patch(
+                "handler.filesystem.resources_handler._resolve_local_file_uri",
+                return_value=source,
+            ),
+            patch.object(
+                handler, "copy_file", new=AsyncMock(side_effect=counting_copy)
+            ),
+        ):
+            await handler.get_cover(rom, False, "file://art.png")
+
+        assert copied_to == ["roms/1/1/cover/big.png"]
+        cover_dir = self._cover_dir(handler, rom)
+        assert self._image_size(cover_dir / "big.png") == (900, 1200)
+        assert self._image_size(cover_dir / "small.png") == (180, 240)
+        # A hardlinked destination would be rewritten in place by a later scan,
+        # mutating the user's source image.
+        assert (cover_dir / "big.png").stat().st_nlink == 1
+        assert self._image_size(source) == (900, 1200)
+
+    async def test_discards_both_sizes_for_a_chroma_key_placeholder(
+        self, handler: FSResourcesHandler, rom: Rom
+    ):
+        cover_dir = self._cover_dir(handler, rom)
+        self._write_cover(cover_dir / "small.png")
+        client = _CountingClient(_png_bytes(color=(0, 255, 0)))
+
+        result = await self._get_cover(handler, rom, True, client)
+
+        assert client.requests == [COVER_URL]
+        assert not (cover_dir / "big.png").exists()
+        assert not (cover_dir / "small.png").exists()
+        assert result == (None, None)
+
+    async def test_leaves_no_cover_behind_on_a_dropped_connection(
+        self, handler: FSResourcesHandler, rom: Rom
+    ):
+        result = await self._get_cover(
+            handler, rom, True, _FakeHttpxClient(_DroppedResponse())
+        )
+
+        cover_dir = self._cover_dir(handler, rom)
+        assert not (cover_dir / "big.png").exists()
+        assert not (cover_dir / "small.png").exists()
+        assert result == (None, None)
+
+    async def test_leaves_no_cover_behind_for_undecodable_bytes(
+        self, handler: FSResourcesHandler, rom: Rom
+    ):
+        # A file PIL can't open satisfies cover_exists(), so leaving it would
+        # stop every later scan from refetching a working cover.
+        client = _CountingClient(b"not an image")
+
+        result = await self._get_cover(handler, rom, True, client)
+
+        assert client.requests == [COVER_URL]
+        cover_dir = self._cover_dir(handler, rom)
+        assert not (cover_dir / "big.png").exists()
+        assert not (cover_dir / "small.png").exists()
+        assert result == (None, None)
+
+    async def test_converts_both_sizes_to_webp(
+        self, handler: FSResourcesHandler, rom: Rom
+    ):
+        client = _CountingClient(_png_bytes())
+
+        with patch(
+            "handler.filesystem.resources_handler.ENABLE_SCHEDULED_CONVERT_IMAGES_TO_WEBP",
+            True,
+        ):
+            await self._get_cover(handler, rom, False, client)
+
+        cover_dir = self._cover_dir(handler, rom)
+        assert (cover_dir / "big.webp").exists()
+        assert (cover_dir / "small.webp").exists()
+
+    async def test_low_resolution_cover_uses_the_larger_ratio(
+        self, handler: FSResourcesHandler, rom: Rom
+    ):
+        client = _CountingClient(_png_bytes(size=(600, 800)))
+
+        await self._get_cover(handler, rom, False, client)
+
+        cover_dir = self._cover_dir(handler, rom)
+        assert self._image_size(cover_dir / "big.png") == (600, 800)
+        assert self._image_size(cover_dir / "small.png") == (240, 320)
+
+    async def test_fetches_a_collection_cover_once(self, handler: FSResourcesHandler):
+        collection = Mock(spec=Collection)
+        collection.id = 3
+        collection.fs_resources_path = "collections/3"
+        client = _CountingClient(_png_bytes())
+
+        path_small, path_big = await self._get_cover(handler, collection, False, client)
+
+        assert client.requests == [COVER_URL]
+        assert path_small == "collections/3/cover/small.png"
+        assert path_big == "collections/3/cover/big.png"


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

`get_cover()` called `_store_cover()` once for `CoverSize.SMALL` and once for `CoverSize.BIG` with the same URL, and each call performed a complete fetch. The small cover has no distinct source: it is the large image downloaded in full and then resized in place, so the second request only re-retrieved bytes already on disk.

Measured against the real code path with a local HTTP server counting inbound requests: 2 GETs per cover, to a byte-identical URL. Covers in this repo's `romm_mock/resources` average 556 KiB, so a 5,000-ROM library re-scraped with `overwrite=True` throws away roughly 2.6 GiB of downloads. On ScreenScraper it costs quota rather than just bandwidth, since media is served from the same authenticated api2 endpoints as metadata lookups and routes through the same limiters (`media_download_slot`), so every cover spends two requests from the account's allowance instead of one. Local sources (`file://` / `launchbox-file://`) did two full file copies off the user's disk per cover.

`_store_cover()` no longer takes a size. It fetches once into `big.png` and derives `small.png` from it, the way `store_artwork()` already did. The local work (chroma-key check, resize, WebP conversion) still runs after the provider's request slot has been handed back. `get_cover()`'s signature and return value are unchanged, so all four call sites (scan socket, two collection endpoints, the ROM update endpoint) are untouched. No response schema change, so no regenerated types, no i18n, no frontend code.

A missing small cover no longer triggers a fetch at all. `get_cover()` downloads only when overwriting or when the large cover is absent; when the large one is already on disk and only the small is missing, `_derive_small_cover()` rebuilds it locally for zero requests. That keeps a good large cover out of the blast radius of a download that might fail, and drops the torn-pair case from one request to none.

**What a reviewer should look at hardest**, in order:

1. **The split between fetching and deriving in `get_cover()`.** The condition is now "URL present and (overwriting or no large cover)", with the derive path as the `elif`. The important property is that `_store_cover()` only ever clobbers `big.png` when the caller asked for an overwrite or there was nothing there, so no failure path can cost a large cover that was already good. `_derive_small_cover()` resolves the source through `_get_cover_path`, so an uploaded `big.jpg` or a converted `big.webp` produces a matching `small.jpg` / `small.webp` rather than assuming `.png`.
2. **`_derive_small_cover()` deliberately does not discard an unreadable large cover**, where `_store_cover()` does. The distinction: `_store_cover()` just wrote those bytes itself and knows they're bad, while the derive path found them on disk and can't rule out a format PIL lacks a plugin for. It logs and drops only the partial small.
3. **A failed `overwrite=True` refresh now leaves the old `small.png` behind** (`big.png`, being truncated, is still discarded), where the old code destroyed both. `get_cover` then returns `(small, None)`, and v2 resolves `path_cover_large ?? path_cover_small`, so the ROM detail page shows the upscaled thumbnail instead of the dark placeholder until the next scan refetches. Deliberate: a network blip no longer wipes working artwork. Trade is visible, so flagging it.
4. **`UnidentifiedImageError` now discards both files.** Undecodable bytes satisfy `cover_exists()`, so leaving them on disk meant no later scan ever retried and the UI rendered a broken image permanently. Same reasoning as `_discard_partial_file`'s docstring. An `OSError` in the resize/convert tail is now caught too; it previously escaped into the scan. Relatedly, a non-200 on the small fetch used to reach `Image.open()` on a file that was never written, raising an uncaught `FileNotFoundError` out into the scan; the `downloaded` guard removes that.
5. **`allow_link=False` on the local-file copy is still load-bearing**, for a new reason: `big.png` is no longer resized in place, but an overwriting scan opens the destination `"wb"` via `write_file_streamed`, which would truncate the user's library file through a hardlink. Covered by an `st_nlink == 1` assertion.

Fixes #4102

<sub>**AI assistance disclosure**: this PR was written primarily by Claude Code (Claude Opus 5), under my direction and review. AI generated the handler change, the tests, this description, and the commit message; I specified the approach, reviewed every line, and ran the verification below myself. PR responses will be written by me, with AI assistance disclosed if that changes.</sub>

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

<details>
<summary>Verification</summary>

Backend, from `backend/`:

```
uv run pytest tests/handler/filesystem/test_resources_handler.py -q
  baseline (before any edit):  104 passed
  tests written, no impl yet:   11 failed, 104 passed   <- failing for the right reason
  final:                       118 passed

uv run pytest -q     ->  2760 passed, 2 skipped in 814.96s (exit 0)
trunk fmt / trunk check <both changed files>  ->  no issues
```

Two tests asserted the old behaviour (`assert mock_store.call_count == 2`) and were deleted; mocking `_store_cover` is exactly what let this ship. The 16 replacements in `TestCoverSingleFetch` use a counting httpx client serving real PNG bytes, so the resize actually runs and the request count is the assertion: one fetch when neither cover exists, one when overwriting, one when only the small exists, zero when both exist, zero without a URL, zero when only the large exists (rebuilt from disk instead), one `copy_file` on the local branch, plus the chroma-key / dropped-connection / undecodable-bytes / unreadable-large-cover / non-PNG-extension / WebP / resize-ratio / collection-entity cases. One test pins the failure mode directly: with a large cover on disk and a provider that drops the connection, the file must come out byte-identical.

End-to-end against the real handler (not mocks), driving `fs_resource_handler.get_cover()` at a local server counting inbound GETs: **1 GET** per cover with `overwrite=True`, **0** when covers are present, `big.png` 900x1200 and `small.png` 180x240. Serving ScreenScraper's green placeholder to the same path returns `(None, None)` and clears a stale small left by an earlier pass.

Browser (v2, light and dark, kiosk stack): platform gallery renders both covers with no failed `/cover/` requests, ROM detail renders the large cover at 1000x1424. For the derive path specifically, `small.png` was deleted with `big.png` left in place and the real `get_cover()` run against a request-counting local server: **0 GETs**, `big.png` byte-identical by SHA, and both small covers rebuilt at the same dimensions as the originals (200x284 and 198x272, covering both `resize_cover_to_small` ratio branches). The rebuilt files decode in-page at those sizes and render as clean downscales of the box art. Custom uploaded artwork goes through `store_artwork()`, which this diff doesn't touch.

`npm run test:e2e` → 1 failed, 19 passed. The failure (`e2e/game-media-files.spec.ts:44`) is pre-existing: stashing both changed files and re-running against master's `resources_handler.py` reproduces it identically.

</details>
