### PR TITLE
fix(i18n): translate route titles once locale messages are loaded

### DIFF
--- a/frontend/src/RomM.vue
+++ b/frontend/src/RomM.vue
@@ -24,7 +24,9 @@ const BackendStatusBanner = defineAsyncComponent(
   () => import("@/v2/components/AppShell/BackendStatusBanner.vue"),
 );
 
-const { locale } = useI18n();
+// Global scope is explicit because this write switches the whole app:
+// an <i18n> block in this SFC would otherwise flip it to component-local.
+const { locale } = useI18n({ useScope: "global" });
 const languageStore = storeLanguage();
 const consoleStore = storeConsole();
 const vuetifyTheme = useTheme();

--- a/frontend/src/locales/index.ts
+++ b/frontend/src/locales/index.ts
@@ -1,15 +1,33 @@
+import { watch } from "vue";
 import { createI18n } from "vue-i18n";
 
-type NamespacedMessages = Record<string, Record<string, string>>;
+type LocaleModule = { default: Record<string, string> };
 
-const localeModules = import.meta.glob<{ default: Record<string, string> }>(
-  "./*/**/*.json",
-);
+const FALLBACK_LOCALE = "en_US";
+
+// Written by the language selector via `useLocalStorage`, so it holds the
+// raw locale name.
+const STORED_LOCALE_KEY = "settings.locale";
+
+const localeModules = import.meta.glob<LocaleModule>("./*/**/*.json");
+
+const modulesByLocale = new Map<
+  string,
+  Map<string, () => Promise<LocaleModule>>
+>();
+for (const [path, load] of Object.entries(localeModules)) {
+  const matched = path.match(/\.\/([A-Za-z0-9-_]+)\/([A-Za-z0-9-_]+)\.json$/i);
+  if (!matched) continue;
+
+  const [, locale, namespace] = matched;
+  if (!modulesByLocale.has(locale)) modulesByLocale.set(locale, new Map());
+  modulesByLocale.get(locale)?.set(namespace, load);
+}
 
 const i18n = createI18n({
   legacy: false,
-  locale: "en_US",
-  fallbackLocale: "en_US",
+  locale: FALLBACK_LOCALE,
+  fallbackLocale: FALLBACK_LOCALE,
   messages: {},
   pluralRules: {
     cs_CZ(choice: number) {
@@ -20,37 +38,56 @@ const i18n = createI18n({
   },
 });
 
-// Each namespace is its own chunk, so messages only land a tick or two after
-// this module evaluates. Bootstrap awaits this before installing the router:
-// the navigation guard translates the route title on the very first
-// navigation, and without messages it would write the raw key to the tab.
-export const localesReady = (async () => {
-  const messages: Record<string, NamespacedMessages> = {};
+const pendingLocales = new Map<string, Promise<void>>();
 
-  await Promise.all(
-    Object.entries(localeModules).map(async ([path, load]) => {
-      const matched = path.match(
-        /\.\/([A-Za-z0-9-_]+)\/([A-Za-z0-9-_]+)\.json$/i,
-      );
-      if (!matched) return;
+// Fetches every namespace of a language and registers them as one message
+// bundle. Memoized, so repeated calls (a language toggled back and forth)
+// reuse the first load.
+export function loadLocale(locale: string): Promise<void> {
+  const pending = pendingLocales.get(locale);
+  if (pending) return pending;
 
-      const [, locale, namespace] = matched;
-      try {
-        const localeModule = await load();
-        messages[locale] ??= {};
-        messages[locale][namespace] = localeModule.default;
-      } catch (error) {
-        // A namespace that fails to load (stale chunk after a redeploy) must
-        // not hold up the app: the rest of the UI still translates, and the
-        // missing keys fall back to their key names.
-        console.error(`Error loading locale messages for ${path}: `, error);
-      }
-    }),
-  );
+  const namespaces = modulesByLocale.get(locale);
+  if (!namespaces) return Promise.resolve();
 
-  Object.entries(messages).forEach(([locale, localeMessages]) => {
-    i18n.global.setLocaleMessage(locale, localeMessages);
-  });
-})();
+  const loading = (async () => {
+    const messages: Record<string, Record<string, string>> = {};
+
+    await Promise.all(
+      [...namespaces].map(async ([namespace, load]) => {
+        try {
+          messages[namespace] = (await load()).default;
+        } catch (error) {
+          // A namespace that fails to load (a stale chunk after a redeploy)
+          // must not hold up the app: the rest of the UI still translates,
+          // and the missing keys fall back to their key names.
+          console.error(
+            `Error loading ${locale}/${namespace} messages:`,
+            error,
+          );
+        }
+      }),
+    );
+
+    i18n.global.setLocaleMessage(locale, messages);
+  })();
+
+  pendingLocales.set(locale, loading);
+  return loading;
+}
+
+// Namespaces are separate chunks, so messages only land a tick or two after
+// this module evaluates. Bootstrap awaits the two bundles the first paint can
+// need before installing the router: the navigation guard translates the
+// route title on the very first navigation, and without messages it would
+// write the raw key to the tab. Other languages load when switched to.
+export const localesReady = Promise.all([
+  loadLocale(FALLBACK_LOCALE),
+  loadLocale(localStorage.getItem(STORED_LOCALE_KEY) ?? FALLBACK_LOCALE),
+]);
+
+watch(i18n.global.locale, (locale) => {
+  void loadLocale(locale);
+});
 
 export default i18n;

--- a/frontend/src/locales/index.ts
+++ b/frontend/src/locales/index.ts
@@ -1,32 +1,16 @@
 import { createI18n } from "vue-i18n";
 
-function loadLocales() {
-  const locales = import.meta.glob("./*/**/*.json");
-  const messages: {
-    [key: string]: { [namespace: string]: Record<string, string> };
-  } = {};
-  Object.keys(locales).forEach(async (key) => {
-    const matched = key.match(/\.\/([A-Za-z0-9-_]+)\/([A-Za-z0-9-_]+)\.json$/i);
-    if (matched && matched.length > 2) {
-      const locale = matched[1];
-      const namespace = matched[2];
-      if (!messages[locale]) {
-        messages[locale] = {};
-      }
-      const localeModule = (await locales[key]()) as {
-        default: Record<string, string>;
-      };
-      messages[locale][namespace] = localeModule.default;
-    }
-  });
-  return messages;
-}
+type NamespacedMessages = Record<string, Record<string, string>>;
+
+const localeModules = import.meta.glob<{ default: Record<string, string> }>(
+  "./*/**/*.json",
+);
 
 const i18n = createI18n({
   legacy: false,
   locale: "en_US",
   fallbackLocale: "en_US",
-  messages: loadLocales(),
+  messages: {},
   pluralRules: {
     cs_CZ(choice: number) {
       if (choice === 0) return 0;
@@ -35,5 +19,38 @@ const i18n = createI18n({
     },
   },
 });
+
+// Each namespace is its own chunk, so messages only land a tick or two after
+// this module evaluates. Bootstrap awaits this before installing the router:
+// the navigation guard translates the route title on the very first
+// navigation, and without messages it would write the raw key to the tab.
+export const localesReady = (async () => {
+  const messages: Record<string, NamespacedMessages> = {};
+
+  await Promise.all(
+    Object.entries(localeModules).map(async ([path, load]) => {
+      const matched = path.match(
+        /\.\/([A-Za-z0-9-_]+)\/([A-Za-z0-9-_]+)\.json$/i,
+      );
+      if (!matched) return;
+
+      const [, locale, namespace] = matched;
+      try {
+        const localeModule = await load();
+        messages[locale] ??= {};
+        messages[locale][namespace] = localeModule.default;
+      } catch (error) {
+        // A namespace that fails to load (stale chunk after a redeploy) must
+        // not hold up the app: the rest of the UI still translates, and the
+        // missing keys fall back to their key names.
+        console.error(`Error loading locale messages for ${path}: `, error);
+      }
+    }),
+  );
+
+  Object.entries(messages).forEach(([locale, localeMessages]) => {
+    i18n.global.setLocaleMessage(locale, localeMessages);
+  });
+})();
 
 export default i18n;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,7 @@
 import { createApp } from "vue";
 import App from "@/RomM.vue";
 import "@/console/index.css";
+import { localesReady } from "@/locales";
 import { registerPlugins } from "@/plugins";
 import router from "@/plugins/router";
 import storeAuth from "@/stores/auth";
@@ -61,7 +62,10 @@ async function initializeApp() {
   // Registrar vuetify + pinia + i18n + emitter
   registerPlugins(app);
 
-  await initializeData();
+  // Locale messages gate the router alongside the initial data: the guard
+  // resolves the route title as soon as the router is installed, and with
+  // messages still in flight it would set the raw key as the tab title.
+  await Promise.all([initializeData(), localesReady]);
 
   // Route-level lazy imports fail outside vite's preload helper, so stale
   // chunks during navigation surface here instead of as vite:preloadError.

--- a/frontend/src/plugins/router.test.ts
+++ b/frontend/src/plugins/router.test.ts
@@ -1,0 +1,31 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeAll, describe, expect, it } from "vitest";
+import i18n, { localesReady } from "@/locales";
+import router from "@/plugins/router";
+
+// Titles that are plain strings rather than i18n keys.
+const LITERAL_TITLES = new Set(["RomM", "Controller debug"]);
+
+describe("route titles", () => {
+  beforeAll(async () => {
+    setActivePinia(createPinia());
+    await localesReady;
+  });
+
+  it("stores i18n keys that resolve against the locale messages", () => {
+    const titles = router
+      .getRoutes()
+      .map((route) => route.meta.title)
+      .filter((title): title is string => typeof title === "string")
+      .filter((title) => !LITERAL_TITLES.has(title));
+
+    expect(titles.length).toBeGreaterThan(0);
+
+    for (const title of titles) {
+      // Route definitions must hold the key, not an eagerly translated
+      // string: messages load after the route table is built.
+      expect(title).toMatch(/^[a-z0-9-]+\.[a-z0-9-]+$/);
+      expect(i18n.global.t(title)).not.toBe(title);
+    }
+  });
+});

--- a/frontend/src/plugins/router.test.ts
+++ b/frontend/src/plugins/router.test.ts
@@ -3,9 +3,6 @@ import { beforeAll, describe, expect, it } from "vitest";
 import i18n, { localesReady } from "@/locales";
 import router from "@/plugins/router";
 
-// Titles that are plain strings rather than i18n keys.
-const LITERAL_TITLES = new Set(["RomM", "Controller debug"]);
-
 describe("route titles", () => {
   beforeAll(async () => {
     setActivePinia(createPinia());
@@ -16,8 +13,7 @@ describe("route titles", () => {
     const titles = router
       .getRoutes()
       .map((route) => route.meta.title)
-      .filter((title): title is string => typeof title === "string")
-      .filter((title) => !LITERAL_TITLES.has(title));
+      .filter((title): title is string => typeof title === "string");
 
     expect(titles.length).toBeGreaterThan(0);
 

--- a/frontend/src/plugins/router.ts
+++ b/frontend/src/plugins/router.ts
@@ -6,7 +6,7 @@ import {
   type NavigationGuardWithThis,
   type RouteLocationNormalized,
 } from "vue-router";
-import i18n from "@/locales";
+import i18n, { loadLocale } from "@/locales";
 import { startViewTransition } from "@/plugins/transition";
 import romApi from "@/services/api/rom";
 import storeAuth from "@/stores/auth";
@@ -155,9 +155,6 @@ const routes = [
   {
     path: "/",
     name: ROUTES.MAIN,
-    meta: {
-      title: "RomM",
-    },
     // Named views let v1 and v2 coexist at the same URL. The v2 layout owns
     // its own <router-view name="v2"> so child routes with a `v2` component
     // render inside the v2 shell.
@@ -448,7 +445,7 @@ const routes = [
             // settings-adjacent tool rather than a standalone view.
             path: "controller-debug",
             name: ROUTES.CONTROLLER_DEBUG,
-            meta: { title: "Controller debug", bare: true },
+            meta: { title: "settings.controller-debug", bare: true },
             components: {
               // v1 has no equivalent; redirect to home if a v1 user
               // somehow lands here.
@@ -611,8 +608,8 @@ function checkRoutePermissions(route: string, user: User | null): boolean {
 }
 
 // `meta.title` holds an i18n key, translated per navigation rather than when
-// the route table is built — messages load asynchronously and aren't there
-// yet at module-eval time.
+// the route table is built. Messages load asynchronously and aren't there yet
+// at module-eval time.
 function applyRouteTitle(route: RouteLocationNormalized) {
   document.title = route.meta.title
     ? i18n.global.t(route.meta.title as string)
@@ -690,10 +687,10 @@ router.beforeEach(async (to, _from, next) => {
 // The stored language is applied when the app mounts, after the first
 // navigation has already resolved the title in the default locale. Routes
 // whose view owns its title (usePageTitle) carry no `meta.title` and keep it.
-watch(i18n.global.locale, () => {
-  if (router.currentRoute.value.meta.title) {
-    applyRouteTitle(router.currentRoute.value);
-  }
+watch(i18n.global.locale, async (locale) => {
+  await loadLocale(locale);
+  const route = router.currentRoute.value;
+  if (route.meta.title) applyRouteTitle(route);
 });
 
 router.beforeResolve(async (to, from) => {

--- a/frontend/src/plugins/router.ts
+++ b/frontend/src/plugins/router.ts
@@ -1,8 +1,10 @@
 import { storeToRefs } from "pinia";
+import { watch } from "vue";
 import {
   createRouter,
   createWebHistory,
   type NavigationGuardWithThis,
+  type RouteLocationNormalized,
 } from "vue-router";
 import i18n from "@/locales";
 import { startViewTransition } from "@/plugins/transition";
@@ -81,7 +83,7 @@ const routes = [
         path: "",
         name: ROUTES.SETUP,
         meta: {
-          title: i18n.global.t("login.setup-wizard"),
+          title: "login.setup-wizard",
         },
         components: {
           default: () => import("@/views/Auth/Setup.vue"),
@@ -101,7 +103,7 @@ const routes = [
         path: "",
         name: ROUTES.LOGIN,
         meta: {
-          title: i18n.global.t("login.login"),
+          title: "login.login",
         },
         components: {
           default: () => import("@/views/Auth/Login.vue"),
@@ -121,7 +123,7 @@ const routes = [
         path: "",
         name: ROUTES.RESET_PASSWORD,
         meta: {
-          title: i18n.global.t("login.reset-password"),
+          title: "login.reset-password",
         },
         components: {
           default: () => import("@/views/Auth/ResetPassword.vue"),
@@ -141,7 +143,7 @@ const routes = [
         path: "",
         name: ROUTES.REGISTER,
         meta: {
-          title: i18n.global.t("login.register"),
+          title: "login.register",
         },
         components: {
           default: () => import("@/views/Auth/Register.vue"),
@@ -168,7 +170,7 @@ const routes = [
         path: "",
         name: ROUTES.HOME,
         meta: {
-          title: i18n.global.t("settings.home"),
+          title: "settings.home",
         },
         components: {
           default: () => import("@/views/Home.vue"),
@@ -179,7 +181,7 @@ const routes = [
         path: "search",
         name: ROUTES.SEARCH,
         meta: {
-          title: i18n.global.t("common.search"),
+          title: "common.search",
         },
         components: {
           default: () => import("@/views/Gallery/Search.vue"),
@@ -294,7 +296,7 @@ const routes = [
             path: "scan",
             name: ROUTES.SCAN,
             meta: {
-              title: i18n.global.t("scan.scan"),
+              title: "scan.scan",
               bare: true,
             },
             components: {
@@ -306,7 +308,7 @@ const routes = [
             path: "upload",
             name: ROUTES.UPLOAD,
             meta: {
-              title: i18n.global.t("common.upload-roms", "Upload ROMs"),
+              title: "common.upload-roms",
             },
             components: {
               // v1 has no Upload view (the dialog was its only entry
@@ -320,7 +322,7 @@ const routes = [
             path: "activity",
             name: ROUTES.ACTIVITY,
             meta: {
-              title: i18n.global.t("activity.active-sessions"),
+              title: "activity.active-sessions",
               bare: true,
             },
             components: {
@@ -343,7 +345,7 @@ const routes = [
             path: "user-interface",
             name: ROUTES.USER_INTERFACE,
             meta: {
-              title: i18n.global.t("common.user-interface"),
+              title: "common.user-interface",
               bare: true,
             },
             components: {
@@ -355,7 +357,7 @@ const routes = [
             path: "library-management",
             name: ROUTES.LIBRARY_MANAGEMENT,
             meta: {
-              title: i18n.global.t("common.library-management"),
+              title: "common.library-management",
               bare: true,
             },
             components: {
@@ -367,7 +369,7 @@ const routes = [
             path: "scan-settings",
             name: ROUTES.SCAN_SETTINGS,
             meta: {
-              title: i18n.global.t("settings.scan-settings"),
+              title: "settings.scan-settings",
               bare: true,
             },
             components: {
@@ -379,7 +381,7 @@ const routes = [
             path: "metadata-sources",
             name: ROUTES.METADATA_SOURCES,
             meta: {
-              title: i18n.global.t("scan.metadata-sources"),
+              title: "scan.metadata-sources",
               bare: true,
             },
             components: {
@@ -391,7 +393,7 @@ const routes = [
             path: "client-api-tokens",
             name: ROUTES.CLIENT_API_TOKENS,
             meta: {
-              title: i18n.global.t("settings.client-api-tokens"),
+              title: "settings.client-api-tokens",
               bare: true,
             },
             components: {
@@ -403,7 +405,7 @@ const routes = [
             path: "administration",
             name: ROUTES.ADMINISTRATION,
             meta: {
-              title: i18n.global.t("common.administration"),
+              title: "common.administration",
               bare: true,
             },
             components: {
@@ -415,7 +417,7 @@ const routes = [
             path: "server-stats",
             name: ROUTES.SERVER_STATS,
             meta: {
-              title: i18n.global.t("common.server-stats"),
+              title: "common.server-stats",
               bare: true,
             },
             components: {
@@ -427,7 +429,7 @@ const routes = [
             path: "logs",
             name: ROUTES.LOGS,
             meta: {
-              title: i18n.global.t("common.logs"),
+              title: "common.logs",
               bare: true,
               // The log panel fills the viewport and scrolls internally
               // instead of growing the document — see SettingsLayout `fill`.
@@ -461,7 +463,7 @@ const routes = [
         // it redirects this URL home; v2 renders PlatformsIndex.vue.
         path: "platforms",
         name: ROUTES.PLATFORMS_INDEX,
-        meta: { title: i18n.global.t("common.platforms") },
+        meta: { title: "common.platforms" },
         components: {
           default: () => import("@/views/Home.vue"),
           v2: v2For(ROUTES.PLATFORMS_INDEX),
@@ -470,7 +472,7 @@ const routes = [
       {
         path: "collections",
         name: ROUTES.COLLECTIONS_INDEX,
-        meta: { title: i18n.global.t("common.collections") },
+        meta: { title: "common.collections" },
         components: {
           default: () => import("@/views/Home.vue"),
           v2: v2For(ROUTES.COLLECTIONS_INDEX),
@@ -608,6 +610,15 @@ function checkRoutePermissions(route: string, user: User | null): boolean {
   );
 }
 
+// `meta.title` holds an i18n key, translated per navigation rather than when
+// the route table is built — messages load asynchronously and aren't there
+// yet at module-eval time.
+function applyRouteTitle(route: RouteLocationNormalized) {
+  document.title = route.meta.title
+    ? i18n.global.t(route.meta.title as string)
+    : "RomM";
+}
+
 router.beforeEach(async (to, _from, next) => {
   const heartbeat = storeHeartbeat();
   const auth = storeAuth();
@@ -621,9 +632,7 @@ router.beforeEach(async (to, _from, next) => {
     // allows; the offline notice explains it and the connection layer
     // re-routes correctly once the backend answers again.
     if (!heartbeat.connected) {
-      document.title = to.meta.title
-        ? i18n.global.t(to.meta.title as string)
-        : "RomM";
+      applyRouteTitle(to);
       return next();
     }
 
@@ -669,16 +678,21 @@ router.beforeEach(async (to, _from, next) => {
       return next({ name: ROUTES.NOT_FOUND });
     }
 
-    if (to.meta.title) {
-      document.title = i18n.global.t(to.meta.title as string);
-    } else {
-      document.title = "RomM";
-    }
+    applyRouteTitle(to);
     next();
   } catch (error) {
     console.error("Navigation guard error:", error);
     document.title = "RomM";
     next({ name: ROUTES.LOGIN });
+  }
+});
+
+// The stored language is applied when the app mounts, after the first
+// navigation has already resolved the title in the default locale. Routes
+// whose view owns its title (usePageTitle) carry no `meta.title` and keep it.
+watch(i18n.global.locale, () => {
+  if (router.currentRoute.value.meta.title) {
+    applyRouteTitle(router.currentRoute.value);
   }
 });
 

--- a/frontend/src/v2/components/shared/LanguageSelector.vue
+++ b/frontend/src/v2/components/shared/LanguageSelector.vue
@@ -21,7 +21,9 @@ interface Props {
 }
 withDefaults(defineProps<Props>(), { prefixLabel: false });
 
-const { t, locale } = useI18n();
+// Global scope is explicit because this write switches the whole app:
+// an <i18n> block in this SFC would otherwise flip it to component-local.
+const { t, locale } = useI18n({ useScope: "global" });
 const languageStore = storeLanguage();
 const { languages, selectedLanguage } = storeToRefs(languageStore);
 const { locale: localeStorage } = useUISettings();


### PR DESCRIPTION
**Description**

Opening a route in a new tab (or reloading one directly) showed the raw i18n key as the browser tab title — e.g. `settings.scan-settings` instead of "Scan settings". Most visible on the settings pages, since their views don't set a title of their own.

Two causes, both on the tab-title path:

1. **Locale messages weren't loaded when the router guard ran.** `loadLocales()` used `import.meta.glob` without `eager` and filled the `messages` object inside `async` callbacks that nobody awaited, so namespaces landed a few ticks after `createI18n`. On a fresh page load the `beforeEach` guard ran first, and `t("settings.scan-settings")` returned the key. In-app navigation looked fine because the chunks had landed by then.
2. **Route definitions translated at module-eval time.** Every `meta.title` was built with `i18n.global.t(...)` while the route table was constructed — before any messages existed — and the guard then translated the result a second time.

Changes:

- `locales/index.ts` — adds a memoized `loadLocale()` that fetches a language's namespaces and registers them as one bundle, plus a `localesReady` promise covering the two bundles the first paint can need (the fallback and the stored language). Other languages load on demand when switched to, so boot doesn't block on all 19. Namespace loads are fail-soft, so one stale chunk after a redeploy can't block boot.
- `main.ts` — awaits `localesReady` alongside `initializeData()` before `app.use(router)`, so the first guard run always has messages.
- `plugins/router.ts` — `meta.title` now holds the plain i18n key, a single `applyRouteTitle()` helper does the translating, and a watcher on the locale loads the incoming language before re-translating the current route's title. The two literal titles are gone: the controller-debug tool uses the `settings.controller-debug` key that already existed, and the root route drops its redundant `"RomM"` (the guard falls back to that anyway).

That last watcher fixes a second, latent bug: the user's stored language is applied when `RomM.vue` mounts, *after* the first navigation, so even with messages loaded a non-English user's new tab would have shown the English title. A fresh load of `/scan-settings` with `ja_JP` now correctly reads スキャン設定.

No translation strings were added or changed: every key involved already exists in all 19 locales (including `settings.controller-debug`, which now gives that page a translated tab title instead of hardcoded English).

**Verification**

Reproduced against the unpatched code in a browser: a fresh load of `/scan-settings` set `document.title` to `settings.scan-settings`. After the fix, fresh loads of `/scan-settings`, `/user-interface`, `/administration` and `/metadata-sources` all show real titles, router pushes across the remaining settings routes are correct, and switching language live updates the title.

On-demand loading verified too: a fresh load with `ja_JP` stored fetched only the `en_US` and `ja_JP` bundles, and switching to `fr_FR` (never loaded that session) pulled it in and updated the title to Paramètres de scan.

Note: the browser checks ran against a small stub backend (no RomM backend available locally), so the settings pages rendered with stub data — the guard logic exercised is identical.

`npm run typecheck`, `npm run test` (737 passed), `check_i18n_locales.py`, `check_i18n_sorted.py`, prettier and eslint all pass. Trunk isn't installed in this environment, so its underlying JS linters were run directly.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The AI diagnosed the bug, wrote the fix and the regression test, and ran the verification described above; the result was reviewed by me before submitting.
