### PR TITLE
fix(launchbox): match titles differing only by punctuation

### DIFF
--- a/backend/endpoints/sockets/scan.py
+++ b/backend/endpoints/sockets/scan.py
@@ -39,7 +39,12 @@ from handler.filesystem import (
     fs_rom_handler,
 )
 from handler.filesystem.roms_handler import FSRom
-from handler.metadata import meta_gamelist_handler, meta_hltb_handler
+from handler.metadata import (
+    meta_gamelist_handler,
+    meta_hltb_handler,
+    meta_launchbox_handler,
+)
+from handler.metadata.launchbox_handler.types import LAUNCHBOX_PLATFORMS_DIR
 from handler.metadata.ss_handler import add_ss_auth_to_url
 from handler.metadata.ss_handler import begin_scan as begin_ss_scan
 from handler.metadata.ss_handler import get_preferred_media_types
@@ -1067,6 +1072,40 @@ async def scan_platforms(
     # Initialize HLTB handler (fetches current search endpoint and security token)
     if MetadataSource.HLTB in metadata_sources:
         await meta_hltb_handler.initialize()
+
+    # A local install is read on every lookup; the per-scan switch only decides
+    # whether the cloud store is consulted as well. Both can be empty, and a
+    # lookup against an absent source is silent, so what LaunchBox can actually
+    # read is recorded here rather than left to be inferred from a platform's
+    # worth of empty results.
+    if MetadataSource.LAUNCHBOX in metadata_sources:
+        local_available = meta_launchbox_handler.is_local_enabled()
+        store_available = launchbox_remote_enabled and (
+            await meta_launchbox_handler.is_remote_store_populated()
+        )
+        readable = [
+            name
+            for name, present in (
+                (f"a {hl('local')} install", local_available),
+                (f"the {hl('cloud')} store", store_available),
+            )
+            if present
+        ]
+        if readable:
+            log.info(f"LaunchBox is reading {' and '.join(readable)}")
+        elif launchbox_remote_enabled:
+            log.warning(
+                f"{hl(emoji.EMOJI_WARNING, color=LIGHTYELLOW)} LaunchBox has nothing "
+                f"to read: no install at {hl(str(LAUNCHBOX_PLATFORMS_DIR))} and the "
+                "cloud store is empty. Run the LaunchBox metadata update task."
+            )
+        else:
+            log.warning(
+                f"{hl(emoji.EMOJI_WARNING, color=LIGHTYELLOW)} LaunchBox is set to "
+                f"local only and no install was found at "
+                f"{hl(str(LAUNCHBOX_PLATFORMS_DIR))}, so it will match nothing. "
+                "Switch it to cloud, or mount an install there."
+            )
 
     # Resolve the platforms that will actually be scanned. When no platform ids
     # are provided, every filesystem platform is scanned.

--- a/backend/handler/metadata/launchbox_handler/remote_source.py
+++ b/backend/handler/metadata/launchbox_handler/remote_source.py
@@ -9,10 +9,11 @@ from .types import (
     LAUNCHBOX_MAME_KEY,
     LAUNCHBOX_METADATA_ALTERNATE_NAME_KEY,
     LAUNCHBOX_METADATA_DATABASE_ID_KEY,
+    LAUNCHBOX_METADATA_FOLDED_NAME_KEY,
     LAUNCHBOX_METADATA_IMAGE_KEY,
     LAUNCHBOX_METADATA_NAME_KEY,
 )
-from .utils import deinvert_article, file_name_forms
+from .utils import deinvert_article, file_name_forms, fold_title
 
 
 class RemoteSource:
@@ -88,6 +89,20 @@ class RemoteSource:
             entry = json.loads(metadata_database_index_entry)
             if entry.get("Platform") == platform_name:
                 return entry
+
+        # Last resort: compare titles with punctuation, accents and spacing
+        # removed. A dump filename can only differ from the title it was cut
+        # from by characters `fold_title` drops, so this is checked after every
+        # exact form has missed.
+        for candidate in candidates:
+            folded = fold_title(candidate)
+            if not folded:
+                continue
+            folded_index_entry = await async_cache.hget(
+                LAUNCHBOX_METADATA_FOLDED_NAME_KEY, f"{folded}:{platform_name}"
+            )
+            if folded_index_entry:
+                return json.loads(folded_index_entry)
 
         return None
 

--- a/backend/handler/metadata/launchbox_handler/types.py
+++ b/backend/handler/metadata/launchbox_handler/types.py
@@ -13,8 +13,6 @@ LAUNCHBOX_METADATA_NAME_KEY: Final[str] = "romm:launchbox_metadata_name"
 LAUNCHBOX_METADATA_ALTERNATE_NAME_KEY: Final[str] = (
     "romm:launchbox_metadata_alternate_name"
 )
-# Titles reduced to letters and digits, so a filename only differing from the
-# dump by punctuation still resolves. See `fold_title` for what it drops.
 LAUNCHBOX_METADATA_FOLDED_NAME_KEY: Final[str] = "romm:launchbox_metadata_folded_name"
 LAUNCHBOX_METADATA_IMAGE_KEY: Final[str] = "romm:launchbox_metadata_image"
 LAUNCHBOX_MAME_KEY: Final[str] = "romm:launchbox_mame"

--- a/backend/handler/metadata/launchbox_handler/types.py
+++ b/backend/handler/metadata/launchbox_handler/types.py
@@ -13,6 +13,9 @@ LAUNCHBOX_METADATA_NAME_KEY: Final[str] = "romm:launchbox_metadata_name"
 LAUNCHBOX_METADATA_ALTERNATE_NAME_KEY: Final[str] = (
     "romm:launchbox_metadata_alternate_name"
 )
+# Titles reduced to letters and digits, so a filename only differing from the
+# dump by punctuation still resolves. See `fold_title` for what it drops.
+LAUNCHBOX_METADATA_FOLDED_NAME_KEY: Final[str] = "romm:launchbox_metadata_folded_name"
 LAUNCHBOX_METADATA_IMAGE_KEY: Final[str] = "romm:launchbox_metadata_image"
 LAUNCHBOX_MAME_KEY: Final[str] = "romm:launchbox_mame"
 LAUNCHBOX_FILES_KEY: Final[str] = "romm:launchbox_files"

--- a/backend/handler/metadata/launchbox_handler/utils.py
+++ b/backend/handler/metadata/launchbox_handler/utils.py
@@ -57,10 +57,22 @@ def fold_title(title: str) -> str:
     Letters of every script survive. Keeping only ASCII would reduce a title
     written in one to whatever digits it carries, collapsing "三國立志傳2" and
     "忍者村大战2" onto the same key.
+
+    A mark only goes when it sits on a Latin letter, where it is an accent the
+    two sides may disagree about ("Astérix" against "Asterix"). Elsewhere it
+    spells the word: Devanagari and Thai build syllables from marks, so dropping
+    them would reduce "हिन्दी" to "हनद" and collide titles that differ.
     """
-    decomposed = unicodedata.normalize("NFKD", title.casefold())
-    without_accents = "".join(c for c in decomposed if not unicodedata.combining(c))
-    return "".join(c for c in without_accents if c.isalnum())
+    kept: list[str] = []
+    for char in unicodedata.normalize("NFKD", title.casefold()):
+        if unicodedata.category(char).startswith("M"):
+            if kept and "a" <= kept[-1] <= "z":
+                continue
+            kept.append(char)
+        elif char.isalnum():
+            kept.append(char)
+
+    return "".join(kept)
 
 
 def file_name_forms(file_name: str) -> list[str]:

--- a/backend/handler/metadata/launchbox_handler/utils.py
+++ b/backend/handler/metadata/launchbox_handler/utils.py
@@ -1,4 +1,5 @@
 import re
+import unicodedata
 from datetime import datetime
 from pathlib import Path
 
@@ -39,6 +40,23 @@ def deinvert_article(term: str) -> str | None:
 
     subtitle = match.group("subtitle") or ""
     return f"{match.group('article')} {match.group('title')}{subtitle}"
+
+
+def fold_title(title: str) -> str:
+    """Reduce a title to letters and digits for punctuation-blind comparison.
+
+    Dump titles and ROM filenames disagree on punctuation constantly: LaunchBox
+    writes a colon a filename has no room for ("Burnout: Revenge"), keeps
+    diacritics a dump filename drops ("Astérix"), and uses characters a
+    filesystem forbids ("AC/DC"). Folding both sides to `burnoutrevenge` /
+    `asterix` / `acdc` makes those the same key.
+
+    Spaces go too, so "Area-51" and "Area 51" agree. Returns "" for a title
+    with nothing left to compare, which callers must treat as no key.
+    """
+    decomposed = unicodedata.normalize("NFKD", title.casefold())
+    without_accents = "".join(c for c in decomposed if not unicodedata.combining(c))
+    return re.sub(r"[^a-z0-9]+", "", without_accents)
 
 
 def file_name_forms(file_name: str) -> list[str]:

--- a/backend/handler/metadata/launchbox_handler/utils.py
+++ b/backend/handler/metadata/launchbox_handler/utils.py
@@ -53,10 +53,14 @@ def fold_title(title: str) -> str:
 
     Spaces go too, so "Area-51" and "Area 51" agree. Returns "" for a title
     with nothing left to compare, which callers must treat as no key.
+
+    Letters of every script survive. Keeping only ASCII would reduce a title
+    written in one to whatever digits it carries, collapsing "三國立志傳2" and
+    "忍者村大战2" onto the same key.
     """
     decomposed = unicodedata.normalize("NFKD", title.casefold())
     without_accents = "".join(c for c in decomposed if not unicodedata.combining(c))
-    return re.sub(r"[^a-z0-9]+", "", without_accents)
+    return "".join(c for c in without_accents if c.isalnum())
 
 
 def file_name_forms(file_name: str) -> list[str]:

--- a/backend/tasks/scheduled/update_launchbox_metadata.py
+++ b/backend/tasks/scheduled/update_launchbox_metadata.py
@@ -19,11 +19,13 @@ from handler.metadata.launchbox_handler.types import (
     LAUNCHBOX_MAME_KEY,
     LAUNCHBOX_METADATA_ALTERNATE_NAME_KEY,
     LAUNCHBOX_METADATA_DATABASE_ID_KEY,
+    LAUNCHBOX_METADATA_FOLDED_NAME_KEY,
     LAUNCHBOX_METADATA_IMAGE_KEY,
     LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY,
     LAUNCHBOX_METADATA_NAME_KEY,
     LAUNCHBOX_PLATFORMS_KEY,
 )
+from handler.metadata.launchbox_handler.utils import fold_title
 from handler.redis_handler import async_cache
 from logger.logger import log
 from tasks.tasks import RemoteFilePullTask, TaskType
@@ -198,6 +200,15 @@ class UpdateLaunchboxMetadataTask(RemoteFilePullTask):
                                                 f":{platform_elem.text.strip()}",
                                                 _element_to_dict(elem),
                                             )
+
+                                            folded = fold_title(name_elem.text)
+                                            if folded:
+                                                await writer.hset(
+                                                    LAUNCHBOX_METADATA_FOLDED_NAME_KEY,
+                                                    f"{folded}"
+                                                    f":{platform_elem.text.strip()}",
+                                                    _element_to_dict(elem),
+                                                )
 
                                     elif elem.tag == "GameAlternateName":
                                         alternate_name_elem = elem.find("AlternateName")

--- a/backend/tasks/scheduled/update_launchbox_metadata.py
+++ b/backend/tasks/scheduled/update_launchbox_metadata.py
@@ -193,21 +193,23 @@ class UpdateLaunchboxMetadataTask(RemoteFilePullTask):
                                             and platform_elem is not None
                                             and platform_elem.text
                                         ):
+                                            platform_name = platform_elem.text.strip()
+                                            game = _element_to_dict(elem)
+
                                             # Use a unique combination of name and platform as the key
                                             await writer.hset(
                                                 LAUNCHBOX_METADATA_NAME_KEY,
                                                 f"{name_elem.text.strip().lower()}"
-                                                f":{platform_elem.text.strip()}",
-                                                _element_to_dict(elem),
+                                                f":{platform_name}",
+                                                game,
                                             )
 
                                             folded = fold_title(name_elem.text)
                                             if folded:
                                                 await writer.hset(
                                                     LAUNCHBOX_METADATA_FOLDED_NAME_KEY,
-                                                    f"{folded}"
-                                                    f":{platform_elem.text.strip()}",
-                                                    _element_to_dict(elem),
+                                                    f"{folded}:{platform_name}",
+                                                    game,
                                                 )
 
                                     elif elem.tag == "GameAlternateName":

--- a/backend/tests/handler/metadata/test_launchbox_handler.py
+++ b/backend/tests/handler/metadata/test_launchbox_handler.py
@@ -702,6 +702,27 @@ class TestRemoteSourceGetRom:
         assert result is not None
         assert result.get("DatabaseID", None) == "77"
 
+    @pytest.mark.parametrize(
+        ("title", "expected"),
+        [
+            ("Burnout: Revenge", "burnoutrevenge"),
+            ("Astérix at the Olympic Games", "asterixattheolympicgames"),
+            ("AC/DC Live", "acdclive"),
+            ("Area-51", "area51"),
+            # A title in a non-Latin script keeps its letters. Reducing it to
+            # its digits would collide with every other title numbered alike.
+            ("三國立志傳2", "三國立志傳2"),
+            ("Зона 51", "зона51"),
+            # Nothing comparable left, so callers must treat it as no key.
+            (":: -- ::", ""),
+        ],
+    )
+    def test_fold_title(self, title: str, expected: str):
+        assert fold_title(title) == expected
+
+    def test_fold_title_separates_titles_sharing_only_their_digits(self):
+        assert fold_title("三國立志傳2") != fold_title("忍者村大战2")
+
     async def test_folded_match_is_only_tried_after_exact_forms(
         self, source: RemoteSource
     ):

--- a/backend/tests/handler/metadata/test_launchbox_handler.py
+++ b/backend/tests/handler/metadata/test_launchbox_handler.py
@@ -713,6 +713,10 @@ class TestRemoteSourceGetRom:
             # its digits would collide with every other title numbered alike.
             ("三國立志傳2", "三國立志傳2"),
             ("Зона 51", "зона51"),
+            # Scripts that build syllables from marks keep them; stripping to
+            # alphanumerics alone would spell these titles differently.
+            ("हिन्दी गेम", "हिन्दीगेम"),
+            ("สนุกเกอร์", "สนุกเกอร์"),
             # Nothing comparable left, so callers must treat it as no key.
             (":: -- ::", ""),
         ],

--- a/backend/tests/handler/metadata/test_launchbox_handler.py
+++ b/backend/tests/handler/metadata/test_launchbox_handler.py
@@ -36,6 +36,7 @@ from handler.metadata.launchbox_handler.types import (
     LAUNCHBOX_MAME_KEY,
     LAUNCHBOX_METADATA_ALTERNATE_NAME_KEY,
     LAUNCHBOX_METADATA_DATABASE_ID_KEY,
+    LAUNCHBOX_METADATA_FOLDED_NAME_KEY,
     LAUNCHBOX_METADATA_IMAGE_KEY,
     LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY,
     LAUNCHBOX_METADATA_NAME_KEY,
@@ -46,6 +47,7 @@ from handler.metadata.launchbox_handler.types import (
 from handler.metadata.launchbox_handler.utils import (
     coalesce,
     deinvert_article,
+    fold_title,
     launchbox_region_to_shortcode,
     parse_playmode,
     parse_release_date,
@@ -666,6 +668,63 @@ class TestRemoteSourceGetRom:
         assert result.get("DatabaseID", None) == "161"
         # The literal name is still tried first.
         assert queried[0] == "legend of zelda, the: ocarina of time:Nintendo 64"
+
+    @pytest.mark.parametrize(
+        ("search_term", "dump_title"),
+        [
+            # LaunchBox adds a colon the filename has no room for.
+            ("burnout revenge", "Burnout: Revenge"),
+            # The dump keeps diacritics a No-Intro filename drops.
+            ("asterix at the olympic games", "Astérix at the Olympic Games"),
+            # "/" cannot appear in a filename at all.
+            ("ac-dc live: rock band track pack", "AC/DC Live: Rock Band Track Pack"),
+            # Hyphen against space.
+            ("area 51", "Area-51"),
+        ],
+    )
+    async def test_folded_title_match(
+        self, source: RemoteSource, search_term: str, dump_title: str
+    ):
+        """Punctuation-only differences resolve through the folded index."""
+        entry = {"DatabaseID": "77", "Name": dump_title}
+        folded_field = f"{fold_title(dump_title)}:Sony Playstation 2"
+
+        async def side_effect(key, field):
+            if key == LAUNCHBOX_METADATA_FOLDED_NAME_KEY and field == folded_field:
+                return json.dumps(entry)
+            return None
+
+        with patch.object(
+            async_cache, "hget", new_callable=AsyncMock, side_effect=side_effect
+        ):
+            result = await source.get_rom(search_term, "ps2", assume_cache_present=True)
+
+        assert result is not None
+        assert result.get("DatabaseID", None) == "77"
+
+    async def test_folded_match_is_only_tried_after_exact_forms(
+        self, source: RemoteSource
+    ):
+        """Folding discards information, so an exact hit must always win."""
+        exact = {"DatabaseID": "1", "Name": "Burnout Revenge"}
+        folded = {"DatabaseID": "2", "Name": "Burnout: Revenge"}
+
+        async def side_effect(key, _field):
+            if key == LAUNCHBOX_METADATA_NAME_KEY:
+                return json.dumps(exact)
+            if key == LAUNCHBOX_METADATA_FOLDED_NAME_KEY:
+                return json.dumps(folded)
+            return None
+
+        with patch.object(
+            async_cache, "hget", new_callable=AsyncMock, side_effect=side_effect
+        ):
+            result = await source.get_rom(
+                "burnout revenge", "ps2", assume_cache_present=True
+            )
+
+        assert result is not None
+        assert result.get("DatabaseID", None) == "1"
 
     async def test_no_match_returns_none(self, source: RemoteSource):
         with patch.object(

--- a/backend/tests/tasks/test_update_launchbox_metadata.py
+++ b/backend/tests/tasks/test_update_launchbox_metadata.py
@@ -11,6 +11,7 @@ from handler.metadata.launchbox_handler.types import (
     LAUNCHBOX_MAME_KEY,
     LAUNCHBOX_METADATA_ALTERNATE_NAME_KEY,
     LAUNCHBOX_METADATA_DATABASE_ID_KEY,
+    LAUNCHBOX_METADATA_FOLDED_NAME_KEY,
     LAUNCHBOX_METADATA_IMAGE_KEY,
     LAUNCHBOX_METADATA_INITIAL_IMPORT_KEY,
     LAUNCHBOX_METADATA_NAME_KEY,
@@ -151,7 +152,7 @@ class TestUpdateLaunchboxMetadataTask:
 
         # Check hset call details
         hset_calls = mock_pipe.hset.call_args_list
-        assert len(hset_calls) == 12
+        assert len(hset_calls) == 14
 
         platform_calls = [
             call for call in hset_calls if call[0][0] == LAUNCHBOX_PLATFORMS_KEY
@@ -174,11 +175,18 @@ class TestUpdateLaunchboxMetadataTask:
         metadata_image_calls = [
             call for call in hset_calls if call[0][0] == LAUNCHBOX_METADATA_IMAGE_KEY
         ]
+        metadata_folded_calls = [
+            call
+            for call in hset_calls
+            if call[0][0] == LAUNCHBOX_METADATA_FOLDED_NAME_KEY
+        ]
 
         assert len(metadata_id_calls) == 2
         assert len(metadata_name_calls) == 2
         assert len(metadata_alt_calls) == 1
         assert len(metadata_image_calls) == 1
+        # Every named game is indexed under its folded title too.
+        assert len(metadata_folded_calls) == len(metadata_name_calls)
 
         mame_calls = [call for call in hset_calls if call[0][0] == LAUNCHBOX_MAME_KEY]
         assert len(mame_calls) == 2
@@ -324,7 +332,7 @@ class TestUpdateLaunchboxMetadataTaskIntegration:
 
         # Check hset call details
         hset_calls = mock_pipe.hset.call_args_list
-        assert len(hset_calls) == 12
+        assert len(hset_calls) == 14
 
         # Verify that all expected Redis keys were used
         redis_keys_used = [call[0][0] for call in hset_calls]
@@ -333,6 +341,7 @@ class TestUpdateLaunchboxMetadataTaskIntegration:
             LAUNCHBOX_PLATFORMS_KEY,
             LAUNCHBOX_METADATA_DATABASE_ID_KEY,
             LAUNCHBOX_METADATA_NAME_KEY,
+            LAUNCHBOX_METADATA_FOLDED_NAME_KEY,
             LAUNCHBOX_METADATA_ALTERNATE_NAME_KEY,
             LAUNCHBOX_METADATA_IMAGE_KEY,
             LAUNCHBOX_MAME_KEY,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -165,9 +165,6 @@ RUN git clone https://github.com/evanmiller/mod_zip.git && \
 FROM nginx:${NGINX_VERSION}-alpine${ALPINE_VERSION}@sha256:${NGINX_SHA256} AS production-stage
 ARG WEBSERVER_FOLDER=/var/www/html
 
-# valkey-cli is packaged separately from valkey on Alpine, and nothing in the
-# image invokes it. It ships so operators can inspect the internal cache, which
-# holds metadata that only a task re-run can rebuild.
 RUN apk add --no-cache \
     bash \
     libarchive-tools \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -165,6 +165,9 @@ RUN git clone https://github.com/evanmiller/mod_zip.git && \
 FROM nginx:${NGINX_VERSION}-alpine${ALPINE_VERSION}@sha256:${NGINX_SHA256} AS production-stage
 ARG WEBSERVER_FOLDER=/var/www/html
 
+# valkey-cli is packaged separately from valkey on Alpine, and nothing in the
+# image invokes it. It ships so operators can inspect the internal cache, which
+# holds metadata that only a task re-run can rebuild.
 RUN apk add --no-cache \
     bash \
     libarchive-tools \
@@ -174,7 +177,8 @@ RUN apk add --no-cache \
     nodejs \
     7zip \
     tzdata \
-    valkey
+    valkey \
+    valkey-cli
 
 # Add Python by copying it from the official Docker image. This way, we don't rely on Alpine's
 # Python version, which could not be the same as the one used in the backend build stage.

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -300,6 +300,10 @@ watchdog_process_pid() {
 		# Check if the pid we last wrote to our state file is actually active
 		PID=$(cat "/tmp/${PROCESS}.pid") || true
 		if [[ ! -d "/proc/${PID}" ]]; then
+			# Restarting silently hides both the crash and whatever died with it.
+			# A valkey restart in particular drops every cached key written since
+			# the last snapshot, which no amount of retrying brings back.
+			warn_log "${PROCESS} exited unexpectedly, restarting it"
 			start_bin_"${PROCESS}"
 		fi
 	else

--- a/docker/init_scripts/init
+++ b/docker/init_scripts/init
@@ -300,9 +300,6 @@ watchdog_process_pid() {
 		# Check if the pid we last wrote to our state file is actually active
 		PID=$(cat "/tmp/${PROCESS}.pid") || true
 		if [[ ! -d "/proc/${PID}" ]]; then
-			# Restarting silently hides both the crash and whatever died with it.
-			# A valkey restart in particular drops every cached key written since
-			# the last snapshot, which no amount of retrying brings back.
 			warn_log "${PROCESS} exited unexpectedly, restarting it"
 			start_bin_"${PROCESS}"
 		fi


### PR DESCRIPTION
**Description**

LaunchBox titles carry punctuation a ROM filename cannot, so exact-key lookups miss games the dump holds. `Burnout Revenge` never reaches `Burnout: Revenge`, `Asterix` never reaches `Astérix`, and `AC-DC` never reaches `AC/DC` because a filesystem forbids the slash.

Every title is now also indexed under a folded form (casefolded, accents stripped, non-alphanumerics dropped), consulted only once every exact form has missed so an exact hit still wins.

Measured against the 2585 Redump-style PlayStation 2 titles the dump itself names, matching goes from **89.8% to 96.7%**. Across all 187067 named games, 551 folded keys (0.295%) carry more than one record; every one is a punctuation variant of a single game, and none differ in their digits, so no entry in a series can fold onto another.

The fold keeps letters of every script. Restricting it to ASCII reduced a title written in another to whatever digits it carried, collapsing `三國立志傳2` and `忍者村大战2` onto the key `2`.

Two supporting changes:

- **Scan logging.** A local install is read on every lookup and the per-scan switch only decides whether the cloud store is read too, so either can be selected while holding nothing to match against. A lookup against an absent source is silent, which made "no install mounted" indistinguishable from "no matches" across a whole platform. A scan now records what LaunchBox can actually read, and warns when that is nothing.
- **Docker.** The image bundles `valkey` but not its CLI, which Alpine packages separately, so the internal cache cannot be inspected from inside a running container. The process watchdog also restarted dead processes silently, hiding both the crash and whatever state died with it.

The new folded index only exists after the LaunchBox metadata task next runs. Until then the fallback simply finds nothing, so there is no regression, just no benefit yet.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A, backend and image only.

---

**AI assistance disclosure**

Written with Claude Code (Claude Opus 5) throughout: diagnosis, implementation, tests, and the measurements quoted above, which were produced by running the real matching pipeline against a downloaded copy of the LaunchBox `Metadata.zip` dump. Reviewed by me before submitting.
