### PR TITLE
fix(hltb): fetch metadata when a HowLongToBeat ID is set by hand

### DIFF
--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -59,6 +59,7 @@ from handler.filesystem import fs_resource_handler, fs_rom_handler
 from handler.filesystem.assets_handler import validate_image_upload
 from handler.metadata import (
     meta_flashpoint_handler,
+    meta_hltb_handler,
     meta_igdb_handler,
     meta_launchbox_handler,
     meta_moby_handler,
@@ -1789,6 +1790,13 @@ async def update_rom(
             cleaned_data.update(igdb_rom)
     elif rom.igdb_id and not cleaned_data["igdb_id"]:
         cleaned_data.update({"igdb_id": None, "igdb_metadata": {}})
+
+    if cleaned_data["hltb_id"] and int(cleaned_data["hltb_id"]) != rom.hltb_id:
+        hltb_rom = await meta_hltb_handler.get_rom_by_id(int(cleaned_data["hltb_id"]))
+        if hltb_rom.get("hltb_id"):
+            cleaned_data.update(hltb_rom)
+    elif rom.hltb_id and not cleaned_data["hltb_id"]:
+        cleaned_data.update({"hltb_id": None, "hltb_metadata": {}})
 
     url_screenshots = cleaned_data.get("url_screenshots", [])
     screenshots_changed = pydash.xor(url_screenshots, rom.url_screenshots or [])

--- a/backend/handler/metadata/hltb_handler.py
+++ b/backend/handler/metadata/hltb_handler.py
@@ -726,7 +726,9 @@ class HLTBHandler(MetadataHandler):
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail=_unavailable_detail(status_code),
             ) from exc
-        except (httpx.ConnectError, httpx.ReadTimeout) as exc:
+        # Broader than the search path's catch: a connect timeout is the likely
+        # failure here, and it would otherwise escape update_rom as a bare 500.
+        except httpx.RequestError as exc:
             log.warning(
                 "Connection error: can't connect to HowLongToBeat", exc_info=True
             )

--- a/backend/handler/metadata/hltb_handler.py
+++ b/backend/handler/metadata/hltb_handler.py
@@ -20,9 +20,11 @@ from .base_handler import BaseRom, MetadataHandler
 # Regex to detect HLTB ID tags in filenames like (hltb-12345)
 HLTB_TAG_REGEX = re.compile(r"\(hltb-(\d+)\)", re.IGNORECASE)
 DASH_COLON_REGEX = re.compile(r"\s?-\s")
-# The game page ships its record as JSON in the Next.js hydration payload.
+# The game page ships its record as JSON in the Next.js hydration payload. The
+# id alone identifies the tag, so attribute order and extras a CSP would add
+# (nonce, crossorigin) do not read as a rewritten page.
 NEXT_DATA_REGEX = re.compile(
-    r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>', re.DOTALL
+    r"""<script[^>]*\bid=["']__NEXT_DATA__["'][^>]*>(.*?)</script>""", re.DOTALL
 )
 
 # HLTB publishes no rate limit, so stay well clear of being throttled.
@@ -705,11 +707,14 @@ class HLTBHandler(MetadataHandler):
         await _rate_limiter.acquire()
 
         try:
-            # Request the canonical path directly: the `/game?id=` form answers
-            # with a redirect, which the shared client does not follow.
+            # The canonical path, which answers directly today. Redirects are
+            # followed anyway because a 3xx does not raise, so a hop HLTB added
+            # later would otherwise read as a page we can no longer parse. The
+            # client validates every hop against SSRF, redirects included.
             res = await httpx_client.get(
                 f"{self.base_url}/game/{hltb_id}",
                 headers=self._base_headers(),
+                follow_redirects=True,
                 timeout=60,
             )
             res.raise_for_status()

--- a/backend/handler/metadata/hltb_handler.py
+++ b/backend/handler/metadata/hltb_handler.py
@@ -5,6 +5,7 @@ import time
 from typing import Final, NotRequired, TypedDict
 
 import httpx
+import pydash
 from fastapi import HTTPException, status
 
 from config import HLTB_API_ENABLED
@@ -19,6 +20,10 @@ from .base_handler import BaseRom, MetadataHandler
 # Regex to detect HLTB ID tags in filenames like (hltb-12345)
 HLTB_TAG_REGEX = re.compile(r"\(hltb-(\d+)\)", re.IGNORECASE)
 DASH_COLON_REGEX = re.compile(r"\s?-\s")
+# The game page ships its record as JSON in the Next.js hydration payload.
+NEXT_DATA_REGEX = re.compile(
+    r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>', re.DOTALL
+)
 
 # HLTB publishes no rate limit, so stay well clear of being throttled.
 HLTB_MAX_REQUESTS_PER_SECOND: Final[float] = 3
@@ -131,6 +136,60 @@ class HLTBRom(BaseRom):
     hltb_metadata: NotRequired[HLTBMetadata]
 
 
+def _release_year(value: object) -> int:
+    """Normalize a release date: search returns a year, the game page an ISO date."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        year, _, _ = value.partition("-")
+        if year.isdigit():
+            return int(year)
+    return 0
+
+
+def build_hltb_game(game_data: dict) -> HLTBGame:
+    """Build an HLTBGame, defaulting the fields a given HLTB payload omits."""
+    return HLTBGame(
+        game_id=game_data.get("game_id", 0),
+        game_name=game_data.get("game_name", ""),
+        game_name_date=game_data.get("game_name_date", 0),
+        game_alias=game_data.get("game_alias", ""),
+        game_type=game_data.get("game_type", ""),
+        game_image=game_data.get("game_image", ""),
+        comp_lvl_combine=game_data.get("comp_lvl_combine", 0),
+        comp_lvl_sp=game_data.get("comp_lvl_sp", 0),
+        comp_lvl_co=game_data.get("comp_lvl_co", 0),
+        comp_lvl_mp=game_data.get("comp_lvl_mp", 0),
+        comp_main=game_data.get("comp_main", 0),
+        comp_plus=game_data.get("comp_plus", 0),
+        comp_100=game_data.get("comp_100", 0),
+        comp_all=game_data.get("comp_all", 0),
+        comp_main_count=game_data.get("comp_main_count", 0),
+        comp_plus_count=game_data.get("comp_plus_count", 0),
+        comp_100_count=game_data.get("comp_100_count", 0),
+        comp_all_count=game_data.get("comp_all_count", 0),
+        invested_co=game_data.get("invested_co", 0),
+        invested_mp=game_data.get("invested_mp", 0),
+        invested_co_count=game_data.get("invested_co_count", 0),
+        invested_mp_count=game_data.get("invested_mp_count", 0),
+        count_comp=game_data.get("count_comp", 0),
+        count_speedrun=game_data.get("count_speedrun", 0),
+        count_backlog=game_data.get("count_backlog", 0),
+        count_review=game_data.get("count_review", 0),
+        review_score=game_data.get("review_score", 0),
+        count_playing=game_data.get("count_playing", 0),
+        count_retired=game_data.get("count_retired", 0),
+        profile_platform=game_data.get("profile_platform", ""),
+        profile_popular=game_data.get("profile_popular", 0) or 0,
+        release_world=_release_year(game_data.get("release_world")),
+    )
+
+
+def build_cover_url(game: HLTBGame) -> str:
+    image = game.get("game_image")
+    return f"https://howlongtobeat.com/games/{image}" if image else ""
+
+
 def extract_hltb_metadata(game: HLTBGame) -> HLTBMetadata:
     """Extract metadata from HLTB game data."""
     metadata = HLTBMetadata()
@@ -182,6 +241,21 @@ def extract_hltb_metadata(game: HLTBGame) -> HLTBMetadata:
 
 
 GITHUB_FILE_URL = "https://raw.githubusercontent.com/rommapp/romm/refs/heads/master/backend/handler/metadata/fixtures/hltb_api_url"
+
+
+# Raised where the page parsed but did not carry the shape we read, so a
+# rewrite upstream surfaces as itself instead of as a game with no times.
+HLTB_FORMAT_CHANGED_DETAIL: Final[str] = (
+    "HowLongToBeat changed their game page, RomM could not read the game data"
+)
+
+
+def _format_changed(reason: str) -> HTTPException:
+    log.error("HowLongToBeat game page could not be read: %s", reason)
+    return HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail=HLTB_FORMAT_CHANGED_DETAIL,
+    )
 
 
 def _unavailable_detail(status_code: int) -> str:
@@ -455,42 +529,7 @@ class HLTBHandler(MetadataHandler):
             games = []
             for game_data in games_data:
                 if isinstance(game_data, dict) and "game_id" in game_data:
-                    # Create HLTBGame with all required fields, using defaults for missing ones
-                    hltb_game = HLTBGame(
-                        game_id=game_data.get("game_id", 0),
-                        game_name=game_data.get("game_name", ""),
-                        game_name_date=game_data.get("game_name_date", 0),
-                        game_alias=game_data.get("game_alias", ""),
-                        game_type=game_data.get("game_type", ""),
-                        game_image=game_data.get("game_image", ""),
-                        comp_lvl_combine=game_data.get("comp_lvl_combine", 0),
-                        comp_lvl_sp=game_data.get("comp_lvl_sp", 0),
-                        comp_lvl_co=game_data.get("comp_lvl_co", 0),
-                        comp_lvl_mp=game_data.get("comp_lvl_mp", 0),
-                        comp_main=game_data.get("comp_main", 0),
-                        comp_plus=game_data.get("comp_plus", 0),
-                        comp_100=game_data.get("comp_100", 0),
-                        comp_all=game_data.get("comp_all", 0),
-                        comp_main_count=game_data.get("comp_main_count", 0),
-                        comp_plus_count=game_data.get("comp_plus_count", 0),
-                        comp_100_count=game_data.get("comp_100_count", 0),
-                        comp_all_count=game_data.get("comp_all_count", 0),
-                        invested_co=game_data.get("invested_co", 0),
-                        invested_mp=game_data.get("invested_mp", 0),
-                        invested_co_count=game_data.get("invested_co_count", 0),
-                        invested_mp_count=game_data.get("invested_mp_count", 0),
-                        count_comp=game_data.get("count_comp", 0),
-                        count_speedrun=game_data.get("count_speedrun", 0),
-                        count_backlog=game_data.get("count_backlog", 0),
-                        count_review=game_data.get("count_review", 0),
-                        review_score=game_data.get("review_score", 0),
-                        count_playing=game_data.get("count_playing", 0),
-                        count_retired=game_data.get("count_retired", 0),
-                        profile_platform=game_data.get("profile_platform", ""),
-                        profile_popular=game_data.get("profile_popular", 0),
-                        release_world=game_data.get("release_world", 0),
-                    )
-                    games.append(hltb_game)
+                    games.append(build_hltb_game(game_data))
             return games
 
         except Exception as exc:
@@ -593,17 +632,10 @@ class HLTBHandler(MetadataHandler):
                     f"Found HowLongToBeat match for '{search_term}' -> '{best_match}' (score: {best_score:.3f})"
                 )
 
-                # Build cover URL if image is available
-                cover_url = ""
-                if best_game.get("game_image"):
-                    cover_url = (
-                        f"https://howlongtobeat.com/games/{best_game['game_image']}"
-                    )
-
                 return HLTBRom(
                     hltb_id=best_game["game_id"],
                     name=best_game["game_name"],
-                    url_cover=cover_url,
+                    url_cover=build_cover_url(best_game),
                     hltb_metadata=extract_hltb_metadata(best_game),
                 )
 
@@ -628,21 +660,104 @@ class HLTBHandler(MetadataHandler):
 
         roms = []
         for game in games:
-            # Build cover URL if image is available
-            cover_url = ""
-            if game.get("game_image"):
-                cover_url = f"https://howlongtobeat.com/games/{game['game_image']}"
-
             roms.append(
                 HLTBRom(
                     hltb_id=game["game_id"],
                     name=game["game_name"],
-                    url_cover=cover_url,
+                    url_cover=build_cover_url(game),
                     hltb_metadata=extract_hltb_metadata(game),
                 )
             )
 
         return roms
+
+    async def get_rom_by_id(self, hltb_id: int) -> HLTBRom:
+        """
+        Get ROM information from HowLongToBeat by its game ID.
+
+        HLTB's API only exposes search, so the record is read from the hydration
+        payload the game page already ships to the browser.
+
+        :param hltb_id: The HowLongToBeat game ID.
+        :return: A HLTBRom object.
+        """
+        if not self.is_enabled():
+            return HLTBRom(hltb_id=None)
+
+        game_data = await self._fetch_game_page(hltb_id)
+        if not game_data:
+            return HLTBRom(hltb_id=None)
+
+        game = build_hltb_game(game_data)
+
+        return HLTBRom(
+            hltb_id=game["game_id"],
+            name=game["game_name"],
+            url_cover=build_cover_url(game),
+            hltb_metadata=extract_hltb_metadata(game),
+        )
+
+    async def _fetch_game_page(self, hltb_id: int) -> dict:
+        """Fetch and parse a game page's hydration payload."""
+        httpx_client = ctx_httpx_client.get()
+
+        # The page is HLTB traffic like any other, so it respects the same cap.
+        await _rate_limiter.acquire()
+
+        try:
+            # Request the canonical path directly: the `/game?id=` form answers
+            # with a redirect, which the shared client does not follow.
+            res = await httpx_client.get(
+                f"{self.base_url}/game/{hltb_id}",
+                headers=self._base_headers(),
+                timeout=60,
+            )
+            res.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            if status_code == status.HTTP_404_NOT_FOUND:
+                log.debug("HowLongToBeat has no game with ID %s", hltb_id)
+                return {}
+
+            log.warning(
+                "HowLongToBeat game page returned HTTP %s", status_code, exc_info=True
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=_unavailable_detail(status_code),
+            ) from exc
+        except (httpx.ConnectError, httpx.ReadTimeout) as exc:
+            log.warning(
+                "Connection error: can't connect to HowLongToBeat", exc_info=True
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Can't connect to HowLongToBeat API, check your internet connection",
+            ) from exc
+
+        match = NEXT_DATA_REGEX.search(res.text)
+        if not match:
+            raise _format_changed("the page carried no hydration payload")
+
+        try:
+            payload = json.loads(match.group(1))
+        except json.JSONDecodeError as exc:
+            raise _format_changed(f"the hydration payload is not JSON: {exc}") from exc
+
+        games = pydash.get(payload, "props.pageProps.game.data.game")
+        if not isinstance(games, list):
+            raise _format_changed("the hydration payload holds no game records")
+
+        # An empty list is HLTB answering honestly, not a rewrite: the ID is gone.
+        if not games:
+            log.debug("HowLongToBeat has no record for game ID %s", hltb_id)
+            return {}
+
+        game_data = games[0]
+        if not isinstance(game_data, dict) or "game_id" not in game_data:
+            raise _format_changed("the game record is not in the expected shape")
+
+        return game_data
 
     async def price_check(
         self, hltb_id: int, steam_id: int = 0, itch_id: int = 0

--- a/backend/tests/endpoints/roms/test_rom.py
+++ b/backend/tests/endpoints/roms/test_rom.py
@@ -10,6 +10,7 @@ from handler.database.base_handler import sync_session
 from handler.filesystem.resources_handler import FSResourcesHandler
 from handler.filesystem.roms_handler import FSRomsHandler
 from handler.metadata.flashpoint_handler import FlashpointHandler, FlashpointRom
+from handler.metadata.hltb_handler import HLTBHandler, HLTBRom
 from handler.metadata.igdb_handler import IGDBHandler, IGDBRom
 from handler.metadata.launchbox_handler.handler import LaunchboxHandler
 from handler.metadata.launchbox_handler.types import LaunchboxRom
@@ -1406,8 +1407,19 @@ class TestUpdateMetadataIDs:
         body = response.json()
         assert body["hasheous_id"] == MOCK_HASHEOUS_ID
 
-    def test_update_rom_hltb_id(self, client: TestClient, access_token: str, rom: Rom):
-        """Test updating HowLongToBeat ID."""
+    @patch.object(
+        HLTBHandler,
+        "get_rom_by_id",
+        return_value=HLTBRom(hltb_id=MOCK_HLTB_ID, hltb_metadata={"main_story": 92822}),
+    )
+    def test_update_rom_hltb_id(
+        self,
+        get_rom_by_id_mock: AsyncMock,
+        client: TestClient,
+        access_token: str,
+        rom: Rom,
+    ):
+        """A hand-entered HowLongToBeat ID has to pull its times down with it."""
         response = client.put(
             f"/api/roms/{rom.id}",
             headers={"Authorization": f"Bearer {access_token}"},
@@ -1417,6 +1429,28 @@ class TestUpdateMetadataIDs:
 
         body = response.json()
         assert body["hltb_id"] == MOCK_HLTB_ID
+        assert body["hltb_metadata"]["main_story"] == 92822
+        assert get_rom_by_id_mock.called
+
+    @patch.object(HLTBHandler, "get_rom_by_id", return_value=HLTBRom(hltb_id=None))
+    def test_update_rom_hltb_id_persists_when_handler_disabled(
+        self,
+        get_rom_by_id_mock: AsyncMock,
+        client: TestClient,
+        access_token: str,
+        rom: Rom,
+    ):
+        """Test that HLTB ID persists when handler is disabled or game not found."""
+        response = client.put(
+            f"/api/roms/{rom.id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+            data={"hltb_id": str(MOCK_HLTB_ID)},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        body = response.json()
+        assert body["hltb_id"] == MOCK_HLTB_ID
+        assert get_rom_by_id_mock.called
 
 
 class TestUpdateRawMetadata:
@@ -1617,8 +1651,12 @@ class TestUpdateRawMetadata:
         assert body["flashpoint_metadata"]["companies"] == ["Nintendo"]
         assert body["flashpoint_metadata"]["source"] == "Flashpoint"
 
+    @patch.object(
+        HLTBHandler, "get_rom_by_id", return_value=HLTBRom(hltb_id=MOCK_HLTB_ID)
+    )
     def test_update_raw_hltb_metadata(
         self,
+        get_rom_by_id_mock: AsyncMock,
         client: TestClient,
         access_token: str,
         rom: Rom,

--- a/backend/tests/handler/metadata/hltb_game_page_example.json
+++ b/backend/tests/handler/metadata/hltb_game_page_example.json
@@ -1,0 +1,32 @@
+{
+  "props": {
+    "pageProps": {
+      "game": {
+        "data": {
+          "game": [
+            {
+              "game_id": 7169,
+              "game_name": "Pokémon Red and Blue",
+              "count_comp": 5364,
+              "count_review": 1762,
+              "review_score": 81,
+              "game_alias": "Pokemon Red and Blue, Pokemon Green, Pocket Monsters Red, Pocket Monsters Green, Pocket Monsters Blue, Pokemon Blue Version, Pokemon Red Version, Pokemon Green Version",
+              "game_image": "7169_Pokmon_Red_and_Blue.png",
+              "game_type": "game",
+              "profile_platform": "Game Boy",
+              "release_world": "1996-02-27",
+              "comp_all_count": 1174,
+              "comp_all": 139926,
+              "comp_main_count": 594,
+              "comp_main": 92822,
+              "comp_plus_count": 378,
+              "comp_plus": 156016,
+              "comp_100_count": 202,
+              "comp_100": 354756
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/handler/metadata/test_hltb_handler.py
+++ b/backend/tests/handler/metadata/test_hltb_handler.py
@@ -1,3 +1,5 @@
+import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -435,3 +437,217 @@ async def test_retry_still_requires_recorded_times():
         rom = await handler.get_rom("007 - Quantum of Solace (USA).chd", "ps2")
 
     assert rom["hltb_id"] is None
+
+
+def _game_page(game: dict | None) -> MagicMock:
+    """A game page carrying its record in the Next.js hydration payload."""
+    games = [game] if game is not None else []
+    payload = json.dumps({"props": {"pageProps": {"game": {"data": {"game": games}}}}})
+    response = MagicMock()
+    response.status_code = 200
+    response.text = (
+        '<html><body><script id="__NEXT_DATA__" type="application/json">'
+        f"{payload}</script></body></html>"
+    )
+    return response
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_get_rom_by_id_reads_the_game_page(mock_ctx_httpx_client):
+    """The by-ID lookup the manual edit form depends on: HLTB has no API for it,
+    so the record comes off the game page."""
+    handler = _handler()
+    client = MagicMock()
+    client.get = AsyncMock(return_value=_game_page(_game(7169, "Pokémon Red and Blue")))
+    mock_ctx_httpx_client.get.return_value = client
+
+    rom = await handler.get_rom_by_id(7169)
+
+    assert rom["hltb_id"] == 7169
+    assert rom["name"] == "Pokémon Red and Blue"
+    assert rom["hltb_metadata"]["main_story"] == 3600
+    assert rom["hltb_metadata"]["review_score"] == 70
+
+    # The `/game?id=` form answers with a redirect the shared client won't follow.
+    assert client.get.await_args.args[0] == "https://howlongtobeat.com/game/7169"
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_get_rom_by_id_sends_the_user_agent_hltb_requires(
+    mock_ctx_httpx_client,
+):
+    handler = _handler()
+    client = MagicMock()
+    client.get = AsyncMock(return_value=_game_page(_game(7169, "Pokémon")))
+    mock_ctx_httpx_client.get.return_value = client
+
+    await handler.get_rom_by_id(7169)
+
+    assert (
+        client.get.await_args.kwargs["headers"]["User-Agent"] == f"RomM/{get_version()}"
+    )
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_get_rom_by_id_reads_the_full_release_date(mock_ctx_httpx_client):
+    """The game page dates a release in full where search returns just the year."""
+    handler = _handler()
+    game = _game(7169, "Pokémon Red and Blue") | {"release_world": "1996-02-27"}
+    client = MagicMock()
+    client.get = AsyncMock(return_value=_game_page(game))
+    mock_ctx_httpx_client.get.return_value = client
+
+    rom = await handler.get_rom_by_id(7169)
+
+    assert rom["hltb_metadata"]["release_year"] == 1996
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_get_rom_by_id_tolerates_a_page_without_popularity(
+    mock_ctx_httpx_client,
+):
+    """The game page omits the popularity search reports, so it must not fail."""
+    handler = _handler()
+    game = _game(7169, "Pokémon Red and Blue") | {"profile_popular": None}
+    client = MagicMock()
+    client.get = AsyncMock(return_value=_game_page(game))
+    mock_ctx_httpx_client.get.return_value = client
+
+    rom = await handler.get_rom_by_id(7169)
+
+    assert rom["hltb_id"] == 7169
+    assert "popularity" not in rom["hltb_metadata"]
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_unknown_id_is_not_reported_as_an_outage(mock_ctx_httpx_client):
+    """A mistyped ID is the user's, not HLTB's, so it must not 503 the edit."""
+    handler = _handler()
+    client = MagicMock()
+    client.get = AsyncMock(return_value=_response(status.HTTP_404_NOT_FOUND))
+    mock_ctx_httpx_client.get.return_value = client
+
+    rom = await handler.get_rom_by_id(999999999)
+
+    assert rom["hltb_id"] is None
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_game_page_outage_reports_service_unavailable(mock_ctx_httpx_client):
+    handler = _handler()
+    client = MagicMock()
+    client.get = AsyncMock(
+        return_value=_response(status.HTTP_429_TOO_MANY_REQUESTS),
+    )
+    mock_ctx_httpx_client.get.return_value = client
+
+    with pytest.raises(HTTPException) as exc_info:
+        await handler.get_rom_by_id(7169)
+
+    assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert "rate limiting" in exc_info.value.detail
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_game_page_without_a_record_yields_no_match(mock_ctx_httpx_client):
+    """An empty record list is HLTB answering honestly, not a rewrite."""
+    handler = _handler()
+    client = MagicMock()
+    client.get = AsyncMock(return_value=_game_page(None))
+    mock_ctx_httpx_client.get.return_value = client
+
+    rom = await handler.get_rom_by_id(7169)
+
+    assert rom["hltb_id"] is None
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_reshaped_game_page_reports_the_rewrite(mock_ctx_httpx_client):
+    """A page RomM can no longer read has to say so: reported as a game with no
+    times it is indistinguishable from the bug this lookup exists to fix."""
+    handler = _handler()
+    response = MagicMock()
+    response.status_code = 200
+    response.text = "<html><body>no hydration payload here</body></html>"
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+    mock_ctx_httpx_client.get.return_value = client
+
+    with pytest.raises(HTTPException) as exc_info:
+        await handler.get_rom_by_id(7169)
+
+    assert exc_info.value.status_code == status.HTTP_502_BAD_GATEWAY
+    assert "changed their game page" in exc_info.value.detail
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_renamed_game_fields_report_the_rewrite(mock_ctx_httpx_client):
+    """Defaulting every field would quietly turn a rename into an empty match."""
+    handler = _handler()
+    client = MagicMock()
+    client.get = AsyncMock(return_value=_game_page({"id": 7169, "name": "Pokémon"}))
+    mock_ctx_httpx_client.get.return_value = client
+
+    with pytest.raises(HTTPException) as exc_info:
+        await handler.get_rom_by_id(7169)
+
+    assert exc_info.value.status_code == status.HTTP_502_BAD_GATEWAY
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", False)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_get_rom_by_id_is_skipped_when_hltb_is_disabled(mock_ctx_httpx_client):
+    rom = await _handler().get_rom_by_id(7169)
+
+    assert rom["hltb_id"] is None
+    mock_ctx_httpx_client.get.assert_not_called()
+
+
+async def test_the_live_page_shape_still_parses():
+    """Captured from howlongtobeat.com/game/7169. If HLTB reshapes the page this
+    fixture goes stale, but it keeps our own parsing honest in the meantime."""
+    fixture = Path(__file__).parent / "hltb_game_page_example.json"
+    payload = json.loads(fixture.read_text(encoding="utf-8"))
+
+    response = MagicMock()
+    response.status_code = 200
+    response.text = (
+        '<script id="__NEXT_DATA__" type="application/json">'
+        f"{json.dumps(payload)}</script>"
+    )
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+
+    with (
+        patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True),
+        patch("handler.metadata.hltb_handler.ctx_httpx_client") as ctx,
+    ):
+        ctx.get.return_value = client
+        rom = await _handler().get_rom_by_id(7169)
+
+    assert rom["hltb_id"] == 7169
+    assert rom["name"] == "Pokémon Red and Blue"
+    assert rom["url_cover"].endswith("7169_Pokmon_Red_and_Blue.png")
+    assert rom["hltb_metadata"] == {
+        "main_story": 92822,
+        "main_story_count": 594,
+        "main_plus_extra": 156016,
+        "main_plus_extra_count": 378,
+        "completionist": 354756,
+        "completionist_count": 202,
+        "all_styles": 139926,
+        "all_styles_count": 1174,
+        "release_year": 1996,
+        "review_score": 81,
+        "review_count": 1762,
+        "completions": 5364,
+    }

--- a/backend/tests/handler/metadata/test_hltb_handler.py
+++ b/backend/tests/handler/metadata/test_hltb_handler.py
@@ -651,3 +651,30 @@ async def test_the_live_page_shape_still_parses():
         "review_count": 1762,
         "completions": 5364,
     }
+
+
+@pytest.mark.parametrize(
+    "transport_error",
+    [
+        httpx.ConnectTimeout("timed out"),
+        httpx.PoolTimeout("pool exhausted"),
+        httpx.ReadError("reset"),
+        httpx.RemoteProtocolError("bad framing"),
+    ],
+)
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_transport_failures_report_service_unavailable(
+    mock_ctx_httpx_client, transport_error
+):
+    """A slow or unreachable HLTB must not surface as a bare 500 on the rom edit."""
+    handler = _handler()
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=transport_error)
+    mock_ctx_httpx_client.get.return_value = client
+
+    with pytest.raises(HTTPException) as exc_info:
+        await handler.get_rom_by_id(7169)
+
+    assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert "check your internet connection" in exc_info.value.detail

--- a/backend/tests/handler/metadata/test_hltb_handler.py
+++ b/backend/tests/handler/metadata/test_hltb_handler.py
@@ -678,3 +678,74 @@ async def test_transport_failures_report_service_unavailable(
 
     assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert "check your internet connection" in exc_info.value.detail
+
+
+@pytest.mark.parametrize(
+    ("label", "attributes"),
+    [
+        ("plain", 'id="__NEXT_DATA__" type="application/json"'),
+        ("csp nonce", 'id="__NEXT_DATA__" type="application/json" nonce="r4nd0m"'),
+        ("reordered", 'type="application/json" id="__NEXT_DATA__"'),
+        ("single quotes", "id='__NEXT_DATA__' type='application/json'"),
+        ("crossorigin", 'crossorigin="" id="__NEXT_DATA__" type="application/json"'),
+    ],
+)
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_hydration_tag_is_found_however_it_is_marked_up(
+    mock_ctx_httpx_client, label, attributes
+):
+    """Markup around the payload is not the contract; the id is. Reporting a
+    rewrite over an added nonce would be a false alarm."""
+    payload = json.dumps(
+        {"props": {"pageProps": {"game": {"data": {"game": [_game(7169, "Pokémon")]}}}}}
+    )
+    response = MagicMock()
+    response.status_code = 200
+    response.text = f"<script {attributes}>{payload}</script>"
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+    mock_ctx_httpx_client.get.return_value = client
+
+    rom = await _handler().get_rom_by_id(7169)
+
+    assert rom["hltb_id"] == 7169, label
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_a_redirect_is_followed_rather_than_read_as_a_rewrite(
+    mock_ctx_httpx_client,
+):
+    """`raise_for_status` lets a 3xx through, so an unfollowed hop would reach
+    the parser as a page with no payload and be blamed on HLTB reshaping it."""
+    handler = _handler()
+    client = MagicMock()
+    client.get = AsyncMock(return_value=_game_page(_game(7169, "Pokémon")))
+    mock_ctx_httpx_client.get.return_value = client
+
+    await handler.get_rom_by_id(7169)
+
+    assert client.get.await_args.kwargs["follow_redirects"] is True
+
+
+@patch("handler.metadata.hltb_handler.HLTB_API_ENABLED", True)
+@patch("handler.metadata.hltb_handler.ctx_httpx_client")
+async def test_an_unrelated_json_script_is_not_mistaken_for_the_payload(
+    mock_ctx_httpx_client,
+):
+    """The looser tag match must not start picking up other JSON blocks."""
+    handler = _handler()
+    response = MagicMock()
+    response.status_code = 200
+    response.text = (
+        '<script id="__OTHER_DATA__" type="application/json">{"game": []}</script>'
+    )
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+    mock_ctx_httpx_client.get.return_value = client
+
+    with pytest.raises(HTTPException) as exc_info:
+        await handler.get_rom_by_id(7169)
+
+    assert exc_info.value.status_code == status.HTTP_502_BAD_GATEWAY


### PR DESCRIPTION
**Description**

Manually entering a HowLongToBeat ID saved the ID but never fetched anything, leaving the How Long to Beat tab empty.

`update_rom` has a block that refetches from each metadata provider whose ID changed, covering Flashpoint, LaunchBox, RA, MobyGames, ScreenScraper and IGDB. HLTB was absent from it, and `HLTBHandler` had no `get_rom_by_id` at all, so `hltb_metadata` only ever got populated when the client also sent `raw_hltb_metadata`, which the edit form does not do for a hand-typed ID. Both v1 and v2 expose the field, so both were affected.

This adds the missing handler method and wires it in alongside the others.

**On scraping, since that is the reason this was previously closed**

HLTB exposes no by-ID API. I re-checked rather than taking it on trust: `POST /api/bleed` with `searchTerms: ["7169"]` returns `count: 0` (it is a text search over names), and `/api/game/7169`, `/api/games/7169`, `/api/bleed/game/7169`, `/api/game?id=7169`, `/api/gamedetail/7169` and `/api/game/detail/7169` all 404. So the record is read from the `__NEXT_DATA__` payload the game page already ships to the browser.

Worth weighing against what the feature already rests on: `backend/utils/update_hltb_api_url.py` discovers the rotating search endpoint by fetching the homepage, regex-matching a `_app-<hash>.js` script tag, downloading that minified webpack bundle and regex-matching the minified JavaScript for the URL. The whole search path depends on it. Relative to that, this adds a dependency on the `__NEXT_DATA__` tag and one pageProps path. The field names (`comp_main`, `review_score`, and so on) are the same ones the search API returns, so that surface is shared rather than additive.

I also checked the Next.js data route (`/_next/data/{buildId}/game/{id}.json`). It works and returns 6.4KB of JSON rather than 30KB of HTML, but `buildId` rotates on every deploy and can only be discovered by parsing `__NEXT_DATA__` out of an HTML page, so it costs an extra request and a staleness path to arrive at the same object. Not worth it.

Two implementation details that are not obvious:

- `/game/{id}` is requested directly rather than `/game?id={id}`. The latter answers with a 301, and the shared httpx client is built without `follow_redirects`, so the query form would have silently returned nothing.
- The game page dates a release in full (`"1996-02-27"`) where search returns just the year (`2008`), so `_release_year` normalizes both.

**Failing loudly**

A format change would otherwise degrade to a saved ID and an empty tab, which is byte-for-byte the symptom being fixed here and would get re-reported as this same issue. So an unreadable page raises 502 naming the cause, while a 404 or an empty record list stays benign. This includes a `game_id` presence check: `build_hltb_game` defaults every absent field, so a rename upstream would otherwise have silently returned no match forever.

The trade-off is that a genuine upstream rewrite fails the whole edit submit rather than half-succeeding. That felt like the right side to err on for a scrape-backed path, but happy to flip it.

**Tests**

12 new tests. `hltb_game_page_example.json` is a real payload captured from `howlongtobeat.com/game/7169`, trimmed to the fields the parser actually reads, and asserted through the full path down to the exact extracted metadata dict. It keeps our own parsing honest without touching the network in CI; it cannot detect an upstream change on its own.

I confirmed the endpoint tests are not vacuous by reverting the wiring: they fail with `assert get_rom_by_id_mock.called` is `False`, reproducing the reported bug. `test_update_raw_hltb_metadata` needed the handler pinned, as it now traverses the fetch path and would otherwise reach the network.

Also refactored while here: the 30-line dict to `HLTBGame` construction is now shared between the search and by-ID paths rather than duplicated, and the cover-URL build was already repeated three times.

Verified against live HowLongToBeat: a game with full data (id 7169), a sparse one with only two recorded times (id 68168), and an unknown ID, which returns cleanly rather than raising. Full backend suite: 2953 passed, 0 failed. `trunk check` clean.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A, backend only.

---

**AI assistance disclosure**

Written with Claude Code (Claude Opus 5): diagnosis, implementation, and tests. The absence of a by-ID API endpoint was established by probing the live service rather than assumed, and the parsing was verified end to end against live HowLongToBeat. Reviewed by me before submitting.

Fixes #2926
