### PR TITLE
fix(v2): close open overlays when the route changes

### DIFF
--- a/frontend/src/v2/components/shared/ConfirmDialog.vue
+++ b/frontend/src/v2/components/shared/ConfirmDialog.vue
@@ -55,6 +55,8 @@ function onShow(p: Payload) {
   });
 }
 
+// Closing without picking (header X, route change) counts as a cancel.
+// `useConfirm`'s promise is awaited, so it has to settle either way.
 function resolve(confirmed: boolean) {
   const id = payload.value?.id;
   open.value = false;
@@ -77,7 +79,7 @@ onBeforeUnmount(() => emitter?.off("showConfirm", onShow));
 </script>
 
 <template>
-  <RDialog v-model="open" width="440" persistent>
+  <RDialog v-model="open" width="440" persistent @close="onCancel">
     <template v-if="payload" #header>
       <span>{{ payload.title }}</span>
     </template>

--- a/frontend/src/v2/composables/useOverlayRouteDismiss/index.test.ts
+++ b/frontend/src/v2/composables/useOverlayRouteDismiss/index.test.ts
@@ -2,12 +2,12 @@ import { mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 import { nextTick, ref } from "vue";
 import { createMemoryHistory, createRouter } from "vue-router";
+import RDialog from "@/v2/lib/overlays/RDialog/RDialog.vue";
 import {
   type EscapableEntry,
   popEscapable,
   pushEscapable,
 } from "@/v2/lib/overlays/RDialog/escapeStack";
-import RDialog from "@/v2/lib/overlays/RDialog/RDialog.vue";
 import { installOverlayRouteDismiss } from "./index";
 
 const Blank = { template: "<div />" };

--- a/frontend/src/v2/composables/useOverlayRouteDismiss/index.test.ts
+++ b/frontend/src/v2/composables/useOverlayRouteDismiss/index.test.ts
@@ -1,0 +1,138 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { nextTick, ref } from "vue";
+import { createMemoryHistory, createRouter } from "vue-router";
+import {
+  type EscapableEntry,
+  popEscapable,
+  pushEscapable,
+} from "@/v2/lib/overlays/RDialog/escapeStack";
+import RDialog from "@/v2/lib/overlays/RDialog/RDialog.vue";
+import { installOverlayRouteDismiss } from "./index";
+
+const Blank = { template: "<div />" };
+
+function makeRouter() {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: "/", name: "home", component: Blank },
+      { path: "/rom/:id", name: "rom", component: Blank },
+    ],
+  });
+  const remove = installOverlayRouteDismiss(router);
+  return { router, remove };
+}
+
+function openOverlay(persistent = false): {
+  entry: EscapableEntry;
+  close: ReturnType<typeof vi.fn>;
+} {
+  const close = vi.fn();
+  const entry: EscapableEntry = { close, persistent };
+  pushEscapable(entry);
+  return { entry, close };
+}
+
+describe("installOverlayRouteDismiss", () => {
+  it("closes open overlays when the route changes", async () => {
+    const { router, remove } = makeRouter();
+    await router.push("/rom/1");
+    const { entry, close } = openOverlay();
+
+    await router.push("/");
+
+    expect(close).toHaveBeenCalledTimes(1);
+    popEscapable(entry);
+    remove();
+  });
+
+  // A persistent dialog only blocks Esc / scrim clicks; once the page it
+  // belonged to is gone it has nothing left to guard.
+  it("closes persistent overlays too", async () => {
+    const { router, remove } = makeRouter();
+    await router.push("/rom/1");
+    const { entry, close } = openOverlay(true);
+
+    await router.push("/");
+
+    expect(close).toHaveBeenCalledTimes(1);
+    popEscapable(entry);
+    remove();
+  });
+
+  // Filters, view mode and details subtabs live in the query string and
+  // rewrite it via router.replace while the drawer that owns them is open.
+  it("leaves overlays open on a query-only navigation", async () => {
+    const { router, remove } = makeRouter();
+    await router.push("/rom/1");
+    const { entry, close } = openOverlay();
+
+    await router.replace({ path: "/rom/1", query: { tab: "saves" } });
+
+    expect(close).not.toHaveBeenCalled();
+    popEscapable(entry);
+    remove();
+  });
+
+  it("closes stacked overlays innermost first", async () => {
+    const { router, remove } = makeRouter();
+    await router.push("/rom/1");
+    const order: string[] = [];
+    const outer: EscapableEntry = {
+      close: () => order.push("outer"),
+      persistent: false,
+    };
+    const inner: EscapableEntry = {
+      close: () => order.push("inner"),
+      persistent: false,
+    };
+    pushEscapable(outer);
+    pushEscapable(inner);
+
+    await router.push("/");
+
+    expect(order).toEqual(["inner", "outer"]);
+    popEscapable(inner);
+    popEscapable(outer);
+    remove();
+  });
+
+  // End to end over the real primitive: a dialog mounted above the router
+  // view (as GlobalDialogs does) must leave the DOM when the route changes.
+  it("takes a mounted RDialog off the page", async () => {
+    const { router, remove } = makeRouter();
+    await router.push("/rom/1");
+    const open = ref(true);
+    const wrapper = mount(
+      {
+        components: { RDialog },
+        setup: () => ({ open }),
+        template: `<RDialog v-model="open"><template #content>body</template></RDialog>`,
+      },
+      { global: { plugins: [router] } },
+    );
+    await nextTick();
+    expect(document.body.querySelector(".r-dialog")).not.toBeNull();
+
+    await router.push("/");
+    await nextTick();
+
+    expect(open.value).toBe(false);
+    expect(document.body.querySelector(".r-dialog")).toBeNull();
+    wrapper.unmount();
+    remove();
+  });
+
+  it("stops dismissing once removed", async () => {
+    const { router, remove } = makeRouter();
+    await router.push("/rom/1");
+    const { entry, close } = openOverlay();
+    remove();
+
+    await router.push("/");
+
+    expect(close).not.toHaveBeenCalled();
+    popEscapable(entry);
+  });
+});

--- a/frontend/src/v2/composables/useOverlayRouteDismiss/index.ts
+++ b/frontend/src/v2/composables/useOverlayRouteDismiss/index.ts
@@ -1,0 +1,33 @@
+// useOverlayRouteDismiss: a route change takes the open overlays with it.
+//
+// v2 dialogs are mounted once by GlobalDialogs at the layout level, above
+// the <router-view>, so nothing tears them down when the route changes.
+// Browser back / forward (and any navigation triggered from inside a
+// dialog) swapped the page underneath the panel and left it floating over
+// a view it has nothing to do with. Every escapable v2 surface already
+// registers itself while open, so the shared escape stack is the
+// dismissal list.
+//
+// Only a change of route identity dismisses. Gallery filters, view mode,
+// tile search and the details subtabs all `router.replace` their state
+// into the query string while an overlay is open (useGalleryFilterUrl,
+// FilterDrawer, ...), and those updates must leave it alone.
+import { nextTick } from "vue";
+import type { Router } from "vue-router";
+import {
+  closeAllEscapables,
+  hasOpenEscapable,
+} from "@/v2/lib/overlays/RDialog/escapeStack";
+
+/** Register the guard on the app router. Returns the remove function. */
+export function installOverlayRouteDismiss(router: Router): () => void {
+  return router.beforeEach(async (to, from) => {
+    if (to.path === from.path) return;
+    if (!hasOpenEscapable()) return;
+    closeAllEscapables();
+    // Let the overlays leave the DOM before the navigation resolves, so
+    // the back-morph view transition (installBackMorph, a beforeResolve
+    // guard) snapshots the page without a panel on top of it.
+    await nextTick();
+  });
+}

--- a/frontend/src/v2/layouts/AppLayout.vue
+++ b/frontend/src/v2/layouts/AppLayout.vue
@@ -35,6 +35,7 @@ import { installGalleryProvenance } from "@/v2/composables/useGalleryProvenance"
 import { useGamepad } from "@/v2/composables/useGamepad";
 import { useGlobalHotkeys } from "@/v2/composables/useGlobalHotkeys";
 import { useInputModality } from "@/v2/composables/useInputModality";
+import { installOverlayRouteDismiss } from "@/v2/composables/useOverlayRouteDismiss";
 import { prefetchPlatformIcons } from "@/v2/composables/usePlatformIconCache";
 import { useReducedMotion } from "@/v2/composables/useReducedMotion";
 import { installScanLifecycle } from "@/v2/composables/useScanLifecycle";
@@ -119,11 +120,15 @@ const router = useRouter();
 
 let removeBackMorph: (() => void) | null = null;
 let removeGalleryProvenance: (() => void) | null = null;
+let removeOverlayRouteDismiss: (() => void) | null = null;
 
 onMounted(() => {
   installInputModality();
   installGamepad();
   installGlobalHotkeys();
+  // Dialogs and drawers are mounted above the router view, so nothing else
+  // dismisses them when the route changes under them (browser back included).
+  removeOverlayRouteDismiss = installOverlayRouteDismiss(router);
   // Mirror morph: GameDetails cover → destination card on back/navbar/popstate.
   // Forward direction is handled at the source side in GameCard.
   removeBackMorph = installBackMorph(router);
@@ -167,6 +172,8 @@ onBeforeUnmount(() => {
   removeBackMorph = null;
   removeGalleryProvenance?.();
   removeGalleryProvenance = null;
+  removeOverlayRouteDismiss?.();
+  removeOverlayRouteDismiss = null;
   if (bgTimer !== null) {
     clearTimeout(bgTimer);
     bgTimer = null;

--- a/frontend/src/v2/lib/overlays/RDialog/escapeStack.ts
+++ b/frontend/src/v2/lib/overlays/RDialog/escapeStack.ts
@@ -75,3 +75,13 @@ export function closeTopEscapable(): void {
   if (!top || top.persistent) return;
   top.close();
 }
+
+/** Close every open overlay, innermost first. Used on route changes (see
+ *  `useOverlayRouteDismiss`), where `persistent` does not apply: it
+ *  guards against dismissing a surface by accident, but the page that
+ *  surface belonged to is already gone. Iterates over a snapshot since
+ *  each `close()` removes its own entry (asynchronously, via the owner's
+ *  `modelValue` watcher). */
+export function closeAllEscapables(): void {
+  for (const entry of [...stack].reverse()) entry.close();
+}


### PR DESCRIPTION
v2 dialogs and drawers are mounted by GlobalDialogs at the layout level, above the router view, so nothing dismissed them when the route changed underneath: a browser back with the Match ROM dialog open left the panel floating over the gallery.

Add a router guard that closes every surface registered on the shared escape stack when the route identity changes. Query-only navigations are left alone, since gallery filters, view mode and the details subtabs rewrite the query string while their overlay is open.

Also settle useConfirm's promise when the confirm dialog is closed without a pick, which the header close button could already do.

<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)
