### PR TITLE
Match LaunchBox dumps that separate words with underscores

### DIFF
--- a/backend/handler/metadata/launchbox_handler/handler.py
+++ b/backend/handler/metadata/launchbox_handler/handler.py
@@ -155,6 +155,10 @@ class LaunchboxHandler(MetadataHandler):
             else:
                 search_term = fs_name
 
+            # The rewrites below are anchored on spaces, so a dump that separates
+            # words with underscores reaches none of them.
+            search_term = search_term.replace("_", " ")
+
             # Resolve MAME arcade filename (e.g. wrlok_l3.zip) to its full title
             # via LaunchBox's Mame.xml before name-based lookup.
             if platform_slug == UPS.ARCADE:

--- a/backend/tests/handler/metadata/test_launchbox_handler.py
+++ b/backend/tests/handler/metadata/test_launchbox_handler.py
@@ -1614,6 +1614,66 @@ class TestLaunchboxHandlerGetRom:
         assert result.get("launchbox_id", None) == 1234
         assert result.get("name", None) == "Super Mario Bros."
 
+    @pytest.mark.parametrize(
+        "no_tags_name",
+        (
+            "Legend of Zelda, The - A Link to the Past",
+            "Legend_of_Zelda,_The_-_A_Link_to_the_Past",
+        ),
+    )
+    async def test_underscore_separator_rewrites_like_spaced_form(
+        self, handler: LaunchboxHandler, no_tags_name: str
+    ):
+        mock_get_rom = AsyncMock(return_value=None)
+        with (
+            patch.object(handler._remote, "get_rom", new=mock_get_rom),
+            patch(
+                "handler.metadata.launchbox_handler.handler.fs_rom_handler"
+            ) as mock_fs,
+        ):
+            mock_fs.get_file_name_with_no_tags.return_value = no_tags_name
+            await handler.get_rom(f"{no_tags_name}.smc", "snes")
+
+        assert (
+            mock_get_rom.call_args.args[0] == "legend of zelda, the: a link to the past"
+        )
+
+    async def test_underscore_separated_inverted_article_hits_name_index(
+        self, handler: LaunchboxHandler
+    ):
+        """Both the dash and the article rewrite must fire to reach the key."""
+        entry = {
+            "DatabaseID": "5678",
+            "Name": "The Legend of Zelda: A Link to the Past",
+            "Platform": "Super Nintendo Entertainment System",
+        }
+        index = {
+            (
+                LAUNCHBOX_METADATA_NAME_KEY,
+                "the legend of zelda: a link to the past"
+                ":Super Nintendo Entertainment System",
+            ): json.dumps(entry)
+        }
+
+        async def hget(key, field):
+            return index.get((key, field))
+
+        with (
+            patch.object(handler._remote, "get_rom", new=RemoteSource().get_rom),
+            patch.object(async_cache, "hget", new=AsyncMock(side_effect=hget)),
+            patch(
+                "handler.metadata.launchbox_handler.handler.fs_rom_handler"
+            ) as mock_fs,
+        ):
+            mock_fs.get_file_name_with_no_tags.return_value = (
+                "Legend_of_Zelda,_The_-_A_Link_to_the_Past"
+            )
+            result = await handler.get_rom(
+                "Legend_of_Zelda,_The_-_A_Link_to_the_Past.smc", "snes"
+            )
+
+        assert result.get("launchbox_id", None) == 5678
+
     async def test_name_search_fails_returns_fallback(self, handler: LaunchboxHandler):
         with patch(
             "handler.metadata.launchbox_handler.handler.fs_rom_handler"


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes name-based LaunchBox matching for ROM dumps that separate words with underscores instead of spaces.

Before the metadata index is queried, `LaunchboxHandler.get_rom` rewrites the search term twice: `DASH_COLON_REGEX` (`\s?-\s`) turns `" - "` into `": "` to match LaunchBox's subtitle convention, and `deinvert_article` moves a trailing article back to the front (`legend of zelda, the: ...` becomes `the legend of zelda: ...`). Both are anchored on literal spaces, so a term still carrying underscores reaches neither: `_-_` is not a dash-with-space, and `,_the` is not `", the"`.

The folded fallback in `RemoteSource.get_rom` does not rescue it. `fold_title` drops underscores, but with the article never de-inverted it folds to `legendofzeldathealinktothepast` while the index key is `thelegendofzeldaalinktothepast`.

Net effect, for the same game and the same dump convention:

```
Legend of Zelda, The - A Link to the Past.smc   ->  match
Legend_of_Zelda,_The_-_A_Link_to_the_Past.smc   ->  no match
```

The fix swaps underscores for spaces once, before the rewrites that need them. It is placed after tag stripping and before the MAME branch, so `get_rom_by_file_name` still receives the raw filename that the Files.xml index is keyed on.

**Why not `normalize_search_term`**

The other providers run their search term through `normalize_search_term`, which already maps `_` to a space. Reusing it here would be a regression. LaunchBox does exact hash lookups against indexes keyed off raw dump titles, and `normalize_search_term` also strips leading articles, so normalizing only the query side walks away from keys that currently match:

| `The_Legend_of_Zelda_-_A_Link_to_the_Past.smc` | folded key | result |
| --- | --- | --- |
| this PR | `thelegendofzeldaalinktothepast` | match |
| with `normalize_search_term` | `legendofzeldaalinktothepast` | miss |

That would break `The ...` and `A ...` titles broadly. Everything LaunchBox actually needs from normalization is already done symmetrically on both sides by `fold_title`.

**Testing**

- `test_underscore_separator_rewrites_like_spaced_form`, parametrized over the spaced and underscored forms of the same dump, asserting both produce the same search term. The spaced case is the control.
- `test_underscore_separated_inverted_article_hits_name_index`, driving a real `RemoteSource` against a stubbed cache keyed exactly as `update_launchbox_metadata.py` keys it, proving the underscored filename now resolves.

Both were confirmed to fail without the one-line change and pass with it. `tests/handler/metadata/` is green at 440 passed, and `trunk fmt` / `trunk check` report no issues.

Reviewer note: the full backend suite also shows 24 pre-existing failures in `test_identity.py`, `test_oauth.py`, `test_auth.py` and `test_tasks.py` when Redis is not running locally. Those reproduce identically on a clean `master` checkout and are unrelated to this change.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The underscore behavior across every metadata handler was investigated with AI, and the fix, the tests, and this description were AI-drafted, then reviewed and verified locally by me.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

n/a, backend only.
