### PR TITLE
fix(v2): remember the core a game was launched with

### DIFF
--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -59,6 +59,7 @@ import {
 } from "@/v2/utils/playerBezel";
 import { resolveStoredDisc } from "@/v2/utils/playerDisc";
 import { installIOSFullscreenShim } from "@/views/Player/EmulatorJS/utils";
+import { rememberCore, resolveRememberedCore } from "./coreStorage";
 
 // Reuse v1's heavy emulator integration — do NOT rewrite this. Lazy so the
 // bundle doesn't pull in the EJS shims until we actually mount the player.
@@ -261,6 +262,9 @@ async function onPlay() {
   removeIOSFullscreenShim.value?.();
   removeIOSFullscreenShim.value = installIOSFullscreenShim();
 
+  if (rom.value) {
+    rememberCore(rom.value.id, rom.value.platform_slug, selectedCore.value);
+  }
   gameRunning.value = true;
   window.EJS_fullscreenOnLoaded = fullscreenOnPlay.value;
   fullScreen.value = fullscreenOnPlay.value;
@@ -427,16 +431,11 @@ onMounted(async () => {
   }
   selectedDisc.value = discId;
 
-  // Prefer the core saved for this game, then the platform default, validating
-  // each candidate so a stale entry falls through instead of masking the next
-  const gameCore = localStorage.getItem(`player:${rom.value.id}:core`);
-  const platformCore = localStorage.getItem(
-    `player:${rom.value.platform_slug}:core`,
+  selectedCore.value = resolveRememberedCore(
+    rom.value.id,
+    rom.value.platform_slug,
+    supportedCores.value,
   );
-  selectedCore.value =
-    [gameCore, platformCore].find(
-      (core): core is string => !!core && supportedCores.value.includes(core),
-    ) ?? supportedCores.value[0];
 
   const coreOptions = configStore.getEJSCoreOptions(selectedCore.value);
   const storedBiosID = localStorage.getItem(

--- a/frontend/src/v2/views/Player/coreStorage.test.ts
+++ b/frontend/src/v2/views/Player/coreStorage.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { rememberCore, resolveRememberedCore } from "./coreStorage";
+
+const ARCADE_CORES = ["mame2003", "mame2003_plus", "fbneo"];
+const ROM_ID = 7;
+const SLUG = "arcade";
+
+describe("coreStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("falls back to the platform's first core when nothing is remembered", () => {
+    expect(resolveRememberedCore(ROM_ID, SLUG, ARCADE_CORES)).toBe("mame2003");
+  });
+
+  it("remembers a launch under both the game and the platform", () => {
+    rememberCore(ROM_ID, SLUG, "mame2003_plus");
+
+    expect(localStorage.getItem(`player:${ROM_ID}:core`)).toBe("mame2003_plus");
+    expect(localStorage.getItem(`player:${SLUG}:core`)).toBe("mame2003_plus");
+  });
+
+  it("applies the platform default to a game never launched before", () => {
+    rememberCore(ROM_ID, SLUG, "mame2003_plus");
+
+    expect(resolveRememberedCore(999, SLUG, ARCADE_CORES)).toBe(
+      "mame2003_plus",
+    );
+  });
+
+  it("prefers the game's own core over the platform default", () => {
+    rememberCore(ROM_ID, SLUG, "mame2003_plus");
+    localStorage.setItem(`player:${ROM_ID}:core`, "fbneo");
+
+    expect(resolveRememberedCore(ROM_ID, SLUG, ARCADE_CORES)).toBe("fbneo");
+  });
+
+  it("skips a remembered core the platform no longer supports", () => {
+    localStorage.setItem(`player:${ROM_ID}:core`, "mame2010");
+    localStorage.setItem(`player:${SLUG}:core`, "fbneo");
+
+    expect(resolveRememberedCore(ROM_ID, SLUG, ARCADE_CORES)).toBe("fbneo");
+  });
+
+  it("falls back to the first core when every remembered one is stale", () => {
+    localStorage.setItem(`player:${ROM_ID}:core`, "mame2010");
+    localStorage.setItem(`player:${SLUG}:core`, "mame2016");
+
+    expect(resolveRememberedCore(ROM_ID, SLUG, ARCADE_CORES)).toBe("mame2003");
+  });
+
+  it("forgets both keys when the selection is cleared", () => {
+    rememberCore(ROM_ID, SLUG, "mame2003_plus");
+    rememberCore(ROM_ID, SLUG, null);
+
+    expect(localStorage.getItem(`player:${ROM_ID}:core`)).toBeNull();
+    expect(localStorage.getItem(`player:${SLUG}:core`)).toBeNull();
+  });
+});

--- a/frontend/src/v2/views/Player/coreStorage.ts
+++ b/frontend/src/v2/views/Player/coreStorage.ts
@@ -1,0 +1,36 @@
+// The core a game is played with is remembered twice: under the game, and
+// under its platform as the default for every other game on that platform.
+const gameKey = (romId: number) => `player:${romId}:core`;
+const platformKey = (platformSlug: string) => `player:${platformSlug}:core`;
+
+/**
+ * The first remembered core the platform still supports, else its first core.
+ *
+ * Each candidate is validated so a core that is no longer offered (renamed
+ * upstream, or gated behind netplay) falls through instead of masking the next.
+ */
+export function resolveRememberedCore(
+  romId: number,
+  platformSlug: string,
+  supportedCores: readonly string[],
+): string {
+  return (
+    [
+      localStorage.getItem(gameKey(romId)),
+      localStorage.getItem(platformKey(platformSlug)),
+    ].find((core): core is string => !!core && supportedCores.includes(core)) ??
+    supportedCores[0]
+  );
+}
+
+/** Remember `core` for the game and its platform, or forget both when null. */
+export function rememberCore(
+  romId: number,
+  platformSlug: string,
+  core: string | null,
+): void {
+  for (const key of [gameKey(romId), platformKey(platformSlug)]) {
+    if (core) localStorage.setItem(key, core);
+    else localStorage.removeItem(key);
+  }
+}


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #4248.

The v2 EmulatorJS player *read* `player:<rom_id>:core` and `player:<platform_slug>:core` at mount to pick a core, but nothing ever wrote either key. The only `watch(selectedCore, ...)` just cleared a save state made on a different core. So the Core dropdown applied for the current session and was forgotten on reload, and there was no way to change a platform's default at all.

v1 does write both keys, in `views/Player/EmulatorJS/Player.vue`'s `onMounted`, i.e. at launch. This ports the missing half: `onPlay()` in the v2 player now records the selection under the game and under its platform, matching v1's semantics exactly ("remember what you actually played with").

Arcade is where this bites, and it's what the issue reports: `_EJS_CORES_MAP.arcade` starts with `mame2003`, resolution falls back to `supportedCores[0]`, and a library that only runs under `mame2003_plus` had no way to make the switch stick.

Both directions now live in one small module, `v2/views/Player/coreStorage.ts`, so the read and the write can't drift on the key format. The resolve helper keeps the existing behaviour verbatim: prefer the game's core, then the platform default, validating each candidate against the platform's supported cores so a stale entry falls through instead of masking the next.

No behaviour change for anyone whose platform already defaults to a working core.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

<sub>`npm run typecheck` clean, full `npm run test` green (747 tests, 67 files) including 7 new cases in `coreStorage.test.ts` covering the fallback, both persistence keys, game-over-platform precedence, stale-core skipping, and clearing. `trunk fmt && trunk check` clean. Not exercised in a browser against a real emulator boot: the change is the storage read/write around the launch path, and that path is covered by the unit tests, but a second pair of eyes on an actual arcade launch would be welcome.</sub>

#### Screenshots (if applicable)

n/a

---

**AI assistance disclosure**

Written with Claude Code (Opus 5). The agent traced the v1/v2 divergence from the issue report, wrote the fix and its tests, and drafted this description. I reviewed and directed the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
