### PR TITLE
feat(soundtrack player): improve artwork

### DIFF
--- a/frontend/src/stores/soundtrackPlayer.test.ts
+++ b/frontend/src/stores/soundtrackPlayer.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { FRONTEND_RESOURCES_PATH } from "@/utils";
+import {
+  resolveSoundtrackGameArtwork,
+  type SoundtrackArtworkRom,
+} from "./soundtrackPlayer";
+
+function makeRom(
+  overrides: Partial<SoundtrackArtworkRom> = {},
+): SoundtrackArtworkRom {
+  return {
+    ss_metadata: null,
+    launchbox_metadata: null,
+    platform_slug: "psx",
+    path_cover_large: null,
+    path_cover_small: null,
+    url_cover: null,
+    ...overrides,
+  } as SoundtrackArtworkRom;
+}
+
+describe("resolveSoundtrackGameArtwork", () => {
+  it("prefers the ScreenScraper disc over the logo on a CD system", () => {
+    const url = resolveSoundtrackGameArtwork(
+      makeRom({
+        ss_metadata: { physical_path: "disc.png", logo_path: "logo.png" },
+      }),
+    );
+    expect(url).toBe(`${FRONTEND_RESOURCES_PATH}/disc.png`);
+  });
+
+  it("falls back to the LaunchBox disc when ScreenScraper has none", () => {
+    const url = resolveSoundtrackGameArtwork(
+      makeRom({
+        ss_metadata: { logo_path: "logo.png" },
+        launchbox_metadata: {
+          images: [
+            {
+              url: "https://images.launchbox-app.com/box.png",
+              type: "Box - Front",
+            },
+            { url: "https://images.launchbox-app.com/disc.png", type: "Disc" },
+          ],
+        },
+      }),
+    );
+    expect(url).toBe("https://images.launchbox-app.com/disc.png");
+  });
+
+  it("skips LaunchBox media the browser cannot load", () => {
+    const url = resolveSoundtrackGameArtwork(
+      makeRom({
+        ss_metadata: { logo_path: "logo.png" },
+        launchbox_metadata: {
+          images: [
+            { url: "launchbox-file://Images/PS1/Disc/game.png", type: "Disc" },
+          ],
+        },
+      }),
+    );
+    expect(url).toBe(`${FRONTEND_RESOURCES_PATH}/logo.png`);
+  });
+
+  it("ignores physical media on a non-CD system", () => {
+    const url = resolveSoundtrackGameArtwork(
+      makeRom({
+        platform_slug: "snes",
+        ss_metadata: { physical_path: "cart.png", logo_path: "logo.png" },
+        launchbox_metadata: {
+          images: [
+            { url: "https://images.launchbox-app.com/disc.png", type: "Disc" },
+          ],
+        },
+      }),
+    );
+    expect(url).toBe(`${FRONTEND_RESOURCES_PATH}/logo.png`);
+  });
+
+  it("falls back to the cover chain when no artwork is scraped", () => {
+    expect(
+      resolveSoundtrackGameArtwork(
+        makeRom({ path_cover_small: "small.png", url_cover: "remote.png" }),
+      ),
+    ).toBe("small.png");
+    expect(resolveSoundtrackGameArtwork(makeRom())).toBeUndefined();
+  });
+});

--- a/frontend/src/stores/soundtrackPlayer.ts
+++ b/frontend/src/stores/soundtrackPlayer.ts
@@ -4,7 +4,7 @@ import { defineStore } from "pinia";
 import { computed, ref, shallowRef } from "vue";
 import type { TrackMetaSchema } from "@/__generated__";
 import type { DetailedRom } from "@/stores/roms";
-import { FRONTEND_RESOURCES_PATH } from "@/utils";
+import { FRONTEND_RESOURCES_PATH, isCDBasedSystem } from "@/utils";
 
 const volumeStorage = useLocalStorage<number>("soundtrack.volume", 1);
 const mutedStorage = useLocalStorage<boolean>("soundtrack.muted", false);
@@ -32,20 +32,48 @@ export type PlayerMeta = {
 
 export type SoundtrackArtworkRom = Pick<
   DetailedRom,
-  "ss_metadata" | "path_cover_large" | "path_cover_small" | "url_cover"
+  | "ss_metadata"
+  | "launchbox_metadata"
+  | "platform_slug"
+  | "path_cover_large"
+  | "path_cover_small"
+  | "url_cover"
 >;
+
+// LaunchBox image type depicting the physical disc.
+const LAUNCHBOX_DISC_TYPE = "disc";
+
+// LaunchBox media can be a `launchbox-file://` URI pointing at the server's
+// local LaunchBox folder, which the browser cannot load.
+function isBrowserLoadable(url: string): boolean {
+  return /^https?:\/\//i.test(url) || url.startsWith("/");
+}
+
+function launchboxDiscArtwork(rom: SoundtrackArtworkRom): string | undefined {
+  return rom.launchbox_metadata?.images?.find(
+    (image) =>
+      (image.type ?? "").trim().toLowerCase() === LAUNCHBOX_DISC_TYPE &&
+      isBrowserLoadable(image.url),
+  )?.url;
+}
 
 export function resolveSoundtrackGameArtwork(
   rom: SoundtrackArtworkRom,
 ): string | undefined {
+  // A disc scan reads as album art, so it outranks the logo on CD systems.
+  if (isCDBasedSystem(rom.platform_slug)) {
+    const physicalPath = rom.ss_metadata?.physical_path;
+    if (physicalPath) return `${FRONTEND_RESOURCES_PATH}/${physicalPath}`;
+
+    const discUrl = launchboxDiscArtwork(rom);
+    if (discUrl) return discUrl;
+  }
+
   const logoPath = rom.ss_metadata?.logo_path;
   if (logoPath) return `${FRONTEND_RESOURCES_PATH}/${logoPath}`;
 
   return (
-    rom.path_cover_large ??
-    rom.path_cover_small ??
-    rom.url_cover ??
-    undefined
+    rom.path_cover_large ?? rom.path_cover_small ?? rom.url_cover ?? undefined
   );
 }
 

--- a/frontend/src/stores/soundtrackPlayer.ts
+++ b/frontend/src/stores/soundtrackPlayer.ts
@@ -30,8 +30,13 @@ export type PlayerMeta = {
   gameArtworkUrl?: string;
 };
 
+export type SoundtrackArtworkRom = Pick<
+  DetailedRom,
+  "ss_metadata" | "path_cover_large" | "path_cover_small" | "url_cover"
+>;
+
 export function resolveSoundtrackGameArtwork(
-  rom: DetailedRom,
+  rom: SoundtrackArtworkRom,
 ): string | undefined {
   const logoPath = rom.ss_metadata?.logo_path;
   if (logoPath) return `${FRONTEND_RESOURCES_PATH}/${logoPath}`;

--- a/frontend/src/stores/soundtrackPlayer.ts
+++ b/frontend/src/stores/soundtrackPlayer.ts
@@ -3,6 +3,8 @@ import { throttle } from "lodash";
 import { defineStore } from "pinia";
 import { computed, ref, shallowRef } from "vue";
 import type { TrackMetaSchema } from "@/__generated__";
+import type { DetailedRom } from "@/stores/roms";
+import { FRONTEND_RESOURCES_PATH } from "@/utils";
 
 const volumeStorage = useLocalStorage<number>("soundtrack.volume", 1);
 const mutedStorage = useLocalStorage<boolean>("soundtrack.muted", false);
@@ -25,7 +27,22 @@ export type PlayerMeta = {
   duration?: number;
   coverUrl?: string;
   folderCoverUrl?: string;
+  gameArtworkUrl?: string;
 };
+
+export function resolveSoundtrackGameArtwork(
+  rom: DetailedRom,
+): string | undefined {
+  const logoPath = rom.ss_metadata?.logo_path;
+  if (logoPath) return `${FRONTEND_RESOURCES_PATH}/${logoPath}`;
+
+  return (
+    rom.path_cover_large ??
+    rom.path_cover_small ??
+    rom.url_cover ??
+    undefined
+  );
+}
 
 const useSoundtrackPlayer = defineStore("soundtrackPlayer", () => {
   const track = ref<PlayerTrack | null>(null);

--- a/frontend/src/v2/components/GameDetails/SoundtrackPanel.vue
+++ b/frontend/src/v2/components/GameDetails/SoundtrackPanel.vue
@@ -677,6 +677,7 @@ function seekValueText(v: number): string {
   display: grid;
   place-items: center;
   background: color-mix(in srgb, black 45%, transparent);
+  z-index: 3;
 }
 
 @keyframes r-v2-stp-spin {

--- a/frontend/src/v2/components/GameDetails/SoundtrackPanel.vue
+++ b/frontend/src/v2/components/GameDetails/SoundtrackPanel.vue
@@ -106,9 +106,7 @@ const folderCoverUrl = computed(() => {
   return cover ? fileUrl(cover.id, cover.file_name) : null;
 });
 
-const gameArtworkUrl = computed(() =>
-  resolveSoundtrackGameArtwork(props.rom),
-);
+const gameArtworkUrl = computed(() => resolveSoundtrackGameArtwork(props.rom));
 
 // ---------- Metadata fetch ----------
 const tracksMeta = ref<Map<number, TrackMetaSchema>>(new Map());

--- a/frontend/src/v2/components/GameDetails/SoundtrackPanel.vue
+++ b/frontend/src/v2/components/GameDetails/SoundtrackPanel.vue
@@ -30,6 +30,7 @@ import type { DetailedRom } from "@/stores/roms";
 import useSoundtrackPlayer, {
   type PlayerMeta,
   type PlayerTrack,
+  resolveSoundtrackGameArtwork,
 } from "@/stores/soundtrackPlayer";
 import { FRONTEND_RESOURCES_PATH, formatBytes } from "@/utils";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
@@ -105,6 +106,10 @@ const folderCoverUrl = computed(() => {
   return cover ? fileUrl(cover.id, cover.file_name) : null;
 });
 
+const gameArtworkUrl = computed(() =>
+  resolveSoundtrackGameArtwork(props.rom),
+);
+
 // ---------- Metadata fetch ----------
 const tracksMeta = ref<Map<number, TrackMetaSchema>>(new Map());
 const isLoadingMeta = ref(false);
@@ -127,6 +132,7 @@ function toPlayerMeta(m: TrackMetaSchema | undefined): PlayerMeta {
     duration: m?.duration_seconds ?? undefined,
     coverUrl: coverUrlForMeta(m) ?? undefined,
     folderCoverUrl: folderCoverUrl.value ?? undefined,
+    gameArtworkUrl: gameArtworkUrl.value,
   };
 }
 
@@ -207,6 +213,7 @@ const activeArtUrl = computed(
   () =>
     coverUrlForMeta(activeMeta.value) ??
     folderCoverUrl.value ??
+    gameArtworkUrl.value ??
     "/assets/default/album_cover.jpg",
 );
 
@@ -355,16 +362,16 @@ function seekValueText(v: number): string {
   <div class="r-v2-stp">
     <!-- Now playing / placeholder header -->
     <header class="r-v2-stp__now">
-      <div
-        class="r-v2-stp__cover"
-        :class="{ 'r-v2-stp__cover--spinning': activeTrack && isPlaying }"
-      >
-        <img
+      <div class="r-v2-stp__cover">
+        <div
           v-if="activeArtUrl"
-          :src="activeArtUrl"
-          class="r-v2-stp__cover-img"
-          alt=""
-        />
+          class="r-v2-stp__cover-rotor"
+          :class="{
+            'r-v2-stp__cover-rotor--spinning': activeTrack && isPlaying,
+          }"
+        >
+          <img :src="activeArtUrl" class="r-v2-stp__cover-img" alt="" />
+        </div>
         <RIcon v-else icon="mdi-music-note" size="48" />
         <div
           v-if="activeTrack && isBuffering"
@@ -629,15 +636,24 @@ function seekValueText(v: number): string {
     0 0 0 4px color-mix(in srgb, black 20%, transparent);
 }
 
-.r-v2-stp__cover-img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+.r-v2-stp__cover-rotor {
+  position: absolute;
+  inset: 0;
+  transform-origin: 50% 50%;
+  transform-box: border-box;
   animation: r-v2-stp-spin 12s linear infinite;
   animation-play-state: paused;
 }
 
-.r-v2-stp__cover--spinning .r-v2-stp__cover-img {
+.r-v2-stp__cover-img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+}
+
+.r-v2-stp__cover-rotor--spinning {
   animation-play-state: running;
 }
 
@@ -673,7 +689,7 @@ function seekValueText(v: number): string {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .r-v2-stp__cover-img {
+  .r-v2-stp__cover-rotor {
     animation: none;
   }
 }

--- a/frontend/src/v2/components/Soundtrack/MiniPlayer.vue
+++ b/frontend/src/v2/components/Soundtrack/MiniPlayer.vue
@@ -63,6 +63,7 @@ const coverUrl = computed(
   () =>
     meta.value.coverUrl ??
     meta.value.folderCoverUrl ??
+    meta.value.gameArtworkUrl ??
     "/assets/default/album_cover.jpg",
 );
 
@@ -196,12 +197,13 @@ function openRom() {
     >
       <!-- Top row: cover + meta + close/open-rom -->
       <div class="r-v2-mp__top">
-        <div
-          class="r-v2-mp__disc"
-          :class="{ 'r-v2-mp__disc--spinning': isPlaying }"
-          aria-hidden="true"
-        >
-          <img :src="coverUrl" class="r-v2-mp__disc-img" alt="" />
+        <div class="r-v2-mp__disc" aria-hidden="true">
+          <div
+            class="r-v2-mp__disc-rotor"
+            :class="{ 'r-v2-mp__disc-rotor--spinning': isPlaying }"
+          >
+            <img :src="coverUrl" class="r-v2-mp__disc-img" alt="" />
+          </div>
           <div v-if="isBuffering" class="r-v2-mp__disc-buffering">
             <RSpinner :size="20" :width="2" color="white" />
           </div>
@@ -347,15 +349,24 @@ html[data-bp~="sm-and-down"] .r-v2-mp {
   flex-shrink: 0;
   box-shadow: 0 0 0 2px color-mix(in srgb, black 50%, transparent);
 }
-.r-v2-mp__disc-img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+.r-v2-mp__disc-rotor {
+  position: absolute;
+  inset: 0;
+  transform-origin: 50% 50%;
+  transform-box: border-box;
   animation: r-v2-mp-spin 12s linear infinite;
   animation-play-state: paused;
 }
-.r-v2-mp__disc--spinning .r-v2-mp__disc-img {
+.r-v2-mp__disc-rotor--spinning {
   animation-play-state: running;
+}
+
+.r-v2-mp__disc-img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
 }
 /* Static vinyl-record spindle — gives the rotation a fixed visual
    reference so the spin reads as motion rather than a flat circle. */
@@ -390,7 +401,7 @@ html[data-bp~="sm-and-down"] .r-v2-mp {
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .r-v2-mp__disc-img {
+  .r-v2-mp__disc-rotor {
     animation: none;
   }
 }


### PR DESCRIPTION
## Description
Soundtrack artwork helps users identify the currently playing game and track at a glance. Previously, the player only displayed embedded ID3 artwork or an image stored in the soundtrack folder, otherwise falling back directly to the default album image.

This change adds game artwork fallbacks and improves how artwork rotates in both the embedded soundtrack player and floating mini-player.

**Changes:**
- Preserve embedded ID3 artwork as the highest-priority source
- Preserve soundtrack-folder images as the second-priority source
- Use the game logo when track-specific artwork is unavailable
- Fall back to the canonical game cover when no logo is available
- Keep the default album image as the final fallback
- Share the resolved game artwork with the persistent mini-player
- Add a dedicated full-size rotor layer to both players
- Align the rotation axis with the fixed vinyl spindle
- Zoom and center artwork to fill the circular frame without empty areas
- Respect the user's reduced-motion preference

**Artwork Priority:**
1. Embedded ID3 artwork
2. Soundtrack-folder image
3. Game logo
4. Game cover
5. Default album image

## Testing
- [x] Verify embedded ID3 artwork is displayed after scanning
- [x] Verify the embedded player artwork rotates while playing
- [x] Verify the floating mini-player artwork rotates while playing
- [x] Verify the rotation axis remains aligned with the center spindle
- [x] Verify game artwork fills the circular player frame

## Screenshots : test using game cover 
https://github.com/user-attachments/assets/dfdc3120-ed6c-45c7-b182-c22400daa5ae

## AI Assistance Disclosure
This PR was developed with Codex assistance. Codex was used to inspect the soundtrack player implementation.