### PR TITLE
fix(states): enforce ROM visibility when uploading a state

### DIFF
--- a/backend/endpoints/states.py
+++ b/backend/endpoints/states.py
@@ -51,14 +51,7 @@ async def add_state(
     if not rom:
         raise RomNotFoundInDatabaseException(rom_id)
 
-    log.info(f"Uploading state of {rom.name}")
-
-    states_path = fs_asset_handler.build_states_file_path(
-        user=request.user,
-        platform_fs_slug=rom.platform.fs_slug,
-        rom_id=rom_id,
-        emulator=emulator,
-    )
+    assert_rom_visible(request, rom)
 
     if not stateFile.filename:
         log.error("State file has no filename")
@@ -73,10 +66,6 @@ async def add_state(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid state filename: {str(exc)}",
         ) from exc
-
-    rom = db_rom_handler.get_rom(rom_id)
-    if not rom:
-        raise RomNotFoundInDatabaseException(rom_id)
 
     log.info(
         f"Uploading state {hl(sanitized_state_filename)} for {hl(str(rom.name), color=BLUE)}"

--- a/backend/tests/endpoints/test_states.py
+++ b/backend/tests/endpoints/test_states.py
@@ -155,6 +155,54 @@ def test_add_state_rejects_oversized_uploads(
     assert response.status_code == status.HTTP_413_CONTENT_TOO_LARGE
 
 
+@mock.patch("endpoints.states.fs_asset_handler.write_file", new_callable=mock.AsyncMock)
+@mock.patch("endpoints.states.scan_state", new_callable=mock.AsyncMock)
+def test_hidden_rom_masks_state_upload(
+    _mock_scan,
+    mock_write,
+    client,
+    viewer_access_token: str,
+    viewer_user: User,
+    rom: Rom,
+):
+    # Uploading onto a ROM hidden from the caller is 404-masked the same way
+    # downloading from one is, and nothing reaches disk.
+    _hide(PermEntity.ROMS, rom.id, viewer_user.id)
+
+    response = client.post(
+        f"/api/states?rom_id={rom.id}",
+        files={"stateFile": ("game.state", b"STATE!", "application/octet-stream")},
+        headers=_auth(viewer_access_token),
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    mock_write.assert_not_awaited()
+
+
+@mock.patch("endpoints.states.fs_asset_handler.write_file", new_callable=mock.AsyncMock)
+@mock.patch("endpoints.states.scan_state", new_callable=mock.AsyncMock)
+def test_hidden_platform_masks_state_upload(
+    _mock_scan,
+    mock_write,
+    client,
+    viewer_access_token: str,
+    viewer_user: User,
+    rom: Rom,
+    platform: Platform,
+):
+    # Hiding the parent platform cascades to uploads against its ROMs.
+    _hide(PermEntity.PLATFORMS, platform.id, viewer_user.id)
+
+    response = client.post(
+        f"/api/states?rom_id={rom.id}",
+        files={"stateFile": ("game.state", b"STATE!", "application/octet-stream")},
+        headers=_auth(viewer_access_token),
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    mock_write.assert_not_awaited()
+
+
 @mock.patch(
     "endpoints.states.fs_asset_handler.remove_file", new_callable=mock.AsyncMock
 )


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

`add_state` (`POST /api/states`) fetched the ROM and never checked it was visible to the caller. Any `ASSETS_WRITE` holder could upload a state against a ROM an admin had hidden from them, and distinguish an existing `rom_id` from a nonexistent one by the presence of the 404.

`download_state` already guards exactly this boundary, with the comment *"Sharing must not override the hidden-ROM/platform policy: a state on a ROM hidden from the caller stays 404-masked, just like the ROM itself."* The upload path now matches it: `assert_rom_visible(request, rom)` runs immediately after the fetch, before any filesystem or DB work, and 404-masks rather than 403s.

To keep the guard unambiguous I also collapsed some duplication in the same function. `add_state` fetched the ROM **twice** with an identical `get_rom` + 404 block, and the `states_path` computed after the first fetch was dead — recomputed after the second and unused in between. Adding a check to each fetch would have been the wrong shape, so the two blocks became one guarded fetch. That accounts for the removed lines; the only behavior change is the new visibility check (a redundant `log.info` also went, superseded by the more detailed one that includes the filename).

Scope note: this is not a regression from a recent release — the gap predates `5.1.1-beta.1`. It surfaced during a security audit of the `5.1.1-beta.1...5.1.1-beta.2` diff rather than from a bug report, so there is no issue to link.

`update_state` (`PUT /api/states/{id}`) has a narrower version of the same gap: it scopes the lookup by `user_id`, so the caller always owns the state, but a ROM can be hidden *after* the state was created. I left it out of this PR since the caller isn't reaching for someone else's ROM there. Happy to extend it in a follow-up if you'd like the policy applied uniformly.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Two tests added, mirroring the existing `test_hidden_rom_masks_public_state_download` / `test_hidden_platform_masks_public_state_download` pair — one for a hidden ROM, one for a hidden parent platform. Both assert the 404 **and** `mock_write.assert_not_awaited()`, so a regression that merely reorders the check (letting bytes hit disk before the 404) still fails.

I verified the tests actually catch the bug: with the guard temporarily removed both fail, with it restored both pass.

- `tests/endpoints/test_states.py` — 14 passed
- `tests/endpoints/` full suite — 829 passed
- `trunk fmt` + `trunk check` — no issues

**AI assistance disclosure**

This PR was written with AI assistance (Claude Opus 5 via Claude Code). The finding came out of an AI-run security audit of the `5.1.1-beta.1...5.1.1-beta.2` diff; the fix, the tests, and the local verification above were AI-authored and human-reviewed before submission.