### PR TITLE
fix(libretro): cache missing thumbnail listings

### DIFF
--- a/backend/adapters/services/libretro_thumbnails.py
+++ b/backend/adapters/services/libretro_thumbnails.py
@@ -16,6 +16,9 @@ from utils.context import ctx_aiohttp_session
 LIBRETRO_THUMBNAIL_ROOT = "https://thumbnails.libretro.com"
 LIBRETRO_LISTING_CACHE_KEY = "romm:libretro:listing"
 LIBRETRO_LISTING_CACHE_TTL = 60 * 60 * 24  # 24 hours
+# Not every system has every art type, so misses are cached too, on a shorter
+# TTL in case the directory is added upstream later.
+LIBRETRO_MISSING_LISTING_CACHE_TTL = 60 * 60  # 1 hour
 
 
 class _AnchorHrefParser(HTMLParser):
@@ -99,6 +102,12 @@ class LibretroThumbnailsService:
                 exc.status,
                 url,
             )
+            # Client errors mean the directory isn't there, which won't change
+            # between ROMs of the same platform. Server errors might.
+            if exc.status < 500:
+                await self._cache_listing(
+                    cache_key, [], ttl=LIBRETRO_MISSING_LISTING_CACHE_TTL
+                )
             return []
         except aiohttp.client_exceptions.ClientError as exc:
             log.warning("Libretro listing request failed for URL %s: %s", url, exc)
@@ -108,14 +117,16 @@ class LibretroThumbnailsService:
         parser.feed(body)
         filenames = parser.filenames
 
-        try:
-            await async_cache.set(
-                cache_key, json.dumps(filenames), ex=LIBRETRO_LISTING_CACHE_TTL
-            )
-        except Exception as exc:  # pragma: no cover - cache is best-effort
-            log.warning("Failed to cache libretro listing %s: %s", cache_key, exc)
+        await self._cache_listing(cache_key, filenames, ttl=LIBRETRO_LISTING_CACHE_TTL)
 
         return filenames
+
+    @staticmethod
+    async def _cache_listing(cache_key: str, filenames: list[str], *, ttl: int) -> None:
+        try:
+            await async_cache.set(cache_key, json.dumps(filenames), ex=ttl)
+        except Exception as exc:  # pragma: no cover - cache is best-effort
+            log.warning("Failed to cache libretro listing %s: %s", cache_key, exc)
 
     async def head(self) -> bool:
         """Lightweight connectivity check against the thumbnail server root."""

--- a/backend/adapters/services/libretro_thumbnails.py
+++ b/backend/adapters/services/libretro_thumbnails.py
@@ -19,6 +19,9 @@ LIBRETRO_LISTING_CACHE_TTL = 60 * 60 * 24  # 24 hours
 # Not every system has every art type, so misses are cached too, on a shorter
 # TTL in case the directory is added upstream later.
 LIBRETRO_MISSING_LISTING_CACHE_TTL = 60 * 60  # 1 hour
+# Statuses that mean the directory isn't there, as opposed to a request that
+# could succeed on a retry (429, 408, 403, 5xx).
+LIBRETRO_MISSING_LISTING_STATUSES = frozenset({404, 410})
 
 
 class _AnchorHrefParser(HTMLParser):
@@ -102,9 +105,9 @@ class LibretroThumbnailsService:
                 exc.status,
                 url,
             )
-            # Client errors mean the directory isn't there, which won't change
-            # between ROMs of the same platform. Server errors might.
-            if exc.status < 500:
+            # An absent directory won't reappear between ROMs of the same
+            # platform, so remember it. Anything retryable stays uncached.
+            if exc.status in LIBRETRO_MISSING_LISTING_STATUSES:
                 await self._cache_listing(
                     cache_key, [], ttl=LIBRETRO_MISSING_LISTING_CACHE_TTL
                 )

--- a/backend/tests/adapters/services/test_libretro_thumbnails.py
+++ b/backend/tests/adapters/services/test_libretro_thumbnails.py
@@ -1,0 +1,129 @@
+"""Tests for the libretro thumbnails service."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp.client_exceptions
+import pytest
+
+from adapters.services.libretro_thumbnails import (
+    LIBRETRO_LISTING_CACHE_TTL,
+    LIBRETRO_MISSING_LISTING_CACHE_TTL,
+    LibretroThumbnailsService,
+)
+from adapters.services.libretro_thumbnails_types import LibretroArtType
+from handler.redis_handler import async_cache
+
+LISTING_BODY = """
+<html><body>
+<a href="?C=N;O=D">Name</a>
+<a href="/">Parent Directory</a>
+<a href="Final%20Fantasy%20VII%20(USA).png">Final Fantasy VII (USA).png</a>
+</body></html>
+"""
+
+
+@pytest.fixture
+def service() -> LibretroThumbnailsService:
+    return LibretroThumbnailsService()
+
+
+def mock_session_returning(body: str) -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.text = AsyncMock(return_value=body)
+    session = MagicMock()
+    session.get = AsyncMock(return_value=response)
+    return session
+
+
+def mock_session_raising(exc: Exception) -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status.side_effect = exc
+    session = MagicMock()
+    session.get = AsyncMock(return_value=response)
+    return session
+
+
+def response_error(status: int) -> aiohttp.client_exceptions.ClientResponseError:
+    return aiohttp.client_exceptions.ClientResponseError(
+        request_info=MagicMock(), history=(), status=status
+    )
+
+
+async def fetch_with(
+    service: LibretroThumbnailsService,
+    session: MagicMock,
+    system_name: str,
+    art_type: LibretroArtType = LibretroArtType.LOGO,
+) -> list[str]:
+    mock_context = MagicMock()
+    mock_context.get.return_value = session
+    with patch(
+        "adapters.services.libretro_thumbnails.ctx_aiohttp_session", mock_context
+    ):
+        return await service.fetch_listing(system_name, art_type)
+
+
+@pytest.mark.asyncio
+async def test_fetch_listing_caches_parsed_filenames(service):
+    system_name = "Test - Success"
+    session = mock_session_returning(LISTING_BODY)
+
+    result = await fetch_with(service, session, system_name)
+
+    assert result == ["Final Fantasy VII (USA).png"]
+
+    cache_key = service._cache_key(system_name, LibretroArtType.LOGO)
+    assert json.loads(await async_cache.get(cache_key)) == result
+    assert await async_cache.ttl(cache_key) == LIBRETRO_LISTING_CACHE_TTL
+
+
+@pytest.mark.asyncio
+async def test_fetch_listing_caches_miss_on_404(service):
+    """A missing directory is stable, so the empty result should be cached."""
+    system_name = "Test - Missing"
+    session = mock_session_raising(response_error(404))
+
+    assert await fetch_with(service, session, system_name) == []
+
+    cache_key = service._cache_key(system_name, LibretroArtType.LOGO)
+    assert json.loads(await async_cache.get(cache_key)) == []
+    assert await async_cache.ttl(cache_key) == LIBRETRO_MISSING_LISTING_CACHE_TTL
+
+
+@pytest.mark.asyncio
+async def test_fetch_listing_serves_cached_miss_without_a_request(service):
+    """The second lookup for a missing directory must not hit the network."""
+    system_name = "Test - Missing Repeat"
+    first_session = mock_session_raising(response_error(404))
+    await fetch_with(service, first_session, system_name)
+
+    second_session = mock_session_raising(response_error(404))
+    assert await fetch_with(service, second_session, system_name) == []
+
+    second_session.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_listing_does_not_cache_server_errors(service):
+    system_name = "Test - Server Error"
+    session = mock_session_raising(response_error(503))
+
+    assert await fetch_with(service, session, system_name) == []
+
+    cache_key = service._cache_key(system_name, LibretroArtType.LOGO)
+    assert await async_cache.get(cache_key) is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_listing_does_not_cache_connection_errors(service):
+    system_name = "Test - Connection Error"
+    session = mock_session_raising(
+        aiohttp.client_exceptions.ClientConnectionError("nope")
+    )
+
+    assert await fetch_with(service, session, system_name) == []
+
+    cache_key = service._cache_key(system_name, LibretroArtType.LOGO)
+    assert await async_cache.get(cache_key) is None

--- a/backend/tests/adapters/services/test_libretro_thumbnails.py
+++ b/backend/tests/adapters/services/test_libretro_thumbnails.py
@@ -106,9 +106,22 @@ async def test_fetch_listing_serves_cached_miss_without_a_request(service):
 
 
 @pytest.mark.asyncio
-async def test_fetch_listing_does_not_cache_server_errors(service):
-    system_name = "Test - Server Error"
-    session = mock_session_raising(response_error(503))
+async def test_fetch_listing_caches_miss_on_410(service):
+    system_name = "Test - Gone"
+    session = mock_session_raising(response_error(410))
+
+    assert await fetch_with(service, session, system_name) == []
+
+    cache_key = service._cache_key(system_name, LibretroArtType.LOGO)
+    assert json.loads(await async_cache.get(cache_key)) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [403, 408, 429, 503])
+async def test_fetch_listing_does_not_cache_retryable_errors(service, status):
+    """A directory that exists must not be masked by a transient failure."""
+    system_name = f"Test - Retryable {status}"
+    session = mock_session_raising(response_error(status))
 
     assert await fetch_with(service, session, system_name) == []
 


### PR DESCRIPTION
**Description**

Failed libretro thumbnail listing requests returned early without writing to Redis, so only successful listings were cached. Any platform missing a directory for an art type re-requested it on every ROM, producing a 404 per ROM for the entire scan:

```
WARNING [libretro_thumbnails] Libretro listing request failed with status 404 for URL: https://thumbnails.libretro.com/Nintendo%20-%20Nintendo%203DS/Named_Logos/?F=2
```

That repeated ~490 times while scanning a 3DS library. `Named_Logos` genuinely 404s for that system (`Named_Boxarts` and `Named_Titles` return 200), so it is an expected miss that was simply never remembered.

This caches the empty result on a 4xx, under a shorter 1 hour TTL than the 24 hour TTL used for real listings, since a missing directory is stable but could be added upstream later. 5xx and connection errors stay uncached, since those are transient and shouldn't poison the cache for an hour off a brief network drop. The existing warning still logs, so a newly missing directory remains visible, just once per platform per hour instead of once per ROM.

Caching moved into a small `_cache_listing` helper shared by the success and miss paths.

**Testing**

New `backend/tests/adapters/services/test_libretro_thumbnails.py` covers: success caches parsed filenames at the 24h TTL, a 404 caches `[]` at the 1h TTL, a repeat lookup after a 404 makes no HTTP request at all, and 503 / connection errors leave the cache empty. All 27 tests across the new file and the existing `test_libretro_handler.py` pass.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The root cause analysis, the fix, and the tests were AI-generated, then reviewed and verified locally by me.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
