### PR TITLE
fix(v2): pin mobile bottom nav with sticky instead of fixed

### DIFF
--- a/frontend/src/v2/components/AppShell/BottomNav.vue
+++ b/frontend/src/v2/components/AppShell/BottomNav.vue
@@ -23,11 +23,7 @@ const { t } = useI18n();
 const { smAndDown } = useBreakpoint();
 const { destinations, activeId } = useNavDestinations();
 
-// iOS Safari can leave a `position: fixed` element stuck at a stale
-// offset after a scroll gesture, with no relayout able to correct it.
-// `position: sticky` (see the anchor below) is computed through ordinary
-// layout instead of that separate viewport-anchoring path, so it isn't
-// affected.
+// Sticky avoids a Safari bug where fixed elements can get stuck after scrolling.
 </script>
 
 <template>
@@ -45,11 +41,7 @@ const { destinations, activeId } = useNavDestinations();
 </template>
 
 <style scoped>
-/* `position: absolute; inset: 0` matches the height `.r-v2-shell__app`
-   already has without adding to it, so other views' bottom-nav clearance
-   math is unaffected. `flex-end` puts the pill's un-stuck position at the
-   bottom of that height, so `sticky; bottom: 0` below engages immediately
-   on any scrollable page. */
+/* Matches .r-v2-shell__app's height without adding to it; flex-end anchors the pill to sticky's bottom. */
 .r-v2-bottom-nav-anchor {
   position: absolute;
   inset: 0;

--- a/frontend/src/v2/components/AppShell/BottomNav.vue
+++ b/frontend/src/v2/components/AppShell/BottomNav.vue
@@ -22,33 +22,65 @@ import { useNavDestinations } from "@/v2/composables/useNavDestinations";
 const { t } = useI18n();
 const { smAndDown } = useBreakpoint();
 const { destinations, activeId } = useNavDestinations();
+
+// On-device testing (iOS Safari, real hardware) found `position: fixed`
+// unreliable here: during scroll it visibly tracked the page's momentum
+// instead of staying pinned, and it never correctly reset once scrolling
+// stopped — confirmed with getBoundingClientRect() reads showing it
+// permanently parked wherever the gesture happened to end, immune even to
+// a manually forced synchronous relayout (display toggle). That points to
+// a stale value in the engine's internal fixed-position viewport reference
+// that plain CSS/JS on the page can't reach or invalidate.
+//
+// `position: sticky` goes through the ordinary layout pipeline instead of
+// that separate "anchor to viewport" mechanism, so it isn't subject to the
+// same bug. See the `.r-v2-bottom-nav-anchor` comment below for how it's
+// wired up to behave identically to the old fixed strip.
 </script>
 
 <template>
-  <div v-if="smAndDown" class="r-v2-bottom-nav">
-    <RSliderBtnGroup
-      :model-value="activeId"
-      :items="destinations"
-      variant="tab"
-      class="r-v2-bottom-nav__group"
-      :aria-label="t('common.primary-navigation')"
-    />
+  <div v-if="smAndDown" class="r-v2-bottom-nav-anchor">
+    <div class="r-v2-bottom-nav">
+      <RSliderBtnGroup
+        :model-value="activeId"
+        :items="destinations"
+        variant="tab"
+        class="r-v2-bottom-nav__group"
+        :aria-label="t('common.primary-navigation')"
+      />
+    </div>
   </div>
 </template>
 
 <style scoped>
-/* Fixed bottom strip that just hosts the pill. Transparent — the pill
-   itself carries the glass surface (tab variant), so it reads as a
-   floating control matching the top nav. Side gutters follow the
-   responsive `--r-row-pad`; the safe-area inset keeps the pill above a
-   notched phone's home indicator. `pointer-events: none` on the strip +
-   `auto` on the pill so taps in the transparent gutters fall through. */
-.r-v2-bottom-nav {
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
+/* `position: absolute; inset: 0` makes this anchor span exactly the same
+   height `.r-v2-shell__app` already occupies (it doesn't contribute to
+   that height itself, same as a `fixed` element wouldn't) — so no other
+   view's `100dvh - ...` clearance math needs to change. `flex-end` puts
+   the pill's un-stuck flow position at the very bottom of that full page
+   height, so `position: sticky; bottom: 0` on the pill activates
+   immediately on any page taller than one screen, exactly mimicking the
+   old fixed strip, but computed through ordinary layout instead of the
+   buggy fixed-to-viewport path. */
+.r-v2-bottom-nav-anchor {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  pointer-events: none;
   z-index: 100;
+}
+
+/* Transparent — the pill itself carries the glass surface (tab variant),
+   so it reads as a floating control matching the top nav. Side gutters
+   follow the responsive `--r-row-pad`; the safe-area inset keeps the pill
+   above a notched phone's home indicator. `pointer-events: none` on the
+   strip + `auto` on the pill so taps in the transparent gutters fall
+   through. */
+.r-v2-bottom-nav {
+  position: sticky;
+  bottom: 0;
   display: flex;
   justify-content: center;
   padding: 8px var(--r-row-pad) calc(8px + env(safe-area-inset-bottom));

--- a/frontend/src/v2/components/AppShell/BottomNav.vue
+++ b/frontend/src/v2/components/AppShell/BottomNav.vue
@@ -23,19 +23,11 @@ const { t } = useI18n();
 const { smAndDown } = useBreakpoint();
 const { destinations, activeId } = useNavDestinations();
 
-// On-device testing (iOS Safari, real hardware) found `position: fixed`
-// unreliable here: during scroll it visibly tracked the page's momentum
-// instead of staying pinned, and it never correctly reset once scrolling
-// stopped — confirmed with getBoundingClientRect() reads showing it
-// permanently parked wherever the gesture happened to end, immune even to
-// a manually forced synchronous relayout (display toggle). That points to
-// a stale value in the engine's internal fixed-position viewport reference
-// that plain CSS/JS on the page can't reach or invalidate.
-//
-// `position: sticky` goes through the ordinary layout pipeline instead of
-// that separate "anchor to viewport" mechanism, so it isn't subject to the
-// same bug. See the `.r-v2-bottom-nav-anchor` comment below for how it's
-// wired up to behave identically to the old fixed strip.
+// iOS Safari can leave a `position: fixed` element stuck at a stale
+// offset after a scroll gesture, with no relayout able to correct it.
+// `position: sticky` (see the anchor below) is computed through ordinary
+// layout instead of that separate viewport-anchoring path, so it isn't
+// affected.
 </script>
 
 <template>
@@ -53,15 +45,11 @@ const { destinations, activeId } = useNavDestinations();
 </template>
 
 <style scoped>
-/* `position: absolute; inset: 0` makes this anchor span exactly the same
-   height `.r-v2-shell__app` already occupies (it doesn't contribute to
-   that height itself, same as a `fixed` element wouldn't) — so no other
-   view's `100dvh - ...` clearance math needs to change. `flex-end` puts
-   the pill's un-stuck flow position at the very bottom of that full page
-   height, so `position: sticky; bottom: 0` on the pill activates
-   immediately on any page taller than one screen, exactly mimicking the
-   old fixed strip, but computed through ordinary layout instead of the
-   buggy fixed-to-viewport path. */
+/* `position: absolute; inset: 0` matches the height `.r-v2-shell__app`
+   already has without adding to it, so other views' bottom-nav clearance
+   math is unaffected. `flex-end` puts the pill's un-stuck position at the
+   bottom of that height, so `sticky; bottom: 0` below engages immediately
+   on any scrollable page. */
 .r-v2-bottom-nav-anchor {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
**Description**

On iOS Safari, the v2 mobile bottom nav (`BottomNav.vue`) could visually detach from the bottom of the screen during and after scrolling, ending up stuck floating mid-screen instead of pinned to the bottom edge. This reproduced consistently on a real iPhone across multiple pages (Home, Settings, Gallery, Game Details) but never in a resized desktop Safari window.

Root cause: iOS Safari has a known engine-level issue where `position: fixed` elements can lose their correct viewport anchor during a scroll gesture and never properly reset, even after scrolling stops. On-device debugging (via Web Inspector) confirmed the element's layout box was frozen at a stale offset — and critically, this persisted even under a manually forced, synchronous relayout (toggling `display` off/on), which normally forces a fresh layout pass in any browser. That ruled out a page-level CSS/JS fix aimed at `position: fixed` itself.

The fix switches `BottomNav.vue` from `position: fixed` to `position: sticky`, wrapped in a full-height, non-flow-affecting anchor (`position: absolute; inset: 0` with `flex-direction: column; justify-content: flex-end`) so the pill's natural (un-stuck) position sits at the bottom of the full page height. `position: sticky` is computed through the ordinary layout pipeline rather than the separate fixed-to-viewport mechanism, so it isn't subject to the same bug. The anchor doesn't contribute to its parent's layout height (same as the old `fixed` element didn't), so no other view's bottom-nav clearance calculations needed to change.

Note: `AppNav.vue` (the top nav) still uses `position: fixed` and was intentionally left unchanged — it isn't meant to behave like a sticky element, and there's no evidence it has the same issue.

**AI assistance disclosure**

This PR was developed with Claude Code: diagnosing the bug (including live on-device debugging via Safari Web Inspector) and implementing/iterating on the fix were done in collaboration with Claude, with the author driving device testing and reviewing/directing each step.

**Testing**

- Reproduced the original bug on a real iPhone (Safari) against a local dev build.
- Verified the fix resolves it on the same device across Home, Settings, a game detail page, and gallery/platform browsing.
- `npm run typecheck`, ESLint, Prettier, `npm run test` (636/636 passing), and `npm run build` all pass.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes (this is a CSS/browser-layout behavioral fix not practically covered by the Vitest/happy-dom unit test environment)

#### Screenshots (if applicable)

N/A