### PR TITLE
fix(hashing): surface unreadable zip and tar archives

### DIFF
--- a/backend/handler/filesystem/roms_handler.py
+++ b/backend/handler/filesystem/roms_handler.py
@@ -491,7 +491,10 @@ class FSRomsHandler(FSHandler):
                             }
                         )
                 except ArchiveReadError as e:
-                    log.error(f"Incomplete read of archive {rom_dir}: {e}")
+                    log.error(
+                        f"Incomplete read of archive {rom_dir}: {e}. Hashing the "
+                        "archive itself instead, which won't match a hash database."
+                    )
                     return [], original_crc, None, None
                 return members, crc, md5_h, sha1_h
 

--- a/backend/tests/handler/filesystem/test_roms_handler.py
+++ b/backend/tests/handler/filesystem/test_roms_handler.py
@@ -1118,9 +1118,8 @@ class TestFSRomsHandler:
 
         parsed = await test_handler.get_rom_files(rom)
 
-        # On a malformed zip, the reader yields nothing and the fallback path
-        # hashes the archive file itself; read_zip_file's BadZipFile guard
-        # routes that to raw-byte hashing.
+        # On a malformed zip, the reader raises ArchiveReadError and the
+        # fallback path hashes the archive file itself.
         assert parsed.md5_hash == hashlib.md5(junk, usedforsecurity=False).hexdigest()
         assert parsed.sha1_hash == hashlib.sha1(junk, usedforsecurity=False).hexdigest()
         assert len(parsed.rom_files) == 1

--- a/backend/tests/utils/test_archives.py
+++ b/backend/tests/utils/test_archives.py
@@ -1,10 +1,12 @@
 import time
+import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from utils import archives
+from utils.zip_cache import _ensure_zipfile_writable
 
 
 def _fake_7z_listing(names: list[str]) -> str:
@@ -471,3 +473,62 @@ class TestRarArchives:
             "--",
             "game.gba",
         ]
+
+
+class TestZipAndTarReadFailures:
+    """Unreadable zip/tar archives must be reported, not silently swallowed.
+
+    A swallowed failure yields no members, which the hashing path can't tell
+    apart from an empty archive: it falls back to hashing the container's raw
+    bytes, so the ROM ends up with hashes that match no hash database and no
+    log line saying why (GitHub issue #4159).
+    """
+
+    def _write_zip(self, path: Path, members: dict[str, bytes]) -> None:
+        # Importing `archives` patches zipfile for Enhanced Deflate, which
+        # leaves the writer unusable until this is called.
+        _ensure_zipfile_writable()
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_STORED) as z:
+            for name, data in members.items():
+                z.writestr(name, data)
+
+    def test_unopenable_zip_raises(self, tmp_path):
+        path = tmp_path / "game.zip"
+        path.write_bytes(b"not a zip at all")
+
+        with pytest.raises(archives.ArchiveReadError):
+            list(archives.read_zip_archive_files(path, [], []))
+
+    def test_corrupt_zip_member_raises_while_streaming(self, tmp_path):
+        """The failure surfaces as the member's bytes are consumed, which
+        happens outside the reader's own error handling."""
+        path = tmp_path / "game.zip"
+        self._write_zip(path, {"a.bin": b"A" * 64, "b.bin": b"B" * 64})
+
+        # Corrupt b.bin's stored data so its CRC check fails on read.
+        raw = bytearray(path.read_bytes())
+        start = raw.index(b"B" * 64)
+        raw[start : start + 64] = b"C" * 64
+        path.write_bytes(bytes(raw))
+
+        with pytest.raises(archives.ArchiveReadError):
+            for _name, _size, chunks in archives.read_zip_archive_files(path, [], []):
+                list(chunks)
+
+    def test_healthy_zip_streams_every_member(self, tmp_path):
+        path = tmp_path / "game.zip"
+        self._write_zip(path, {"b.bin": b"B" * 32, "a.bin": b"A" * 16})
+
+        result = [
+            (name, size, b"".join(chunks))
+            for name, size, chunks in archives.read_zip_archive_files(path, [], [])
+        ]
+
+        assert result == [("a.bin", 16, b"A" * 16), ("b.bin", 32, b"B" * 32)]
+
+    def test_unopenable_tar_raises(self, tmp_path):
+        path = tmp_path / "game.tar"
+        path.write_bytes(b"not a tar at all")
+
+        with pytest.raises(archives.ArchiveReadError):
+            list(archives.read_tar_archive_files(path, [], []))

--- a/backend/tests/utils/test_archives.py
+++ b/backend/tests/utils/test_archives.py
@@ -559,8 +559,8 @@ class TestZipAndTarReadFailures:
         covered directly here for every archive type that uses it.
         """
 
-        class _FailingReader(io.RawIOBase):
-            def read(self, size=-1):
+        class _FailingReader(io.BytesIO):
+            def read(self, size: int | None = -1) -> bytes:
                 raise EOFError("Compressed file ended before the end-of-stream marker")
 
         with pytest.raises(archives.ArchiveReadError):

--- a/backend/tests/utils/test_archives.py
+++ b/backend/tests/utils/test_archives.py
@@ -1,3 +1,5 @@
+import io
+import tarfile
 import time
 import zipfile
 from pathlib import Path
@@ -532,3 +534,34 @@ class TestZipAndTarReadFailures:
 
         with pytest.raises(archives.ArchiveReadError):
             list(archives.read_tar_archive_files(path, [], []))
+
+    def test_truncated_tar_raises(self, tmp_path):
+        path = tmp_path / "game.tar"
+        with tarfile.open(path, "w") as tf:
+            for name, data in (("a.bin", b"A" * 4096), ("b.bin", b"B" * 8192)):
+                info = tarfile.TarInfo(name)
+                info.size = len(data)
+                tf.addfile(info, io.BytesIO(data))
+
+        # Cut into the second member's data, not just the trailing padding.
+        raw = path.read_bytes()
+        path.write_bytes(raw[: len(raw) // 2])
+
+        with pytest.raises(archives.ArchiveReadError):
+            for _name, _size, chunks in archives.read_tar_archive_files(path, [], []):
+                list(chunks)
+
+    def test_member_read_failure_is_wrapped(self):
+        """A member that fails mid-stream is reported as an archive error.
+
+        Tar failures surface while listing rather than while streaming, since
+        `getmembers()` walks the whole archive first, so the streaming guard is
+        covered directly here for every archive type that uses it.
+        """
+
+        class _FailingReader(io.RawIOBase):
+            def read(self, size=-1):
+                raise EOFError("Compressed file ended before the end-of-stream marker")
+
+        with pytest.raises(archives.ArchiveReadError):
+            list(archives._iter_chunks(_FailingReader(), Path("/fake.tar.gz"), "a.bin"))

--- a/backend/utils/archives.py
+++ b/backend/utils/archives.py
@@ -10,6 +10,7 @@ import tempfile
 import threading
 import time
 import zipfile
+import zlib
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import IO, Final, Literal
@@ -221,9 +222,24 @@ def read_bz2_file(file_path: Path) -> Iterator[bytes]:
             yield chunk
 
 
-def _iter_chunks(reader: IO[bytes]) -> Iterator[bytes]:
-    while chunk := reader.read(FILE_READ_CHUNK_SIZE):
-        yield chunk
+def _iter_chunks(reader: IO[bytes], file_path: Path, name: str) -> Iterator[bytes]:
+    """Stream a member's bytes, raising `ArchiveReadError` if it can't be read.
+
+    Chunks are consumed by the caller, outside the reader's own error
+    handling, so decompression failures (a bad CRC, truncated data) surface
+    here rather than escaping as a raw zipfile/tarfile error.
+    """
+    try:
+        while chunk := reader.read(FILE_READ_CHUNK_SIZE):
+            yield chunk
+    except (
+        zipfile.BadZipFile,
+        tarfile.TarError,
+        zlib.error,
+        EOFError,
+        OSError,
+    ) as e:
+        raise ArchiveReadError(f"Error reading {name} from {file_path}: {e}") from e
 
 
 def read_zip_archive_files(
@@ -236,6 +252,9 @@ def read_zip_archive_files(
     Each yielded `(internal_name, file_size_bytes, chunks)` streams its
     member's bytes lazily; chunks must be fully consumed before advancing
     to the next entry, since the underlying file is closed at that point.
+
+    Raises `ArchiveReadError` if the archive can't be read in full, so callers
+    never mistake a partial read for a complete one.
     """
     try:
         with zipfile.ZipFile(file_path, "r") as z:
@@ -254,9 +273,9 @@ def read_zip_archive_files(
                 ):
                     continue
                 with z.open(entry, "r") as f:
-                    yield name, entry.file_size, _iter_chunks(f)
-    except (zipfile.BadZipFile, RuntimeError, OSError):
-        return
+                    yield name, entry.file_size, _iter_chunks(f, file_path, name)
+    except (zipfile.BadZipFile, RuntimeError, NotImplementedError, OSError) as e:
+        raise ArchiveReadError(f"Error reading zip {file_path}: {e}") from e
 
 
 def read_tar_archive_files(
@@ -269,6 +288,9 @@ def read_tar_archive_files(
     Each yielded `(internal_name, file_size_bytes, chunks)` streams its
     member's bytes lazily; chunks must be fully consumed before advancing
     to the next entry, since the underlying file is closed at that point.
+
+    Raises `ArchiveReadError` if the archive can't be read in full, so callers
+    never mistake a partial read for a complete one.
     """
     try:
         with tarfile.open(file_path, "r:*") as tf:
@@ -295,9 +317,9 @@ def read_tar_archive_files(
                     continue
 
                 with ef:
-                    yield member.name, member.size, _iter_chunks(ef)
-    except tarfile.ReadError:
-        return
+                    yield member.name, member.size, _iter_chunks(ef, file_path, name)
+    except (tarfile.TarError, OSError) as e:
+        raise ArchiveReadError(f"Error reading tar {file_path}: {e}") from e
 
 
 def _stream_7z_chunks(


### PR DESCRIPTION
**Description**

`read_zip_archive_files` and `read_tar_archive_files` caught their read failures and returned an empty iterator. The hashing path can't distinguish that from an empty archive, so it takes the fallback at `roms_handler.py:518` and hashes the container's raw bytes, leaving the ROM with hashes that match no hash database, `archive_members: null`, and nothing in the logs to explain it. That is what #4159 reports: one archived ROM whose hashes match the inner file (correct) and another whose hashes match the zip (this fallback).

The 7z and rar readers already raise `ArchiveReadError` for exactly this reason, and `_hash_archive_entries` catches and logs it. This makes zip and tar behave the same way.

Two failure modes are covered:

- **Open/list failure** (not a zip, corrupt central directory, encrypted, unsupported compression) now raises instead of yielding nothing. The end result is still the raw-bytes fallback, but it is logged with the underlying reason rather than being silent.
- **Member stream failure** (bad CRC, truncated member data) now raises `ArchiveReadError` too. Member chunks are consumed by the caller, outside the reader's own `try`, so a `BadZipFile` raised mid-stream previously escaped `_hash_archive_entries` as a raw zipfile error instead of degrading to the fallback.

The log line on the fallback now also states that the archive itself was hashed and won't match a hash database, since that is the user-visible symptom.

**Verification**

Reproduced both paths before and after against real archives (a non-zip payload, a zip corrupted in its first member, and a zip corrupted only inside its second member's data). Added tests in `tests/utils/test_archives.py`. Behavior for healthy archives is unchanged, as are the existing empty-archive and all-entries-excluded fallbacks.

Fixes #4159

**AI assistance disclosure**

Investigated and written with Claude Code (Claude Opus 5), including the reproduction of both failure paths. All output was reviewed by me before submitting.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

<sub>The new `tests/utils/test_archives.py` cases pass locally. The suites that need the test database (including the existing archive-fallback cases in `tests/handler/filesystem/test_roms_handler.py`) could not be run in my environment, so I'm relying on CI for those.</sub>
