### PR TITLE
fix(ss): don't use the Switch icon URL as the manual URL

### DIFF
--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -940,7 +940,6 @@ class SSHandler(MetadataHandler):
                     name=index_entry["name"],
                     summary=index_entry.get("description", ""),
                     url_cover=index_entry.get("iconUrl", ""),
-                    url_manual=index_entry.get("iconUrl", ""),
                     url_screenshots=index_entry.get("screenshots", None) or [],
                 )
 
@@ -956,7 +955,6 @@ class SSHandler(MetadataHandler):
                     name=index_entry["name"],
                     summary=index_entry.get("description", ""),
                     url_cover=index_entry.get("iconUrl", ""),
-                    url_manual=index_entry.get("iconUrl", ""),
                     url_screenshots=index_entry.get("screenshots", None) or [],
                 )
 

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -20,6 +20,7 @@ from handler.metadata import ss_handler
 from handler.metadata.base_handler import PS1_SERIAL_INDEX_KEY
 from handler.metadata.ss_handler import (
     PS1_SS_ID,
+    SWITCH_SS_ID,
     SSHandler,
     _get_rom_type,
     _is_daily_quota_error,
@@ -1851,3 +1852,37 @@ class TestSonySerialFilenames:
         mock_hget.assert_awaited_once_with(PS1_SERIAL_INDEX_KEY, "SCUS-94163")
         assert result.get("name") == "Gran Turismo"
         assert result["ss_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_switch_titledb_fallback_does_not_set_icon_as_manual(self):
+        """The Switch TitleDB index has no manual, so the fallback must not
+        reuse the icon URL as ``url_manual``. Doing so made RomM try to fetch
+        an icon as a game manual on every scan of such a ROM."""
+        handler = SSHandler()
+
+        with (
+            patch(
+                "handler.metadata.ss_handler.SSHandler.is_enabled",
+                return_value=True,
+            ),
+            patch.object(async_cache, "exists", new_callable=AsyncMock) as mock_exists,
+            patch.object(async_cache, "hget", new_callable=AsyncMock) as mock_hget,
+            patch.object(
+                SSHandler, "_search_rom", new_callable=AsyncMock, return_value=None
+            ),
+        ):
+            mock_exists.return_value = True
+            mock_hget.return_value = json.dumps(
+                {
+                    "name": "Switch Game",
+                    "description": "A game",
+                    "iconUrl": "https://example.net/icon.png",
+                }
+            )
+            result = await handler.get_rom(
+                MagicMock(), "70123456789012.nsp", SWITCH_SS_ID
+            )
+
+        assert result.get("name") == "Switch Game"
+        assert result.get("url_cover") == "https://example.net/icon.png"
+        assert not result.get("url_manual")


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Both Switch TitleDB fallbacks in `ss_handler.get_rom()` set `url_manual` to the icon URL, the same value as `url_cover`:

```python
url_cover=index_entry.get("iconUrl", ""),
url_manual=index_entry.get("iconUrl", ""),
```

The TitleDB index has no manual, so this is just the cover line copied with the key renamed. `igdb_handler.py` and `moby_handler.py` have the identical fallback blocks and set only `url_cover`, so ScreenScraper is the only handler doing this.

Effect: any Switch ROM resolved through the title ID or product ID fallback gets an icon URL stored as its manual, and `_store_manual()` then fetches that icon on scan while trying to download a manual. The content type check in `resources_handler` rejects a PNG, so no bogus PDF is written, but the request is made and thrown away every time, and the wrong value is still persisted and served over the API.

`url_manual` is `NotRequired` on `BaseRom`, so dropping the line is enough; nothing needs a placeholder.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Added `test_switch_titledb_fallback_does_not_set_icon_as_manual`, which drives `get_rom()` through the title ID fallback with a mocked TitleDB entry and asserts the icon lands in `url_cover` but not in `url_manual`. It fails before the change (`assert not 'https://example.net/icon.png'`) and passes after. Full `tests/handler/metadata/` suite is green at 417 passed.

**AI disclosure**

Written with Claude (Claude Code), as required by `CONTRIBUTING.md`. I verified the failing-before and passing-after states locally and checked the sibling handlers to confirm which behaviour is the intended one.