### PR TITLE
fix(v2): bulk favorite no-ops on a fresh instance and reports the wrong direction

### DIFF
--- a/frontend/src/v2/components/Gallery/SelectionBar.test.ts
+++ b/frontend/src/v2/components/Gallery/SelectionBar.test.ts
@@ -1,0 +1,263 @@
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+import storeCollections, { type Collection } from "@/stores/collections";
+import storeRoms, { type SimpleRom } from "@/stores/roms";
+import storeGalleryRoms from "@/v2/stores/galleryRoms";
+import storeGallerySelection from "@/v2/stores/gallerySelection";
+import SelectionBar from "./SelectionBar.vue";
+
+const {
+  addRomsToCollection,
+  createCollection,
+  getCollections,
+  removeRomsFromCollection,
+  snackbarError,
+  snackbarSuccess,
+} = vi.hoisted(() => ({
+  addRomsToCollection: vi.fn(),
+  createCollection: vi.fn(),
+  getCollections: vi.fn(),
+  removeRomsFromCollection: vi.fn(),
+  snackbarError: vi.fn(),
+  snackbarSuccess: vi.fn(),
+}));
+
+// `t` echoes the key plus its params so a test can assert *which* message was
+// shown -- the whole point of the add/remove polarity cases.
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}::${JSON.stringify(params)}` : key,
+  }),
+}));
+
+vi.mock("@/services/api/collection", () => ({
+  default: {
+    addRomsToCollection,
+    createCollection,
+    getCollections,
+    removeRomsFromCollection,
+  },
+}));
+
+vi.mock("@/v2/composables/useSnackbar", () => ({
+  useSnackbar: () => ({
+    success: snackbarSuccess,
+    error: snackbarError,
+    warning: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+vi.mock("@/v2/composables/useCan", () => ({
+  useCan: () => ({ value: true }),
+}));
+
+vi.mock("@/v2/composables/useBreakpoint", () => ({
+  useBreakpoint: () => ({ xs: ref(false) }),
+}));
+
+function rom(id: number): SimpleRom {
+  return { id, name: `Game ${id}`, platform_id: 1 } as SimpleRom;
+}
+
+function favorites(romIds: number[]): Collection {
+  return {
+    id: 7,
+    name: "Favorites",
+    is_favorite: true,
+    rom_ids: romIds,
+    rom_count: romIds.length,
+  } as Collection;
+}
+
+function select(...roms: SimpleRom[]) {
+  const selection = storeGallerySelection();
+  roms.forEach((r, i) => selection.toggle(r, i));
+}
+
+function mountBar() {
+  return mount(SelectionBar, {
+    global: {
+      stubs: {
+        RToolbar: {
+          template:
+            "<div><slot name='prepend' /><slot /><slot name='append' /></div>",
+        },
+        RTooltip: {
+          template: "<div><slot name='activator' :props='{}' /></div>",
+        },
+        RBtn: {
+          emits: ["click"],
+          template: "<button @click=\"$emit('click')\"><slot /></button>",
+        },
+        RMenu: true,
+        RMenuItem: true,
+        RIcon: true,
+        RDivider: true,
+      },
+    },
+  });
+}
+
+// The heart's label flips with `allFavorited`, so accept either.
+function heart(wrapper: VueWrapper) {
+  const add = wrapper.find('[aria-label="gallery.selection-favorite"]');
+  return add.exists()
+    ? add
+    : wrapper.get('[aria-label="gallery.selection-unfavorite"]');
+}
+
+async function clickHeart(wrapper: VueWrapper) {
+  await heart(wrapper).trigger("click");
+  await flushPromises();
+}
+
+describe("SelectionBar bulk favorite", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it("creates the favourites collection when the instance has none", async () => {
+    getCollections.mockResolvedValue({ data: [] });
+    createCollection.mockResolvedValue(favorites([]));
+    addRomsToCollection.mockResolvedValue({ data: favorites([1, 2]) });
+    select(rom(1), rom(2));
+
+    await clickHeart(mountBar());
+
+    expect(createCollection).toHaveBeenCalledTimes(1);
+    expect(addRomsToCollection).toHaveBeenCalledWith(7, [1, 2]);
+    expect(snackbarSuccess).toHaveBeenCalledWith(
+      'gallery.selection-favorite-success::{"n":2}',
+    );
+    expect(snackbarError).not.toHaveBeenCalled();
+  });
+
+  it("reports an add as added, not removed", async () => {
+    const collections = storeCollections();
+    collections.setCollections([favorites([])]);
+    collections.setFavoriteCollection(favorites([]));
+    addRomsToCollection.mockResolvedValue({ data: favorites([1, 2]) });
+    select(rom(1), rom(2));
+
+    await clickHeart(mountBar());
+
+    expect(addRomsToCollection).toHaveBeenCalledWith(7, [1, 2]);
+    expect(snackbarSuccess).toHaveBeenCalledWith(
+      'gallery.selection-favorite-success::{"n":2}',
+    );
+  });
+
+  it("reports a removal as removed, not added", async () => {
+    const collections = storeCollections();
+    collections.setCollections([favorites([1, 2])]);
+    collections.setFavoriteCollection(favorites([1, 2]));
+    removeRomsFromCollection.mockResolvedValue({ data: favorites([]) });
+    select(rom(1), rom(2));
+
+    await clickHeart(mountBar());
+
+    expect(removeRomsFromCollection).toHaveBeenCalledWith(7, [1, 2]);
+    expect(snackbarSuccess).toHaveBeenCalledWith(
+      'gallery.selection-unfavorite-success::{"n":2}',
+    );
+  });
+
+  it("adds when only some of the selection is favourited", async () => {
+    const collections = storeCollections();
+    collections.setCollections([favorites([1])]);
+    collections.setFavoriteCollection(favorites([1]));
+    addRomsToCollection.mockResolvedValue({ data: favorites([1, 2]) });
+    select(rom(1), rom(2));
+
+    await clickHeart(mountBar());
+
+    expect(addRomsToCollection).toHaveBeenCalledWith(7, [1, 2]);
+    expect(removeRomsFromCollection).not.toHaveBeenCalled();
+    expect(snackbarSuccess).toHaveBeenCalledWith(
+      'gallery.selection-favorite-success::{"n":2}',
+    );
+  });
+
+  it("drops the roms from the grid when unfavouriting inside the favourites collection", async () => {
+    const collections = storeCollections();
+    collections.setCollections([favorites([1, 2])]);
+    collections.setFavoriteCollection(favorites([1, 2]));
+    removeRomsFromCollection.mockResolvedValue({ data: favorites([]) });
+    const gallery = storeGalleryRoms();
+    gallery.setCurrentCollection(favorites([1, 2]));
+    const galleryRemove = vi.spyOn(gallery, "remove").mockImplementation(() => {
+      /* the real one refetches the gallery */
+    });
+    const roms = storeRoms();
+    const romsRemove = vi.spyOn(roms, "remove");
+    select(rom(1), rom(2));
+
+    await clickHeart(mountBar());
+
+    expect(galleryRemove).toHaveBeenCalledTimes(1);
+    expect(galleryRemove.mock.calls[0][0].map((r) => r.id)).toEqual([1, 2]);
+    expect(romsRemove).toHaveBeenCalledTimes(1);
+    expect(storeGallerySelection().count).toBe(0);
+  });
+
+  it("keeps the roms on screen when unfavouriting from a platform gallery", async () => {
+    const collections = storeCollections();
+    collections.setCollections([favorites([1, 2])]);
+    collections.setFavoriteCollection(favorites([1, 2]));
+    removeRomsFromCollection.mockResolvedValue({ data: favorites([]) });
+    const gallery = storeGalleryRoms();
+    const galleryRemove = vi.spyOn(gallery, "remove");
+    select(rom(1), rom(2));
+
+    await clickHeart(mountBar());
+
+    expect(removeRomsFromCollection).toHaveBeenCalledWith(7, [1, 2]);
+    expect(galleryRemove).not.toHaveBeenCalled();
+    expect(storeGallerySelection().count).toBe(2);
+  });
+
+  it("surfaces an error when the collection cannot be created", async () => {
+    getCollections.mockResolvedValue({ data: [] });
+    createCollection.mockRejectedValue(new Error("Forbidden"));
+    select(rom(1), rom(2));
+
+    await clickHeart(mountBar());
+
+    expect(addRomsToCollection).not.toHaveBeenCalled();
+    expect(snackbarError).toHaveBeenCalledWith(
+      "gallery.selection-favorite-fail",
+    );
+    expect(snackbarSuccess).not.toHaveBeenCalled();
+  });
+
+  it("does nothing without a selection", async () => {
+    getCollections.mockResolvedValue({ data: [] });
+
+    await clickHeart(mountBar());
+
+    expect(createCollection).not.toHaveBeenCalled();
+    expect(addRomsToCollection).not.toHaveBeenCalled();
+    expect(snackbarSuccess).not.toHaveBeenCalled();
+    expect(snackbarError).not.toHaveBeenCalled();
+  });
+
+  it("ignores a second click while the first is still in flight", async () => {
+    getCollections.mockResolvedValue({ data: [] });
+    createCollection.mockResolvedValue(favorites([]));
+    addRomsToCollection.mockResolvedValue({ data: favorites([1, 2]) });
+    select(rom(1), rom(2));
+    const wrapper = mountBar();
+
+    await heart(wrapper).trigger("click");
+    await heart(wrapper).trigger("click");
+    await flushPromises();
+
+    expect(createCollection).toHaveBeenCalledTimes(1);
+    expect(addRomsToCollection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/v2/components/Gallery/SelectionBar.vue
+++ b/frontend/src/v2/components/Gallery/SelectionBar.vue
@@ -80,8 +80,6 @@ const selection = storeGallerySelection();
 const collectionsStore = storeCollections();
 const romsStore = storeRoms();
 const galleryRomsStore = storeGalleryRoms();
-// No emitter: the composable's own creation toast is v1 copy, and this
-// surface reports the outcome with its own localized message below.
 const { ensureFavoriteCollection } = useFavoriteToggle();
 
 const canRefresh = useCan("rom.refresh");
@@ -114,22 +112,22 @@ const favoriteLabel = computed(() =>
     : t("gallery.selection-favorite"),
 );
 
-// Guards the create-if-missing call below: a double click would otherwise
-// race two POSTs for the same collection, and the loser 409s.
+// Guards the create-if-missing call below.
 const favoritePending = ref(false);
 
 async function bulkFavorite() {
   const ids = selection.ids;
   const roms = selection.roms;
   if (ids.length === 0 || favoritePending.value) return;
+  // `allFavorited` tracks the live selection and the collection's rom_ids,
+  // both of which can move while the calls below are in flight, so the
+  // direction has to be snapshotted alongside the ids it applies to.
+  const wasAllFavorited = allFavorited.value;
   favoritePending.value = true;
   try {
     // A fresh instance has no favourites collection until something is
-    // favourited — same lazy creation the per-rom toggle relies on.
+    // favourited.
     const fav = await ensureFavoriteCollection();
-    // `allFavorited` reads the collection's rom_ids, which the response
-    // below replaces, so the direction has to be snapshotted here.
-    const wasAllFavorited = allFavorited.value;
     const { data } = wasAllFavorited
       ? await collectionApi.removeRomsFromCollection(fav.id, ids)
       : await collectionApi.addRomsToCollection(fav.id, ids);

--- a/frontend/src/v2/components/Gallery/SelectionBar.vue
+++ b/frontend/src/v2/components/Gallery/SelectionBar.vue
@@ -14,7 +14,9 @@
 //   * favorite / unfavorite — direct collectionApi bulk call against
 //     the favorite collection. The Card/Row's per-rom favourite
 //     toggle still routes through `useGameActions` per-rom; here we
-//     bypass it to issue a single add/remove call for the whole set.
+//     bypass only its per-rom write to issue a single add/remove call
+//     for the whole set, while still reusing its
+//     `ensureFavoriteCollection` so a fresh instance gets one.
 //   * manage collections — re-uses the existing
 //     `ManageCollectionsDialog` (already accepts SimpleRom[]) via
 //     the `showManageCollectionsDialog` emitter event.
@@ -42,9 +44,10 @@ import {
   RDivider,
 } from "@v2/lib";
 import type { Emitter } from "mitt";
-import { computed, inject } from "vue";
+import { computed, inject, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import type { RomUserData, RomUserStatus } from "@/__generated__";
+import { useFavoriteToggle } from "@/composables/useFavoriteToggle";
 import collectionApi from "@/services/api/collection";
 import romApi from "@/services/api/rom";
 import storeCollections from "@/stores/collections";
@@ -54,6 +57,7 @@ import { romStatusMap } from "@/utils";
 import { useBreakpoint } from "@/v2/composables/useBreakpoint";
 import { useCan } from "@/v2/composables/useCan";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
+import storeGalleryRoms from "@/v2/stores/galleryRoms";
 import storeGallerySelection from "@/v2/stores/gallerySelection";
 import {
   ENUM_KEYS,
@@ -75,6 +79,10 @@ const snackbar = useSnackbar();
 const selection = storeGallerySelection();
 const collectionsStore = storeCollections();
 const romsStore = storeRoms();
+const galleryRomsStore = storeGalleryRoms();
+// No emitter: the composable's own creation toast is v1 copy, and this
+// surface reports the outcome with its own localized message below.
+const { ensureFavoriteCollection } = useFavoriteToggle();
 
 const canRefresh = useCan("rom.refresh");
 const canDownload = useCan("rom.download");
@@ -106,29 +114,44 @@ const favoriteLabel = computed(() =>
     : t("gallery.selection-favorite"),
 );
 
+// Guards the create-if-missing call below: a double click would otherwise
+// race two POSTs for the same collection, and the loser 409s.
+const favoritePending = ref(false);
+
 async function bulkFavorite() {
-  const fav = collectionsStore.favoriteCollection;
   const ids = selection.ids;
-  if (!fav || ids.length === 0) return;
+  const roms = selection.roms;
+  if (ids.length === 0 || favoritePending.value) return;
+  favoritePending.value = true;
   try {
-    const { data } = allFavorited.value
+    // A fresh instance has no favourites collection until something is
+    // favourited — same lazy creation the per-rom toggle relies on.
+    const fav = await ensureFavoriteCollection();
+    // `allFavorited` reads the collection's rom_ids, which the response
+    // below replaces, so the direction has to be snapshotted here.
+    const wasAllFavorited = allFavorited.value;
+    const { data } = wasAllFavorited
       ? await collectionApi.removeRomsFromCollection(fav.id, ids)
       : await collectionApi.addRomsToCollection(fav.id, ids);
     collectionsStore.updateCollection(data);
     collectionsStore.setFavoriteCollection(data);
-    if (allFavorited.value && romsStore.currentCollection?.id === fav.id) {
+    if (wasAllFavorited && galleryRomsStore.currentCollection?.id === fav.id) {
       // We were on the favourites collection view and just removed
       // every selected rom from it — drop them from the visible
       // roms so the UI reflects the new membership immediately.
-      romsStore.remove(selection.roms);
+      selection.removeIds(ids);
+      romsStore.remove(roms);
+      galleryRomsStore.remove(roms);
     }
     snackbar.success(
-      allFavorited.value
+      wasAllFavorited
         ? t("gallery.selection-unfavorite-success", { n: ids.length })
         : t("gallery.selection-favorite-success", { n: ids.length }),
     );
   } catch {
     snackbar.error(t("gallery.selection-favorite-fail"));
+  } finally {
+    favoritePending.value = false;
   }
 }
 


### PR DESCRIPTION
**Description**

Fixes #4148

The v2 gallery's multi-select favorite button (the heart in the `SelectionBar`) had two
faults, both in `bulkFavorite`:

1. **Silent no-op on a fresh instance.** Nothing on the backend ever seeds a Favorites
   collection; it is created lazily by the frontend, in `useFavoriteToggle`'s
   `ensureFavoriteCollection`. `bulkFavorite` deliberately bypasses `useFavoriteToggle`
   to issue one add/remove call for the whole set rather than N per-rom calls, and in
   doing so it also skipped the ensure step, bailing early with `if (!fav) return`.
   Because the bail sat outside the `try`, not even the error snackbar fired: the click
   was completely silent, no games favorited, no collection created. Favoriting a single
   game from its card worked and created the collection, after which bulk favorite
   started working, which is why this only bit new instances.

2. **Inverted confirmation message.** `allFavorited` is a computed over the favourite
   collection's `rom_ids`. `bulkFavorite` read it again *after* writing the API response
   back into the store, so the computed had already recomputed against the new
   membership: adding N games reported "N removed from favorites" and vice versa. The
   write itself was always correct; only the message lied.

The same stale read also disabled the "prune the removed rows from the grid" branch. That
branch turned out to be dead code independently of the polarity bug: it gated on
`romsStore.currentCollection`, which only v1 views ever set. v2 sets
`galleryRoms.currentCollection`, so the condition was always false. It now uses the v2
store, and prunes via the same triple `DeleteRomDialog` uses (drop from the selection,
`romsStore.remove`, `galleryRomsStore.remove`) so the sparse gallery windows are actually
invalidated.

`bulkFavorite` now calls `ensureFavoriteCollection()` from inside the `try`, snapshots
the toggle direction into a local before the write, and uses that local for both the
prune branch and the message. No new strings; the four existing
`gallery.selection-*favorite*` keys cover every path.

**What to look at hardest**

- The placement of the `wasAllFavorited` snapshot. It has to sit *after* the ensure (a
  `fetchCollections()` inside it can leave the snapshot stale) and *before* the write
  (the store mutation flips it). Both edges are covered by tests.
- The new in-flight guard. `ensureFavoriteCollection` issues a `POST /collections`, which
  a double click would race; the loser gets a 409 from
  `CollectionAlreadyExistsException`. The guard is the one thing here beyond the issue
  text, and it exists only because the POST is new to this path.
- Reusing the shared v1+v2 `useFavoriteToggle` from a v2 component. Its signature is
  untouched (`useGameActions` already imports it), and it is called without the emitter
  argument on purpose: that optional emitter only drives the composable's own hardcoded
  English "Collection Favorites created successfully!" toast, and this surface owns the
  localized message instead.

**Known limitation, out of scope**

On the Favorites collection view the header's game count goes stale after a prune
(screenshot 6 vs 7: the grid correctly empties, the header still reads "2 GAMES").
`Collection.vue` keeps its own `currentCollection` ref that `collectionsStore.updateCollection()`
does not reach, since it replaces the array entry with a new object. This is pre-existing
for any membership change; before this fix the grid stayed populated too, so the two
merely agreed with each other. Worth its own issue.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**Testing**

New `SelectionBar.test.ts` — 9 cases mounting the real component against *real* Pinia
stores for collections, gallery selection, roms and gallery roms (a mocked collections
store cannot reproduce the computed-flip at all); only the collection API, snackbar,
`useCan`, `useBreakpoint` and `vue-i18n` are mocked. The heart is clicked through the
rendered DOM by its `aria-label`. Written first and run against the unmodified component:
**7 of 9 failed**, each for the predicted reason, the 2 passers being the behaviours that
were already correct (roms stay put in a platform gallery; empty selection is a no-op).
After the fix, 9/9, with no test edited to go green.

- `npm run typecheck` — clean
- `npm run test` — 676 passed / 57 files
- `npm run build` — clean
- `trunk fmt && trunk check` — no new issues
- No locale file touched, no backend file touched, no schema or route change

Browser pass against the dev stack as a freshly seeded admin owning no collections (so it
genuinely is the fresh-instance case), driven by Playwright and asserted, not eyeballed:
create-denied surfaces the error toast; fresh-instance click creates the collection and
reports "2 added to favorites"; the reverse reports "2 removed from favorites"; a mixed
selection takes the add branch; removing inside the Favorites collection drops the tiles
with no reload; and the same flows over keyboard (Enter and Space on the focused heart) in
the light theme. Dark and light both covered; mouse and keyboard both covered. Touch and
gamepad were not exercised — the change is behavioural and the bar's layout is untouched.

The full Playwright suite was 19 passed / 1 failed on `game-media-files.spec.ts:44`. That
failure is pre-existing and unrelated: stashing the change (tree then identical to master)
reproduces it.

No e2e spec was added, deliberately. `playwright.config.ts` states the suite reads server
state rather than mutating it and runs `fullyParallel`; a favourites spec writes to the
shared library.

**AI assistance disclosure**

Per CONTRIBUTING.md: this PR was written primarily by Claude Code (Opus 5). The
investigation, the code change, the unit tests and this description were AI-generated, and
the browser verification was AI-driven via Playwright. I reviewed the diff and the test
results myself before opening it. PR responses will be written by me unless noted
otherwise.