### PR TITLE
chore(deps): bump starlette from 1.0.1 to 1.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   #       Related PR: https://github.com/rq/rq-scheduler/pull/325
   "rq-scheduler @ git+https://github.com/adamantike/rq-scheduler.git@feat/script-options-username-ssl",
   "sentry-sdk ~= 2.32",
-  "starlette ~= 1.0.1",
+  "starlette ~= 1.6.0",
   "streaming-form-data ~= 1.19",
   "ua-parser ~= 1.0",
   "strsimpy ~= 0.2",
@@ -146,7 +146,7 @@ package = false
 exclude-newer = "7 days"
 # vcrpy >= 8.2.0 is required for aiohttp 3.14 compatibility (the removal of
 # `AsyncStreamReaderMixin`); allow it past the rolling 7-day window.
-exclude-newer-package = { starlette = "2026-05-22", vcrpy = "2026-06-17" }
+exclude-newer-package = { vcrpy = "2026-06-17" }
 
 [tool.ty.environment]
 root = ["./backend"]

--- a/uv.lock
+++ b/uv.lock
@@ -11,8 +11,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-starlette = "2026-05-23T00:00:00Z"
-vcrpy = "2026-06-18T00:00:00Z"
+vcrpy = "2026-06-18T05:00:00Z"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -2324,7 +2323,7 @@ requires-dist = [
     { name = "rq-scheduler", git = "https://github.com/adamantike/rq-scheduler.git?rev=feat%2Fscript-options-username-ssl" },
     { name = "sentry-sdk", specifier = "~=2.32" },
     { name = "sqlalchemy", extras = ["mariadb-connector", "mysql-connector", "postgresql-psycopg"], specifier = "~=2.0" },
-    { name = "starlette", specifier = "~=1.0.1" },
+    { name = "starlette", specifier = "~=1.6.0" },
     { name = "streaming-form-data", specifier = "~=1.19" },
     { name = "strsimpy", specifier = "~=0.2" },
     { name = "types-colorama", marker = "extra == 'dev'", specifier = "~=0.4" },
@@ -2501,14 +2500,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.1"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Description**

Upgrades `starlette` from **1.0.1** to **1.6.0**.

Two things were holding it back:

1. `starlette ~= 1.0.1` in `pyproject.toml`, a compatible-release spec that caps at `<1.1.0`.
2. An `exclude-newer-package = { starlette = "2026-05-22" }` uv pin, added in e013ee78e (commit message: "fix"), which froze resolution to anything published before 1.1.0's release date. I couldn't find a recorded reason for it, and nothing in the 1.1.0+ release notes appears to break us.

`fastapi` only requires `starlette>=0.46.0`, so nothing else needed touching. Re-locking moved starlette and nothing else.

**Why it's worth doing**

1.0.1 -> 1.6.0 is entirely minor/patch on the stable 1.x line, with no breaking changes in the release notes. Several fixes are directly relevant to a codebase that serves files and accepts uploads:

- **1.5.1**: reject inverted single-byte ranges in `FileResponse`; cap it at 100 ranges
- **1.3.1**: enforce `max_fields` / `max_part_size` in `FormParser`, including in its callbacks
- **1.3.0**: clamp oversized suffix ranges in `FileResponse`; stop collapsing exception groups raised from user code

**Testing**

- Full backend suite on a clean, isolated MariaDB: **2977 passed, 2 skipped** (5m29s)
- `trunk check` on both changed files: no issues
- Verified `starlette._utils.is_async_callable` (used in `backend/decorators/auth.py`) still resolves on 1.6.0. It's a private symbol, but `fastapi` depends on the same one, so the risk is unchanged from before.

**Checklist**

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

<sup>No comment or test changes: this is a dependency bump with no behavior change on our side, covered by the existing suite.</sup>

---

**AI assistance disclosure**

This PR was written entirely by Claude Code (Opus 5), including the dependency investigation, the version bump, running the test suite, and this description. It was reviewed by me before opening.
