### PR TITLE
Changed default compose, will explain more in pull

### DIFF
--- a/examples/docker-compose.example.yml
+++ b/examples/docker-compose.example.yml
@@ -19,6 +19,8 @@ services:
       - RETROACHIEVEMENTS_API_KEY= # https://docs.romm.app/latest/Getting-Started/Metadata-Providers/#retroachievements
       - STEAMGRIDDB_API_KEY= # https://docs.romm.app/latest/Getting-Started/Metadata-Providers/#steamgriddb
       - HASHEOUS_API_ENABLED=true # https://docs.romm.app/latest/Getting-Started/Metadata-Providers/#hasheous
+      - SCAN_WORKERS=2 # How many items you want scanned at once, we recommend 1 worker per CPU.
+      - WEB_SERVER_CONCURRENCY=3 # How many workers you want available for API calls and tasks we recommend 2 x CPU + 1
     volumes:
       - romm_resources:/romm/resources # Resources fetched from IGDB (covers, screenshots, etc.)
       - romm_redis_data:/redis-data # Cached data for background tasks


### PR DESCRIPTION
During some API testing I saw that having the default gunicorn workers set to 1 caused massive issues.

If a worker was stuck and got took over by one API call that is over-running with a long timeout, it makes the rest of RomM incredibly hard to use.

As our formula is 2 X CPU + 1 and we will always have 1 CPU. I recommend upping the default limit to 3 is a safe spot, especially with all the applications being introduced lately that will be taking advantage of the API, we need to have our (future) systems ready.

I know this is the example, but hopefully people see this and take note.

The SCAN_WORKERS is to prove you scan more then one item, not everyone reads the docs and this will set a good default to begin with. 
