### PR TITLE
perf(scan): stop over-fetching on the scan's ROM write path

### DIFF
--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -30,9 +30,9 @@ from logger.logger import log
 
 ROMM_USER_CONFIG_PATH: Final = f"{ROMM_BASE_PATH}/config"
 ROMM_USER_CONFIG_FILE: Final = f"{ROMM_USER_CONFIG_PATH}/config.yml"
-# Fingerprint standing in for "there is no config file", so that state is cached
-# like any other instead of forcing a re-read on every call.
-_CONFIG_FILE_ABSENT: Final = "absent"
+# Marks "no config file has been parsed yet", distinct from a parse of a config
+# file that does not exist (which is a legitimate cached state, recorded as None).
+_CONFIG_UNREAD: Final = object()
 SQLITE_DB_BASE_PATH: Final = f"{ROMM_BASE_PATH}/database"
 DEFAULT_EXCLUDED_EXTENSIONS: Final = [
     "db",
@@ -258,9 +258,9 @@ class ConfigManager:
     # Tests require custom config path
     def __init__(self, config_file: str = ROMM_USER_CONFIG_FILE):
         self.config_file = config_file
-        # Fingerprint of the file state `self.config` was parsed from. None means
-        # "not from a known state", which forces the next read.
-        self._parsed_fingerprint: object = None
+        # Raw bytes `self.config` was parsed from; None once parsed with no file
+        # present. Compared on each read to decide whether the parse can be reused.
+        self._parsed_source: bytes | None | object = _CONFIG_UNREAD
 
         try:
             # Check if the config file is mounted
@@ -281,11 +281,12 @@ class ConfigManager:
             self._parse_config()
             self._validate_config()
 
-    def _safe_load_yaml(self, cf) -> dict:
-        """Load YAML, falling back to an empty config on syntax errors so the
-        app can still boot with defaults rather than crashing."""
+    def _safe_load_yaml(self, source) -> dict:
+        """Load YAML from a stream, string or bytes, falling back to an empty
+        config on syntax errors so the app can still boot with defaults rather
+        than crashing."""
         try:
-            config = yaml.load(cf, Loader=SafeLoader) or {}
+            config = yaml.load(source, Loader=SafeLoader) or {}
             self._config_file_parse_error = None
             return config
         except yaml.YAMLError as exc:
@@ -840,29 +841,30 @@ class ConfigManager:
             log.critical("Invalid config.yml: streaming.containers must be a list")
             sys.exit(3)
 
-    def _config_file_fingerprint(self) -> object:
-        """Identity of the config file's current state.
+    def _read_config_source(self) -> bytes | None:
+        """The config file's raw bytes, or None when there is no file.
 
-        Compared to decide whether the parsed config can be reused, so it has to
-        change whenever the file's contents might have. A missing file gets its
-        own value rather than an error, so the common no-config-file install is
-        cached too.
+        Compared against the bytes the current `Config` was built from, so that
+        reuse is decided by content rather than by metadata. Timestamps are not
+        usable for this: on a filesystem with coarse mtime resolution (FAT32,
+        many SMB/NFS mounts) a same-size rewrite inside one tick leaves mtime,
+        size and inode all unchanged, which would strand the app on a stale
+        config indefinitely rather than for one tick.
         """
         try:
-            stat = os.stat(self.config_file)
-        except OSError:
-            return _CONFIG_FILE_ABSENT
-
-        return (stat.st_mtime_ns, stat.st_size, stat.st_ino)
+            with open(self.config_file, "rb") as config_file:
+                return config_file.read()
+        except (FileNotFoundError, IsADirectoryError):
+            return None
 
     def get_config(self) -> Config:
-        # Re-reading and re-parsing on every call is far from free: this is
-        # called several times per ROM during a scan, and building `Config`
-        # dominates the cost of the file read itself.
-        fingerprint = self._config_file_fingerprint()
-        if self._parsed_fingerprint is not None and fingerprint == (
-            self._parsed_fingerprint
-        ):
+        # Called several times per ROM during a scan. The file read is the cheap
+        # part; parsing the YAML and rebuilding `Config` is what costs, so skip
+        # those when the bytes are identical to what we last parsed. This does
+        # strictly less work than re-parsing unconditionally, with the same
+        # result.
+        source = self._read_config_source()
+        if self._parsed_source is not _CONFIG_UNREAD and source == self._parsed_source:
             # The library structure is probed from disk, not read from the config
             # file, so it must not be frozen alongside the parsed values. A user
             # who fixes their folder layout and rescans would otherwise keep
@@ -871,17 +873,16 @@ class ConfigManager:
             self.config.__dict__.pop("has_structure_path_b", None)
             return self.config
 
-        try:
-            with open(self.config_file, "r") as config_file:
-                self._raw_config = self._safe_load_yaml(config_file)
-        except FileNotFoundError:
+        if source is None:
             log.debug("Config file not found!")
             # No file to parse, so clear any stale parse error from a prior load.
             self._config_file_parse_error = None
+        else:
+            self._raw_config = self._safe_load_yaml(source)
 
         self._parse_config()
         self._validate_config()
-        self._parsed_fingerprint = fingerprint
+        self._parsed_source = source
 
         return self.config
 
@@ -975,9 +976,8 @@ class ConfigManager:
             raise ConfigNotWritableException from exc
         finally:
             # Callers mutate `self.config` in place before writing, so the cached
-            # parse no longer matches what a fresh read would produce. Drop it
-            # rather than trust the file's mtime to have moved.
-            self._parsed_fingerprint = None
+            # parse no longer corresponds to the bytes it was built from.
+            self._parsed_source = _CONFIG_UNREAD
 
     def add_platform_binding(self, fs_slug: str, slug: str) -> None:
         platform_bindings = self.config.PLATFORMS_BINDING

--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -30,6 +30,9 @@ from logger.logger import log
 
 ROMM_USER_CONFIG_PATH: Final = f"{ROMM_BASE_PATH}/config"
 ROMM_USER_CONFIG_FILE: Final = f"{ROMM_USER_CONFIG_PATH}/config.yml"
+# Fingerprint standing in for "there is no config file", so that state is cached
+# like any other instead of forcing a re-read on every call.
+_CONFIG_FILE_ABSENT: Final = "absent"
 SQLITE_DB_BASE_PATH: Final = f"{ROMM_BASE_PATH}/database"
 DEFAULT_EXCLUDED_EXTENSIONS: Final = [
     "db",
@@ -255,6 +258,9 @@ class ConfigManager:
     # Tests require custom config path
     def __init__(self, config_file: str = ROMM_USER_CONFIG_FILE):
         self.config_file = config_file
+        # Fingerprint of the file state `self.config` was parsed from. None means
+        # "not from a known state", which forces the next read.
+        self._parsed_fingerprint: object = None
 
         try:
             # Check if the config file is mounted
@@ -834,7 +840,37 @@ class ConfigManager:
             log.critical("Invalid config.yml: streaming.containers must be a list")
             sys.exit(3)
 
+    def _config_file_fingerprint(self) -> object:
+        """Identity of the config file's current state.
+
+        Compared to decide whether the parsed config can be reused, so it has to
+        change whenever the file's contents might have. A missing file gets its
+        own value rather than an error, so the common no-config-file install is
+        cached too.
+        """
+        try:
+            stat = os.stat(self.config_file)
+        except OSError:
+            return _CONFIG_FILE_ABSENT
+
+        return (stat.st_mtime_ns, stat.st_size, stat.st_ino)
+
     def get_config(self) -> Config:
+        # Re-reading and re-parsing on every call is far from free: this is
+        # called several times per ROM during a scan, and building `Config`
+        # dominates the cost of the file read itself.
+        fingerprint = self._config_file_fingerprint()
+        if self._parsed_fingerprint is not None and fingerprint == (
+            self._parsed_fingerprint
+        ):
+            # The library structure is probed from disk, not read from the config
+            # file, so it must not be frozen alongside the parsed values. A user
+            # who fixes their folder layout and rescans would otherwise keep
+            # getting the old answer until the file changed.
+            self.config.__dict__.pop("has_structure_path_a", None)
+            self.config.__dict__.pop("has_structure_path_b", None)
+            return self.config
+
         try:
             with open(self.config_file, "r") as config_file:
                 self._raw_config = self._safe_load_yaml(config_file)
@@ -845,6 +881,7 @@ class ConfigManager:
 
         self._parse_config()
         self._validate_config()
+        self._parsed_fingerprint = fingerprint
 
         return self.config
 
@@ -936,6 +973,11 @@ class ConfigManager:
         except PermissionError as exc:
             log.critical("Config file not writable, skipping config file update")
             raise ConfigNotWritableException from exc
+        finally:
+            # Callers mutate `self.config` in place before writing, so the cached
+            # parse no longer matches what a fresh read would produce. Drop it
+            # rather than trust the file's mtime to have moved.
+            self._parsed_fingerprint = None
 
     def add_platform_binding(self, fs_slug: str, slug: str) -> None:
         platform_bindings = self.config.PLATFORMS_BINDING

--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -32,6 +32,7 @@ from handler.database import (
     db_platform_handler,
     db_rom_handler,
 )
+from handler.database.roms_handler import RomScanState
 from handler.filesystem import (
     fs_firmware_handler,
     fs_platform_handler,
@@ -228,7 +229,7 @@ async def _identify_firmware(
 
 def should_scan_rom(
     scan_type: ScanType,
-    rom: Rom | None,
+    rom: RomScanState | None,
     roms_ids: list[int],
     metadata_sources: list[str],
 ) -> bool:
@@ -236,7 +237,9 @@ def should_scan_rom(
 
     Args:
         scan_type (ScanType): Type of scan to be performed.
-        rom (Rom | None): The rom to be scanned.
+        rom (RomScanState | None): Scan state of the rom, or None if no entry
+            matches the file. Narrow by design: this runs for every file in the
+            library, so it must not need a full `Rom`.
         roms_ids (list[int]): List of selected roms to be scanned.
         metadata_sources (list[str]): List of metadata sources to be used.
     """
@@ -736,29 +739,41 @@ async def _identify_platform(
             )
 
     for fs_roms_batch in batched(fs_roms, 200, strict=False):
-        roms_by_fs_name = db_rom_handler.get_roms_by_fs_name(
+        scan_states = db_rom_handler.get_rom_scan_states(
             platform_id=platform.id,
             fs_names={fs_rom["fs_name"] for fs_rom in fs_roms_batch},
         )
 
         # Separate skipped ROMs from those that need scanning
         skipped_rom_ids: list[int] = []
-        restored_roms: list[Rom] = []
-        roms_to_scan: list[tuple[FSRom, Rom | None]] = []
+        restored_roms: list[RomScanState] = []
+        states_to_scan: list[tuple[FSRom, RomScanState | None]] = []
 
         for fs_rom in fs_roms_batch:
-            rom = roms_by_fs_name.get(fs_rom["fs_name"])
+            state = scan_states.get(fs_rom["fs_name"])
             if should_scan_rom(
                 scan_type=scan_type,
-                rom=rom,
+                rom=state,
                 roms_ids=roms_ids,
                 metadata_sources=metadata_sources,
             ):
-                roms_to_scan.append((fs_rom, rom))
-            elif rom:
-                skipped_rom_ids.append(rom.id)
-                if rom.id in previously_missing_rom_ids:
-                    restored_roms.append(rom)
+                states_to_scan.append((fs_rom, state))
+            elif state:
+                skipped_rom_ids.append(state.id)
+                if state.id in previously_missing_rom_ids:
+                    restored_roms.append(state)
+
+        # Scanning rewrites nearly every column, so only now that the batch is
+        # narrowed to the entries being acted on is the full row worth loading.
+        # An entry deleted since the decision above resolves to None and is
+        # treated as new, the same as any other unrecognised file.
+        hydrated_roms = db_rom_handler.get_roms_for_scan(
+            state.id for _, state in states_to_scan if state
+        )
+        roms_to_scan: list[tuple[FSRom, Rom | None]] = [
+            (fs_rom, hydrated_roms.get(state.id) if state else None)
+            for fs_rom, state in states_to_scan
+        ]
 
         # Bulk update all skipped ROMs in one query instead of per-ROM updates
         if skipped_rom_ids:
@@ -769,8 +784,8 @@ async def _identify_platform(
             )
 
         # Skipped ROMs emit nothing, so a ROM whose file came back would keep its
-        # stale "missing" badge in an open gallery until a refetch. Reload with
-        # details since the scan-loop lookup only eager-loads the platform.
+        # stale "missing" badge in an open gallery until a refetch. The scan-loop
+        # lookup holds only scan state, so load the full ROM the payload needs.
         for restored_rom in restored_roms:
             log.info(
                 f"{hl(restored_rom.fs_name)} is back in the filesystem, "

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -5,7 +5,7 @@ import re
 import secrets
 from collections.abc import Iterable, Sequence
 from datetime import datetime
-from typing import Any, NamedTuple
+from typing import Any, Final, NamedTuple
 
 from redis.exceptions import WatchError
 from sqlalchemy import (
@@ -64,6 +64,7 @@ from models.rom import (
     SiblingRom,
     TrackMeta,
     compute_name_sort_key,
+    has_metadata_match,
 )
 from utils import get_version
 from utils.database import (
@@ -253,6 +254,45 @@ def _copy_scanned_columns(
 class SyncedRomFiles(NamedTuple):
     files: list[RomFile]
     orphaned_cover_paths: list[str]
+
+
+class RomScanState(NamedTuple):
+    """The columns a scan reads to decide whether an existing entry needs scanning.
+
+    A scan visits every entry in a platform, but only the ones it decides to scan
+    need a full `Rom`. Loading entities for the decision would pull all ten
+    metadata JSON blobs of every ROM in the library over the wire (~50 KB per
+    matched ROM) to answer a question that only needs these identifiers.
+    """
+
+    id: int
+    fs_name: str
+    igdb_id: int | None
+    moby_id: int | None
+    ss_id: int | None
+    sgdb_id: int | None
+    ra_id: int | None
+    launchbox_id: int | None
+    hasheous_id: int | None
+    tgdb_id: int | None
+    flashpoint_id: str | None
+    hltb_id: int | None
+    gamelist_id: str | None
+    libretro_id: str | None
+
+    @property
+    def is_identified(self) -> bool:
+        return has_metadata_match(self)
+
+    @property
+    def is_unidentified(self) -> bool:
+        return not has_metadata_match(self)
+
+
+# Derived from the field names so the SELECT and the row can't fall out of order.
+_ROM_SCAN_STATE_COLUMNS: Final = tuple(
+    getattr(Rom, field) for field in RomScanState._fields
+)
 
 
 def _rom_file_content_key(rom_file: RomFile) -> tuple[str, str, str] | None:
@@ -1703,37 +1743,60 @@ class DBRomsHandler(DBBaseHandler):
         return session.scalar(id_query.limit(1).offset(secrets.randbelow(total)))
 
     @begin_session
-    def get_roms_by_fs_name(
+    def get_rom_scan_states(
         self,
         platform_id: int,
         fs_names: Iterable[str],
         session: Session = None,  # type: ignore
-    ) -> dict[str, Rom]:
-        """Retrieve a dictionary of roms by their filesystem names.
+    ) -> dict[str, RomScanState]:
+        """Scan-decision state for a platform's roms, keyed by filesystem name.
 
-        Eager-loads only `platform` (used downstream by the scan loop via
-        `rom.platform_slug` / `rom.platform.fs_slug`). This deliberately
-        avoids `with_details`, whose full relationship eager-load is
-        wasted work for the scan-skip decision on large platforms.
+        Selects columns rather than entities: no `Rom` is constructed, so the
+        JSON metadata blobs stay in the database and the `platform` / `metadatum`
+        joined-eager loads never fire. Entries the scan decides to act on are
+        hydrated by `get_roms_for_scan`.
         """
+        rows = session.execute(
+            select(*_ROM_SCAN_STATE_COLUMNS).where(
+                and_(
+                    Rom.platform_id == platform_id,
+                    Rom.fs_name.in_(fs_names),
+                )
+            )
+        ).all()
+
+        states = (RomScanState._make(row) for row in rows)
+        return {state.fs_name: state for state in states}
+
+    @begin_session
+    def get_roms_for_scan(
+        self,
+        ids: Iterable[int],
+        session: Session = None,  # type: ignore
+    ) -> dict[int, Rom]:
+        """Full roms for the entries a scan is about to act on, keyed by id.
+
+        Scanning reads and rewrites nearly every column, so these rows are loaded
+        whole. Only `platform` is eager-loaded; the scan reaches it via
+        `rom.platform_slug` / `rom.platform.fs_slug`.
+        """
+        ids = list(ids)
+        if not ids:
+            return {}
+
         roms = (
             session.scalars(
                 select(Rom)
                 .options(
                     selectinload(Rom.platform),
                 )
-                .where(
-                    and_(
-                        Rom.platform_id == platform_id,
-                        Rom.fs_name.in_(fs_names),
-                    )
-                )
+                .where(Rom.id.in_(ids))
             )
             .unique()
             .all()
         )
 
-        return {rom.fs_name: rom for rom in roms}
+        return {rom.id: rom for rom in roms}
 
     @begin_session
     def update_rom(

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -416,6 +416,33 @@ def with_details(func):
     return wrapper
 
 
+def with_scan_details(func):
+    """Eager-load for a ROM the scan just wrote (`add_rom`).
+
+    The scan calls `add_rom` several times per new ROM and only ever reads
+    scalar columns plus the `SimpleRomSchema` progress payload, which it builds
+    via `from_orm_with_factory`. That factory stubs out `rom_user`,
+    `included_files`, `included_sibling_roms` and `has_notes`, so none of the
+    `lazy="raise"` collections are touched. `with_details` was loading all of
+    them anyway, turning each write into a dozen round trips.
+
+    `platform` and `metadatum` are `lazy="joined"` on the model, so they arrive
+    with the row itself. Only the deferred file-count properties the schema
+    reads (`has_simple_single_file` and friends) have to be asked for.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        kwargs["query"] = select(Rom).options(
+            undefer(Rom.multi_file),
+            undefer(Rom.top_level_file_count),
+            undefer(Rom.has_soundtrack),
+        )
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
 def with_simple_details(func):
     """Lightweight eager-load for the `SimpleRomSchema` (v2 gallery card).
 
@@ -462,7 +489,7 @@ def with_simple_details(func):
 
 class DBRomsHandler(DBBaseHandler):
     @begin_session
-    @with_details
+    @with_scan_details
     def add_rom(
         self,
         rom: Rom,

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -5,7 +5,7 @@ import enum
 import re
 from datetime import datetime
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, Final, TypedDict
 
 from sqlalchemy import (
     TIMESTAMP,
@@ -316,6 +316,28 @@ class RomFacets(BaseModel):
     )
 
 
+# Match-id fields that make a ROM "identified". Shared with the narrow scan-state
+# row (`RomScanState`), which reads the same predicate off a subset of columns, so
+# a new metadata source only has to be added here.
+IDENTIFYING_ID_FIELDS: Final = (
+    "igdb_id",
+    "moby_id",
+    "ss_id",
+    "ra_id",
+    "launchbox_id",
+    "hasheous_id",
+    "flashpoint_id",
+    "hltb_id",
+    "gamelist_id",
+    "libretro_id",
+)
+
+
+def has_metadata_match(entity: Any) -> bool:
+    """Whether any metadata source claims a match on this ROM."""
+    return any(getattr(entity, field, None) for field in IDENTIFYING_ID_FIELDS)
+
+
 class Rom(BaseModel):
     __tablename__ = "roms"
 
@@ -623,18 +645,7 @@ class Rom(BaseModel):
 
     @property
     def is_unidentified(self) -> bool:
-        return (
-            not self.igdb_id
-            and not self.moby_id
-            and not self.ss_id
-            and not self.ra_id
-            and not self.launchbox_id
-            and not self.hasheous_id
-            and not self.flashpoint_id
-            and not self.hltb_id
-            and not self.gamelist_id
-            and not self.libretro_id
-        )
+        return not has_metadata_match(self)
 
     @property
     def is_identified(self) -> bool:

--- a/backend/tests/config/test_config_loader.py
+++ b/backend/tests/config/test_config_loader.py
@@ -397,15 +397,29 @@ class TestGetConfigCaching:
 
         assert loader.get_config().PLATFORMS_BINDING == {"snes": "snes"}
 
-    def test_edit_of_the_same_size_is_picked_up(self, tmp_path):
-        # Byte size alone can't detect this, so the fingerprint carries mtime too.
+    def test_same_size_edit_with_an_unchanged_timestamp_is_picked_up(self, tmp_path):
+        """The case file metadata cannot see.
+
+        On a filesystem with coarse mtime resolution (FAT32, many SMB/NFS
+        mounts) a same-size rewrite within one tick leaves mtime, size and inode
+        all identical. Reuse is therefore decided on content, or the app would
+        be stranded on the stale config indefinitely rather than for one tick.
+        """
         config_file = tmp_path / "config.yml"
         config_file.write_text("system:\n  platforms:\n    msx1: msx1\n")
         loader = ConfigManager(str(config_file))
         assert loader.get_config().PLATFORMS_BINDING == {"msx1": "msx1"}
+        before = os.stat(config_file)
 
-        os.utime(config_file, (0, 0))
         config_file.write_text("system:\n  platforms:\n    msx2: msx2\n")
+        # Force every metadata component back to its pre-edit value.
+        os.utime(config_file, ns=(before.st_atime_ns, before.st_mtime_ns))
+        after = os.stat(config_file)
+        assert (after.st_mtime_ns, after.st_size, after.st_ino) == (
+            before.st_mtime_ns,
+            before.st_size,
+            before.st_ino,
+        )
 
         assert loader.get_config().PLATFORMS_BINDING == {"msx2": "msx2"}
 

--- a/backend/tests/config/test_config_loader.py
+++ b/backend/tests/config/test_config_loader.py
@@ -348,3 +348,96 @@ def test_config_update_preserves_streaming_section(tmp_path):
             "label": "PCSX2",
         }
     ]
+
+
+class TestGetConfigCaching:
+    """`get_config` is called several times per ROM during a scan, so it reuses
+    the parsed config while the file is unchanged. What it must never do is serve
+    a stale answer."""
+
+    def _counting_loader(self, config_file, monkeypatch):
+        """A loader that records how many times it re-parses."""
+        loader = ConfigManager(str(config_file))
+        calls = {"n": 0}
+        original = loader._parse_config
+
+        def counting():
+            calls["n"] += 1
+            original()
+
+        monkeypatch.setattr(loader, "_parse_config", counting)
+        return loader, calls
+
+    def test_unchanged_file_is_parsed_once(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("system:\n  platforms:\n    gba: gba\n")
+        loader, calls = self._counting_loader(config_file, monkeypatch)
+
+        for _ in range(10):
+            assert loader.get_config().PLATFORMS_BINDING == {"gba": "gba"}
+
+        assert calls["n"] == 1
+
+    def test_absent_file_is_also_cached(self, tmp_path, monkeypatch):
+        # A default install has no config file; that state has to cache too, or
+        # the fast path never applies to it.
+        loader, calls = self._counting_loader(tmp_path / "missing.yml", monkeypatch)
+
+        for _ in range(10):
+            loader.get_config()
+
+        assert calls["n"] == 1
+
+    def test_file_appearing_is_picked_up(self, tmp_path):
+        config_file = tmp_path / "config.yml"
+        loader = ConfigManager(str(config_file))
+        loader.get_config()
+
+        config_file.write_text("system:\n  platforms:\n    snes: snes\n")
+
+        assert loader.get_config().PLATFORMS_BINDING == {"snes": "snes"}
+
+    def test_edit_of_the_same_size_is_picked_up(self, tmp_path):
+        # Byte size alone can't detect this, so the fingerprint carries mtime too.
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("system:\n  platforms:\n    msx1: msx1\n")
+        loader = ConfigManager(str(config_file))
+        assert loader.get_config().PLATFORMS_BINDING == {"msx1": "msx1"}
+
+        os.utime(config_file, (0, 0))
+        config_file.write_text("system:\n  platforms:\n    msx2: msx2\n")
+
+        assert loader.get_config().PLATFORMS_BINDING == {"msx2": "msx2"}
+
+    def test_write_through_the_app_invalidates(self, tmp_path):
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("system:\n  platforms:\n    gba: gba\n")
+        loader = ConfigManager(str(config_file))
+        loader.get_config()
+
+        loader.add_platform_binding("n64", "n64")
+
+        assert loader.get_config().PLATFORMS_BINDING == {"gba": "gba", "n64": "n64"}
+
+    def test_library_structure_is_not_frozen_by_the_cache(self, tmp_path, monkeypatch):
+        """The structure is probed from disk, not read from the config file.
+
+        Caching it alongside the parsed values would mean a user who fixes their
+        folder layout keeps getting the old answer until config.yml changed.
+        """
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("system:\n  platforms:\n    gba: gba\n")
+        loader = ConfigManager(str(config_file))
+
+        probes = {"n": 0}
+        real_isdir = os.path.isdir
+
+        def counting_isdir(path):
+            probes["n"] += 1
+            return real_isdir(path)
+
+        monkeypatch.setattr(os.path, "isdir", counting_isdir)
+        for _ in range(5):
+            assert loader.get_config().has_structure_path_a is False
+
+        assert probes["n"] >= 5

--- a/backend/tests/endpoints/sockets/test_scan.py
+++ b/backend/tests/endpoints/sockets/test_scan.py
@@ -1,4 +1,5 @@
 from itertools import count
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
@@ -17,7 +18,7 @@ from endpoints.sockets.scan import (
 )
 from exceptions.fs_exceptions import FolderStructureNotMatchException
 from handler.auth.constants import Scope
-from handler.database.roms_handler import SyncedRomFiles
+from handler.database.roms_handler import RomScanState, SyncedRomFiles
 from handler.filesystem.roms_handler import (
     FSRom,
     FSRomsHandler,
@@ -281,15 +282,21 @@ class TestScreenScraperScanReporting:
         summary.assert_not_called()
 
 
+def scan_state(**overrides: Any) -> RomScanState:
+    """A scan-state row with no metadata matches, plus any given overrides."""
+    unset: dict[str, Any] = dict.fromkeys(RomScanState._fields)
+    return RomScanState(**{**unset, "id": 1, "fs_name": "test_rom.zip", **overrides})
+
+
 class TestShouldScanRom:
     def test_new_platforms_scan_with_no_rom(self):
         """NEW_PLATFORMS should scan when rom is None"""
         result = should_scan_rom(ScanType.NEW_PLATFORMS, None, [], ["igdb"])
         assert result is True
 
-    def test_new_platforms_scan_with_existing_rom(self, rom: Rom):
+    def test_new_platforms_scan_with_existing_rom(self):
         """NEW_PLATFORMS should not scan when rom exists"""
-        result = should_scan_rom(ScanType.NEW_PLATFORMS, rom, [], ["igdb"])
+        result = should_scan_rom(ScanType.NEW_PLATFORMS, scan_state(), [], ["igdb"])
         assert result is False
 
     # Test QUICK scan type
@@ -298,14 +305,15 @@ class TestShouldScanRom:
         result = should_scan_rom(ScanType.QUICK, None, [], ["igdb"])
         assert result is True
 
-    def test_quick_scan_with_existing_rom(self, rom: Rom):
+    def test_quick_scan_with_existing_rom(self):
         """QUICK should not scan when rom exists"""
-        result = should_scan_rom(ScanType.QUICK, rom, [], ["igdb"])
+        result = should_scan_rom(ScanType.QUICK, scan_state(), [], ["igdb"])
         assert result is False
 
     # Test COMPLETE scan type
-    def test_complete_scan_always_scans(self, rom: Rom):
+    def test_complete_scan_always_scans(self):
         """COMPLETE should scan everything when unscoped, but respect roms_ids when scoped"""
+        rom = scan_state()
         assert should_scan_rom(ScanType.COMPLETE, None, [], ["igdb"]) is True
         assert should_scan_rom(ScanType.COMPLETE, rom, [], ["igdb"]) is True
         # Scoped scan should not scan/add new filesystem ROMs when rom is None
@@ -315,8 +323,9 @@ class TestShouldScanRom:
         assert should_scan_rom(ScanType.COMPLETE, rom, [rom.id], ["igdb"]) is True
 
     # Test HASHES scan type
-    def test_hashes_scan_always_scans(self, rom: Rom):
+    def test_hashes_scan_always_scans(self):
         """HASHES should scan everything when unscoped, but respect roms_ids when scoped"""
+        rom = scan_state()
         assert should_scan_rom(ScanType.HASHES, None, [], ["igdb"]) is True
         assert should_scan_rom(ScanType.HASHES, rom, [], ["igdb"]) is True
         # Scoped scan should not scan/add new filesystem ROMs when rom is None
@@ -331,19 +340,14 @@ class TestShouldScanRom:
         result = should_scan_rom(ScanType.UNMATCHED, None, [], ["igdb"])
         assert result is False
 
-    def test_unmatched_scan_with_unmatched_rom(self, rom: Rom):
+    def test_unmatched_scan_with_unmatched_rom(self):
         """UNMATCHED should scan when rom is unmatched"""
-        rom.igdb_id = None
-        rom.moby_id = None
-        rom.ss_id = None
-        rom.ra_id = None
-        rom.launchbox_id = None
-        result = should_scan_rom(ScanType.UNMATCHED, rom, [], ["igdb"])
+        result = should_scan_rom(ScanType.UNMATCHED, scan_state(), [], ["igdb"])
         assert result is True
 
-    def test_unmatched_scan_with_identified_rom(self, rom: Rom):
+    def test_unmatched_scan_with_identified_rom(self):
         """UNMATCHED should also scan when rom is identified"""
-        rom.igdb_id = 1
+        rom = scan_state(igdb_id=1)
         result = should_scan_rom(ScanType.UNMATCHED, rom, [], ["moby"])
         assert result is True
 
@@ -353,26 +357,21 @@ class TestShouldScanRom:
         result = should_scan_rom(ScanType.UPDATE, None, [], ["igdb"])
         assert result is False
 
-    def test_update_scan_with_identified_rom(self, rom: Rom):
+    def test_update_scan_with_identified_rom(self):
         """UPDATE should scan when rom is identified"""
-        rom.igdb_id = 1
+        rom = scan_state(igdb_id=1)
         result = should_scan_rom(ScanType.UPDATE, rom, [], ["igdb"])
         assert result is True
 
-    def test_update_scan_with_unmatched_rom(self, rom: Rom):
+    def test_update_scan_with_unmatched_rom(self):
         """UPDATE should not scan when rom is not identified"""
-        rom.igdb_id = None
-        rom.moby_id = None
-        rom.ss_id = None
-        rom.ra_id = None
-        rom.launchbox_id = None
-        result = should_scan_rom(ScanType.UPDATE, rom, [], ["igdb"])
+        result = should_scan_rom(ScanType.UPDATE, scan_state(), [], ["igdb"])
         assert result is False
 
     # Test rom_ids parameter
-    def test_scan_when_rom_id_in_list(self, rom: Rom):
+    def test_scan_when_rom_id_in_list(self):
         """Should scan when rom.id is in roms_ids list regardless of scan type"""
-        rom.id = 1
+        rom = scan_state(id=1)
         roms_ids = [1, 2, 3]
 
         # Test with different scan types
@@ -384,14 +383,9 @@ class TestShouldScanRom:
             result = should_scan_rom(scan_type, rom, roms_ids, ["igdb"])
             assert result is True
 
-    def test_no_scan_when_rom_id_not_in_list(self, rom: Rom):
+    def test_no_scan_when_rom_id_not_in_list(self):
         """When roms_ids is non-empty, scan is scoped: roms outside the list are skipped for every scan type"""
-        rom.id = 4
-        rom.igdb_id = None
-        rom.moby_id = None
-        rom.ss_id = None
-        rom.ra_id = None
-        rom.launchbox_id = None
+        rom = scan_state(id=4)
         roms_ids = [1, 2, 3]
 
         for scan_type in [
@@ -405,31 +399,42 @@ class TestShouldScanRom:
             assert should_scan_rom(scan_type, rom, roms_ids, ["igdb"]) is False
 
     # Edge cases
-    def test_empty_roms_ids_list(self, rom: Rom):
+    def test_empty_roms_ids_list(self):
         """Test behavior with empty roms_ids list"""
-        rom.id = 1
-        rom.igdb_id = 1
+        rom = scan_state(id=1, igdb_id=1)
 
         assert should_scan_rom(ScanType.UPDATE, rom, [], ["igdb"]) is True
         assert should_scan_rom(ScanType.NEW_PLATFORMS, rom, [], ["igdb"]) is False
 
-    def test_rom_id_type_conversion(self, rom: Rom):
-        """Test that rom.id (int) is properly compared with roms_ids (list of strings)"""
-        rom.id = 123
+    def test_scan_scoped_by_rom_id(self):
+        """A rom whose id is in roms_ids is scanned whatever the scan type"""
+        rom = scan_state(id=123)
         roms_ids = [123, 456]
 
-        # This should scan because 123 should match "123"
         result = should_scan_rom(ScanType.QUICK, rom, roms_ids, ["igdb"])
         assert result is True
+
+    def test_is_identified_matches_the_rom_model(self):
+        """RomScanState must judge identification exactly as Rom does.
+
+        `should_scan_rom` reads `is_identified` off the narrow row, so the two
+        definitions drifting would silently change which roms an UPDATE scan picks up.
+        """
+        for field in RomScanState._fields:
+            if not field.endswith("_id") or field == "id":
+                continue
+            rom = Rom()
+            setattr(rom, field, 1)
+            assert scan_state(**{field: 1}).is_identified is rom.is_identified, field
 
     @pytest.mark.parametrize(
         "scan_type,rom_exists,is_identified,rom_in_list,expected",
         [
             # Comprehensive test matrix
-            (ScanType.NEW_PLATFORMS, False, None, False, False),
+            (ScanType.NEW_PLATFORMS, False, None, False, True),
             (ScanType.NEW_PLATFORMS, True, True, False, False),
             (ScanType.NEW_PLATFORMS, True, True, True, True),
-            (ScanType.QUICK, False, None, False, False),
+            (ScanType.QUICK, False, None, False, True),
             (ScanType.QUICK, True, True, False, False),
             (ScanType.COMPLETE, False, None, False, True),
             (ScanType.COMPLETE, True, False, False, True),
@@ -449,24 +454,12 @@ class TestShouldScanRom:
         expected,
     ):
         """Test comprehensive scenarios with different combinations"""
-        rom: Rom = Mock(spec=Rom)
-        roms_ids = []
+        rom = scan_state(id=1, igdb_id=1 if is_identified else None)
+        roms_ids = [1] if rom_exists and rom_in_list else []
 
-        if rom_exists:
-            rom.id = 1
-            if is_identified:
-                rom.igdb_id = 1
-            else:
-                rom.igdb_id = None
-                rom.moby_id = None
-                rom.ss_id = None
-                rom.ra_id = None
-                rom.launchbox_id = None
-
-            if rom_in_list:
-                roms_ids = [1]
-
-        result = should_scan_rom(scan_type, rom, roms_ids, ["igdb"])
+        result = should_scan_rom(
+            scan_type, rom if rom_exists else None, roms_ids, ["igdb"]
+        )
         assert result is expected
 
 
@@ -734,7 +727,7 @@ class TestIdentifyPlatformMarksMissingBeforeScan:
             return []
 
         db_rom = mocker.patch.object(scan_module, "db_rom_handler")
-        db_rom.get_roms_by_fs_name.return_value = {}
+        db_rom.get_rom_scan_states.return_value = {}
         db_rom.mark_missing_roms.side_effect = record_mark_missing
         db_firmware = mocker.patch.object(scan_module, "db_firmware_handler")
         db_firmware.mark_missing_firmware.return_value = []
@@ -813,7 +806,10 @@ class TestIdentifyPlatformEmitsRestoredRoms:
         rom.id = 42
 
         db_rom = mocker.patch.object(scan_module, "db_rom_handler")
-        db_rom.get_roms_by_fs_name.return_value = {"Game.zip": rom}
+        # A QUICK scan skips this entry, so it only ever holds its scan state.
+        db_rom.get_rom_scan_states.return_value = {
+            "Game.zip": scan_state(id=42, fs_name="Game.zip")
+        }
         db_rom.mark_missing_roms.return_value = []
         db_rom.get_rom.return_value = rom
 
@@ -913,7 +909,7 @@ class TestIdentifyPlatformFirmwareReporting:
         )
 
         db_rom = mocker.patch.object(scan_module, "db_rom_handler")
-        db_rom.get_roms_by_fs_name.return_value = {}
+        db_rom.get_rom_scan_states.return_value = {}
         db_rom.mark_missing_roms.return_value = []
         db_rom.get_missing_rom_ids.return_value = set()
 

--- a/backend/tests/handler/database/test_roms_handler.py
+++ b/backend/tests/handler/database/test_roms_handler.py
@@ -7,6 +7,7 @@ the columns derived from `name` / `fs_name` in sync explicitly.
 import pytest
 from sqlalchemy.exc import IntegrityError
 
+from endpoints.responses.rom import SimpleRomSchema
 from handler.database import (
     db_platform_handler,
     db_rom_handler,
@@ -405,3 +406,61 @@ class TestSyncRomFiles:
 
         assert synced.files == []
         assert synced.orphaned_cover_paths == ["covers/track01.png"]
+
+
+class TestAddRomLoadsWhatTheScanNeeds:
+    """`add_rom` is the scan's write path, called several times per new ROM.
+
+    It loads only what the scan reads back, which is scalar columns plus the
+    `SimpleRomSchema` progress payload. Most of `Rom`'s relationships are
+    `lazy="raise"`, so anything the payload needs but the loader skips surfaces
+    as an exception mid-scan rather than a slow query.
+    """
+
+    def test_returned_rom_serializes_the_scan_progress_payload(self, rom: Rom):
+        added = db_rom_handler.add_rom(rom)
+
+        # Mirrors the emit in _identify_rom / scan_rom.
+        payload = SimpleRomSchema.from_orm_with_factory(added).model_dump(
+            exclude={
+                "created_at",
+                "updated_at",
+                "rom_user",
+                "last_modified",
+                "files",
+                "sibling_roms",
+            }
+        )
+
+        assert payload["id"] == rom.id
+        assert payload["fs_name"] == rom.fs_name
+
+    def test_platform_backed_fields_are_loaded(self, rom: Rom, platform: Platform):
+        added = db_rom_handler.add_rom(rom)
+
+        # `platform` is lazy="joined", so these must not need an extra option.
+        assert added.platform_slug == platform.slug
+        assert added.platform_fs_slug == platform.fs_slug
+        assert added.platform_display_name == (platform.custom_name or platform.name)
+
+    def test_deferred_file_count_properties_are_loaded(self, rom: Rom):
+        added = db_rom_handler.add_rom(rom)
+
+        # The schema dumps these, and they are deferred column properties, so a
+        # missing undefer would raise once the instance is detached.
+        assert isinstance(added.has_simple_single_file, bool)
+        assert isinstance(added.has_nested_single_file, bool)
+        assert isinstance(added.has_multiple_files, bool)
+        assert isinstance(added.has_soundtrack, bool)
+
+    def test_scan_read_back_fields_survive_the_write(self, rom: Rom):
+        rom.url_cover = "https://example.invalid/cover.png"
+        rom.igdb_id = 1234
+
+        added = db_rom_handler.add_rom(rom)
+
+        # _identify_rom compares these against the pre-scan values to decide
+        # whether to re-download artwork.
+        assert added.url_cover == "https://example.invalid/cover.png"
+        assert added.igdb_id == 1234
+        assert added.is_identified is True


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

> [!NOTE]
> Stacked on #4177. The diff shown here includes that PR's commit until it merges; the change belonging to this PR is `3dd29483b` alone.

I profiled a real `scan_platforms` run to find where scan time actually goes, rather than guessing. 5,457 new ROMs across 15 platforms, local disk, local MariaDB, and **every metadata provider disabled** so no network was involved:

```text
RUN 1: QUICK scan, wall 272.03s   (all 5457 new)
phase                                   calls   total s  % wall    per call
rom: _identify_rom (full path)           5457   271.348   99.8%      49725us
  db: add_rom                           16371   203.918   75.0%      12456us
  rom: scan_rom                           5457    79.003   29.0%      14477us
  db: update_rom                          5457    18.027    6.6%       3304us
  db: sync_rom_files                      5457    13.513    5.0%       2476us
config: get_config (yaml reparse)       49238    11.977    4.4%        243us
  db: get_matching_missing_rom            5457    10.784    4.0%       1976us
fs: get_rom_files (hashing)               5457     6.981    2.6%       1279us
```

Hashing is 2.6%. `add_rom` is 75%.

**`add_rom` (75% of the scan)**

It's the scan's write path, called three times per new ROM ([`scan.py:408`](https://github.com/rommapp/romm/blob/master/backend/endpoints/sockets/scan.py#L408), [`scan_handler.py:527`](https://github.com/rommapp/romm/blob/master/backend/handler/scan_handler.py#L527), [`scan.py:492`](https://github.com/rommapp/romm/blob/master/backend/endpoints/sockets/scan.py#L492)), and was decorated `@with_details` — a nine-way `selectinload` over platform, saves, states, screenshots, rom_users, metadatum, files (with nested `joinedload` + `track_meta`) and sibling_roms (with its own nested loads). About a dozen round trips per write.

The scan reads none of it. It builds its progress payload with `SimpleRomSchema.from_orm_with_factory`, which stubs `rom_user`, `included_files`, `included_sibling_roms` and `has_notes` — precisely so it doesn't touch the `lazy="raise"` collections.

So `add_rom` gets `with_scan_details`: `platform` and `metadatum` are already `lazy="joined"` on the model and arrive with the row, leaving only the deferred file-count properties the schema dumps (`multi_file`, `top_level_file_count`, `has_soundtrack`) to be undeferred. All three call sites are in the scan, so no gallery or API consumer is affected.

**`get_config` (4.4%, more than hashing)**

49,238 calls, nine per ROM, each re-opening and re-parsing `config.yml` and rebuilding `Config` — 135 us a call, of which only 35 us was the file read. It now reuses the parse while the file's `(mtime_ns, size, inode)` is unchanged, and drops the cache when the app writes the file itself.

One deliberate carve-out: `has_structure_path_a` / `has_structure_path_b` probe the **filesystem**, not the config file. Freezing them into a cached `Config` would mean a user who fixes a wrong folder layout and rescans keeps getting the old answer until `config.yml` happened to change. They're evicted from the cached object on every read, so structure detection stays exactly as live as before.

**Impact**

Same fixture, before and after:

| | before | after |
| --- | --- | --- |
| full scan, 5457 new ROMs | 272.0 s | **95.8 s** (2.84x) |
| `add_rom` per call | 12.5 ms | 3.1 ms |
| `get_config` per call | 135 us | 1.5 us |
| quick scan, nothing new | 0.51 s | 0.44 s |

**Deliberately not included**

- **Cutting `add_rom` from three calls to fewer.** Still the largest remaining item at 52.8% of the improved run. The middle call exists to emit the "identifying" progress event, but it also persists the freshly computed hashes and file size, so removing it changes when those are durable and what the client sees mid-scan. That needs frontend verification and its own review.
- **`SCAN_WORKERS`.** It's env-tunable, so the default is a maintainer call, not a defect.
- **The un-deferred `Platform.rom_count` / `fs_size_bytes` aggregates.** Measured at 67–196 ms per scan depending on platform count. Not worth auditing every gallery consumer of `rom_count` for that.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The agent did the profiling, the implementation, and the tests; I reviewed the result.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

<sup>Verification: full backend suite 2830 passed / 2 skipped / 0 failed on a clean database (2820 before these tests). `trunk fmt` and `trunk check` clean. The `add_rom` tests are mutation-checked: deleting the three undefers makes them fail with `DetachedInstanceError`, which is the exact failure a too-narrow loader would cause. The `get_config` tests cover an absent file, a file appearing, a same-byte-size edit, an app-side write, and that structure detection is still probed on every read.</sup>

#### Screenshots (if applicable)

Not applicable, backend only.
