### PR TITLE
Fix missing v2 auth notifications

### DIFF
--- a/frontend/src/v2/layouts/AuthLayout.test.ts
+++ b/frontend/src/v2/layouts/AuthLayout.test.ts
@@ -1,0 +1,49 @@
+import { mount } from "@vue/test-utils";
+import mitt from "mitt";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+import type { Events } from "@/types/emitter";
+import AuthLayout from "./AuthLayout.vue";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/v2/composables/useBreakpoint", () => ({
+  installBreakpointAttribute: vi.fn(),
+}));
+
+vi.mock("@/v2/composables/useInputModality", () => ({
+  useInputModality: () => ({ install: vi.fn() }),
+}));
+
+describe("AuthLayout", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("renders snackbar events from auth views", async () => {
+    const emitter = mitt<Events>();
+    const wrapper = mount(AuthLayout, {
+      global: {
+        provide: { emitter },
+        stubs: {
+          LanguageSelector: true,
+          RIcon: true,
+          RouterView: true,
+          VersionTag: true,
+        },
+      },
+    });
+
+    emitter.emit("snackbarShow", {
+      msg: "Unable to register user",
+      color: "error",
+      timeout: 0,
+    });
+    await nextTick();
+
+    expect(wrapper.text()).toContain("Unable to register user");
+  });
+});

--- a/frontend/src/v2/layouts/AuthLayout.vue
+++ b/frontend/src/v2/layouts/AuthLayout.vue
@@ -3,6 +3,7 @@
 // for the auth flows (Login / Register / ResetPassword / Setup). Bottom
 // corners hold the LanguageSelector (left) and VersionTag (right).
 import { onMounted } from "vue";
+import NotificationHost from "@/v2/components/Notifications/NotificationHost.vue";
 import LanguageSelector from "@/v2/components/shared/LanguageSelector.vue";
 import VersionTag from "@/v2/components/shared/VersionTag.vue";
 import { installBreakpointAttribute } from "@/v2/composables/useBreakpoint";
@@ -32,6 +33,7 @@ onMounted(installInputModality);
       </div>
       <VersionTag class="r-v2-auth__version" />
     </div>
+    <NotificationHost />
   </div>
 </template>
 


### PR DESCRIPTION
**Description**

Fixes #4164

Mount the v2 notification host in the auth layout so registration and other auth views display their existing success and error messages. Add a regression test for auth snackbar events.

AI assistance: Codex was used for investigation, implementation, testing, and PR text.

**Checklist**

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

Not applicable.
