### PR TITLE
feat(hasheous): map famicom to the NES platform

### DIFF
--- a/backend/handler/metadata/hasheous_handler.py
+++ b/backend/handler/metadata/hasheous_handler.py
@@ -850,6 +850,14 @@ HASHEOUS_PLATFORM_LIST: dict[UPS, SlugToHasheousId] = {
         "ra_id": 57,
         "tgdb_id": None,
     },
+    UPS.FAMICOM: {
+        "id": 68,
+        "igdb_id": 18,
+        "igdb_slug": "nes",
+        "name": "Nintendo Entertainment System",
+        "ra_id": 7,
+        "tgdb_id": None,
+    },
     UPS.FDS: {
         "id": 54692,
         "igdb_id": 51,


### PR DESCRIPTION
**Description**

Famicom ROMs were never sent to Hasheous. The scan gates the Hasheous hash lookup on `platform.hasheous_id` (`scan_handler.py:505` and `:841`), and `HASHEOUS_PLATFORM_LIST` had no `famicom` entry, so the lookup was skipped before any hashing mattered.

Hasheous has no standalone Famicom platform. Its NES data object ([id 68](https://hasheous.org/index.html?page=dataobjectdetail&type=platform&id=68)) covers both regional variants: its signature sets include `NES/Famicom` and `Nintendo Famicom & Entertainment System`, and the games cited in the issue are in that object's verified No-Intro set. This maps `UPS.FAMICOM` to platform 68, mirroring the existing NES entry. The same aliasing already exists in the other handlers, where famicom maps to RA id 7 (`ra_handler.py:430`) and to the NES thumbnail set (`libretro_handler.py:231`).

No platform metadata regression: `igdb_id`, `ra_id` and `name` still resolve from IGDB (99, "Family Computer") and RA (7), which take priority over the Hasheous fallbacks in `scan_handler.py:250-265`. The Hasheous ID only opens the lookup and drives the provider link in the UI; matching itself is hash-based and platform-agnostic.

Note that `UPS.FDS` is unchanged and remains mapped to the Disk System (54692), which is a separate platform from Famicom cartridges.

Fixes #4157

**AI assistance disclosure**

Written with Claude Code (Claude Opus 5). The mapping was verified against the live Hasheous API (`/api/v1/DataObjects/Platform`) to confirm that no separate Famicom platform exists among its 681 platform objects and that object 68 carries the Famicom signature sets. All output was reviewed by me before submitting.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

<sup>This is a one-line data entry in an existing platform table, which has no test coverage today; happy to add one if you'd prefer. Verified locally that `get_platform("famicom")` now returns `hasheous_id: 68`. The backend suite could not be run in my environment (unrelated local alembic/database state), so I'm relying on CI for it.</sup>
