### PR TITLE
feat(v2): link Server Stats platform rows to their platform

### DIFF
--- a/frontend/src/locales/bg_BG/settings.json
+++ b/frontend/src/locales/bg_BG/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "Платформената връзка е изтрита",
   "platform-mapping-updated": "Платформената връзка е обновена",
   "platform-metadata-matches": "Съвпадения в {source}: {matched} / {total}",
+  "platform-open": "Отвори {name}",
   "platform-regions-show-less": "Покажи по-малко региони",
   "platform-regions-show-more": "Покажи още региони",
   "platform-variant": "Вариант на платформа",

--- a/frontend/src/locales/cs_CZ/settings.json
+++ b/frontend/src/locales/cs_CZ/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "Mapování platformy bylo odstraněno",
   "platform-mapping-updated": "Mapování platformy bylo aktualizováno",
   "platform-metadata-matches": "Shody v {source}: {matched} / {total}",
+  "platform-open": "Otevřít {name}",
   "platform-regions-show-less": "Zobrazit méně regionů",
   "platform-regions-show-more": "Zobrazit více regionů",
   "platform-variant": "Varianta platformy",

--- a/frontend/src/locales/de_DE/settings.json
+++ b/frontend/src/locales/de_DE/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "Plattform-Zuordnung gelöscht",
   "platform-mapping-updated": "Plattform-Zuordnung aktualisiert",
   "platform-metadata-matches": "{source}-Treffer: {matched} / {total}",
+  "platform-open": "{name} öffnen",
   "platform-regions-show-less": "Weniger Regionen anzeigen",
   "platform-regions-show-more": "Mehr Regionen anzeigen",
   "platform-variant": "Plattform-Variante",

--- a/frontend/src/locales/en_GB/settings.json
+++ b/frontend/src/locales/en_GB/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "Platform mapping deleted",
   "platform-mapping-updated": "Platform mapping updated",
   "platform-metadata-matches": "{source} matches: {matched} / {total}",
+  "platform-open": "Open {name}",
   "platform-regions-show-less": "Show fewer regions",
   "platform-regions-show-more": "Show more regions",
   "platform-variant": "Platform variant",

--- a/frontend/src/locales/en_US/settings.json
+++ b/frontend/src/locales/en_US/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "Platform mapping deleted",
   "platform-mapping-updated": "Platform mapping updated",
   "platform-metadata-matches": "{source} matches: {matched} / {total}",
+  "platform-open": "Open {name}",
   "platform-regions-show-less": "Show fewer regions",
   "platform-regions-show-more": "Show more regions",
   "platform-variant": "Platform variant",

--- a/frontend/src/locales/es_ES/settings.json
+++ b/frontend/src/locales/es_ES/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "Asignación de plataforma eliminada",
   "platform-mapping-updated": "Asignación de plataforma actualizada",
   "platform-metadata-matches": "Coincidencias en {source}: {matched} / {total}",
+  "platform-open": "Abrir {name}",
   "platform-regions-show-less": "Mostrar menos regiones",
   "platform-regions-show-more": "Mostrar más regiones",
   "platform-variant": "Variante de plataforma",

--- a/frontend/src/locales/fr_FR/settings.json
+++ b/frontend/src/locales/fr_FR/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "Mappage de plateforme supprimé",
   "platform-mapping-updated": "Mappage de plateforme mis à jour",
   "platform-metadata-matches": "Correspondances {source} : {matched} / {total}",
+  "platform-open": "Ouvrir {name}",
   "platform-regions-show-less": "Afficher moins de régions",
   "platform-regions-show-more": "Afficher plus de régions",
   "platform-variant": "Variante de plateforme",

--- a/frontend/src/locales/hu_HU/settings.json
+++ b/frontend/src/locales/hu_HU/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "Platformleképezés törölve",
   "platform-mapping-updated": "Platformleképezés frissítve",
   "platform-metadata-matches": "{source} találatok: {matched} / {total}",
+  "platform-open": "{name} megnyitása",
   "platform-regions-show-less": "Kevesebb régió megjelenítése",
   "platform-regions-show-more": "További régiók megjelenítése",
   "platform-variant": "Platform változat",

--- a/frontend/src/locales/it_IT/settings.json
+++ b/frontend/src/locales/it_IT/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "Mappatura della piattaforma eliminata",
   "platform-mapping-updated": "Mappatura della piattaforma aggiornata",
   "platform-metadata-matches": "Corrispondenze {source}: {matched} / {total}",
+  "platform-open": "Apri {name}",
   "platform-regions-show-less": "Mostra meno regioni",
   "platform-regions-show-more": "Mostra più regioni",
   "platform-variant": "Variante piattaforma",

--- a/frontend/src/locales/ja_JP/settings.json
+++ b/frontend/src/locales/ja_JP/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "プラットフォームマッピングを削除しました",
   "platform-mapping-updated": "プラットフォームマッピングを更新しました",
   "platform-metadata-matches": "{source} の一致: {matched} / {total}",
+  "platform-open": "{name}を開く",
   "platform-regions-show-less": "リージョンの表示を減らす",
   "platform-regions-show-more": "リージョンをさらに表示",
   "platform-variant": "プラットフォームバリアント",

--- a/frontend/src/locales/ko_KR/settings.json
+++ b/frontend/src/locales/ko_KR/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "플랫폼 매핑이 삭제되었습니다",
   "platform-mapping-updated": "플랫폼 매핑이 업데이트되었습니다",
   "platform-metadata-matches": "{source} 일치: {matched} / {total}",
+  "platform-open": "{name} 열기",
   "platform-regions-show-less": "지역 간략히 보기",
   "platform-regions-show-more": "지역 더 보기",
   "platform-variant": "플랫폼 변형",

--- a/frontend/src/locales/pl_PL/settings.json
+++ b/frontend/src/locales/pl_PL/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "Mapowanie platformy usunięte",
   "platform-mapping-updated": "Mapowanie platformy zaktualizowane",
   "platform-metadata-matches": "Dopasowania {source}: {matched} / {total}",
+  "platform-open": "Otwórz {name}",
   "platform-regions-show-less": "Pokaż mniej regionów",
   "platform-regions-show-more": "Pokaż więcej regionów",
   "platform-variant": "Wariant platformy",

--- a/frontend/src/locales/pt_BR/settings.json
+++ b/frontend/src/locales/pt_BR/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "Mapeamento de plataforma excluído",
   "platform-mapping-updated": "Mapeamento de plataforma atualizado",
   "platform-metadata-matches": "Correspondências do {source}: {matched} / {total}",
+  "platform-open": "Abrir {name}",
   "platform-regions-show-less": "Mostrar menos regiões",
   "platform-regions-show-more": "Mostrar mais regiões",
   "platform-variant": "Variante de plataforma",

--- a/frontend/src/locales/ro_RO/settings.json
+++ b/frontend/src/locales/ro_RO/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "Maparea platformei a fost ștearsă",
   "platform-mapping-updated": "Maparea platformei a fost actualizată",
   "platform-metadata-matches": "Potriviri {source}: {matched} / {total}",
+  "platform-open": "Deschide {name}",
   "platform-regions-show-less": "Afișează mai puține regiuni",
   "platform-regions-show-more": "Afișează mai multe regiuni",
   "platform-variant": "Variantă platformă",

--- a/frontend/src/locales/ru_RU/settings.json
+++ b/frontend/src/locales/ru_RU/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "Сопоставление платформы удалено",
   "platform-mapping-updated": "Сопоставление платформы обновлено",
   "platform-metadata-matches": "Совпадения {source}: {matched} / {total}",
+  "platform-open": "Открыть {name}",
   "platform-regions-show-less": "Показать меньше регионов",
   "platform-regions-show-more": "Показать больше регионов",
   "platform-variant": "Вариант платформы",

--- a/frontend/src/locales/tr_TR/settings.json
+++ b/frontend/src/locales/tr_TR/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "Platform eşlemesi silindi",
   "platform-mapping-updated": "Platform eşlemesi güncellendi",
   "platform-metadata-matches": "{source} eşleşmeleri: {matched} / {total}",
+  "platform-open": "{name} platformunu aç",
   "platform-regions-show-less": "Daha az bölge göster",
   "platform-regions-show-more": "Daha fazla bölge göster",
   "platform-variant": "Platform varyantı",

--- a/frontend/src/locales/zh_CN/settings.json
+++ b/frontend/src/locales/zh_CN/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "平台映射已删除",
   "platform-mapping-updated": "平台映射已更新",
   "platform-metadata-matches": "{source} 匹配: {matched} / {total}",
+  "platform-open": "打开 {name}",
   "platform-regions-show-less": "显示更少地区",
   "platform-regions-show-more": "显示更多地区",
   "platform-variant": "平台变体",

--- a/frontend/src/locales/zh_TW/settings.json
+++ b/frontend/src/locales/zh_TW/settings.json
@@ -294,6 +294,7 @@
   "platform-mapping-deleted": "平台對應已刪除",
   "platform-mapping-updated": "平台對應已更新",
   "platform-metadata-matches": "{source} 比對結果：{matched} / {total}",
+  "platform-open": "開啟 {name}",
   "platform-regions-show-less": "顯示較少地區",
   "platform-regions-show-more": "顯示更多地區",
   "platform-variant": "平台變體",

--- a/frontend/src/v2/components/Settings/PlatformsStatsSection.test.ts
+++ b/frontend/src/v2/components/Settings/PlatformsStatsSection.test.ts
@@ -13,6 +13,12 @@ vi.mock("@/stores/heartbeat", () => ({
   default: () => ({ getMetadataOptionsByPriority: () => [] }),
 }));
 
+const push = vi.fn();
+vi.mock("vue-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-router")>()),
+  useRouter: () => ({ push }),
+}));
+
 // Real messages rather than a key-echoing stub, so plural selection is
 // exercised the way it renders in the app.
 const i18n = createI18n({
@@ -47,10 +53,13 @@ function platform(overrides: Partial<Platform> = {}): Platform {
   } as Platform;
 }
 
-function mountSection(platforms: Platform[]) {
+function mountSection(
+  platforms: Platform[],
+  regionBreakdown: Record<string, { region: string; count: number }[]> = {},
+) {
   storePlatforms().set(platforms);
   return mount(PlatformsStatsSection, {
-    props: { totalFilesize: 0, metadataCoverage: {}, regionBreakdown: {} },
+    props: { totalFilesize: 0, metadataCoverage: {}, regionBreakdown },
     global: {
       plugins: [i18n],
       stubs: {
@@ -156,6 +165,50 @@ function duplicateSlugLibrary(): Platform[] {
 describe("PlatformsStatsSection", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    push.mockClear();
+  });
+
+  it("links each row to its platform gallery", async () => {
+    const wrapper = mountSection(duplicateSlugLibrary());
+
+    const rows = wrapper.findAll(".r-v2-plat-stats__row");
+    expect(rows.map((r) => r.attributes("href"))).toEqual([
+      "/platform/1",
+      "/platform/2",
+      "/platform/3",
+      "/platform/4",
+      "/platform/5",
+      "/platform/6",
+    ]);
+    expect(rows[0].attributes("aria-label")).toBe("Open Atari 2600");
+
+    await rows[3].trigger("click", { button: 0 });
+    expect(push).toHaveBeenCalledWith("/platform/4");
+  });
+
+  // The regions toggle sits inside the row anchor, so its click must not
+  // bubble into a navigation.
+  it("expands regions without navigating to the platform", async () => {
+    const regions = [
+      { region: "us", count: 5 },
+      { region: "eu", count: 4 },
+      { region: "jp", count: 3 },
+      { region: "au", count: 2 },
+      { region: "br", count: 1 },
+      { region: "ca", count: 1 },
+    ];
+    const wrapper = mountSection([platform({ id: 7, rom_count: 16 })], {
+      "7": regions,
+    });
+
+    expect(wrapper.findAll(".r-v2-plat-stats__region")).toHaveLength(5);
+
+    await wrapper.find(".r-v2-plat-stats__more").trigger("click");
+
+    expect(wrapper.findAll(".r-v2-plat-stats__region")).toHaveLength(
+      regions.length,
+    );
+    expect(push).not.toHaveBeenCalled();
   });
 
   it("renders one row per platform on initial load", () => {

--- a/frontend/src/v2/components/Settings/PlatformsStatsSection.vue
+++ b/frontend/src/v2/components/Settings/PlatformsStatsSection.vue
@@ -3,7 +3,9 @@
 // `Settings/ServerStats/PlatformsStats.vue`. Per-platform breakdown
 // rows: icon · name + meta (games count, metadata coverage chips,
 // region chips with expand/collapse) · size + percentage of total ·
-// progress bar that doubles as the row divider.
+// progress bar that doubles as the row divider. Each row navigates to
+// its platform gallery, with the same icon morph the Platforms index
+// rows use.
 //
 // Toolbar mirrors GalleryToolbar's pattern: inline-prefix search on
 // the left, icon-only segmented sort on the right. No card chrome —
@@ -20,11 +22,16 @@ import type { SliderBtnGroupItem } from "@v2/lib";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
 import type { MetadataCoverageItem } from "@/__generated__/models/MetadataCoverageItem";
 import type { RegionBreakdownItem } from "@/__generated__/models/RegionBreakdownItem";
 import storeHeartbeat from "@/stores/heartbeat";
 import storePlatforms from "@/stores/platforms";
 import { formatBytes, regionToEmoji } from "@/utils";
+import {
+  pendingMorphName,
+  useViewTransition,
+} from "@/v2/composables/useViewTransition";
 
 defineOptions({ inheritAttrs: false });
 
@@ -36,6 +43,8 @@ interface Props {
 const props = defineProps<Props>();
 
 const { t } = useI18n();
+const router = useRouter();
+const { morphTransition } = useViewTransition();
 const platformsStore = storePlatforms();
 // Only platforms that contain games should be displayed
 const { filledPlatforms } = storeToRefs(platformsStore);
@@ -149,6 +158,38 @@ function coveragePercent(matched: number, total: number): string {
   if (!total) return "0";
   return ((matched / total) * 100).toFixed(0);
 }
+
+function morphName(platformId: number): string {
+  return `platform-icon-${platformId}`;
+}
+
+// Paints the morph tag when the user comes back from a platform, so the
+// gallery's icon lands on this row's icon.
+function morphStyle(platformId: number) {
+  return pendingMorphName.value === morphName(platformId)
+    ? { viewTransitionName: morphName(platformId) }
+    : undefined;
+}
+
+function onRowClick(e: MouseEvent, platformId: number): void {
+  // Modifier / non-primary clicks fall through to the anchor's native
+  // navigation so "open in new tab" keeps working.
+  if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
+    return;
+  }
+  e.preventDefault();
+  const navigate = async () => {
+    await router.push(`/platform/${platformId}`);
+  };
+  const icon = (e.currentTarget as HTMLElement).querySelector<HTMLElement>(
+    ".r-v2-plat-stats__icon",
+  );
+  if (!icon) {
+    void navigate();
+    return;
+  }
+  morphTransition({ el: icon, name: morphName(platformId) }, navigate);
+}
 </script>
 
 <template>
@@ -179,10 +220,15 @@ function coveragePercent(matched: number, total: number): string {
     </div>
 
     <div class="r-v2-plat-stats">
-      <div
+      <a
         v-for="platform in sortedPlatforms"
         :key="platform.id"
         class="r-v2-plat-stats__row"
+        :href="`/platform/${platform.id}`"
+        :aria-label="
+          t('settings.platform-open', { name: platform.display_name })
+        "
+        @click="onRowClick($event, platform.id)"
       >
         <RPlatformIcon
           :slug="platform.slug"
@@ -190,6 +236,7 @@ function coveragePercent(matched: number, total: number): string {
           :fs-slug="platform.fs_slug"
           :size="32"
           class="r-v2-plat-stats__icon"
+          :style="morphStyle(platform.id)"
         />
         <div class="r-v2-plat-stats__info">
           <div class="r-v2-plat-stats__name">
@@ -256,7 +303,7 @@ function coveragePercent(matched: number, total: number): string {
                     : t('settings.platform-regions-show-more')
                 "
                 :aria-expanded="expandedRegions.has(platform.id)"
-                @click="toggleRegions(platform.id)"
+                @click.stop.prevent="toggleRegions(platform.id)"
               >
                 {{
                   expandedRegions.has(platform.id)
@@ -282,7 +329,7 @@ function coveragePercent(matched: number, total: number): string {
           color="primary"
           class="r-v2-plat-stats__bar"
         />
-      </div>
+      </a>
       <div v-if="sortedPlatforms.length === 0" class="r-v2-plat-stats__empty">
         <RIcon icon="mdi-folder-question" size="22" />
         <span>{{
@@ -325,16 +372,29 @@ function coveragePercent(matched: number, total: number): string {
   flex-direction: column;
 }
 
+/* Symmetric vertical padding keeps the 14px rhythm between rows while
+   giving the hover/focus band even weight above and below the content. */
 .r-v2-plat-stats__row {
   display: grid;
   grid-template-columns: auto 1fr auto;
   column-gap: 14px;
   row-gap: 12px;
   align-items: center;
-  padding-top: 14px;
+  padding: 7px var(--r-space-2);
+  margin: 0 calc(-1 * var(--r-space-2));
+  border-radius: var(--r-radius-sm);
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background var(--r-motion-fast) var(--r-motion-ease-out);
 }
-.r-v2-plat-stats__row:first-child {
-  padding-top: 0;
+.r-v2-plat-stats__row:hover {
+  background: var(--r-color-bg-elevated);
+}
+.r-v2-plat-stats__row:focus-visible {
+  outline: none;
+  background: var(--r-color-bg-elevated);
+  box-shadow: inset 0 0 0 2px var(--r-color-brand-primary);
 }
 
 .r-v2-plat-stats__icon {


### PR DESCRIPTION
**Description**

The per-platform breakdown rows in **Settings → Server Stats** were purely informational: you could see that PlayStation holds 240 GB across 118 games, but getting to that platform's gallery meant navigating there by hand. This makes each row a link to its platform.

What changed in `frontend/src/v2/components/Settings/PlatformsStatsSection.vue`:

- Each row renders as an `<a href="/platform/<id>">` instead of a `<div>`, so middle-click / cmd-click / ctrl-click open the platform in a new tab. A plain left click is intercepted and pushed through the router with the same `platform-icon-<id>` shared-element morph that `PlatformTile` and `PlatformListRow` use, and the row's icon also paints the morph tag on the way back from a platform (via `pendingMorphName`), so the reverse transition lands correctly.
- The regions `+N` / `−` toggle sits inside the row, so it got `@click.stop.prevent` — expanding regions never navigates.
- Row styling gained a hover band, a keyboard `:focus-visible` ring, and `cursor: pointer`. Vertical padding moved from `padding-top: 14px` to a symmetric `7px` (same 14px rhythm between rows) so the highlight band has even weight above and below the content, plus 8px horizontal padding with a matching negative margin so the progress bar still spans the full row width.
- New i18n key `settings.platform-open` ("Open {name}") for the link's accessible name, translated into all 18 locales.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**Verification**

- `npm run typecheck` clean; full `npm run test` green (66 files, 742 tests).
- Two new cases in `PlatformsStatsSection.test.ts`: rows carry the right `href` / `aria-label` and a click pushes `/platform/<id>`; the regions toggle expands without navigating.
- `check_i18n_locales.py` and `check_i18n_sorted.py` both pass. Prettier/ESLint clean — the two pre-existing ESLint warnings on this file (`vue/html-self-closing`, `vue/html-indent`) were verified to exist unchanged at `HEAD`.
- Visual check in a real browser in both `r-v2-dark` and `r-v2-light`: hover band, keyboard focus ring on Tab, no horizontal overflow, the `+1` toggle expanding regions without navigating, and a row click landing on the platform route. Done through a throwaway Vite harness page, since this composite can't render in Storybook — its store imports hit a pre-existing `services/api` ↔ `plugins/router` circular-import error there (`Cannot access 'api' before initialization`), unrelated to this change.

**Notes for reviewers**

- The row keeps an `aria-label` ("Open {platform}") rather than relying on its inner text, matching how `GameListRow` and `PlatformListRow` name themselves.
- No new primitive or Storybook story: this is a feature composite, and the circular-import issue above blocks a story for it today.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code, Opus 5): the implementation, tests, translations, and the verification steps above were produced in an agent session and reviewed by me before opening this PR.
