### PR TITLE
fix(metadata): identify archives and folder ROMs by the right file

### DIFF
--- a/backend/handler/metadata/hasheous_handler.py
+++ b/backend/handler/metadata/hasheous_handler.py
@@ -270,17 +270,12 @@ class HasheousHandler(MetadataHandler):
         # against any of them.
         data: list[dict] = []
         for file in filtered_files:
-            file_hashes: dict[str, str | None]
-            if file.chd_sha1_hash:
-                # CHD files are indexed by disc-data SHA1 only
-                # Raw file MD5/CRC are hashes of the container and won't match
-                file_hashes = {"shA1": file.chd_sha1_hash}
-            else:
-                file_hashes = {
-                    "mD5": file.md5_hash,
-                    "shA1": file.sha1_hash,
-                    "crc": file.crc_hash,
-                }
+            hashes = file.lookup_hashes
+            file_hashes: dict[str, str | None] = {
+                "mD5": hashes.md5,
+                "shA1": hashes.sha1,
+                "crc": hashes.crc,
+            }
 
             # Drop empty hashes and skip files that have none.
             file_hashes = {key: value for key, value in file_hashes.items() if value}

--- a/backend/handler/metadata/playmatch_handler.py
+++ b/backend/handler/metadata/playmatch_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from collections.abc import Iterable
 from enum import Enum
 from typing import Final, NotRequired, TypedDict
 
@@ -62,6 +63,21 @@ PLAYMATCH_LOOKUP_ROM_ATTRS: frozenset[str] = frozenset(
 PLAYMATCH_SUPPORTED_SOURCES: frozenset[str] = frozenset(
     {"igdb", "moby", "ss", "launchbox", "sgdb"}
 )
+
+
+def _select_lookup_file(files: Iterable[RomFile]) -> RomFile | None:
+    """The single file a ROM is identified by: the biggest top-level one, which
+    is how Hasheous and ScreenScraper choose theirs.
+
+    Equally sized files break the tie on path, so a two-disc set resolves to
+    disc 1. The scanner walks the filesystem unsorted, so without that two
+    machines scanning the same library ask about different files.
+    """
+    return min(
+        (file for file in files if file.file_size_bytes > 0 and file.is_top_level),
+        key=lambda file: (-file.file_size_bytes, file.full_path),
+        default=None,
+    )
 
 
 class GameMatchType(str, Enum):
@@ -221,22 +237,21 @@ class PlaymatchHandler(MetadataHandler):
         if not self.is_enabled():
             return fallback_rom
 
-        first_file = next(
-            (file for file in files if file.file_size_bytes > 0),
-            None,
-        )
-        if first_file is None:
+        match_file = _select_lookup_file(files)
+        if match_file is None:
             return fallback_rom
+
+        hashes = match_file.lookup_hashes
 
         try:
             response = await self._request(
                 self.identify_url,
                 {
-                    "fileName": first_file.file_name,
-                    "fileSize": first_file.file_size_bytes,
-                    "md5": first_file.md5_hash,
-                    "sha1": first_file.sha1_hash,
-                    "crc": first_file.crc_hash,
+                    "fileName": match_file.file_name,
+                    "fileSize": match_file.file_size_bytes,
+                    "md5": hashes.md5,
+                    "sha1": hashes.sha1,
+                    "crc": hashes.crc,
                 },
             )
         except Exception as exc:
@@ -302,27 +317,21 @@ class PlaymatchHandler(MetadataHandler):
             if not mappings:
                 return
 
-            first_file = next(
-                (f for f in rom.files if f.file_size_bytes > 0),
-                None,
-            )
-            if first_file is not None:
-                md5 = first_file.md5_hash
-                sha1 = first_file.sha1_hash
-                file_name = first_file.file_name
-                file_size: int | None = first_file.file_size_bytes
-            else:
-                md5 = rom.md5_hash
-                sha1 = rom.sha1_hash
-                file_name = rom.fs_name
-                file_size = rom.fs_size_bytes or None
+            # A suggestion writes a hash-to-game mapping into a public index.
+            # With no file to take one from, the ROM-level hash is a composite
+            # spanning every file or archive member, so there is nothing here
+            # worth contributing.
+            match_file = _select_lookup_file(rom.files)
+            if match_file is None:
+                return
 
+            hashes = match_file.lookup_hashes
             payload = {
-                "md5": md5,
-                "sha1": sha1,
+                "md5": hashes.md5,
+                "sha1": hashes.sha1,
                 "sha256": None,
-                "fileName": file_name,
-                "fileSize": file_size,
+                "fileName": match_file.file_name,
+                "fileSize": match_file.file_size_bytes,
                 "mappings": mappings,
             }
 

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -5,7 +5,7 @@ import enum
 import re
 from datetime import datetime
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict
 
 from sqlalchemy import (
     TIMESTAMP,
@@ -104,6 +104,14 @@ class RomArchiveMember(TypedDict):
     sha1_hash: str
 
 
+class LookupHashes(NamedTuple):
+    """The hashes a ROM database should be queried with."""
+
+    crc: str | None
+    md5: str | None
+    sha1: str | None
+
+
 class RomFile(BaseModel):
     __tablename__ = "rom_files"
 
@@ -164,6 +172,28 @@ class RomFile(BaseModel):
         from handler.filesystem import fs_rom_handler
 
         return fs_rom_handler.parse_file_extension(self.file_name)
+
+    @cached_property
+    def lookup_hashes(self) -> LookupHashes:
+        """The hashes to identify this file by against a ROM database.
+
+        Often not the file's own digests: a CHD is indexed by the disc data
+        embedded in its header, and a multi-file archive by its largest member
+        (the ROM itself, next to readmes and the like). The file's own hashes
+        cover the container, which no database holds.
+        """
+        if self.chd_sha1_hash:
+            return LookupHashes(crc=None, md5=None, sha1=self.chd_sha1_hash)
+
+        if self.archive_members:
+            largest = max(self.archive_members, key=lambda m: m.get("size") or 0)
+            return LookupHashes(
+                crc=largest.get("crc_hash"),
+                md5=largest.get("md5_hash"),
+                sha1=largest.get("sha1_hash"),
+            )
+
+        return LookupHashes(crc=self.crc_hash, md5=self.md5_hash, sha1=self.sha1_hash)
 
     @cached_property
     def is_nested(self) -> bool:

--- a/backend/tests/handler/metadata/test_playmatch_handler.py
+++ b/backend/tests/handler/metadata/test_playmatch_handler.py
@@ -1,9 +1,10 @@
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import httpx
 
 from handler.metadata.playmatch_handler import PlaymatchHandler
+from models.rom import Rom, RomFile
 from utils import get_version
 
 
@@ -62,3 +63,204 @@ async def test_heartbeat_returns_false_when_disabled():
     handler = PlaymatchHandler()
     with patch.object(handler, "is_enabled", return_value=False):
         assert await handler.heartbeat() is False
+
+
+def _rom_file(*, is_top_level: bool = True, **kwargs) -> RomFile:
+    """Build a RomFile whose `is_top_level` cached_property is pre-seeded, so it
+    reaches lookup_rom's filtering without a persisted rom."""
+    file = RomFile(file_path="psx/Game", **kwargs)
+    file.__dict__["is_top_level"] = is_top_level
+    return file
+
+
+async def _captured_lookup_payload(handler: PlaymatchHandler, files) -> dict | None:
+    with (
+        patch.object(handler, "is_enabled", return_value=True),
+        patch.object(handler, "_request", new_callable=AsyncMock) as mock_request,
+    ):
+        mock_request.return_value = {}
+        await handler.lookup_rom(files)
+
+    if not mock_request.await_args_list:
+        return None
+    return mock_request.await_args_list[-1].args[1]
+
+
+async def test_lookup_rom_identifies_an_archive_by_its_largest_member():
+    """Playmatch indexes a multi-file archive by the ROM inside it, so the
+    archive's composite hash must not be what we ask about. The file name and
+    size stay those of the archive on disk."""
+    archive = _rom_file(
+        file_name="set.zip",
+        file_size_bytes=300,
+        crc_hash="compositecrc",
+        md5_hash="compositemd5",
+        sha1_hash="compositesha1",
+        archive_members=[
+            {
+                "name": "readme.txt",
+                "size": 10,
+                "crc_hash": "readmecrc",
+                "md5_hash": "readmemd5",
+                "sha1_hash": "readmesha1",
+            },
+            {
+                "name": "game.rom",
+                "size": 2048,
+                "crc_hash": "gamecrc",
+                "md5_hash": "gamemd5",
+                "sha1_hash": "gamesha1",
+            },
+        ],
+    )
+
+    payload = await _captured_lookup_payload(PlaymatchHandler(), [archive])
+
+    assert payload == {
+        "fileName": "set.zip",
+        "fileSize": 300,
+        "md5": "gamemd5",
+        "sha1": "gamesha1",
+        "crc": "gamecrc",
+    }
+
+
+def _multi_disc_files(disc_two_size: int = 200) -> list[RomFile]:
+    """A folder ROM the way the scanner emits it: a small playlist next to the
+    discs that actually carry the game."""
+    return [
+        _rom_file(file_name="game.m3u", file_size_bytes=20, md5_hash="playlistmd5"),
+        _rom_file(
+            file_name="disc1.chd", file_size_bytes=300, chd_sha1_hash="disconesha1"
+        ),
+        _rom_file(
+            file_name="disc2.chd",
+            file_size_bytes=disc_two_size,
+            chd_sha1_hash="disctwosha1",
+        ),
+    ]
+
+
+async def test_lookup_rom_asks_about_a_disc_not_the_playlist():
+    """The playlist has no game data in it, so identifying a multi-disc ROM by
+    it can only ever miss."""
+    payload = await _captured_lookup_payload(PlaymatchHandler(), _multi_disc_files())
+
+    assert payload == {
+        "fileName": "disc1.chd",
+        "fileSize": 300,
+        "md5": None,
+        "sha1": "disconesha1",
+        "crc": None,
+    }
+
+
+async def test_lookup_rom_payload_does_not_depend_on_file_order():
+    """The scanner walks the filesystem unsorted and the files relationship has
+    no order_by, so anything that leans on list order asks about a different
+    file on a different machine."""
+    handler = PlaymatchHandler()
+    # Equally sized discs, so only the tie-break can settle which one wins.
+    files = _multi_disc_files(disc_two_size=300)
+
+    payloads = [
+        await _captured_lookup_payload(handler, list(order))
+        for order in (files, reversed(files), files[1:] + files[:1])
+    ]
+
+    assert payloads[0] is not None
+    assert payloads[0] == payloads[1] == payloads[2]
+    assert payloads[0]["fileName"] == "disc1.chd"
+
+
+async def test_lookup_rom_ignores_files_nested_inside_the_rom():
+    """Hasheous and ScreenScraper both filter on is_top_level; a bundled extra
+    or translation patch is not what the ROM should be identified by."""
+    files = [
+        _rom_file(file_name="game.iso", file_size_bytes=100, md5_hash="gamemd5"),
+        _rom_file(
+            file_name="bonus.iso",
+            file_size_bytes=9000,
+            md5_hash="bonusmd5",
+            is_top_level=False,
+        ),
+    ]
+
+    payload = await _captured_lookup_payload(PlaymatchHandler(), files)
+
+    assert payload is not None
+    assert payload["fileName"] == "game.iso"
+
+
+async def test_lookup_rom_skips_the_request_when_no_file_qualifies():
+    """No eligible file must not blow up on an empty max()."""
+    files = [
+        _rom_file(file_name="empty.iso", file_size_bytes=0, md5_hash="emptymd5"),
+        _rom_file(
+            file_name="nested.iso",
+            file_size_bytes=100,
+            md5_hash="nestedmd5",
+            is_top_level=False,
+        ),
+    ]
+
+    assert await _captured_lookup_payload(PlaymatchHandler(), files) is None
+    assert await _captured_lookup_payload(PlaymatchHandler(), []) is None
+
+
+async def _captured_suggestion_payload(rom: Rom) -> dict | None:
+    handler = PlaymatchHandler()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = MagicMock()
+    with (
+        patch.object(handler, "is_enabled", return_value=True),
+        patch(
+            "handler.metadata.playmatch_handler.ctx_httpx_client"
+        ) as mock_ctx_httpx_client,
+        patch(
+            "handler.metadata.playmatch_handler._rate_limiter.acquire",
+            new_callable=AsyncMock,
+        ),
+    ):
+        mock_ctx_httpx_client.get.return_value = mock_client
+        await handler.submit_manual_match_suggestion(rom)
+
+    if not mock_client.post.await_args_list:
+        return None
+    return mock_client.post.await_args.kwargs["json"]
+
+
+async def test_suggestion_contributes_the_selected_files_hashes():
+    """A suggestion writes a hash-to-game mapping into a public index, so it
+    must carry the same digests a lookup would be answered by."""
+    rom = Rom(igdb_id=1234)
+    rom.files = _multi_disc_files() + [
+        _rom_file(
+            file_name="extras.zip",
+            file_size_bytes=50,
+            md5_hash="compositemd5",
+            sha1_hash="compositesha1",
+        )
+    ]
+
+    payload = await _captured_suggestion_payload(rom)
+
+    assert payload == {
+        "md5": None,
+        "sha1": "disconesha1",
+        "sha256": None,
+        "fileName": "disc1.chd",
+        "fileSize": 300,
+        "mappings": ANY,
+    }
+
+
+async def test_suggestion_is_skipped_when_no_file_qualifies():
+    """Falling back to the ROM-level hash would contribute a composite spanning
+    every file, which is not a digest of anything Playmatch indexes."""
+    rom = Rom(igdb_id=1234, fs_name="game.zip", fs_size_bytes=100)
+    rom.md5_hash = "compositemd5"
+    rom.sha1_hash = "compositesha1"
+    rom.files = []
+
+    assert await _captured_suggestion_payload(rom) is None

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -1197,6 +1197,44 @@ class TestLookupRom:
         assert captured.get("rom_name") == "Mario.zip"
 
     @pytest.mark.asyncio
+    async def test_multi_file_archive_keeps_sending_the_composite_hashes(self):
+        """Unlike Hasheous and Playmatch, ScreenScraper stays on the archive's
+        own digests: jeuInfos falls back to romnom, so an arcade set still
+        resolves by name, and moving to the member hash would shift match
+        results across every library."""
+        handler = SSHandler()
+        mock_file = self._make_mock_file()
+        mock_file.file_name = "Mario.zip"
+        mock_file.archive_members = [
+            {
+                "name": "mario.bin",
+                "size": 1024,
+                "crc_hash": "membercrc",
+                "md5_hash": "membermd5",
+                "sha1_hash": "membersha1",
+            },
+            {
+                "name": "mario.cue",
+                "size": 64,
+                "crc_hash": "cuecrc",
+                "md5_hash": "cuemd5",
+                "sha1_hash": "cuesha1",
+            },
+        ]
+        captured = {}
+
+        async def capture(**kwargs):
+            captured.update(kwargs)
+            return None
+
+        with patch.object(handler.ss_service, "get_game_info", side_effect=capture):
+            await handler.lookup_rom(MagicMock(platform_slug="psx"), 57, [mock_file])
+
+        assert captured.get("md5") == "abc123"
+        assert captured.get("sha1") == "def456"
+        assert captured.get("crc") == "12345678"
+
+    @pytest.mark.asyncio
     async def test_romnom_uses_archive_filename_when_no_archive_members(self):
         handler = SSHandler()
         mock_file = self._make_mock_file()

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -773,6 +773,47 @@ async def test_lookup_rom_sends_all_top_level_file_hashes(
 
 @patch.object(meta_hasheous_handler, "_request", new_callable=AsyncMock)
 @patch.object(meta_hasheous_handler, "is_enabled", return_value=True)
+async def test_lookup_rom_sends_the_largest_archive_member_hashes(
+    mock_is_enabled, mock_request
+):
+    """Hasheous indexes a multi-file archive by the ROM inside it, so the
+    archive's composite hash must not be what we ask about."""
+    mock_request.return_value = {}
+
+    files = [
+        _top_level_rom_file(
+            file_name="set.zip",
+            file_size_bytes=300,
+            crc_hash="compositecrc",
+            md5_hash="compositemd5",
+            sha1_hash="compositesha1",
+            archive_members=[
+                {
+                    "name": "readme.txt",
+                    "size": 10,
+                    "crc_hash": "readmecrc",
+                    "md5_hash": "readmemd5",
+                    "sha1_hash": "readmesha1",
+                },
+                {
+                    "name": "game.n64",
+                    "size": 2048,
+                    "crc_hash": "gamecrc",
+                    "md5_hash": "gamemd5",
+                    "sha1_hash": "gamesha1",
+                },
+            ],
+        ),
+    ]
+
+    await meta_hasheous_handler.lookup_rom("n64", files)
+
+    sent_data = mock_request.call_args.kwargs["data"]
+    assert sent_data == [{"mD5": "gamemd5", "shA1": "gamesha1", "crc": "gamecrc"}]
+
+
+@patch.object(meta_hasheous_handler, "_request", new_callable=AsyncMock)
+@patch.object(meta_hasheous_handler, "is_enabled", return_value=True)
 async def test_lookup_rom_maps_every_hasheous_signature_source(
     mock_is_enabled, mock_request
 ):

--- a/backend/tests/models/test_rom.py
+++ b/backend/tests/models/test_rom.py
@@ -1,4 +1,4 @@
-from models.rom import Rom
+from models.rom import LookupHashes, Rom, RomFile
 
 
 def test_rom(rom: Rom):
@@ -11,3 +11,141 @@ def test_rom_with_libretro_match_is_identified(rom: Rom):
 
     assert rom.is_unidentified is False
     assert rom.is_identified is True
+
+
+def _archive(**kwargs) -> RomFile:
+    return RomFile(
+        file_name="sf2.zip",
+        file_path="arcade",
+        file_size_bytes=100,
+        crc_hash="compositecrc",
+        md5_hash="compositemd5",
+        sha1_hash="compositesha1",
+        **kwargs,
+    )
+
+
+def test_lookup_hashes_uses_the_files_own_digests_by_default():
+    file = RomFile(
+        file_name="game.nes",
+        file_path="nes",
+        file_size_bytes=100,
+        crc_hash="crc",
+        md5_hash="md5",
+        sha1_hash="sha1",
+    )
+
+    assert file.lookup_hashes == LookupHashes(crc="crc", md5="md5", sha1="sha1")
+
+
+def test_lookup_hashes_prefers_the_chd_disc_data_sha1():
+    """A CHD's own digests cover the container, so only the embedded SHA1 is
+    worth sending."""
+    file = RomFile(
+        file_name="game.chd",
+        file_path="dc",
+        file_size_bytes=100,
+        crc_hash="containercrc",
+        md5_hash="containermd5",
+        sha1_hash="containersha1",
+        chd_sha1_hash="discsha1",
+    )
+
+    assert file.lookup_hashes == LookupHashes(crc=None, md5=None, sha1="discsha1")
+
+
+def test_lookup_hashes_picks_the_largest_archive_member():
+    """ROM databases index a multi-file archive by the ROM inside it, not by
+    the composite hash RomM stores for the archive as a whole."""
+    file = _archive(
+        archive_members=[
+            {
+                "name": "readme.txt",
+                "size": 10,
+                "crc_hash": "readmecrc",
+                "md5_hash": "readmemd5",
+                "sha1_hash": "readmesha1",
+            },
+            {
+                "name": "sf2.rom",
+                "size": 2048,
+                "crc_hash": "romcrc",
+                "md5_hash": "rommd5",
+                "sha1_hash": "romsha1",
+            },
+        ],
+    )
+
+    assert file.lookup_hashes == LookupHashes(
+        crc="romcrc", md5="rommd5", sha1="romsha1"
+    )
+
+
+def test_lookup_hashes_of_a_single_member_archive_are_the_files_own():
+    """The composite of a one-member archive is that member's digest, so this
+    case must keep sending exactly what it sent before."""
+    file = _archive(
+        archive_members=[
+            {
+                "name": "sf2.rom",
+                "size": 2048,
+                "crc_hash": "compositecrc",
+                "md5_hash": "compositemd5",
+                "sha1_hash": "compositesha1",
+            },
+        ],
+    )
+
+    assert file.lookup_hashes == LookupHashes(
+        crc="compositecrc", md5="compositemd5", sha1="compositesha1"
+    )
+
+
+def test_lookup_hashes_without_archive_members_uses_the_files_own_digests():
+    """Rows scanned before 4.9.0, unreadable archives hashed as raw bytes, and
+    archives nested inside a folder ROM all leave `archive_members` NULL, and
+    their own hash is already the largest member's."""
+    file = _archive(archive_members=None)
+
+    assert file.lookup_hashes == LookupHashes(
+        crc="compositecrc", md5="compositemd5", sha1="compositesha1"
+    )
+
+
+def test_lookup_hashes_with_empty_archive_members_uses_the_files_own_digests():
+    file = _archive(archive_members=[])
+
+    assert file.lookup_hashes == LookupHashes(
+        crc="compositecrc", md5="compositemd5", sha1="compositesha1"
+    )
+
+
+def test_lookup_hashes_tolerates_a_member_without_a_size():
+    file = _archive(
+        archive_members=[
+            {
+                "name": "unsized.bin",
+                "crc_hash": "unsizedcrc",
+                "md5_hash": "unsizedmd5",
+                "sha1_hash": "unsizedsha1",
+            },
+            {
+                "name": "nosize.bin",
+                "size": None,
+                "crc_hash": "nosizecrc",
+                "md5_hash": "nosizemd5",
+                "sha1_hash": "nosizesha1",
+            },
+            {
+                "name": "sf2.rom",
+                "size": 2048,
+                "crc_hash": "romcrc",
+                "md5_hash": "rommd5",
+                "sha1_hash": "romsha1",
+            },
+        ],
+    )
+
+    assert file.lookup_hashes == LookupHashes(
+        crc="romcrc", md5="rommd5", sha1="romsha1"
+    )


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #3742.

Since 4.9.0 an archive's `RomFile` carries a **composite** digest streamed across every
entry in the archive (`a170649fe`, PR #3412). The metadata handlers were never updated
and kept reading their lookup digests straight off that record, so they silently
switched from "the ROM inside the zip" to "a hash of the whole archive". No ROM database
indexes that composite, so any zip with more than one member (arcade/MAME sets, but also
an ordinary ROM zipped next to a readme or patch) stopped matching by hash and fell back
to filename matching. Single-file zips were unaffected, which is why most libraries
never noticed.

This is a re-land of #4059, which implemented exactly this and was closed unmerged on
2026-08-02. The review request on it is still open and no formal review was ever
submitted, so I've kept half A deliberately close to that diff to keep the re-land
legible.

**What changed**

*Which hashes (the 4.9.0 regression).* New `RomFile.lookup_hashes` decides what a ROM
database should be queried with: `chd_sha1_hash` for CHDs, else the largest
`archive_members` entry, else the file's own digests. Hasheous and Playmatch both read
it. CHD behaviour for Hasheous is byte-identical to before; only the archive case moves.

*Which file (pre-existing, not a 4.9.0 regression).* Playmatch picked its file with
`next(file for file in files if file.file_size_bytes > 0)` — the *first* file with bytes,
not the largest, with no `is_top_level` filter. `iter_files` is a bare `os.walk` with no
sort and `Rom.files` has no `order_by`, so for a multi-disc folder ROM the file Playmatch
was asked about was arbitrary filesystem order and could differ between two machines
scanning the same library. It was also frequently the `.m3u` playlist, which carries no
game data and can only ever miss.

To be clear about scope: this half is **not** part of the 4.9.0 regression. 4.8.1 carries
the same three lines verbatim (`ca58028eb`, "playmatch should just use the first file",
2025-07-10). It's in here because fixing only the hash selection would leave multi-disc
folder ROMs still failing on Playmatch, and the two questions are the same question.
A new `_select_lookup_file` replaces both copies of that expression (lookup and
suggestion) with the largest top-level file, tie-broken on path.

**Worth looking at hardest**

1. `_select_lookup_file`'s `is_top_level` filter is a behaviour narrowing, not just a
   tie-break. A folder ROM whose files all live in subdirectories (`Game/Disc 1/game.bin`)
   now gets **no** Playmatch lookup at all, where before it got one against an arbitrary
   nested file. Hasheous and ScreenScraper already drop those libraries, so this aligns
   the three, but it is a real loss for that layout. Happy to add a last-resort fallback
   to the largest sizeable file if you'd rather keep the old reach.

2. `submit_manual_match_suggestion` now contributes the *member's* digests alongside the
   *archive's* `fileName`/`fileSize`. Harmless for lookups (a hash match outranks
   `FileNameAndSize`), but the contributed triple is internally inconsistent. Sending the
   member's name and size would be the fuller fix; I left it out of scope here and it's
   worth its own issue. Relatedly, the suggestion no longer falls back to
   `rom.md5_hash`/`rom.sha1_hash` when no file qualifies — it just returns. Contributing
   nothing to a public index beats contributing a composite that is a digest of no single
   file.

3. Playmatch now looks CHDs up by `chd_sha1_hash` instead of the container digests. This
   is right in principle and matches Hasheous, but Playmatch's CHD behaviour is the one
   leg I couldn't confirm with a live match.

**Deliberately unchanged**

ScreenScraper keeps sending the archive's own composite digests. Its `jeuInfos` lookup
falls back to `romnom` (the filename), which for an arcade zip is the set name, so those
still resolve; moving it would shift match results across many libraries. There's a new
test pinning that, so a future change there has to be a choice rather than a side effect.
RetroAchievements is a separate RAHasher pipeline and is untouched.

**No migration, no re-hash.** `archive_members` has been populated since 4.9.0 and
already carries the member digests, so this reads correct data off rows already in the
database.

**Correction to the issue body:** #3742 claims the arcade fixtures demonstrate the
Playmatch half. They don't — Playmatch does not index MAME sets at all and returns
`NoMatch` for them on *either* hash. An ordinary No-Intro ROM zipped with a readme is
what reproduces the Playmatch half; both are covered below.

---

> **AI assistance disclosure.** This PR was investigated, implemented, and written
> primarily by Claude Code — the root-cause analysis, the code, the tests, and this
> description. I directed the work, made the scope calls, reviewed every line, and ran
> the verification below myself.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

<details>
<summary>Verification</summary>

**Live lookups against the real Hasheous and Playmatch APIs**, driving the real
`FSRomsHandler.get_rom_files()` (only `RAHasherService.calculate_hash` patched out) into
the real `lookup_rom`:

| Fixture | md5 sent before | md5 sent now | Hasheous | Playmatch |
| --- | --- | --- | --- | --- |
| `aerofgt.zip` (8 members) | `c5347ceb…` | `694853ae…` | **'Aero Fighters' hasheous 48064 / igdb 3147** (was HTTP 404) | `NoMatch` (expected) |
| `ga2.zip` (19 members) | `c6ed4e03…` | `0cd4f9af…` | **'Golden Axe: The Revenge of Death Adder' 51687 / igdb 5565** (was 404) | `NoMatch` (expected) |
| SMB3 zip (1 member, control) | `e883e0d4…` | identical | 'Super Mario Bros. 3' 25611 (unchanged) | `SHA1` igdb 1068 (unchanged) |
| SMB3 + readme (2 members) | `9f018a5b…` | `e883e0d4…` | **'Super Mario Bros. 3'** (was 404) | **`SHA1` igdb 1068** (was `NoMatch`) |

The two arcade `NoMatch`es are not a failure: Playmatch doesn't index MAME on either
hash. The SMB3+readme row is the fixture that demonstrates the Playmatch half.

Multi-disc folder ROM (`Metal Gear Solid (USA) (Rev 1)/`, two CHDs plus an `.m3u`):
picks `Disc 1`, not the playlist; sends the CHD's disc-data SHA-1, not the container's;
identical selection across 4 list orderings (order-dependent on master).

**Tests.** 15 new tests. All 7 in `tests/models/test_rom.py` failed on master with
`ImportError: cannot import name 'LookupHashes'`; the Hasheous payload test failed
sending `compositemd5/sha1/crc`; 6 of the 7 Playmatch tests failed on master (composite
hashes, `fileName='game.m3u'`, order-dependent payload, a nested file selected, a
composite POSTed as a suggestion). Edge cases covered: single-member archive unchanged,
`archive_members` `None` and `[]`, a member with a missing or `None` size, CHD
precedence, nested-file exclusion, and no-eligible-file.

Full backend suite: **2762 passed, 2 skipped**. `trunk fmt` + `trunk check --no-fix` on
all 7 files: no issues.

**No OpenAPI change** — proven, not assumed: dumped `app.openapi()` from a `master`
worktree and from this branch and diffed them. Identical, 26,574 lines each. So no
`npm run generate` and no frontend typecheck.

</details>

#### Screenshots (if applicable)

N/A — backend only. No UI, no i18n, no schema change. Evidence is the live-lookup table
above.
