### PR TITLE
fix(v2): drop the roms from the gallery when they leave the collection on screen

### DIFF
--- a/frontend/src/v2/components/Dialogs/DeleteRomDialog.vue
+++ b/frontend/src/v2/components/Dialogs/DeleteRomDialog.vue
@@ -13,9 +13,8 @@ import romApi from "@/services/api/rom";
 import storeConfig from "@/stores/config";
 import storeRoms, { type SimpleRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
+import { useRomSync } from "@/v2/composables/useRomSync";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
-import storeGalleryRoms from "@/v2/stores/galleryRoms";
-import storeGallerySelection from "@/v2/stores/gallerySelection";
 
 defineOptions({ inheritAttrs: false });
 
@@ -24,8 +23,7 @@ const router = useRouter();
 const route = useRoute();
 const show = ref(false);
 const romsStore = storeRoms();
-const galleryRomsStore = storeGalleryRoms();
-const gallerySelectionStore = storeGallerySelection();
+const { removeCachedRoms } = useRomSync();
 const roms = ref<SimpleRom[]>([]);
 const romsToDeleteFromFs = ref<number[]>([]);
 const excludeOnDelete = ref(false);
@@ -117,10 +115,9 @@ async function deleteRoms() {
       }
     }
     romsStore.resetSelection();
-    // Drop the deleted ROMs from the gallery selection
-    gallerySelectionStore.removeIds(deletedRoms.map((rom) => rom.id));
-    romsStore.remove(deletedRoms);
-    galleryRomsStore.remove(deletedRoms);
+    removeCachedRoms(deletedRoms);
+    // Deletion is permanent, so unlike the other `removeCachedRoms` callers
+    // this one also takes the ROMs out of Home's rows.
     romsStore.setRecentRoms(
       romsStore.recentRoms.filter(
         (r) => !deletedRoms.some((rom) => rom.id === r.id),

--- a/frontend/src/v2/components/Dialogs/ManageCollectionsDialog.test.ts
+++ b/frontend/src/v2/components/Dialogs/ManageCollectionsDialog.test.ts
@@ -6,6 +6,7 @@ import { ref } from "vue";
 import storeAuth from "@/stores/auth";
 import storeCollections, { type Collection } from "@/stores/collections";
 import storeRoms, { type SimpleRom } from "@/stores/roms";
+import type { User } from "@/stores/users";
 import type { Events } from "@/types/emitter";
 import storeGalleryRoms from "@/v2/stores/galleryRoms";
 import storeGallerySelection from "@/v2/stores/gallerySelection";
@@ -67,10 +68,24 @@ function collection(romIds: number[]): Collection {
 async function toggleRow(roms: SimpleRom[]) {
   const emitter = mitt<Events>();
   const wrapper = mountDialog(emitter);
-  emitter.emit("showManageCollectionsDialog", roms);
-  await flushPromises();
+  await open(wrapper, emitter, roms);
   await wrapper.get("[data-test-row]").trigger("click");
   await flushPromises();
+  return { wrapper, emitter };
+}
+
+async function open(
+  wrapper: VueWrapper,
+  emitter: Emitter<Events>,
+  roms: SimpleRom[],
+) {
+  emitter.emit("showManageCollectionsDialog", roms);
+  await flushPromises();
+}
+
+/** The tri-state the row is currently painting. */
+function rowState(wrapper: VueWrapper) {
+  return wrapper.get("[data-test-row]").attributes("data-state");
 }
 
 function mountDialog(emitter: Emitter<Events>): VueWrapper {
@@ -83,9 +98,10 @@ function mountDialog(emitter: Emitter<Events>): VueWrapper {
         GameCard: true,
         NewCollectionRow: true,
         CollectionPickerRow: {
+          props: ["state"],
           emits: ["toggle"],
           template:
-            "<button data-test-row @click=\"$emit('toggle')\"></button>",
+            '<button data-test-row :data-state="state" @click="$emit(\'toggle\')"></button>',
         },
       },
     },
@@ -96,7 +112,7 @@ describe("ManageCollectionsDialog gallery reconcile", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
-    storeAuth().setCurrentUser({ id: USER_ID } as never);
+    storeAuth().setCurrentUser({ id: USER_ID } as User);
   });
 
   it("drops the roms from the gallery when removing them from the collection on screen", async () => {
@@ -159,10 +175,35 @@ describe("ManageCollectionsDialog gallery reconcile", () => {
     const selection = storeGallerySelection();
     [rom(1), rom(2)].forEach((r, i) => selection.toggle(r, i));
 
-    await toggleRow([rom(1), rom(2)]);
+    const { wrapper } = await toggleRow([rom(1), rom(2)]);
 
     expect(galleryRemove).not.toHaveBeenCalled();
     expect(selection.count).toBe(2);
     expect(snackbarError).toHaveBeenCalled();
+    // Nothing was written, so the row goes back to real membership.
+    expect(rowState(wrapper)).toBe("all");
+  });
+
+  it("does not pin the row when a failure lands after the dialog reopens", async () => {
+    const collections = storeCollections();
+    collections.setCollections([collection([1, 2])]);
+    let reject: (reason: Error) => void = () => {};
+    removeRomsFromCollection.mockReturnValue(
+      new Promise((_resolve, r) => {
+        reject = r;
+      }),
+    );
+    const emitter = mitt<Events>();
+    const wrapper = mountDialog(emitter);
+
+    await open(wrapper, emitter, [rom(1), rom(2)]);
+    await wrapper.get("[data-test-row]").trigger("click");
+    // Reopened over a game the collection doesn't hold, while the removal
+    // above is still in flight.
+    await open(wrapper, emitter, [rom(3)]);
+    reject(new Error("Forbidden"));
+    await flushPromises();
+
+    expect(rowState(wrapper)).toBe("off");
   });
 });

--- a/frontend/src/v2/components/Dialogs/ManageCollectionsDialog.test.ts
+++ b/frontend/src/v2/components/Dialogs/ManageCollectionsDialog.test.ts
@@ -1,0 +1,168 @@
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import mitt, { type Emitter } from "mitt";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+import storeAuth from "@/stores/auth";
+import storeCollections, { type Collection } from "@/stores/collections";
+import storeRoms, { type SimpleRom } from "@/stores/roms";
+import type { Events } from "@/types/emitter";
+import storeGalleryRoms from "@/v2/stores/galleryRoms";
+import storeGallerySelection from "@/v2/stores/gallerySelection";
+import ManageCollectionsDialog from "./ManageCollectionsDialog.vue";
+
+const { addRomsToCollection, removeRomsFromCollection, snackbarError } =
+  vi.hoisted(() => ({
+    addRomsToCollection: vi.fn(),
+    removeRomsFromCollection: vi.fn(),
+    snackbarError: vi.fn(),
+  }));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/services/api/collection", () => ({
+  default: {
+    addRomsToCollection,
+    removeRomsFromCollection,
+    createCollection: vi.fn(),
+  },
+}));
+
+vi.mock("@/v2/composables/useSnackbar", () => ({
+  useSnackbar: () => ({
+    success: vi.fn(),
+    error: snackbarError,
+    warning: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+vi.mock("@/v2/composables/useBreakpoint", () => ({
+  useBreakpoint: () => ({ mdAndUp: ref(true) }),
+}));
+
+vi.mock("@/v2/composables/useWebpSupport", () => ({
+  useWebpSupport: () => ({ toWebp: (url: string) => url }),
+}));
+
+const USER_ID = 3;
+
+function rom(id: number): SimpleRom {
+  return { id, name: `Game ${id}`, platform_id: 1 } as SimpleRom;
+}
+
+function collection(romIds: number[]): Collection {
+  return {
+    id: 12,
+    name: "Shooters",
+    user_id: USER_ID,
+    rom_ids: romIds,
+    rom_count: romIds.length,
+  } as Collection;
+}
+
+/** Mount the dialog, open it over `roms`, and click the one collection row. */
+async function toggleRow(roms: SimpleRom[]) {
+  const emitter = mitt<Events>();
+  const wrapper = mountDialog(emitter);
+  emitter.emit("showManageCollectionsDialog", roms);
+  await flushPromises();
+  await wrapper.get("[data-test-row]").trigger("click");
+  await flushPromises();
+}
+
+function mountDialog(emitter: Emitter<Events>): VueWrapper {
+  return mount(ManageCollectionsDialog, {
+    global: {
+      provide: { emitter },
+      stubs: {
+        RDialog: { template: "<div><slot name='content' /></div>" },
+        RDivider: true,
+        GameCard: true,
+        NewCollectionRow: true,
+        CollectionPickerRow: {
+          emits: ["toggle"],
+          template:
+            "<button data-test-row @click=\"$emit('toggle')\"></button>",
+        },
+      },
+    },
+  });
+}
+
+describe("ManageCollectionsDialog gallery reconcile", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    storeAuth().setCurrentUser({ id: USER_ID } as never);
+  });
+
+  it("drops the roms from the gallery when removing them from the collection on screen", async () => {
+    const collections = storeCollections();
+    collections.setCollections([collection([1, 2])]);
+    removeRomsFromCollection.mockResolvedValue({ data: collection([]) });
+    const gallery = storeGalleryRoms();
+    gallery.setCurrentCollection(collection([1, 2]));
+    const galleryRemove = vi.spyOn(gallery, "remove").mockImplementation(() => {
+      /* the real one refetches the gallery */
+    });
+    const romsRemove = vi.spyOn(storeRoms(), "remove");
+    const selection = storeGallerySelection();
+    [rom(1), rom(2)].forEach((r, i) => selection.toggle(r, i));
+
+    await toggleRow([rom(1), rom(2)]);
+
+    expect(removeRomsFromCollection).toHaveBeenCalledWith(12, [1, 2]);
+    expect(galleryRemove).toHaveBeenCalledTimes(1);
+    expect(galleryRemove.mock.calls[0][0].map((r) => r.id)).toEqual([1, 2]);
+    expect(romsRemove).toHaveBeenCalledTimes(1);
+    expect(selection.count).toBe(0);
+  });
+
+  it("keeps the roms on screen when removing them from a collection it isn't showing", async () => {
+    const collections = storeCollections();
+    collections.setCollections([collection([1, 2])]);
+    removeRomsFromCollection.mockResolvedValue({ data: collection([]) });
+    const gallery = storeGalleryRoms();
+    gallery.setCurrentCollection({ ...collection([]), id: 99 } as Collection);
+    const galleryRemove = vi.spyOn(gallery, "remove");
+
+    await toggleRow([rom(1), rom(2)]);
+
+    expect(removeRomsFromCollection).toHaveBeenCalledWith(12, [1, 2]);
+    expect(galleryRemove).not.toHaveBeenCalled();
+  });
+
+  it("keeps the roms on screen when adding them to the collection on screen", async () => {
+    const collections = storeCollections();
+    collections.setCollections([collection([])]);
+    addRomsToCollection.mockResolvedValue({ data: collection([1, 2]) });
+    const gallery = storeGalleryRoms();
+    gallery.setCurrentCollection(collection([]));
+    const galleryRemove = vi.spyOn(gallery, "remove");
+
+    await toggleRow([rom(1), rom(2)]);
+
+    expect(addRomsToCollection).toHaveBeenCalledWith(12, [1, 2]);
+    expect(galleryRemove).not.toHaveBeenCalled();
+  });
+
+  it("leaves the gallery alone when the removal fails", async () => {
+    const collections = storeCollections();
+    collections.setCollections([collection([1, 2])]);
+    removeRomsFromCollection.mockRejectedValue(new Error("Forbidden"));
+    const gallery = storeGalleryRoms();
+    gallery.setCurrentCollection(collection([1, 2]));
+    const galleryRemove = vi.spyOn(gallery, "remove");
+    const selection = storeGallerySelection();
+    [rom(1), rom(2)].forEach((r, i) => selection.toggle(r, i));
+
+    await toggleRow([rom(1), rom(2)]);
+
+    expect(galleryRemove).not.toHaveBeenCalled();
+    expect(selection.count).toBe(2);
+    expect(snackbarError).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/v2/components/Dialogs/ManageCollectionsDialog.vue
+++ b/frontend/src/v2/components/Dialogs/ManageCollectionsDialog.vue
@@ -27,16 +27,16 @@ import storeCollections, {
   type Collection,
   type CollectionType,
 } from "@/stores/collections";
-import storeRoms, { type SimpleRom } from "@/stores/roms";
+import type { SimpleRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import CollectionPickerRow from "@/v2/components/Collections/CollectionPickerRow.vue";
 import NewCollectionRow from "@/v2/components/Collections/NewCollectionRow.vue";
 import GameCard from "@/v2/components/GameCard/GameCard.vue";
 import { useBreakpoint } from "@/v2/composables/useBreakpoint";
+import { useRomSync } from "@/v2/composables/useRomSync";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
 import { useWebpSupport } from "@/v2/composables/useWebpSupport";
 import storeGalleryRoms from "@/v2/stores/galleryRoms";
-import storeGallerySelection from "@/v2/stores/gallerySelection";
 import { collectionCoverList } from "@/v2/utils/collectionCovers";
 
 defineOptions({ inheritAttrs: false });
@@ -45,11 +45,10 @@ const { t } = useI18n();
 const { mdAndUp } = useBreakpoint();
 const show = ref(false);
 const collectionsStore = storeCollections();
-const romsStore = storeRoms();
 const galleryRomsStore = storeGalleryRoms();
-const gallerySelectionStore = storeGallerySelection();
 const emitter = inject<Emitter<Events>>("emitter");
 const snackbar = useSnackbar();
+const { removeCachedRoms } = useRomSync();
 const { toWebp } = useWebpSupport();
 
 function coversFor(collection: CollectionType): string[] {
@@ -140,9 +139,7 @@ async function toggle(collection: Collection) {
       // have to go with them. Removing from the collection you're viewing
       // is the only reachable direction here: every selected ROM is
       // already a member, so the row reads "all" and toggles to "off".
-      gallerySelectionStore.removeIds(romIds);
-      romsStore.remove(targetRoms);
-      galleryRomsStore.remove(targetRoms);
+      removeCachedRoms(targetRoms);
     }
   } catch (error: unknown) {
     // Drop the override rather than restoring `prevState`, so the row falls

--- a/frontend/src/v2/components/Dialogs/ManageCollectionsDialog.vue
+++ b/frontend/src/v2/components/Dialogs/ManageCollectionsDialog.vue
@@ -145,7 +145,12 @@ async function toggle(collection: Collection) {
       galleryRomsStore.remove(targetRoms);
     }
   } catch (error: unknown) {
-    optimistic.value.set(collection.id, prevState);
+    // Drop the override rather than restoring `prevState`, so the row falls
+    // back to the collection's real membership. Nothing was written, so that
+    // is `prevState` anyway, and a stale override would pin the row: it was
+    // computed against whichever ROMs the dialog held when the click landed,
+    // which a reopen can replace while the call is in flight.
+    optimistic.value.delete(collection.id);
     const axiosErr = error as { response?: { data?: { detail?: string } } };
     snackbar.error(
       axiosErr.response?.data?.detail ??

--- a/frontend/src/v2/components/Dialogs/ManageCollectionsDialog.vue
+++ b/frontend/src/v2/components/Dialogs/ManageCollectionsDialog.vue
@@ -27,7 +27,7 @@ import storeCollections, {
   type Collection,
   type CollectionType,
 } from "@/stores/collections";
-import type { SimpleRom } from "@/stores/roms";
+import storeRoms, { type SimpleRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import CollectionPickerRow from "@/v2/components/Collections/CollectionPickerRow.vue";
 import NewCollectionRow from "@/v2/components/Collections/NewCollectionRow.vue";
@@ -35,6 +35,8 @@ import GameCard from "@/v2/components/GameCard/GameCard.vue";
 import { useBreakpoint } from "@/v2/composables/useBreakpoint";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
 import { useWebpSupport } from "@/v2/composables/useWebpSupport";
+import storeGalleryRoms from "@/v2/stores/galleryRoms";
+import storeGallerySelection from "@/v2/stores/gallerySelection";
 import { collectionCoverList } from "@/v2/utils/collectionCovers";
 
 defineOptions({ inheritAttrs: false });
@@ -43,6 +45,9 @@ const { t } = useI18n();
 const { mdAndUp } = useBreakpoint();
 const show = ref(false);
 const collectionsStore = storeCollections();
+const romsStore = storeRoms();
+const galleryRomsStore = storeGalleryRoms();
+const gallerySelectionStore = storeGallerySelection();
 const emitter = inject<Emitter<Events>>("emitter");
 const snackbar = useSnackbar();
 const { toWebp } = useWebpSupport();
@@ -118,13 +123,27 @@ async function toggle(collection: Collection) {
   // selected ids — the backend de-dupes against existing membership,
   // so this is safe and saves a per-id diff round-trip from the
   // frontend.
-  const romIds = roms.value.map((r) => r.id);
+  //
+  // Snapshotted because the dialog is a singleton: a fresh
+  // `showManageCollectionsDialog` can replace `roms` while the call below
+  // is in flight, and the response applies to the set we sent.
+  const targetRoms = roms.value;
+  const romIds = targetRoms.map((r) => r.id);
   try {
     const { data } = adding
       ? await collectionApi.addRomsToCollection(collection.id, romIds)
       : await collectionApi.removeRomsFromCollection(collection.id, romIds);
     collectionsStore.updateCollection(data);
     optimistic.value.delete(collection.id);
+    if (!adding && galleryRomsStore.currentCollection?.id === collection.id) {
+      // We're looking at the collection the ROMs just left, so the cards
+      // have to go with them. Removing from the collection you're viewing
+      // is the only reachable direction here: every selected ROM is
+      // already a member, so the row reads "all" and toggles to "off".
+      gallerySelectionStore.removeIds(romIds);
+      romsStore.remove(targetRoms);
+      galleryRomsStore.remove(targetRoms);
+    }
   } catch (error: unknown) {
     optimistic.value.set(collection.id, prevState);
     const axiosErr = error as { response?: { data?: { detail?: string } } };

--- a/frontend/src/v2/components/Gallery/SelectionBar.vue
+++ b/frontend/src/v2/components/Gallery/SelectionBar.vue
@@ -51,7 +51,6 @@ import { useFavoriteToggle } from "@/composables/useFavoriteToggle";
 import collectionApi from "@/services/api/collection";
 import romApi from "@/services/api/rom";
 import storeCollections from "@/stores/collections";
-import storeRoms from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import { romStatusMap } from "@/utils";
 import { useBreakpoint } from "@/v2/composables/useBreakpoint";
@@ -79,10 +78,10 @@ const emitter = inject<Emitter<Events>>("emitter");
 const snackbar = useSnackbar();
 const selection = storeGallerySelection();
 const collectionsStore = storeCollections();
-const romsStore = storeRoms();
 const galleryRomsStore = storeGalleryRoms();
 const { ensureFavoriteCollection } = useFavoriteToggle();
-const { syncCachedRom, refreshAfterUserStateChange } = useRomSync();
+const { syncCachedRom, removeCachedRoms, refreshAfterUserStateChange } =
+  useRomSync();
 
 const canRefresh = useCan("rom.refresh");
 const canDownload = useCan("rom.download");
@@ -139,9 +138,7 @@ async function bulkFavorite() {
       // We were on the favourites collection view and just removed
       // every selected rom from it — drop them from the visible
       // roms so the UI reflects the new membership immediately.
-      selection.removeIds(ids);
-      romsStore.remove(roms);
-      galleryRomsStore.remove(roms);
+      removeCachedRoms(roms);
     }
     // The branch above only covers the Favourites collection view; a
     // favourites filter moves membership just as much.

--- a/frontend/src/v2/composables/useRomSync/index.test.ts
+++ b/frontend/src/v2/composables/useRomSync/index.test.ts
@@ -5,6 +5,7 @@ import storeGalleryFilter from "@/stores/galleryFilter";
 import type { Platform } from "@/stores/platforms";
 import storeRoms, { type DetailedRom, type SimpleRom } from "@/stores/roms";
 import storeGalleryRoms from "@/v2/stores/galleryRoms";
+import storeGallerySelection from "@/v2/stores/gallerySelection";
 import { useRomSync } from "./index";
 
 const { getRoms } = vi.hoisted(() => ({ getRoms: vi.fn() }));
@@ -188,6 +189,40 @@ describe("useRomSync", () => {
 
     expect(gallery.byPosition.size).toBe(1);
     expect(getRoms).not.toHaveBeenCalled();
+  });
+
+  // The three caches a removed ROM has to leave. Missing any one of them is
+  // what #4151 and #4204 each had to fix, one call site at a time.
+  it("removeCachedRoms drops the ROMs from the gallery, the v1 store and the selection", () => {
+    const removed = makeRom({ id: 1 });
+    const kept = makeRom({ id: 2 });
+    const gallery = seedGallery(removed);
+    const romsStore = storeRoms();
+    romsStore._allRoms = [removed, kept];
+    const selection = storeGallerySelection();
+    selection.setSelection([removed, kept]);
+
+    useRomSync().removeCachedRoms([removed]);
+
+    expect(gallery.byPosition.size).toBe(0);
+    expect(getRoms).toHaveBeenCalled();
+    expect(romsStore._allRoms).toEqual([kept]);
+    expect([...selection.selected.keys()]).toEqual([2]);
+  });
+
+  // Leaving a collection isn't leaving the library: the pruning that a real
+  // delete needs stays in DeleteRomDialog rather than folding in here.
+  it("removeCachedRoms leaves Home's rows alone", () => {
+    const removed = makeRom({ id: 1 });
+    seedGallery(removed);
+    const romsStore = storeRoms();
+    romsStore.recentRoms = [removed];
+    romsStore.continuePlayingRoms = [removed];
+
+    useRomSync().removeCachedRoms([removed]);
+
+    expect(romsStore.recentRoms).toEqual([removed]);
+    expect(romsStore.continuePlayingRoms).toEqual([removed]);
   });
 
   it("applyRomWrite leaves an unloaded ROM alone (no row on screen to reorder)", () => {

--- a/frontend/src/v2/composables/useRomSync/index.ts
+++ b/frontend/src/v2/composables/useRomSync/index.ts
@@ -14,6 +14,7 @@ import storeRoms, { type SimpleRom } from "@/stores/roms";
 import storeGalleryRoms, {
   type GalleryOrderKey,
 } from "@/v2/stores/galleryRoms";
+import storeGallerySelection from "@/v2/stores/gallerySelection";
 
 /** The value the gallery is ordered by, per sort key. Declared as a full
  * `Record` so a new `GalleryOrderKey` fails to compile until it's handled
@@ -39,6 +40,7 @@ export function useRomSync() {
   const galleryRomsStore = storeGalleryRoms();
   const galleryFilter = storeGalleryFilter();
   const collectionsStore = storeCollections();
+  const gallerySelection = storeGallerySelection();
 
   /** Apply an already-persisted ROM to every cache that renders it; this
    * writes nothing to the server. Safe to call with a ROM none of them
@@ -55,6 +57,22 @@ export function useRomSync() {
     if (romsStore.currentRom?.id === rom.id) {
       romsStore.currentRom = { ...romsStore.currentRom, ...rom };
     }
+  }
+
+  /** Drop ROMs that have left the current view from every cache holding
+   * them: the gallery's windowed cache, the v1 store, and the selection.
+   * Missing any one of the three leaves the cards on screen.
+   *
+   * Says nothing about *why* they left. Callers that remove a ROM from a
+   * view (a bulk unfavourite, a collection removal) and callers that delete
+   * it outright both need these three, but only the latter should also
+   * prune Home's recent / continue-playing rows: a game taken out of a
+   * collection still belongs in Continue Playing. That pruning stays with
+   * the caller that means it. */
+  function removeCachedRoms(roms: SimpleRom[]) {
+    gallerySelection.removeIds(roms.map((rom) => rom.id));
+    romsStore.remove(roms);
+    galleryRomsStore.remove(roms);
   }
 
   /** Did this write move the value the gallery is currently ordered by?
@@ -135,6 +153,7 @@ export function useRomSync() {
 
   return {
     syncCachedRom,
+    removeCachedRoms,
     applyRomWrite,
     refreshAfterUserStateChange,
     refreshIfOrderedBy,


### PR DESCRIPTION
> [!NOTE]
> This PR was written primarily by Claude Code (code, tests and this description). I reviewed the approach and directed the scope.

**Description**

Removing ROMs from the collection you're currently looking at left their cards on screen.

`ManageCollectionsDialog.toggle()` updated `collectionsStore` and stopped there. The v2 gallery renders from `galleryRoms`, which never heard about the membership change, so the cards sat there until the gallery happened to refetch on its own (navigating away and back, a filter change, a scan).

This is the same bug #4151 fixed in `SelectionBar`, in the other v2 site that writes collection membership. The fix is the same branch: when the write is a *removal* and the gallery is showing that collection, drop the ROMs from the gallery, the v1 store, and the selection.

Two details worth a reviewer's eye:

- **Removal only.** Adding is unreachable for the collection on screen: every selected ROM is already a member, so the row reads "all" and the tri-state cycle only offers "off". Reconciling on add would be dead code.
- **`targetRoms` snapshot.** The dialog is a singleton, so a fresh `showManageCollectionsDialog` can replace `roms` while the request is in flight. `romIds` was already read before the `await`; this extends that to the ROM objects the response applies to.

The second commit fixes a related staleness on the **failure** path, raised in review. It restored `prevState` on error, which pins the row to a value computed against whichever ROMs the dialog held when the click landed. Since a reopen swaps in both a fresh `roms` and a fresh `optimistic` map, a failure arriving after a reopen wrote the old session's answer into the new one. Clearing the override instead falls back to real membership: the same value in the ordinary case (a failed write changed nothing), the correct one after a reopen, and consistent with what the success path already did.

The third commit removes the duplication the first one added, `Closes #4210`. Three v2 sites now reconciled the caches by hand with the identical three calls:

```js
gallerySelectionStore.removeIds(ids);
romsStore.remove(roms);
galleryRomsStore.remove(roms);
```

in `SelectionBar` (bulk unfavourite, #4151), `DeleteRomDialog` (delete), and this dialog. Each was written independently against the same problem, and missing one of the three is exactly what #4151 and this PR each had to fix, one site at a time. They now all call `useRomSync().removeCachedRoms(roms)`, which is where #4153 put the "fan a ROM mutation out to every cache that holds it" job.

One deliberate boundary: `removeCachedRoms` wraps **only** those three calls. `DeleteRomDialog` keeps its own `recentRoms` / `continuePlayingRoms` pruning outside it, because the intent differs. `SelectionBar` and this dialog mean "these ROMs left this view" and the ROMs still exist; only a real delete should take a game out of Continue Playing.

v1 is untouched.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**Testing**

5 unit tests in `ManageCollectionsDialog.test.ts`, covering the fix and its guards:

| Case | Expected |
| --- | --- |
| Remove, while viewing that collection | Cards dropped from gallery + v1 store, selection cleared |
| Remove, while viewing a *different* collection | Gallery untouched |
| Add, while viewing that collection | Gallery untouched |
| Remove fails | Gallery untouched, selection intact, error snackbar, row back to real membership |
| Remove fails *after* the dialog is reopened | Row reflects the new selection, not the old one |

Both bug tests were confirmed to fail against the code they fix (the second with `expected 'all' to be 'off'`); the guard tests pass either way by design, pinning down that the branch doesn't over-fire.

2 more in `useRomSync/index.test.ts` for the extracted helper: that it clears all three caches, and that it leaves Home's recent / continue-playing rows alone. The refactor is behaviour-preserving, so the existing `SelectionBar.test.ts` and `ManageCollectionsDialog.test.ts` reconcile tests pass unchanged, which is the real regression proof. Deleting any one of the three calls from the helper was confirmed to fail tests at all three call sites, which is the point of centralising it.

**Verification run:** rebased onto current `master` (needed: `useRomSync` landed in #4153 after this branch was cut). `npm run typecheck` clean, full frontend suite 736 passed across 64 files, eslint and prettier clean on all five changed files, and the trunk pre-commit hook clean. No locale, token, or `/lib` primitive changes, and no backend or response-schema change, so the i18n check, `build:tokens`, Storybook, and `npm run generate` don't apply.

**Not verified in a running instance.** This is a cache-reconcile fix with no visual change, and it's covered by the tests above, but I didn't exercise it against a live library. Worth a click-through by a reviewer who has one up: open a collection, select a few games, and un-toggle that collection in the manage-collections dialog. The refactor touches delete and bulk-unfavourite too, so those are worth a pass as well.

**Related:** #4153 fixed the neighbouring problem, v2 write sites not reaching the gallery cache at all, and added the `useRomSync` composable. The fix here stays independent of its refresh helpers deliberately: `refreshAfterUserStateChange` guards on `currentCollection?.id === favoriteCollection.id`, so it returns early for an arbitrary collection and would leave this bug in place. Only the removal path is shared, via the new `removeCachedRoms`.
