### PR TITLE
fix(resources): publish downloaded resources atomically

### DIFF
--- a/backend/handler/filesystem/base_handler.py
+++ b/backend/handler/filesystem/base_handler.py
@@ -248,7 +248,9 @@ class FSHandler:
             os.chmod(temp_path, 0o644)
             os.replace(str(temp_path), str(target_path))
 
-        except Exception:
+        # BaseException, not Exception: a cancelled scan raises CancelledError,
+        # which would otherwise skip cleanup and strand a temp file per cancel.
+        except BaseException:
             async_temp = AnyioPath(temp_path)
             if await async_temp.exists():
                 await async_temp.unlink()

--- a/backend/handler/filesystem/base_handler.py
+++ b/backend/handler/filesystem/base_handler.py
@@ -414,15 +414,22 @@ class FSHandler:
                     else:
                         raise ValueError("Unsupported file type for writing")
 
+    @asynccontextmanager
     async def write_file_streamed(self, path: str, filename: str):
         """
         Write file to filesystem using a streamed approach.
+
+        The stream lands in a temporary file that is renamed over the target
+        once the caller's block completes, so a download killed mid-stream
+        leaves any existing file intact instead of truncating it in place. A
+        truncated file is the worse outcome, since it still satisfies the
+        `*_exists` checks and every later scan skips it.
 
         Args:
             path: Relative path within base directory
             filename: Name of the file to write
 
-        Returns:
+        Yields:
             File object for writing
 
         Raises:
@@ -443,8 +450,11 @@ class FSHandler:
             # Ensure target directory exists
             target_directory.mkdir(parents=True, exist_ok=True)
 
-            # Open file for writing
-            return await open_file(final_file_path, "wb")
+            # The handle closes before _atomic_write renames, so the target
+            # never receives a partially flushed file.
+            async with self._atomic_write(final_file_path) as temp_path:
+                async with await open_file(temp_path, "wb") as f:
+                    yield f
 
     async def read_file(self, file_path: str) -> bytes:
         """

--- a/backend/handler/filesystem/base_handler.py
+++ b/backend/handler/filesystem/base_handler.py
@@ -424,7 +424,7 @@ class FSHandler:
         The stream lands in a temporary file that is renamed over the target
         once the caller's block completes, so a download killed mid-stream
         leaves any existing file intact instead of truncating it in place. A
-        truncated file is the worse outcome, since it still satisfies the
+        truncated file is the worst outcome, since it still satisfies the
         `*_exists` checks and every later scan skips it.
 
         Args:

--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -220,7 +220,7 @@ class FSResourcesHandler(FSHandler):
                                 == "gzip"
                             )
 
-                            async with await self.write_file_streamed(
+                            async with self.write_file_streamed(
                                 path=cover_file, filename=f"{CoverSize.BIG.value}.png"
                             ) as f:
                                 if is_gzipped:
@@ -239,11 +239,9 @@ class FSResourcesHandler(FSHandler):
                             downloaded = True
             except httpx.TransportError as exc:
                 log.error(f"Unable to fetch cover at {url_cover}: {str(exc)}")
-                await self._discard_partial_file(big_path)
                 return None
             except OSError as exc:
                 log.error(f"Unable to write cover for {url_cover}: {str(exc)}")
-                await self._discard_partial_file(big_path)
                 return None
 
             if not downloaded:
@@ -453,7 +451,7 @@ class FSResourcesHandler(FSHandler):
                             == "gzip"
                         )
 
-                        async with await self.write_file_streamed(
+                        async with self.write_file_streamed(
                             path=screenshot_path, filename=f"{idx}.jpg"
                         ) as f:
                             if is_gzipped:
@@ -470,11 +468,9 @@ class FSResourcesHandler(FSHandler):
                                     await f.write(chunk)
             except httpx.TransportError as exc:
                 log.error(f"Unable to fetch screenshot at {url_screenhot}: {str(exc)}")
-                await self._discard_partial_file(f"{screenshot_path}/{idx}.jpg")
                 return None
             except OSError as exc:
                 log.error(f"Unable to write screenshot for {url_screenhot}: {str(exc)}")
-                await self._discard_partial_file(f"{screenshot_path}/{idx}.jpg")
                 return None
 
     def screenshots_exist(self, rom: Rom) -> bool:
@@ -583,7 +579,7 @@ class FSResourcesHandler(FSHandler):
                             == "gzip"
                         )
 
-                        async with await self.write_file_streamed(
+                        async with self.write_file_streamed(
                             path=manual_path, filename=f"{rom.id}.pdf"
                         ) as f:
                             if is_gzipped:
@@ -600,11 +596,9 @@ class FSResourcesHandler(FSHandler):
                                     await f.write(chunk)
             except httpx.TransportError as exc:
                 log.error(f"Unable to fetch manual at {url_manual}: {str(exc)}")
-                await self._discard_partial_file(f"{manual_path}/{rom.id}.pdf")
                 return None
             except OSError as exc:
                 log.error(f"Unable to write manual for {url_manual}: {str(exc)}")
-                await self._discard_partial_file(f"{manual_path}/{rom.id}.pdf")
                 return None
 
     def _get_manual_path(self, rom: Rom) -> str | None:
@@ -659,17 +653,15 @@ class FSResourcesHandler(FSHandler):
                     if not _check_content_type(response, ("image/",), "badge"):
                         return
 
-                    async with await self.write_file_streamed(
+                    async with self.write_file_streamed(
                         path=directory, filename=filename
                     ) as f:
                         async for chunk in response.aiter_raw():
                             await f.write(chunk)
         except httpx.TransportError as exc:
             log.error(f"Unable to fetch cover at {url}: {str(exc)}")
-            await self._discard_partial_file(path)
         except OSError as exc:
             log.error(f"Unable to write badge for {url}: {str(exc)}")
-            await self._discard_partial_file(path)
 
     def get_ra_resources_path(self, platform_id: int, rom_id: int) -> str:
         return os.path.join(
@@ -733,18 +725,16 @@ class FSResourcesHandler(FSHandler):
                             ):
                                 return False
 
-                            async with await self.write_file_streamed(
+                            async with self.write_file_streamed(
                                 path=directory, filename=filename
                             ) as f:
                                 async for chunk in response.aiter_raw():
                                     await f.write(chunk)
                 except httpx.TransportError as exc:
                     log.error(f"Unable to fetch media file at {url_media}: {str(exc)}")
-                    await self._discard_partial_file(dest_path)
                     return False
                 except OSError as exc:
                     log.error(f"Unable to write media file for {url_media}: {str(exc)}")
-                    await self._discard_partial_file(dest_path)
                     return False
 
         # Drop ScreenScraper's green "missing art" placeholder so a box face

--- a/backend/handler/filesystem/resources_handler.py
+++ b/backend/handler/filesystem/resources_handler.py
@@ -659,7 +659,7 @@ class FSResourcesHandler(FSHandler):
                         async for chunk in response.aiter_raw():
                             await f.write(chunk)
         except httpx.TransportError as exc:
-            log.error(f"Unable to fetch cover at {url}: {str(exc)}")
+            log.error(f"Unable to fetch badge at {url}: {str(exc)}")
         except OSError as exc:
             log.error(f"Unable to write badge for {url}: {str(exc)}")
 

--- a/backend/tests/handler/filesystem/test_base_handler.py
+++ b/backend/tests/handler/filesystem/test_base_handler.py
@@ -318,7 +318,7 @@ class TestFSHandler:
 
     async def test_write_file_streamed(self, handler: FSHandler, sample_file_content):
         """Test streamed file writing"""
-        async with await handler.write_file_streamed(".", "test_file.txt") as f:
+        async with handler.write_file_streamed(".", "test_file.txt") as f:
             await f.write(sample_file_content)
 
         file_path = handler.base_path / "test_file.txt"

--- a/backend/tests/handler/filesystem/test_resources_handler.py
+++ b/backend/tests/handler/filesystem/test_resources_handler.py
@@ -1,3 +1,4 @@
+import asyncio
 import errno
 import os
 from io import BytesIO
@@ -1110,6 +1111,26 @@ class TestDiskFullHandling:
             await handler._store_cover(rom, "http://example.com/cover.png")
 
         assert target.read_bytes() == b"the good cover"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_download_leaves_no_temp_file(
+        self, handler: FSResourcesHandler, tmp_path
+    ):
+        # Stopping a scan raises CancelledError, which derives from
+        # BaseException. Cleanup has to catch it or every cancel strands a
+        # temp file in the resource directory.
+        handler.base_path = tmp_path
+        cover_dir = tmp_path / "roms/1/1/cover"
+        cover_dir.mkdir(parents=True)
+
+        with pytest.raises(asyncio.CancelledError):
+            async with handler.write_file_streamed(
+                path="roms/1/1/cover", filename="big.png"
+            ) as f:
+                await f.write(b"partial")
+                raise asyncio.CancelledError()
+
+        assert list(cover_dir.iterdir()) == []
 
     @pytest.mark.asyncio
     async def test_interrupted_download_leaves_no_temp_file(

--- a/backend/tests/handler/filesystem/test_resources_handler.py
+++ b/backend/tests/handler/filesystem/test_resources_handler.py
@@ -1001,27 +1001,16 @@ class _FakeHttpxClient:
         return _FakeStreamContext(self._response)
 
 
-class _EnospcWriter:
-    """Writes a truncated file, then fails the way a full disk does."""
+class _EnospcResponse:
+    """Streams one chunk, then fails the way a full disk does."""
 
-    def __init__(self, path: Path):
-        self._path = path
+    def __init__(self, content_type: str = "image/png"):
+        self.status_code = 200
+        self.headers = {"content-type": content_type}
 
-    async def write(self, _data):
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._path.write_bytes(b"partial")
+    async def aiter_raw(self):
+        yield b"partial"
         raise OSError(errno.ENOSPC, "No space left on device")
-
-
-class _EnospcWriteContext:
-    def __init__(self, path: Path):
-        self._path = path
-
-    async def __aenter__(self):
-        return _EnospcWriter(self._path)
-
-    async def __aexit__(self, *_args):
-        return False
 
 
 class TestDiskFullHandling:
@@ -1080,15 +1069,8 @@ class TestDiskFullHandling:
         handler.base_path = tmp_path
         target = tmp_path / "roms/1/1/cover/big.png"
 
-        with (
-            patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx,
-            patch.object(
-                handler,
-                "write_file_streamed",
-                new=AsyncMock(return_value=_EnospcWriteContext(target)),
-            ),
-        ):
-            mock_ctx.get.return_value = _FakeHttpxClient(_FakeResponse())
+        with patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx:
+            mock_ctx.get.return_value = _FakeHttpxClient(_EnospcResponse())
 
             await handler._store_cover(rom, "http://example.com/cover.png")
 
@@ -1111,6 +1093,41 @@ class TestDiskFullHandling:
         assert not target.exists()
 
     @pytest.mark.asyncio
+    async def test_store_cover_keeps_existing_file_when_refresh_dies(
+        self, handler: FSResourcesHandler, rom: Rom, tmp_path
+    ):
+        # Refreshing a cover that is already on disk must not cost the good copy
+        # when the transfer dies: the stream lands in a temp file, so the
+        # existing bytes survive untouched.
+        handler.base_path = tmp_path
+        target = tmp_path / "roms/1/1/cover/big.png"
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"the good cover")
+
+        with patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx:
+            mock_ctx.get.return_value = _FakeHttpxClient(_DroppedResponse())
+
+            await handler._store_cover(rom, "http://example.com/cover.png")
+
+        assert target.read_bytes() == b"the good cover"
+
+    @pytest.mark.asyncio
+    async def test_interrupted_download_leaves_no_temp_file(
+        self, handler: FSResourcesHandler, rom: Rom, tmp_path
+    ):
+        # A temp file left in the cover directory would be served as a resource
+        # and would accumulate one per failed scan.
+        handler.base_path = tmp_path
+        cover_dir = tmp_path / "roms/1/1/cover"
+
+        with patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx:
+            mock_ctx.get.return_value = _FakeHttpxClient(_DroppedResponse())
+
+            await handler._store_cover(rom, "http://example.com/cover.png")
+
+        assert list(cover_dir.iterdir()) == []
+
+    @pytest.mark.asyncio
     async def test_store_ra_badge_discards_partial_download(
         self, handler: FSResourcesHandler, tmp_path
     ):
@@ -1120,15 +1137,8 @@ class TestDiskFullHandling:
         rel = "roms/1/1/ra/badge.png"
         target = tmp_path / rel
 
-        with (
-            patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx,
-            patch.object(
-                handler,
-                "write_file_streamed",
-                new=AsyncMock(return_value=_EnospcWriteContext(target)),
-            ),
-        ):
-            mock_ctx.get.return_value = _FakeHttpxClient(_FakeResponse())
+        with patch("handler.filesystem.resources_handler.ctx_httpx_client") as mock_ctx:
+            mock_ctx.get.return_value = _FakeHttpxClient(_EnospcResponse())
 
             await handler.store_ra_badge("http://example.com/badge.png", rel)
 


### PR DESCRIPTION
**Description**

Splits the atomic-write half out of #4160 so it can be reviewed and land on its own. None of that PR's `locked_fields` provenance work is included here: no migration, no model, endpoint, or scan-handler changes. #4160 stays open for that half.

`write_file_streamed` opened the destination file directly, so an interrupted transfer truncated the target in place. A truncated file is worse than a missing one: it still satisfies the `*_exists` checks, so every later scan skips it and never refetches. The existing error paths cleaned it up, but only when the process survived to run them, which a SIGKILL or host reboot does not.

`write_file_streamed` is now an async context manager that writes to a temp file in the destination directory and renames it over the target once the caller's block completes, reusing the `_atomic_write` helper that uploads already use. The handle closes before the rename, so the target never sees a partial flush.

The `_discard_partial_file` calls that followed a streamed write are gone. There is no longer a partial file to remove, and the target now holds either nothing or the previous good copy, which those calls would delete. Refreshing a cover no longer costs the existing one when the transfer dies. `_discard_partial_file` itself stays, since the non-streamed paths (resize, small cover) still use it.

The second commit fixes cleanup on cancel: `_atomic_write` cleaned up in `except Exception`, which does not catch `CancelledError`, so stopping a scan mid-download stranded a `.romm_tmp_*` file per cancelled transfer. It now catches `BaseException`, which also covers uploads.

On tests: the two disk-full tests patched `write_file_streamed` itself, so they were asserting against the non-atomicity this removes. They now fail the write from the response stream and exercise the real path. Added coverage for an interrupted transfer leaving the previous cover intact, and for a cancelled transfer leaving no temp file behind.

**AI assistance disclosure:** written with Claude Code. The first commit is cherry-picked unchanged from #4160; the second commit and its test were lifted by hand from that PR's follow-up. I reviewed the result and ran the checks listed below.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Verification: full backend suite against MariaDB, 2821 passed. The one failure in my run is pre-existing and unrelated (`test_extract_chd_hash_permission_error` fails on `master` too, because my local run is as root and `chmod` does not deny root). Merges cleanly into `master` at `7f57646`, with the filesystem suite green on the merged tree (333 passed). `black`, `isort`, and `ruff` clean on the changed files.