### PR TITLE
fix(backend): make filters match against all grouped versions instead of only the main version of each game entry

### DIFF
--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -1234,6 +1234,36 @@ class DBRomsHandler(DBBaseHandler):
         if updated_after:
             query = query.filter(Rom.updated_at > updated_after)
 
+        # Apply metadata and rom-level filters efficiently
+        # Moved before applying group_by_meta_id to avoid missing titles when
+        # filters don't match the primary ROM version in a group but would match a different version instead.
+        filters_to_apply = [
+            (genres, genres_logic, self._filter_by_genres),
+            (franchises, franchises_logic, self._filter_by_franchises),
+            (collections, collections_logic, self._filter_by_collections),
+            (companies, companies_logic, self._filter_by_companies),
+            (age_ratings, age_ratings_logic, self._filter_by_age_ratings),
+            (regions, regions_logic, self._filter_by_regions),
+            (languages, languages_logic, self._filter_by_languages),
+            (player_counts, player_counts_logic, self._filter_by_player_counts),
+            (
+                metadata_providers,
+                metadata_providers_logic,
+                self._filter_by_metadata_providers,
+            ),
+            (tags, tags_logic, self._filter_by_tags),
+        ]
+
+        for values, logic, filter_func in filters_to_apply:
+            if values:
+                query = filter_func(
+                    query,
+                    session=session,
+                    values=values,
+                    match_all=(logic == "all"),
+                    match_none=(logic == "none"),
+                )
+
         # BEWARE YE WHO ENTERS HERE 💀
         if group_by_meta_id:
             # Convert NULL is_main_sibling to 0 (false) so it sorts after true values
@@ -1354,34 +1384,6 @@ class DBRomsHandler(DBBaseHandler):
 
         if needs_metadata_join:
             query = query.outerjoin(RomMetadata)
-
-        # Apply metadata and rom-level filters efficiently
-        filters_to_apply = [
-            (genres, genres_logic, self._filter_by_genres),
-            (franchises, franchises_logic, self._filter_by_franchises),
-            (collections, collections_logic, self._filter_by_collections),
-            (companies, companies_logic, self._filter_by_companies),
-            (age_ratings, age_ratings_logic, self._filter_by_age_ratings),
-            (regions, regions_logic, self._filter_by_regions),
-            (languages, languages_logic, self._filter_by_languages),
-            (player_counts, player_counts_logic, self._filter_by_player_counts),
-            (
-                metadata_providers,
-                metadata_providers_logic,
-                self._filter_by_metadata_providers,
-            ),
-            (tags, tags_logic, self._filter_by_tags),
-        ]
-
-        for values, logic, filter_func in filters_to_apply:
-            if values:
-                query = filter_func(
-                    query,
-                    session=session,
-                    values=values,
-                    match_all=(logic == "all"),
-                    match_none=(logic == "none"),
-                )
 
         # The RomUser table is already joined if user_id is set
         if statuses and user_id:


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
If you have a game with mutiple versions, those may be shown under one single game entry, but the library filters try to match just against the one marked or detected as the primary version of the game.

The fix just changes the order of operations already in the code, allowing to apply the filters against all the versions before the grouping has taken effect, instead of doing it afterwards.

**Example scenario**
Let's say our library has these three rom files for the same Nintendo Entertainment System game:
- library/roms/nes/Double Dragon (Europe) (En)/Double Dragon (Europe) [!].nes  -> (Marked as Primary or Main version)
- library/roms/nes/Double Dragon (Japan) (Ja)/Sou Setsu Ryuu (Japan) [!].nes
- library/roms/nes/Double Dragon (USA) (En)/Double Dragon (USA) [!].nes

Before the fix, if you filter the list of games by Regions="Japan", Regions="USA" or Languages="Japanese" the game won't show up at all even if those versions do in fact exist in the library.


**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots

example 1: no filters enabled
<img width="911" height="851" alt="no-filters" src="https://github.com/user-attachments/assets/d055b6c6-c0ef-4ee4-9a64-d15cace2838e" />

example 2: filters -> regions="Japan" before fix (all entries disappear except the one whose main version matches the filter)
<img width="911" height="825" alt="filters-region-japan-without-fix" src="https://github.com/user-attachments/assets/8594c338-9f57-499e-b7b5-2060d6ecbe40" />

example 3: filters -> regions="Japan" after fix (the entries appear again, showing the version that matches the filter)
(double dragon III doesn't have any other version in this example and is therefore correctly still missing)
<img width="915" height="835" alt="filters-region-japan-with-fix" src="https://github.com/user-attachments/assets/2417db8b-294b-4e6a-b03d-f960b8663718" />
