### PR TITLE
fix(metadata): match dot-separated filenames like underscored ones

### DIFF
--- a/backend/handler/metadata/base_handler.py
+++ b/backend/handler/metadata/base_handler.py
@@ -50,6 +50,26 @@ NON_WORD_SPACE_PATTERN = re.compile(r"[^\w\s]")
 MULTIPLE_SPACE_PATTERN = re.compile(r"\s+")
 
 
+def _split_dotted_name(name: str) -> str:
+    """Turn the periods of a dot-separated name into spaces.
+
+    A scene-style dump ("Final.Fantasy.VII") spells its title with periods where
+    another dump uses underscores, and ScreenScraper, HLTB and Flashpoint are
+    searched with punctuation left in, so those periods reach the provider as
+    part of the words. Names that separate words some other way are left alone,
+    keeping the periods of an initialism ("F.E.A.R."), an abbreviation
+    ("Dr. Mario") and a version ("Sonic 3.5") intact for the same providers.
+    """
+    if "." not in name or len(name.split()) != 1:
+        return name
+
+    segments = [segment for segment in name.split(".") if segment]
+    if sum(len(segment) > 1 for segment in segments) < 2:
+        return name
+
+    return " ".join(segments)
+
+
 class BaseRom(TypedDict):
     name: NotRequired[str]
     name_sort_key: NotRequired[str | None]
@@ -83,8 +103,8 @@ SENSITIVE_KEYS_REGEX = re.compile(
 def _normalize_search_term(
     name: str, remove_articles: bool = True, remove_punctuation: bool = True
 ) -> str:
-    # Lower and replace underscores with spaces
-    name = name.lower().replace("_", " ")
+    # Lower, then read both separators a dump can use as word breaks
+    name = _split_dotted_name(name.lower()).replace("_", " ")
 
     # Remove articles (combined if possible)
     if remove_articles:

--- a/backend/models/base.py
+++ b/backend/models/base.py
@@ -11,8 +11,10 @@ FILE_EXTENSION_MAX_LENGTH = 100
 
 # Matches parenthesised/bracketed tag groups, e.g. " (USA)" or " [!]", or " (USA) (Rev 1) [!]"
 TAG_GROUP_REGEX = re.compile(r"(?:\s*(?:\([^)]*\)|\[[^]]*\]))+\s*$")
-# Matches a trailing file extension, including multi-part ones like ".tar.gz".
-EXTENSION_REGEX = re.compile(r"\.(([a-z]+\.)*\w+)$")
+# Matches a trailing file extension, including the tarball family's two-part
+# ones (".tar.gz"). Only that family is compound: any other inner segment is a
+# word of the title, as in a dot-separated name ("final.fantasy.vii.iso").
+EXTENSION_REGEX = re.compile(r"\.((?:tar\.)?\w+)$", re.IGNORECASE)
 
 
 def utc_now() -> datetime:

--- a/backend/tests/handler/filesystem/test_base_handler.py
+++ b/backend/tests/handler/filesystem/test_base_handler.py
@@ -130,7 +130,10 @@ class TestFSHandler:
         """Test file name extraction without extension"""
         assert handler.get_file_name_with_no_extension("test.txt") == "test"
         assert handler.get_file_name_with_no_extension("file.tar.gz") == "file"
-        assert handler.get_file_name_with_no_extension("file.with.dots.txt") == "file"
+        assert (
+            handler.get_file_name_with_no_extension("file.with.dots.txt")
+            == "file.with.dots"
+        )
         assert handler.get_file_name_with_no_extension("no_extension") == "no_extension"
 
     def test_get_file_name_with_no_tags(self, handler: FSHandler):
@@ -145,7 +148,7 @@ class TestFSHandler:
         assert handler.parse_file_extension("test.txt") == "txt"
         assert handler.parse_file_extension("file.tar.gz") == "tar.gz"
         assert handler.parse_file_extension("no_extension") == ""
-        assert handler.parse_file_extension("file.with.dots.txt") == "with.dots.txt"
+        assert handler.parse_file_extension("file.with.dots.txt") == "txt"
 
     def test_exclude_single_files(self, handler: FSHandler):
         """Test file exclusion functionality"""

--- a/backend/tests/handler/metadata/test_base_handler.py
+++ b/backend/tests/handler/metadata/test_base_handler.py
@@ -47,6 +47,27 @@ class TestNormalizeSearchTerm:
         result = _normalize_search_term("Test_Game_Name")
         assert result == "test game name"
 
+    def test_dotted_name_separators(self):
+        """Periods separating words read as word breaks, like underscores."""
+        assert _normalize_search_term("Final.Fantasy.VII") == "final fantasy vii"
+        assert (
+            _normalize_search_term("Castlevania.Symphony.of.the.Night")
+            == "castlevania symphony of the night"
+        )
+        assert _normalize_search_term("Mario_Kart.8.Deluxe") == "mario kart 8 deluxe"
+        # Also for the providers searched with punctuation left in.
+        assert (
+            _normalize_search_term("Final.Fantasy.VII", remove_punctuation=False)
+            == "final fantasy vii"
+        )
+
+    def test_dotted_name_separators_leave_real_periods(self):
+        """An initialism, abbreviation or version keeps its periods."""
+        for name in ("F.E.A.R.", "S.T.A.L.K.E.R.", "Dr. Mario", "Sonic 3.5"):
+            assert _normalize_search_term(name, remove_punctuation=False) == (
+                name.lower()
+            )
+
     def test_remove_leading_articles(self):
         """Test removal of leading articles."""
         assert _normalize_search_term("The Legend of Zelda") == "legend of zelda"

--- a/backend/tests/models/test_base.py
+++ b/backend/tests/models/test_base.py
@@ -11,6 +11,23 @@ from models.rom import Rom, compute_name_sort_key
     [
         ("Sonic (USA) [!].md", "Sonic", "Sonic (USA) [!]", "md"),
         ("game.tar.gz", "game", "game", "tar.gz"),
+        # The tarball family is the only compound extension, and its casing
+        # doesn't matter.
+        ("game.TAR.GZ", "game", "game", "TAR.GZ"),
+        # Every other inner segment is a title word, whatever its casing, so a
+        # dot-separated name keeps all of them.
+        (
+            "final.fantasy.vii.iso",
+            "final.fantasy.vii",
+            "final.fantasy.vii",
+            "iso",
+        ),
+        (
+            "Final.Fantasy.VII.iso",
+            "Final.Fantasy.VII",
+            "Final.Fantasy.VII",
+            "iso",
+        ),
         ("README", "README", "README", ""),
         (
             "Final Fantasy VII (Disc 1).bin",


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

A dump that spells its title with periods reached the metadata providers with those periods intact, while the underscored equivalent was already normalized into words. `_normalize_search_term` replaced underscores unconditionally, but only dropped periods as part of the blanket punctuation removal that ScreenScraper (`ss_handler.py`), HLTB and Flashpoint deliberately opt out of (`remove_punctuation=False`, because those APIs match on punctuation).

So a library holding `jazz_jackrabbit_2_secret_files_windows_gog_(85159).zip` matched everywhere, while `Final.Fantasy.VII.iso` was sent to ScreenScraper as `final.fantasy.vii`.

Two changes:

1. **`_split_dotted_name` in `handler/metadata/base_handler.py`** reads periods as word breaks alongside underscores, so it applies whatever the punctuation flag. It only fires on a name that uses nothing else as a separator and holds at least two multi-character segments, which leaves real punctuation alone for the providers that want it.

2. **`EXTENSION_REGEX` in `models/base.py`** fed that path an already-truncated stem. Its compound-extension group (`([a-z]+\.)*`) walked back over every lowercase segment, so `final.fantasy.vii.iso` parsed as extension `fantasy.vii.iso` and stem `final`, while the title-cased spelling of the same name kept its words. The compound branch is now the tarball family only (`(?:tar\.)?`), matched case-insensitively.

| file name | extension | stem | search term |
| --- | --- | --- | --- |
| `Final.Fantasy.VII.iso` | `iso` | `Final.Fantasy.VII` | `final fantasy vii` |
| `final.fantasy.vii.iso` | `iso` (was `fantasy.vii.iso`) | `final.fantasy.vii` (was `final`) | `final fantasy vii` (was `final`) |
| `castlevania.symphony.of.the.night.chd` | `chd` | full stem | `castlevania symphony of the night` |
| `game.tar.gz` / `GAME.TAR.GZ` | `tar.gz` / `TAR.GZ` | `game` / `GAME` | `game` |
| `F.E.A.R.` / `Dr. Mario` / `Sonic 3.5` | unchanged | unchanged | periods kept |

Knock-on changes from limiting the compound branch, all in the same direction (only the last dot-run is an extension): `file.with.dots.txt` now parses extension `txt` and stem `file.with.dots` (was `with.dots.txt` / `file`); likewise `game.nds.hash.txt` → `txt` and `game.bin.ecm` → `ecm`. Two assertions in `tests/handler/filesystem/test_base_handler.py` encoded the old greedy result and are updated. Extension-based exclusions are unaffected: `exclude_single_files` matches configured suffixes with `endswith`, not this regex.

Not linked to an issue; found while looking at how filenames with periods are matched.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**AI assistance disclosure**

Written with Claude Code (Opus 5), driven interactively. The AI did the codebase investigation, wrote the implementation and the tests, and ran the verification below; every design decision was reviewed and directed by me, including scoping the change down from a larger extension-parser rewrite to these two targeted fixes.

**Verification**

Full backend suite green (`2982 passed, 2 skipped`) and `trunk fmt && trunk check` clean on the diff. New coverage: dot-separated separators plus the initialism/abbreviation/version guard in `tests/handler/metadata/test_base_handler.py`, and the lowercase/title-cased dotted names plus `.TAR.GZ` casing in `tests/models/test_base.py`.
