### PR TITLE
fix(i18n): add the missing playlists permission entity label

### DIFF
--- a/frontend/src/locales/bg_BG/settings.json
+++ b/frontend/src/locales/bg_BG/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/cs_CZ/settings.json
+++ b/frontend/src/locales/cs_CZ/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/de_DE/settings.json
+++ b/frontend/src/locales/de_DE/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/en_GB/settings.json
+++ b/frontend/src/locales/en_GB/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/en_US/settings.json
+++ b/frontend/src/locales/en_US/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/es_ES/settings.json
+++ b/frontend/src/locales/es_ES/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/fr_FR/settings.json
+++ b/frontend/src/locales/fr_FR/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/hu_HU/settings.json
+++ b/frontend/src/locales/hu_HU/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/it_IT/settings.json
+++ b/frontend/src/locales/it_IT/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/ja_JP/settings.json
+++ b/frontend/src/locales/ja_JP/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/ko_KR/settings.json
+++ b/frontend/src/locales/ko_KR/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/pl_PL/settings.json
+++ b/frontend/src/locales/pl_PL/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/pt_BR/settings.json
+++ b/frontend/src/locales/pt_BR/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Plataformas",
+    "playlists": "Listas de reprodução",
     "roms": "Jogos",
     "tasks": "Tarefas",
     "users": "Usuários"

--- a/frontend/src/locales/ro_RO/settings.json
+++ b/frontend/src/locales/ro_RO/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/ru_RU/settings.json
+++ b/frontend/src/locales/ru_RU/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/tr_TR/settings.json
+++ b/frontend/src/locales/tr_TR/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/zh_CN/settings.json
+++ b/frontend/src/locales/zh_CN/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"

--- a/frontend/src/locales/zh_TW/settings.json
+++ b/frontend/src/locales/zh_TW/settings.json
@@ -274,6 +274,7 @@
     "firmware": "Firmware",
     "logs": "Logs",
     "platforms": "Platforms",
+    "playlists": "Playlists",
     "roms": "Games",
     "tasks": "Tasks",
     "users": "Users"


### PR DESCRIPTION
**Description**

The admin permissions matrix renders `settings.perm-entity.playlists` as a row label instead of a name, in every language.

The chain is direct:

- `PermEntity` includes `PLAYLISTS = "playlists"` (`backend/models/permission.py`).
- `/permissions/catalog` returns `entities=list(PermEntity)`, so the whole enum reaches the frontend (`backend/endpoints/permissions.py`).
- `EditUserDialog` passes that list straight into `PermissionsMatrix` / `OverridesMatrix`.
- Both label each row with `` t(`settings.perm-entity.${e}`) ``.

`settings.perm-entity` had labels for the other nine entities but not `playlists`, and vue-i18n renders an unknown key as the key itself.

This adds the missing label to all 18 locales, following the block's existing style: English everywhere, translated in pt_BR, which is the only locale that has translated these permission labels so far.

**Worth a separate pass**

The whole `settings.perm-entity` / `settings.perm-action` block is untranslated English in every locale except pt_BR, so this matrix shows English labels regardless of the user's language. That's pre-existing and out of scope here, but it's real, and it's the reason `playlists` is added as English rather than as the one translated row.

Because the key is interpolated rather than literal, no static check catches this class of miss. It was found by hand-resolving each dynamic key pattern in the frontend against its value union.

**Verification**

`check_i18n_locales.py` and `check_i18n_sorted.py` both pass, and the key now resolves for every locale. `npm run typecheck` and `npm run test` (736) pass.

The fix is verified from the code path rather than in a browser: reaching the matrix needs a running backend with an admin session, which I did not have locally.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

Locale data only; `check_i18n_locales.py` in CI covers the parity this depends on.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The AI traced the bug, made the fix and ran the verification described above; the result was reviewed by me before submitting.
