### PR TITLE
fix: remove double URL-encoding of MobyGames search terms

### DIFF
--- a/backend/handler/metadata/moby_handler.py
+++ b/backend/handler/metadata/moby_handler.py
@@ -1,6 +1,5 @@
 import re
 from typing import Final, NotRequired, TypedDict
-from urllib.parse import quote
 
 import pydash
 from unidecode import unidecode as uc
@@ -110,7 +109,10 @@ class MobyGamesHandler(MetadataHandler):
 
         roms = await self.moby_service.list_games(
             platform_ids=[platform_moby_id],
-            title=quote(uc(search_term), safe="/ "),
+            # Pass the raw term: the service layer URL-encodes it exactly once
+            # when building the query. Pre-quoting here would double-encode
+            # special characters ("&" -> "%2526"), corrupting the search.
+            title=uc(search_term),
         )
         if not roms:
             return None
@@ -299,7 +301,8 @@ class MobyGamesHandler(MetadataHandler):
 
         matched_roms = await self.moby_service.list_games(
             platform_ids=[platform_moby_id],
-            title=quote(uc(search_term), safe="/ "),
+            # Raw term on purpose; see _search_rom for the double-encoding trap.
+            title=uc(search_term),
         )
 
         return [

--- a/backend/handler/metadata/moby_handler.py
+++ b/backend/handler/metadata/moby_handler.py
@@ -109,9 +109,7 @@ class MobyGamesHandler(MetadataHandler):
 
         roms = await self.moby_service.list_games(
             platform_ids=[platform_moby_id],
-            # Pass the raw term: the service layer URL-encodes it exactly once
-            # when building the query. Pre-quoting here would double-encode
-            # special characters ("&" -> "%2526"), corrupting the search.
+            # Pass the raw term to prevent double-encoding
             title=uc(search_term),
         )
         if not roms:
@@ -301,7 +299,6 @@ class MobyGamesHandler(MetadataHandler):
 
         matched_roms = await self.moby_service.list_games(
             platform_ids=[platform_moby_id],
-            # Raw term on purpose; see _search_rom for the double-encoding trap.
             title=uc(search_term),
         )
 

--- a/backend/tests/handler/metadata/test_moby_handler.py
+++ b/backend/tests/handler/metadata/test_moby_handler.py
@@ -41,3 +41,55 @@ class TestSonySerialFilenames:
         mock_hget.assert_awaited_once_with(PS1_SERIAL_INDEX_KEY, "SCUS-94163")
         assert result.get("name") == "Gran Turismo"
         assert result["moby_id"] is None
+
+
+class TestSearchTermEncoding:
+    """Tests that search terms are passed to the service layer unencoded."""
+
+    @pytest.mark.asyncio
+    async def test_search_rom_does_not_pre_encode_special_characters(self):
+        """The service layer URL-encodes the title exactly once via
+        ``with_query``. Regression: the handler pre-quoted the term, so titles
+        containing "&", "+" or "'" were double-encoded ("&" -> "%2526") and
+        never matched (e.g. "Sonic & Knuckles",
+        "Super Mario 3D World + Bowser's Fury")."""
+        handler = MobyGamesHandler()
+
+        with patch.object(
+            handler.moby_service,
+            "list_games",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_list_games:
+            await handler._search_rom("Sonic & Knuckles", platform_moby_id=16)
+
+        mock_list_games.assert_awaited_once()
+        title = mock_list_games.await_args.kwargs["title"]
+        assert title == "Sonic & Knuckles"
+        assert "%" not in title
+
+    @pytest.mark.asyncio
+    async def test_get_matched_roms_by_name_does_not_pre_encode(self):
+        """Same double-encoding regression for the manual-search path."""
+        handler = MobyGamesHandler()
+
+        with (
+            patch(
+                "handler.metadata.moby_handler.MobyGamesHandler.is_enabled",
+                return_value=True,
+            ),
+            patch.object(
+                handler.moby_service,
+                "list_games",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_list_games,
+        ):
+            await handler.get_matched_roms_by_name(
+                "Super Mario 3D World + Bowser's Fury", platform_moby_id=203
+            )
+
+        mock_list_games.assert_awaited_once()
+        title = mock_list_games.await_args.kwargs["title"]
+        assert title == "Super Mario 3D World + Bowser's Fury"
+        assert "%" not in title

--- a/backend/tests/handler/metadata/test_moby_handler.py
+++ b/backend/tests/handler/metadata/test_moby_handler.py
@@ -64,7 +64,9 @@ class TestSearchTermEncoding:
             await handler._search_rom("Sonic & Knuckles", platform_moby_id=16)
 
         mock_list_games.assert_awaited_once()
-        title = mock_list_games.await_args.kwargs["title"]
+        await_args = mock_list_games.await_args
+        assert await_args is not None
+        title = await_args.kwargs["title"]
         assert title == "Sonic & Knuckles"
         assert "%" not in title
 
@@ -90,6 +92,8 @@ class TestSearchTermEncoding:
             )
 
         mock_list_games.assert_awaited_once()
-        title = mock_list_games.await_args.kwargs["title"]
+        await_args = mock_list_games.await_args
+        assert await_args is not None
+        title = await_args.kwargs["title"]
         assert title == "Super Mario 3D World + Bowser's Fury"
         assert "%" not in title


### PR DESCRIPTION
### What

Removes the `quote()` pre-encoding of search terms in the MobyGames metadata
handler. The service layer (`MobyGamesService.list_games`) already URL-encodes
query parameters exactly once via yarl's `with_query()`, so pre-quoting in the
handler double-encoded every special character.

### Why

Titles containing `&`, `+`, or apostrophes could never match on MobyGames:

| Term | Query sent today (buggy) | Query after this PR |
|---|---|---|
| `Sonic & Knuckles` | `title=Sonic+%2526+Knuckles` | `title=Sonic+%26+Knuckles` |
| `Super Mario 3D World + Bowser's Fury` | `title=...+%252B+Bowser%2527s+Fury` | `title=...+%2B+Bowser's+Fury` |

MobyGames receives the literal string `Sonic %26 Knuckles` and finds nothing,
so these games stay unmatched on every scan.

This is the same bug class as #3467 (ScreenScraper): the ScreenScraper handler
was already changed to pass the raw term (`uc(search_term)`), but the MobyGames
handler still pre-quotes. This PR brings it in line.

### How

- `backend/handler/metadata/moby_handler.py`: pass `uc(search_term)` (raw,
  unidecoded) instead of `quote(uc(search_term), safe="/ ")` in both
  `_search_rom()` (scan path) and `get_matched_roms_by_name()` (manual search
  path); drop the now-unused `quote` import.
- `backend/tests/handler/metadata/test_moby_handler.py`: two regression tests
  asserting the term reaching `list_games()` contains no percent-encoding.

### Testing

- `pytest tests/handler/metadata/ tests/adapters/services/test_mobygames.py`
  → 441 passed (includes the 2 new regression tests).
- Verified the URL construction empirically with yarl (table above).

Fixes the MobyGames half of the problem described in #3467.
