### PR TITLE
fix: stop repeating the main franchise in the franchise list

### DIFF
--- a/backend/handler/metadata/igdb_handler.py
+++ b/backend/handler/metadata/igdb_handler.py
@@ -241,9 +241,13 @@ def extract_metadata_from_igdb_rom(
             "aggregated_rating": str(round(rom.get("aggregated_rating", 0.0), 2)),
             "first_release_date": rom.get("first_release_date", None),
             "genres": [g.get("name", "") for g in genres if g.get("name")],
-            "franchises": pydash.compact(
-                [franchise.get("name") if franchise else None]
-                + [f.get("name", "") for f in franchises if f.get("name")]
+            # IGDB reports the main franchise both on its own and inside the
+            # list, so the two sources overlap for most games that have one.
+            "franchises": pydash.uniq(
+                pydash.compact(
+                    [franchise.get("name") if franchise else None]
+                    + [f.get("name", "") for f in franchises if f.get("name")]
+                )
             ),
             "alternative_names": [
                 n.get("name", "") for n in alternative_names if n.get("name")

--- a/backend/tests/handler/metadata/test_igdb_handler.py
+++ b/backend/tests/handler/metadata/test_igdb_handler.py
@@ -16,6 +16,7 @@ from handler.metadata.igdb_handler import (
     IGDBHandler,
     _build_platforms_where,
     _platform_igdb_ids_with_twin,
+    extract_metadata_from_igdb_rom,
     get_igdb_preferred_locale,
 )
 from handler.redis_handler import async_cache
@@ -879,3 +880,43 @@ class TestSearchRomPrefixSupersetVariant:
         assert result is not None
         assert result["id"] == 42
         search_mock.assert_not_awaited()
+
+
+class TestFranchiseDeduplication:
+    """IGDB sends the main franchise both on its own and inside `franchises`.
+
+    Measured on a 14,952-game library: 1,080 of 8,788 games carrying a
+    franchise carried it twice (12.3%), reaching the details page as
+    "Happy Feet, Happy Feet".
+    """
+
+    @staticmethod
+    def _extract(**overrides) -> dict:
+        game = _make_game(1, "Test Game")
+        game.update(overrides)
+        return extract_metadata_from_igdb_rom(IGDBHandler(), game, GENESIS_IGDB_ID)
+
+    def test_the_main_franchise_is_not_repeated_inside_the_list(self):
+        metadata = self._extract(
+            franchise={"name": "Happy Feet"},
+            franchises=[{"name": "Happy Feet"}, {"name": "Mumble"}],
+        )
+
+        assert metadata["franchises"] == ["Happy Feet", "Mumble"]
+
+    def test_the_main_franchise_stays_first(self):
+        """`gamelist` exports `franchises[0]` as <family>, so order matters."""
+        metadata = self._extract(
+            franchise={"name": "Metroid"},
+            franchises=[{"name": "Metroid"}, {"name": "Super Metroid"}],
+        )
+
+        assert metadata["franchises"][0] == "Metroid"
+
+    def test_distinct_franchises_are_both_kept(self):
+        metadata = self._extract(
+            franchise={"name": "Madden"},
+            franchises=[{"name": "NFL"}],
+        )
+
+        assert metadata["franchises"] == ["Madden", "NFL"]


### PR DESCRIPTION
**Description**

IGDB sends the main franchise twice: once on its own as `franchise`, and again inside the `franchises` list. The two are concatenated with `pydash.compact`, which drops falsy values but not duplicates, so the repeat is stored and rendered. The details page shows "Happy Feet, Happy Feet" and "Dragon Ball, Dragon Ball".

Measured on a real 14,952-game library: **1,080 of 8,788** games carrying a franchise carried it twice (12.3%).

The fix is `pydash.uniq`, which preserves first-seen order. That matters here: `gamelist_exporter` writes `franchises[0]` out as `<family>`, and the duplicate is always the main franchise, which is already first, so the exported value is unchanged. There is one test asserting exactly that.

### Notes for review

- **Display only.** Nothing scores or groups on this list in a way the duplicate skews.
- **Existing libraries keep the repeat until the affected games are rescanned**, since it is already stored in `igdb_metadata`. I did not add a data migration to rewrite those blobs, on the grounds that rewriting every row's JSON for a cosmetic fix is disproportionate. Happy to add one if you would rather it self-heal.
- I found this while sampling metadata for other work, not from a bug report.

### A related problem I am deliberately not fixing here

The same duplication affects the `companies` list, and more of it: 1,310 lists on my library repeat a name, because IGDB's `involved_companies` has one entry per involvement (a studio that both made and shipped a game appears twice), ScreenScraper fills `editeur` and `developpeur` separately, and RetroAchievements fills `Publisher` and `Developer`.

I had that in this PR and removed it, because the review flagged that both exporters read `companies` **positionally** — `[0]` as developer, `[1]` as publisher — so deduplicating drops the publisher line for exactly the games where one company holds both roles.

Following that thread, the positional convention is already wrong for two providers:

| Provider | `companies` order | Exporter reads `[0]` as |
| --- | --- | --- |
| RetroAchievements | `[Publisher, Developer]` | developer |
| ScreenScraper | `[editeur, developpeur]` (publisher first) | developer |
| IGDB | `involved_companies` order (no role meaning) | developer |

So for any RA- or SS-matched game with both fields populated, the exported developer and publisher are swapped today.

Deduplicating a list whose entries cannot be interpreted is not the fix; the roles need storing separately, and the exporters need to read them instead of guessing by position. That is a schema change plus an export change, so it belongs in its own PR rather than in this one.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Three new tests: the repeat collapses, the main franchise stays at index 0, and genuinely distinct franchises are both kept. `tests/handler/metadata/test_igdb_handler.py` and both exporter suites: 69 passed.

#### Screenshots (if applicable)

Not applicable: the change removes a repeated word from a list that already renders correctly otherwise.

---

### AI Assistance Notice

This PR was written with Claude Code (Opus 5) — the fix, the tests and this description — directed and reviewed by me. Flagging it per the project's policy.
