### PR TITLE
fix(hltb): match titles whose series prefix the catalogue omits

### DIFF
--- a/backend/handler/metadata/hltb_handler.py
+++ b/backend/handler/metadata/hltb_handler.py
@@ -527,6 +527,32 @@ class HLTBHandler(MetadataHandler):
         search_term = re.sub(DASH_COLON_REGEX, ": ", search_term)
         search_term = self.normalize_search_term(search_term, remove_punctuation=False)
 
+        return await self._search_and_match(search_term, platform_slug)
+
+    async def _search_and_match(self, search_term: str, platform_slug: str) -> HLTBRom:
+        """Search HowLongToBeat for one normalized term and score the results.
+
+        A series prefix the term carries and the catalogue does not sinks the
+        similarity score ("007: Quantum of Solace" scores 0.838 against
+        "Quantum of Solace", under the gate), and a long enough term returns no
+        results at all, so the part after the last separator is tried as well.
+        """
+        rom = await self._search_and_score(search_term, platform_slug)
+        if rom["hltb_id"]:
+            return rom
+
+        terms = re.split(self.SEARCH_TERM_SPLIT_PATTERN, search_term)
+        tail = terms[-1].strip()
+        if len(terms) > 1 and tail and tail != search_term:
+            return await self._search_and_score(
+                tail, platform_slug, split_game_name=True
+            )
+
+        return rom
+
+    async def _search_and_score(
+        self, search_term: str, platform_slug: str, split_game_name: bool = False
+    ) -> HLTBRom:
         # Search for games
         games = await self.search_games(search_term, platform_slug)
 
@@ -540,6 +566,7 @@ class HLTBHandler(MetadataHandler):
             search_term,
             game_names,
             min_similarity_score=self.min_similarity_score,
+            split_game_name=split_game_name,
         )
 
         if best_match:

--- a/backend/handler/metadata/hltb_handler.py
+++ b/backend/handler/metadata/hltb_handler.py
@@ -541,9 +541,13 @@ class HLTBHandler(MetadataHandler):
         if rom["hltb_id"]:
             return rom
 
-        terms = re.split(self.SEARCH_TERM_SPLIT_PATTERN, search_term)
-        tail = terms[-1].strip()
-        if len(terms) > 1 and tail and tail != search_term:
+        # `get_rom` has already rewritten " - " as ": ", so a series separator is
+        # a colon by this point and any hyphen still present is inside a word.
+        # Splitting on those as well would retry "spider-man 2" as "man 2" and
+        # invite a match on an unrelated game.
+        head, _, tail = search_term.rpartition(":")
+        tail = tail.strip()
+        if head and tail:
             return await self._search_and_score(
                 tail, platform_slug, split_game_name=True
             )

--- a/backend/tests/handler/metadata/test_hltb_handler.py
+++ b/backend/tests/handler/metadata/test_hltb_handler.py
@@ -329,3 +329,92 @@ async def test_heartbeat_sends_the_user_agent_hltb_requires(mock_ctx_httpx_clien
     headers = mock_client.get.await_args.kwargs["headers"]
     assert headers["User-Agent"] == f"RomM/{get_version()}"
     assert headers["Referer"] == "https://howlongtobeat.com"
+
+
+def _game(game_id: int, name: str, *, timed: bool = True) -> dict:
+    """A search result carrying only the fields matching depends on."""
+    time = 3600 if timed else 0
+    return {
+        "game_id": game_id,
+        "game_name": name,
+        "game_image": "",
+        "comp_main": time,
+        "comp_plus": time,
+        "comp_100": time,
+        "comp_all": time,
+        "comp_main_count": 1,
+        "comp_plus_count": 1,
+        "comp_100_count": 1,
+        "comp_all_count": 1,
+        "release_world": 2008,
+        "review_score": 70,
+        "count_review": 5,
+        "profile_popular": 3,
+        "count_comp": 4,
+    }
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+async def test_series_prefix_the_catalogue_omits_still_matches():
+    """ "007: Quantum of Solace" scores 0.838 against "Quantum of Solace",
+    under the gate, so the part after the separator has to be searched too."""
+    handler = _handler()
+    searched: list[str] = []
+
+    async def search_games(term, _platform_slug):
+        searched.append(term)
+        return [_game(7467, "Quantum of Solace")]
+
+    with patch.object(handler, "search_games", side_effect=search_games):
+        rom = await handler.get_rom("007 - Quantum of Solace (USA).chd", "ps2")
+
+    assert rom["hltb_id"] == 7467
+    assert searched == ["007: quantum of solace", "quantum of solace"]
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+async def test_full_term_match_does_not_trigger_a_second_search():
+    handler = _handler()
+    searched: list[str] = []
+
+    async def search_games(term, _platform_slug):
+        searched.append(term)
+        return [_game(4806, "James Bond 007: Agent Under Fire")]
+
+    with patch.object(handler, "search_games", side_effect=search_games):
+        rom = await handler.get_rom(
+            "James Bond 007 - Agent Under Fire (USA).chd", "ps2"
+        )
+
+    assert rom["hltb_id"] == 4806
+    assert len(searched) == 1
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+async def test_term_without_a_separator_is_not_searched_twice():
+    handler = _handler()
+    searched: list[str] = []
+
+    async def search_games(term, _platform_slug):
+        searched.append(term)
+        return []
+
+    with patch.object(handler, "search_games", side_effect=search_games):
+        rom = await handler.get_rom("Nothing Like It (USA).chd", "ps2")
+
+    assert rom["hltb_id"] is None
+    assert searched == ["nothing like it"]
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+async def test_retry_still_requires_recorded_times():
+    """A catalogue entry nobody has submitted a time for is not a match."""
+    handler = _handler()
+
+    async def search_games(_term, _platform_slug):
+        return [_game(7467, "Quantum of Solace", timed=False)]
+
+    with patch.object(handler, "search_games", side_effect=search_games):
+        rom = await handler.get_rom("007 - Quantum of Solace (USA).chd", "ps2")
+
+    assert rom["hltb_id"] is None

--- a/backend/tests/handler/metadata/test_hltb_handler.py
+++ b/backend/tests/handler/metadata/test_hltb_handler.py
@@ -407,6 +407,23 @@ async def test_term_without_a_separator_is_not_searched_twice():
 
 
 @patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+async def test_hyphen_inside_a_word_does_not_trigger_a_retry():
+    """A retry on "man 2" would invite a match on an unrelated game."""
+    handler = _handler()
+    searched: list[str] = []
+
+    async def search_games(term, _platform_slug):
+        searched.append(term)
+        return []
+
+    with patch.object(handler, "search_games", side_effect=search_games):
+        rom = await handler.get_rom("Spider-Man 2 (USA).chd", "ps2")
+
+    assert rom["hltb_id"] is None
+    assert searched == ["spider-man 2"]
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
 async def test_retry_still_requires_recorded_times():
     """A catalogue entry nobody has submitted a time for is not a match."""
     handler = _handler()


### PR DESCRIPTION
**Description**

HowLongToBeat is searched with the ROM filename, and a series prefix that one side carries and the other does not sinks a strict similarity gate. HLTB uses a 0.85 Jaro-Winkler threshold, the strictest of any provider here, and Jaro-Winkler weights a shared prefix heavily, so a missing one is punished hard.

Every James Bond title on PlayStation 2 missed, for one of two reasons:

| Search term from filename | HLTB title | Score |
| --- | --- | --- |
| `007: Agent Under Fire` | `James Bond 007: Agent Under Fire` | 0.732 |
| `007: Everything or Nothing` | `James Bond 007: Everything or Nothing` | 0.738 |
| `007: Nightfire` | `James Bond 007: Nightfire` | 0.693 |
| `007: From Russia with Love` | `From Russia with Love` | 0.820 |
| `007: Quantum of Solace` | `Quantum of Solace` | 0.838 |

The last two fail by a hair, and a term long enough returns no results from HLTB's own search at all.

This retries with the part after the last separator, the same recovery `moby_handler` and `ss_handler` already make. One deliberate difference from them: they retry only an empty result set, while this also retries a scored-but-rejected one, because that is exactly how `Quantum of Solace` fails at 0.838.

Verified against the live API: all five titles above now resolve. Six subtitle-heavy titles that could plausibly land on the wrong game from a tail-only search (`Blood Omen 2 - The Legacy of Kain Series`, `Ace Combat 04 - Shattered Skies`, `Arc the Lad - Twilight of the Spirits`, `Baldur's Gate - Dark Alliance II`, `Armored Core - Nine Breaker`, `Atelier Iris 2 - The Azoth of Destiny`) are unaffected, because the full term matches first and the retry never fires. `Blood Omen 2` still misses, failing safe rather than matching something else.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A, backend only.

---

**AI assistance disclosure**

Written with Claude Code (Claude Opus 5): diagnosis, implementation, and tests. The similarity figures were computed with the same `strsimpy` Jaro-Winkler the handler uses, and the match results were verified against the live HowLongToBeat API. Reviewed by me before submitting.

One approach was measured and discarded along the way: passing HLTB the titles other providers had already resolved, mirroring how SGDB builds its candidate list. It recovered nothing in a live sample and was actively worse in places, matching `Astro Boy - The Video Game` to `Astro Boy` rather than `Astro Boy: The Video Game`. Only the separator retry ships.
