### PR TITLE
fix(scan): re-read filename tags on a complete rescan

### DIFF
--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -324,6 +324,28 @@ def _should_get_rom_files(
     )
 
 
+def _should_reparse_tags(
+    scan_type: ScanType,
+    rom: Rom,
+    roms_ids: list[int],
+) -> bool:
+    """Decide if filename tags should be re-read onto an existing rom
+
+    A rom parses its tags when it is first inserted and again when the edit
+    endpoint renames it, but never in between, so a change to `parse_tags` only
+    reaches rows that were scanned after it. A complete rescan or an explicit
+    per-rom selection re-reads them; a hashes rescan does not, since it is
+    scoped to re-reading file bytes.
+
+    Args:
+        scan_type (ScanType): Type of scan to be performed.
+        rom (Rom): The rom whose tags may be re-read.
+        roms_ids (list[int]): List of selected roms to be scanned.
+    """
+
+    return bool(scan_type == ScanType.COMPLETE or (rom and rom.id in roms_ids))
+
+
 def _should_hash_firmware(
     scan_type: ScanType,
     firmware: Firmware | None,
@@ -453,6 +475,17 @@ async def _identify_rom(
                     f"Skipping {hl(fs_rom['fs_name'])}: already created by a concurrent scan"
                 )
                 return
+
+    # Re-read the filename tags onto an existing entry. Written onto the instance
+    # rather than through update_rom because scan_rom carries these columns
+    # forward from the rom it is handed, and merging its result is what persists
+    # them.
+    if not newly_added and _should_reparse_tags(scan_type, rom, roms_ids):
+        rom.regions = parsed_tags.regions
+        rom.languages = parsed_tags.languages
+        rom.tags = parsed_tags.other_tags
+        rom.revision = parsed_tags.revision
+        rom.version = parsed_tags.version
 
     # Build rom files object before scanning. A reassociated ROM always rebuilds
     # its files so the stale paths from the old filename are replaced.

--- a/backend/handler/scan_handler.py
+++ b/backend/handler/scan_handler.py
@@ -404,6 +404,7 @@ async def scan_rom(
         "fs_path": rom.fs_path,
         "regions": rom.regions,
         "revision": rom.revision,
+        "version": rom.version,
         "languages": rom.languages,
         "tags": rom.tags,
         "crc_hash": rom.crc_hash,

--- a/backend/tests/endpoints/sockets/test_scan.py
+++ b/backend/tests/endpoints/sockets/test_scan.py
@@ -11,6 +11,7 @@ from endpoints.sockets.scan import (
     ScanStats,
     _identify_rom,
     _scan_selected_roms,
+    _should_reparse_tags,
     reject_unauthorized_scan,
     scan_handler,
     scan_platforms,
@@ -471,6 +472,195 @@ class TestShouldScanRom:
 
         result = should_scan_rom(scan_type, rom, roms_ids, ["igdb"])
         assert result is expected
+
+
+class TestShouldReparseTags:
+    """Which scans re-read filename tags onto a row that already exists."""
+
+    @pytest.fixture
+    def rom(self) -> Rom:
+        rom: Rom = Mock(spec=Rom)
+        rom.id = 1
+        return rom
+
+    def test_complete_rescan_reparses(self, rom: Rom):
+        assert _should_reparse_tags(ScanType.COMPLETE, rom, []) is True
+
+    @pytest.mark.parametrize(
+        "scan_type",
+        [
+            ScanType.QUICK,
+            ScanType.NEW_PLATFORMS,
+            ScanType.UPDATE,
+            ScanType.UNMATCHED,
+        ],
+    )
+    def test_other_scans_leave_tags_alone(self, scan_type, rom: Rom):
+        assert _should_reparse_tags(scan_type, rom, []) is False
+
+    def test_hashes_rescan_leaves_tags_alone(self, rom: Rom):
+        """A hashes rescan is scoped to file bytes, so it must not touch tags."""
+        assert _should_reparse_tags(ScanType.HASHES, rom, []) is False
+
+    def test_selected_roms_reparse_under_any_scan_type(self, rom: Rom):
+        assert _should_reparse_tags(ScanType.QUICK, rom, [rom.id]) is True
+        assert _should_reparse_tags(ScanType.HASHES, rom, [rom.id]) is True
+
+    def test_unselected_rom_is_left_alone(self, rom: Rom):
+        assert _should_reparse_tags(ScanType.QUICK, rom, [rom.id + 99]) is False
+
+
+class TestIdentifyRomTagReparse:
+    """A complete rescan re-reads filename tags onto an existing entry.
+
+    Tags are parsed once at insert and otherwise never revisited, so a change to
+    `parse_tags` (a new normalization rule, say) would never reach rows scanned
+    before it. A HASHES scan is used for the negative case so the flow returns
+    right after the file-rebuild step.
+    """
+
+    @pytest.fixture
+    def patched(self, mocker):
+        mocker.patch.object(
+            scan_module, "redis_client", Mock(get=Mock(return_value=None))
+        )
+
+        fs = scan_module.fs_rom_handler
+        mocker.patch.object(
+            fs,
+            "parse_tags",
+            return_value=ParsedTags(
+                version="1.1",
+                revision="A",
+                regions=["USA"],
+                languages=["English"],
+                other_tags=["Proto"],
+            ),
+        )
+        mocker.patch.object(fs, "get_roms_fs_structure", return_value="test/roms")
+        mocker.patch.object(fs, "get_file_name_with_no_tags", return_value="Game")
+        mocker.patch.object(
+            fs,
+            "get_rom_files",
+            AsyncMock(
+                return_value=ParsedRomFiles(
+                    rom_files=[],
+                    crc_hash="crc",
+                    md5_hash="md5",
+                    sha1_hash="sha1",
+                    ra_hash="",
+                )
+            ),
+        )
+
+        config = MagicMock()
+        config.SKIP_HASH_CALCULATION = False
+        mocker.patch.object(scan_module.cm, "get_config", return_value=config)
+
+        scan_rom = mocker.patch.object(
+            scan_module,
+            "scan_rom",
+            AsyncMock(return_value=MagicMock(is_identified=False)),
+        )
+
+        # A COMPLETE scan runs past the point a HASHES scan returns at, into the
+        # resource downloads and the closing emit, none of which is under test.
+        resources = mocker.patch.object(
+            scan_module, "fs_resource_handler", new=AsyncMock()
+        )
+        resources.get_cover.return_value = ("cover_s.png", "cover_l.png")
+        resources.get_manual.return_value = "manual.pdf"
+        resources.get_rom_screenshots.return_value = []
+        resources.store_metadata_media.return_value = False
+        mocker.patch.object(scan_module, "SimpleRomSchema", MagicMock())
+
+        db = mocker.patch.object(scan_module, "db_rom_handler")
+        db.add_rom.return_value = MagicMock(
+            is_identified=False,
+            id=1,
+            url_cover="",
+            url_manual="",
+            url_screenshots=[],
+        )
+        db.sync_rom_files.return_value = SyncedRomFiles(
+            files=[], orphaned_cover_paths=[]
+        )
+        return SimpleNamespace(db=db, scan_rom=scan_rom)
+
+    def _existing_rom(self) -> Rom:
+        """A row carrying the raw values an older parser would have written."""
+        rom = Rom(
+            platform_id=1,
+            fs_name="Game (USA) (En) (Proto) (v1.1) (Rev A).zip",
+            fs_path="test/roms",
+            regions=["us"],
+            languages=["en"],
+            tags=["proto"],
+            revision="",
+            version="",
+        )
+        rom.id = 1
+        return rom
+
+    async def _run(self, rom: Rom, scan_type: ScanType, roms_ids: list[int]):
+        fs_rom: FSRom = {
+            "fs_name": "Game (USA) (En) (Proto) (v1.1) (Rev A).zip",
+            "flat": True,
+            "nested": False,
+            "files": [],
+            "crc_hash": "",
+            "md5_hash": "",
+            "sha1_hash": "",
+            "ra_hash": "",
+        }
+        platform = Platform(name="Test", slug="test", fs_slug="test")
+        platform.id = 1
+
+        await _identify_rom(
+            platform=platform,
+            fs_rom=fs_rom,
+            rom=rom,
+            scan_type=scan_type,
+            roms_ids=roms_ids,
+            metadata_sources=[],
+            launchbox_remote_enabled=False,
+            playmatch_enabled=False,
+            socket_manager=AsyncMock(),
+            scan_stats=AsyncMock(),
+        )
+
+    async def test_complete_rescan_rewrites_stale_tags(self, patched):
+        rom = self._existing_rom()
+
+        await self._run(rom, ScanType.COMPLETE, [])
+
+        # scan_rom carries these columns forward from the rom it is handed, and
+        # merging its result is what persists them.
+        assert rom.regions == ["USA"]
+        assert rom.languages == ["English"]
+        assert rom.tags == ["Proto"]
+        assert rom.revision == "A"
+        assert rom.version == "1.1"
+
+        # The mutated instance is the one carried onward, not a copy.
+        assert patched.scan_rom.call_args.kwargs["rom"] is rom
+
+    async def test_hashes_rescan_keeps_existing_tags(self, patched):
+        rom = self._existing_rom()
+
+        await self._run(rom, ScanType.HASHES, [])
+
+        assert rom.regions == ["us"]
+        assert rom.languages == ["en"]
+        assert rom.tags == ["proto"]
+
+    async def test_selected_rom_rewrites_tags(self, patched):
+        rom = self._existing_rom()
+
+        await self._run(rom, ScanType.HASHES, [rom.id])
+
+        assert rom.regions == ["USA"]
+        assert rom.languages == ["English"]
 
 
 class TestScanAuthorization:

--- a/backend/tests/handler/database/test_roms_handler.py
+++ b/backend/tests/handler/database/test_roms_handler.py
@@ -69,6 +69,61 @@ def _make_rom(platform: Platform, fs_name: str) -> Rom:
     )
 
 
+class TestAddRomMergesScannedTags:
+    """`add_rom` merges the partially-populated Rom that `scan_rom` returns.
+
+    A rescan re-reads the filename tags onto the existing row and relies on this
+    merge to persist them, so the tag columns have to survive the round trip
+    while columns the scan never names keep their stored values.
+    """
+
+    def _scanned(self, rom: Rom) -> Rom:
+        """The subset of columns `scan_rom` rebuilds for an existing entry."""
+        return Rom(
+            id=rom.id,
+            platform_id=rom.platform_id,
+            fs_name=rom.fs_name,
+            fs_path=rom.fs_path,
+            regions=["USA"],
+            revision="A",
+            version="1.1",
+            languages=["English"],
+            tags=["Proto"],
+        )
+
+    def test_tag_columns_are_persisted(self, rom: Rom):
+        db_rom_handler.update_rom(
+            rom.id,
+            {
+                "regions": ["us"],
+                "languages": ["en"],
+                "tags": ["proto"],
+                "revision": "",
+                "version": "",
+            },
+        )
+
+        db_rom_handler.add_rom(self._scanned(rom))
+
+        stored = db_rom_handler.get_rom(rom.id)
+        assert stored is not None
+        assert stored.regions == ["USA"]
+        assert stored.languages == ["English"]
+        assert stored.tags == ["Proto"]
+        assert stored.revision == "A"
+        assert stored.version == "1.1"
+
+    def test_columns_the_scan_omits_are_left_alone(self, rom: Rom):
+        db_rom_handler.update_rom(rom.id, {"summary": "kept", "slug": "kept-slug"})
+
+        db_rom_handler.add_rom(self._scanned(rom))
+
+        stored = db_rom_handler.get_rom(rom.id)
+        assert stored is not None
+        assert stored.summary == "kept"
+        assert stored.slug == "kept-slug"
+
+
 class TestUniquePlatformFsName:
     """A platform folder can't hold two entries with the same name, so the DB
     rejects a second ROM with the same (platform_id, fs_name). This is what


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

Follow-up to #4206. That PR canonicalized region and language tags in `parse_tags`, but the normalization only ever reaches rows scanned *after* it, so an existing library keeps its old spellings (`us`, `en`, `es`) indefinitely. The backfill migrations that would have fixed those rows were dropped before merge, and no scan type replaces them either — this closes that second gap.

A rom parses its filename tags when it is first inserted, and after that only if the edit endpoint renames it. In between, nothing re-reads them:

- `_identify_rom` parses tags for every rom into `rom_attrs`, but that dict is only consumed on the insert path (`add_rom(Rom(**rom_attrs))`) and by a throwaway `Rom` built for hashing. For an existing row it is discarded.
- `scan_rom` then reseeds `regions` / `languages` / `tags` / `revision` from the row it was handed, so the stored values are what get merged back.

The net effect is that a `COMPLETE` rescan wipes cached artwork and re-fetches all metadata, but silently leaves filename-derived facets untouched, which is surprising on its own terms and independent of #4206.

**What changed**

- `_should_reparse_tags` in `endpoints/sockets/scan.py`, mirroring the existing `_should_get_rom_files`. Scope is `COMPLETE` plus explicitly selected `roms_ids`. `HASHES` is deliberately excluded: it is scoped to re-reading file bytes, and having it rewrite filename facets as a side effect would be surprising.
- The parsed values are written onto the rom instance before `scan_rom`, rather than through a separate `update_rom`. `scan_rom` carries these columns forward from the rom it is handed and `add_rom`'s `session.merge` is what persists them, so this stays one write.
- `scan_rom` now carries `version` forward. It was the only tag column missing from its attrs, so a re-parsed version would have been dropped on the way through — and the `version` the reassociation path already writes was being discarded for the same reason.

`roms_facets` needs no direct write; it follows through the triggers added in `0100`.

**Scope**

This does not restore the region aliases removed in 9b9dba0d. `(US)` still resolves to no region and stays a plain tag; after a rescan it moves from `regions` to `tags` rather than becoming `USA`. Language codes (`en`, `es`, `fr`) do normalize, since those are canonical `LANGUAGES` shortcodes.

**Testing**

- `TestShouldReparseTags` — per-scan-type coverage, including that `HASHES` leaves tags alone and that an explicitly selected rom re-parses under any scan type.
- `TestIdentifyRomTagReparse` — drives `_identify_rom` end to end for the complete / hashes / selected-rom cases and asserts the mutated instance is the one handed to `scan_rom`.
- `TestAddRomMergesScannedTags` — round-trips through a real database to confirm the assumption the approach rests on: the tag columns survive the merge, and columns the scan never names (`summary`, `slug`) keep their stored values rather than being nulled.
- Full backend suite: 2904 passed, 2 skipped. `trunk fmt && trunk check` clean.

No API surface changed, so no OpenAPI regeneration is needed.

**AI assistance**

This PR was written primarily by Claude Code (Opus 5) — the investigation, the code, the tests and this description. I directed the approach and reviewed the diff; in particular the decision to fix this in the scan path rather than reinstate the backfill migrations that were dropped from #4206. Responses on this PR are written by me unless stated otherwise.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A — no visual change beyond the region and language filter lists collapsing duplicate entries after a complete rescan.
