### PR TITLE
fix(frontend): keep collection ROM counts in step with the gallery

### DIFF
--- a/frontend/src/stores/collections.test.ts
+++ b/frontend/src/stores/collections.test.ts
@@ -1,0 +1,78 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import storeCollections, { type VirtualCollection } from "@/stores/collections";
+
+const { getVirtualCollections } = vi.hoisted(() => ({
+  getVirtualCollections: vi.fn(),
+}));
+
+vi.mock("@/services/api/collection", () => ({
+  default: { getVirtualCollections },
+}));
+
+function virtualCollection(romCount: number): VirtualCollection {
+  return {
+    id: "collection-zelda",
+    name: "The Legend of Zelda",
+    rom_count: romCount,
+  } as VirtualCollection;
+}
+
+/** A request whose response the test releases by hand. */
+function deferred() {
+  let settle!: (value: { data: VirtualCollection[] }) => void;
+  const promise = new Promise<{ data: VirtualCollection[] }>((resolve) => {
+    settle = resolve;
+  });
+  return { promise, settle };
+}
+
+describe("collections store virtual refresh", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    getVirtualCollections.mockReset();
+  });
+
+  // A scan or a metadata write landing mid-fetch used to hit the in-flight
+  // guard and be dropped, leaving the pre-change response cached for the
+  // session, which is the drift this whole change is about.
+  it("re-reads after a fetch that was already in flight", async () => {
+    const first = deferred();
+    getVirtualCollections.mockReturnValueOnce(first.promise);
+    const collections = storeCollections();
+
+    const initial = collections.fetchVirtualCollections("collection");
+    void collections.refreshVirtualCollections();
+
+    getVirtualCollections.mockResolvedValueOnce({
+      data: [virtualCollection(9)],
+    });
+    first.settle({ data: [virtualCollection(8)] });
+    await initial;
+    await vi.waitFor(() =>
+      expect(collections.virtualCollections[0].rom_count).toBe(9),
+    );
+    expect(getVirtualCollections).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the cached slice when the re-read fails", async () => {
+    getVirtualCollections.mockResolvedValueOnce({
+      data: [virtualCollection(8)],
+    });
+    const collections = storeCollections();
+    await collections.fetchVirtualCollections("collection");
+
+    getVirtualCollections.mockRejectedValueOnce(new Error("offline"));
+    // Resolves rather than rejects: every caller fires this in the background,
+    // so a rejection would surface as an unhandled one.
+    await expect(collections.refreshVirtualCollections()).resolves.toEqual([]);
+    expect(collections.virtualCollections[0].rom_count).toBe(8);
+  });
+
+  it("does nothing until a slice has been fetched", async () => {
+    await expect(
+      storeCollections().refreshVirtualCollections(),
+    ).resolves.toEqual([]);
+    expect(getVirtualCollections).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stores/collections.test.ts
+++ b/frontend/src/stores/collections.test.ts
@@ -2,13 +2,18 @@ import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import storeCollections, { type VirtualCollection } from "@/stores/collections";
 
-const { getVirtualCollections } = vi.hoisted(() => ({
+const { getVirtualCollection, getVirtualCollections } = vi.hoisted(() => ({
+  getVirtualCollection: vi.fn(),
   getVirtualCollections: vi.fn(),
 }));
 
 vi.mock("@/services/api/collection", () => ({
-  default: { getVirtualCollections },
+  default: { getVirtualCollection, getVirtualCollections },
 }));
+
+function httpError(status: number) {
+  return Object.assign(new Error(`HTTP ${status}`), { response: { status } });
+}
 
 function virtualCollection(romCount: number): VirtualCollection {
   return {
@@ -30,6 +35,7 @@ function deferred() {
 describe("collections store virtual refresh", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    getVirtualCollection.mockReset();
     getVirtualCollections.mockReset();
   });
 
@@ -74,5 +80,29 @@ describe("collections store virtual refresh", () => {
       storeCollections().refreshVirtualCollections(),
     ).resolves.toEqual([]);
     expect(getVirtualCollections).not.toHaveBeenCalled();
+  });
+
+  // A rescan can take a collection below the ROM threshold that generates it,
+  // and a cached tile for it would outlive the collection itself.
+  it("drops the cached copy when the server says the collection is gone", async () => {
+    const collections = storeCollections();
+    collections.setVirtualCollections([virtualCollection(8)]);
+    getVirtualCollection.mockRejectedValueOnce(httpError(404));
+
+    await expect(
+      collections.refreshVirtualCollection("collection-zelda"),
+    ).resolves.toBeNull();
+    expect(collections.virtualCollections).toEqual([]);
+  });
+
+  it("keeps the cached copy when the read itself failed", async () => {
+    const collections = storeCollections();
+    collections.setVirtualCollections([virtualCollection(8)]);
+    getVirtualCollection.mockRejectedValueOnce(httpError(500));
+
+    await expect(
+      collections.refreshVirtualCollection("collection-zelda"),
+    ).resolves.toBeNull();
+    expect(collections.virtualCollections).toHaveLength(1);
   });
 });

--- a/frontend/src/stores/collections.test.ts
+++ b/frontend/src/stores/collections.test.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from "axios";
 import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import storeCollections, { type VirtualCollection } from "@/stores/collections";
@@ -12,7 +13,9 @@ vi.mock("@/services/api/collection", () => ({
 }));
 
 function httpError(status: number) {
-  return Object.assign(new Error(`HTTP ${status}`), { response: { status } });
+  return Object.assign(new AxiosError(`HTTP ${status}`), {
+    response: { status },
+  });
 }
 
 function virtualCollection(romCount: number): VirtualCollection {
@@ -39,9 +42,8 @@ describe("collections store virtual refresh", () => {
     getVirtualCollections.mockReset();
   });
 
-  // A scan or a metadata write landing mid-fetch used to hit the in-flight
-  // guard and be dropped, leaving the pre-change response cached for the
-  // session, which is the drift this whole change is about.
+  // A response in flight left the server before the change did, so it cannot
+  // stand in for the re-read.
   it("re-reads after a fetch that was already in flight", async () => {
     const first = deferred();
     getVirtualCollections.mockReturnValueOnce(first.promise);

--- a/frontend/src/stores/collections.ts
+++ b/frontend/src/stores/collections.ts
@@ -18,6 +18,9 @@ export default defineStore("collections", {
   state: () => ({
     allCollections: [] as Collection[],
     virtualCollections: [] as VirtualCollection[],
+    // The type `virtualCollections` was fetched for, so a refresh knows which
+    // slice it is re-reading.
+    virtualCollectionType: null as string | null,
     smartCollections: [] as SmartCollection[],
     favoriteCollection: undefined as Collection | undefined,
     filterText: "" as string,
@@ -111,6 +114,7 @@ export default defineStore("collections", {
     fetchVirtualCollections(type: string): Promise<VirtualCollection[]> {
       if (this.fetchingVirtualCollections) return Promise.resolve([]);
       this.fetchingVirtualCollections = true;
+      this.virtualCollectionType = type;
 
       return new Promise((resolve, reject) => {
         collectionApi
@@ -127,6 +131,47 @@ export default defineStore("collections", {
             this.fetchingVirtualCollections = false;
           });
       });
+    },
+    /** Re-read the loaded virtual collections, whose membership (and so ROM
+     * count) is derived from ROM metadata that scans and matches rewrite. */
+    refreshVirtualCollections(): Promise<VirtualCollection[]> {
+      if (this.virtualCollectionType === null) return Promise.resolve([]);
+      return this.fetchVirtualCollections(this.virtualCollectionType);
+    },
+    /** Re-read one collection, refreshing the cached copy on the way through.
+     * Resolves to null when the server refuses it, so the caller can choose
+     * between its cached copy and a not-found state. */
+    async refreshCollection(id: number): Promise<Collection | null> {
+      try {
+        const { data } = await collectionApi.getCollection(id);
+        this.updateCollection(data);
+        return data;
+      } catch (error) {
+        console.error(error);
+        return null;
+      }
+    },
+    async refreshVirtualCollection(
+      id: string,
+    ): Promise<VirtualCollection | null> {
+      try {
+        const { data } = await collectionApi.getVirtualCollection(id);
+        this.updateVirtualCollection(data);
+        return data;
+      } catch (error) {
+        console.error(error);
+        return null;
+      }
+    },
+    async refreshSmartCollection(id: number): Promise<SmartCollection | null> {
+      try {
+        const { data } = await collectionApi.getSmartCollection(id);
+        this.updateSmartCollection(data);
+        return data;
+      } catch (error) {
+        console.error(error);
+        return null;
+      }
     },
     setFavoriteCollection(favoriteCollection: Collection | undefined) {
       this.favoriteCollection = favoriteCollection;
@@ -157,6 +202,13 @@ export default defineStore("collections", {
         value.id === collection.id ? collection : value,
       );
       this._reorderCollections();
+    },
+    // Replaces in place only: the list holds one virtual collection type, and
+    // an id carries its own type, so inserting could mix them.
+    updateVirtualCollection(collection: VirtualCollection) {
+      this.virtualCollections = this.virtualCollections.map((value) =>
+        value.id === collection.id ? collection : value,
+      );
     },
     updateSmartCollection(collection: SmartCollection) {
       this.smartCollections = this.smartCollections.map((value) =>
@@ -211,6 +263,7 @@ export default defineStore("collections", {
     reset() {
       this.allCollections = [];
       this.virtualCollections = [];
+      this.virtualCollectionType = null;
       this.smartCollections = [];
       this.favoriteCollection = undefined;
       this.filterText = "";

--- a/frontend/src/stores/collections.ts
+++ b/frontend/src/stores/collections.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { uniqBy } from "lodash";
 import { defineStore } from "pinia";
 import type {
@@ -14,11 +15,10 @@ export type VirtualCollection = VirtualCollectionSchema;
 export type SmartCollection = SmartCollectionSchema;
 export type CollectionType = Collection | VirtualCollection | SmartCollection;
 
-/** 404 / 403 is the server saying this collection is gone or off limits, which
- * is an answer; any other failure means the read didn't happen. */
+/** A 404 or 403 answers the read (gone, or off limits); anything else means
+ * the read never happened. */
 function isGone(error: unknown): boolean {
-  const status = (error as { response?: { status?: number } })?.response
-    ?.status;
+  const status = axios.isAxiosError(error) ? error.response?.status : undefined;
   return status === 404 || status === 403;
 }
 
@@ -26,10 +26,7 @@ export default defineStore("collections", {
   state: () => ({
     allCollections: [] as Collection[],
     virtualCollections: [] as VirtualCollection[],
-    // The type `virtualCollections` was fetched for, so a refresh knows which
-    // slice it is re-reading.
     virtualCollectionType: null as string | null,
-    // A refresh asked for while a fetch was in flight, to run once it settles.
     virtualCollectionsStale: false as boolean,
     smartCollections: [] as SmartCollection[],
     favoriteCollection: undefined as Collection | undefined,
@@ -146,38 +143,36 @@ export default defineStore("collections", {
           });
       });
     },
-    /** Re-read the loaded virtual collections, whose membership (and so ROM
-     * count) is derived from ROM metadata that scans and matches rewrite.
-     * Never rejects: every caller fires it in the background. */
+    /** Re-read the loaded virtual collections, whose membership is derived
+     * from ROM metadata that scans and matches rewrite. Never rejects: every
+     * caller fires it in the background. */
     refreshVirtualCollections(): Promise<VirtualCollection[]> {
       const type = this.virtualCollectionType;
       if (type === null) return Promise.resolve([]);
-      // A response already in flight left the server before the change did, so
-      // it cannot be the re-read. Queue one behind it instead of being dropped
-      // by the in-flight guard.
+      // A response already in flight left the server before the change did,
+      // so queue the re-read behind it rather than let the guard drop it.
       if (this.fetchingVirtualCollections) {
         this.virtualCollectionsStale = true;
         return Promise.resolve([]);
       }
       return this.fetchVirtualCollections(type).catch(() => []);
     },
-    /** Re-read one collection, refreshing the cached copy on the way through.
-     * Resolves to null either way: a collection the server says is gone is
-     * dropped from the cache too, so the caller reads not-found from the cache
-     * being empty, while a failed read leaves the cached copy to fall back on. */
+    /** Re-read one collection and refresh the cached copy. A gone collection
+     * is dropped from the cache too, so callers read not-found from the cache
+     * rather than from the null. */
     async refreshCollection(id: number): Promise<Collection | null> {
       try {
         const { data } = await collectionApi.getCollection(id);
         this.updateCollection(data);
         return data;
       } catch (error) {
-        if (!isGone(error)) {
+        if (isGone(error)) {
+          this.allCollections = this.allCollections.filter((c) => c.id !== id);
+          if (this.favoriteCollection?.id === id) {
+            this.favoriteCollection = undefined;
+          }
+        } else {
           console.error(error);
-          return null;
-        }
-        this.allCollections = this.allCollections.filter((c) => c.id !== id);
-        if (this.favoriteCollection?.id === id) {
-          this.favoriteCollection = undefined;
         }
         return null;
       }
@@ -246,8 +241,8 @@ export default defineStore("collections", {
       );
       this._reorderCollections();
     },
-    // Replaces in place only: the list holds one virtual collection type, and
-    // an id carries its own type, so inserting could mix them.
+    // Replaces in place only: the list holds one virtual collection type, so
+    // inserting could mix types.
     updateVirtualCollection(collection: VirtualCollection) {
       this.virtualCollections = this.virtualCollections.map((value) =>
         value.id === collection.id ? collection : value,

--- a/frontend/src/stores/collections.ts
+++ b/frontend/src/stores/collections.ts
@@ -14,6 +14,14 @@ export type VirtualCollection = VirtualCollectionSchema;
 export type SmartCollection = SmartCollectionSchema;
 export type CollectionType = Collection | VirtualCollection | SmartCollection;
 
+/** 404 / 403 is the server saying this collection is gone or off limits, which
+ * is an answer; any other failure means the read didn't happen. */
+function isGone(error: unknown): boolean {
+  const status = (error as { response?: { status?: number } })?.response
+    ?.status;
+  return status === 404 || status === 403;
+}
+
 export default defineStore("collections", {
   state: () => ({
     allCollections: [] as Collection[],
@@ -154,15 +162,23 @@ export default defineStore("collections", {
       return this.fetchVirtualCollections(type).catch(() => []);
     },
     /** Re-read one collection, refreshing the cached copy on the way through.
-     * Resolves to null when the server refuses it, so the caller can choose
-     * between its cached copy and a not-found state. */
+     * Resolves to null either way: a collection the server says is gone is
+     * dropped from the cache too, so the caller reads not-found from the cache
+     * being empty, while a failed read leaves the cached copy to fall back on. */
     async refreshCollection(id: number): Promise<Collection | null> {
       try {
         const { data } = await collectionApi.getCollection(id);
         this.updateCollection(data);
         return data;
       } catch (error) {
-        console.error(error);
+        if (!isGone(error)) {
+          console.error(error);
+          return null;
+        }
+        this.allCollections = this.allCollections.filter((c) => c.id !== id);
+        if (this.favoriteCollection?.id === id) {
+          this.favoriteCollection = undefined;
+        }
         return null;
       }
     },
@@ -174,7 +190,13 @@ export default defineStore("collections", {
         this.updateVirtualCollection(data);
         return data;
       } catch (error) {
-        console.error(error);
+        if (isGone(error)) {
+          this.virtualCollections = this.virtualCollections.filter(
+            (c) => c.id !== id,
+          );
+        } else {
+          console.error(error);
+        }
         return null;
       }
     },
@@ -184,7 +206,13 @@ export default defineStore("collections", {
         this.updateSmartCollection(data);
         return data;
       } catch (error) {
-        console.error(error);
+        if (isGone(error)) {
+          this.smartCollections = this.smartCollections.filter(
+            (c) => c.id !== id,
+          );
+        } else {
+          console.error(error);
+        }
         return null;
       }
     },

--- a/frontend/src/stores/collections.ts
+++ b/frontend/src/stores/collections.ts
@@ -21,6 +21,8 @@ export default defineStore("collections", {
     // The type `virtualCollections` was fetched for, so a refresh knows which
     // slice it is re-reading.
     virtualCollectionType: null as string | null,
+    // A refresh asked for while a fetch was in flight, to run once it settles.
+    virtualCollectionsStale: false as boolean,
     smartCollections: [] as SmartCollection[],
     favoriteCollection: undefined as Collection | undefined,
     filterText: "" as string,
@@ -129,14 +131,27 @@ export default defineStore("collections", {
           })
           .finally(() => {
             this.fetchingVirtualCollections = false;
+            if (this.virtualCollectionsStale) {
+              this.virtualCollectionsStale = false;
+              void this.refreshVirtualCollections();
+            }
           });
       });
     },
     /** Re-read the loaded virtual collections, whose membership (and so ROM
-     * count) is derived from ROM metadata that scans and matches rewrite. */
+     * count) is derived from ROM metadata that scans and matches rewrite.
+     * Never rejects: every caller fires it in the background. */
     refreshVirtualCollections(): Promise<VirtualCollection[]> {
-      if (this.virtualCollectionType === null) return Promise.resolve([]);
-      return this.fetchVirtualCollections(this.virtualCollectionType);
+      const type = this.virtualCollectionType;
+      if (type === null) return Promise.resolve([]);
+      // A response already in flight left the server before the change did, so
+      // it cannot be the re-read. Queue one behind it instead of being dropped
+      // by the in-flight guard.
+      if (this.fetchingVirtualCollections) {
+        this.virtualCollectionsStale = true;
+        return Promise.resolve([]);
+      }
+      return this.fetchVirtualCollections(type).catch(() => []);
     },
     /** Re-read one collection, refreshing the cached copy on the way through.
      * Resolves to null when the server refuses it, so the caller can choose
@@ -264,6 +279,7 @@ export default defineStore("collections", {
       this.allCollections = [];
       this.virtualCollections = [];
       this.virtualCollectionType = null;
+      this.virtualCollectionsStale = false;
       this.smartCollections = [];
       this.favoriteCollection = undefined;
       this.filterText = "";

--- a/frontend/src/v2/composables/useRomSync/index.test.ts
+++ b/frontend/src/v2/composables/useRomSync/index.test.ts
@@ -133,9 +133,9 @@ describe("useRomSync", () => {
     expect(getRoms).not.toHaveBeenCalled();
   });
 
-  // Collection heads and tiles read their ROM count off the store, including
-  // when the write comes from GameDetails rather than a gallery.
-  it("applyRomWrite re-reads the virtual collections off the gallery", () => {
+  // Collection heads and tiles read their count off the store, so the re-read
+  // is owed even for a write from GameDetails.
+  it("applyRomWrite re-reads the virtual collections when off the gallery", () => {
     const collections = storeCollections();
     const refresh = vi
       .spyOn(collections, "refreshVirtualCollections")

--- a/frontend/src/v2/composables/useRomSync/index.test.ts
+++ b/frontend/src/v2/composables/useRomSync/index.test.ts
@@ -133,6 +133,20 @@ describe("useRomSync", () => {
     expect(getRoms).not.toHaveBeenCalled();
   });
 
+  // Collection heads and tiles read their ROM count off the store, including
+  // when the write comes from GameDetails rather than a gallery.
+  it("applyRomWrite re-reads the virtual collections off the gallery", () => {
+    const collections = storeCollections();
+    const refresh = vi
+      .spyOn(collections, "refreshVirtualCollections")
+      .mockResolvedValue([]);
+
+    useRomSync().applyRomWrite(makeRom({ igdb_id: 1234 }));
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(getRoms).not.toHaveBeenCalled();
+  });
+
   it("refreshAfterUserStateChange refetches the Favourites collection", () => {
     const gallery = seedGallery(makeRom());
     const collections = storeCollections();

--- a/frontend/src/v2/composables/useRomSync/index.ts
+++ b/frontend/src/v2/composables/useRomSync/index.ts
@@ -103,6 +103,9 @@ export function useRomSync() {
     // Read the pre-write copy before `syncCachedRom` overwrites it.
     const previous = galleryRomsStore.getRomById(rom.id);
     syncCachedRom(rom);
+    // Virtual collection membership is derived from the metadata this write
+    // rewrites, so only the server knows the ROM's new collections and counts.
+    void collectionsStore.refreshVirtualCollections();
     if (!galleryRomsStore.onGalleryView) return;
     if (!galleryFilter.isFiltered() && !sortValueChanged(previous, rom)) return;
     galleryRomsStore.invalidateWindows();

--- a/frontend/src/v2/composables/useRomSync/index.ts
+++ b/frontend/src/v2/composables/useRomSync/index.ts
@@ -103,8 +103,8 @@ export function useRomSync() {
     // Read the pre-write copy before `syncCachedRom` overwrites it.
     const previous = galleryRomsStore.getRomById(rom.id);
     syncCachedRom(rom);
-    // Virtual collection membership is derived from the metadata this write
-    // rewrites, so only the server knows the ROM's new collections and counts.
+    // Only the server knows which virtual collections this write moved the ROM
+    // between.
     void collectionsStore.refreshVirtualCollections();
     if (!galleryRomsStore.onGalleryView) return;
     if (!galleryFilter.isFiltered() && !sortValueChanged(previous, rom)) return;

--- a/frontend/src/v2/composables/useScanLifecycle/index.test.ts
+++ b/frontend/src/v2/composables/useScanLifecycle/index.test.ts
@@ -129,8 +129,6 @@ describe("installScanLifecycle", () => {
     expect(scanning.scanStats.scanned_roms).toBe(12);
   });
 
-  // A scan rewrites the metadata virtual collections derive from, so their
-  // counts drift like the platform ones.
   it("re-reads the virtual collections when the scan settles", () => {
     const collections = storeCollections();
     const refresh = vi

--- a/frontend/src/v2/composables/useScanLifecycle/index.test.ts
+++ b/frontend/src/v2/composables/useScanLifecycle/index.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { defineComponent, reactive } from "vue";
 import type { ScanStats } from "@/__generated__";
 import taskApi from "@/services/api/task";
+import storeCollections from "@/stores/collections";
 import storeScanning from "@/stores/scanning";
 import { installScanLifecycle } from "./index";
 
@@ -126,6 +127,20 @@ describe("installScanLifecycle", () => {
 
     expect(scanning.scanning).toBe(true);
     expect(scanning.scanStats.scanned_roms).toBe(12);
+  });
+
+  // A scan rewrites the metadata virtual collections derive from, so their
+  // counts drift like the platform ones.
+  it("re-reads the virtual collections when the scan settles", () => {
+    const collections = storeCollections();
+    const refresh = vi
+      .spyOn(collections, "refreshVirtualCollections")
+      .mockResolvedValue([]);
+    install();
+
+    fire("scan:done", makeStats({ scanned_roms: 100 }));
+
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   it("reconciles with a running scan job on install", async () => {

--- a/frontend/src/v2/composables/useScanLifecycle/index.ts
+++ b/frontend/src/v2/composables/useScanLifecycle/index.ts
@@ -32,6 +32,7 @@ import type { ScanStats, ScanTaskStatusResponse } from "@/__generated__";
 import platformApi from "@/services/api/platform";
 import taskApi from "@/services/api/task";
 import storeAuth from "@/stores/auth";
+import storeCollections from "@/stores/collections";
 import storePlatforms from "@/stores/platforms";
 import storeRoms, { type SimpleRom } from "@/stores/roms";
 import storeScanning, { type ScanningPlatform } from "@/stores/scanning";
@@ -42,6 +43,7 @@ import storeGalleryRoms from "@/v2/stores/galleryRoms";
 export function installScanLifecycle() {
   const scanningStore = storeScanning();
   const romsStore = storeRoms();
+  const collectionsStore = storeCollections();
   const platformsStore = storePlatforms();
   const galleryRomsStore = storeGalleryRoms();
   const authStore = storeAuth();
@@ -184,8 +186,10 @@ export function installScanLifecycle() {
     scanningStore.setScanStats(stats);
     scanningStore.setScanning(false);
     // Reconcile against the backend once the scan settles: pick up anything
-    // the live updates missed and correct rom_counts that drifted.
+    // the live updates missed and correct rom_counts that drifted, virtual
+    // collections included (a scan rewrites the metadata they derive from).
     void platformsStore.fetchPlatforms();
+    void collectionsStore.refreshVirtualCollections();
     emitter?.emit("snackbarShow", {
       msg: "Scan completed successfully.",
       color: "success",

--- a/frontend/src/v2/composables/useScanLifecycle/index.ts
+++ b/frontend/src/v2/composables/useScanLifecycle/index.ts
@@ -186,8 +186,7 @@ export function installScanLifecycle() {
     scanningStore.setScanStats(stats);
     scanningStore.setScanning(false);
     // Reconcile against the backend once the scan settles: pick up anything
-    // the live updates missed and correct rom_counts that drifted, virtual
-    // collections included (a scan rewrites the metadata they derive from).
+    // the live updates missed and correct rom_counts that drifted.
     void platformsStore.fetchPlatforms();
     void collectionsStore.refreshVirtualCollections();
     emitter?.emit("snackbarShow", {

--- a/frontend/src/v2/views/Gallery/Collection.test.ts
+++ b/frontend/src/v2/views/Gallery/Collection.test.ts
@@ -2,7 +2,7 @@
 import { flushPromises, mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { defineComponent, ref } from "vue";
+import { defineComponent, nextTick, ref } from "vue";
 import storeCollections, {
   type Collection,
   type SmartCollection,
@@ -13,15 +13,19 @@ import storeGalleryRoms from "@/v2/stores/galleryRoms";
 import CollectionView from "./Collection.vue";
 
 const {
+  getCollection,
   getRandomRom,
   getRoms,
+  getVirtualCollection,
   push,
   routeGuards,
   snackbarError,
   snackbarInfo,
 } = vi.hoisted(() => ({
+  getCollection: vi.fn(),
   getRandomRom: vi.fn(),
   getRoms: vi.fn(),
+  getVirtualCollection: vi.fn(),
   push: vi.fn(),
   routeGuards: [] as ((to: {
     name: string;
@@ -62,7 +66,12 @@ vi.mock("@/services/api/rom", () => ({
 }));
 
 vi.mock("@/services/api/collection", () => ({
-  default: { deleteCollection: vi.fn() },
+  default: {
+    deleteCollection: vi.fn(),
+    getCollection,
+    getVirtualCollection,
+    getSmartCollection: vi.fn(),
+  },
 }));
 
 vi.mock("@v2/lib", () => ({
@@ -80,8 +89,9 @@ vi.mock("@/v2/components/Gallery/GalleryShell.vue", () => ({
 
 vi.mock("@/v2/components/Gallery/CollectionHead.vue", () => ({
   default: defineComponent({
+    props: { collection: { type: Object, default: null } },
     emits: ["random"],
-    template: `<header><button class="random" @click="$emit('random')" /></header>`,
+    template: `<header><span class="rom-count">{{ collection?.rom_count }}</span><button class="random" @click="$emit('random')" /></header>`,
   }),
 }));
 
@@ -116,6 +126,14 @@ function collection(id: number): Collection {
   return { id, name: `Collection ${id}`, rom_count: 9000 } as Collection;
 }
 
+function virtualCollection(romCount: number): VirtualCollection {
+  return {
+    id: "collection-zelda",
+    name: "The Legend of Zelda",
+    rom_count: romCount,
+  } as VirtualCollection;
+}
+
 function rom(id: number): SimpleRom {
   return { id, name: "Chrono Trigger" } as SimpleRom;
 }
@@ -139,6 +157,9 @@ describe("Collection view random rom", () => {
     routeState.name = "collection";
     routeState.params = { collection: "1" };
     getRoms.mockResolvedValue({ data: { items: [], total: 0 } });
+    getCollection.mockImplementation((id: number) =>
+      Promise.resolve({ data: collection(id) }),
+    );
     storeCollections().setCollections([collection(1), collection(2)]);
   });
 
@@ -327,5 +348,71 @@ describe("Collection view random rom", () => {
     resolvePick({ data: rom(42) });
     await flushPromises();
     expect(push).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The store's lists load once per session, and a virtual collection's ROM count
+// moves with every scan and match, so a cached count disagrees with the gallery
+// below it.
+describe("Collection view freshness", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    routeGuards.length = 0;
+    routeState.name = "collection";
+    routeState.params = { collection: "1" };
+    getRoms.mockResolvedValue({ data: { items: [], total: 0 } });
+    getCollection.mockImplementation((id: number) =>
+      Promise.resolve({ data: collection(id) }),
+    );
+    // `collection()` caches 9000 ROMs, so any other count came from the server.
+    storeCollections().setCollections([collection(1)]);
+  });
+
+  it("renders the count the server returns, not the cached one", async () => {
+    getCollection.mockResolvedValue({
+      data: { ...collection(1), rom_count: 12 },
+    });
+
+    const wrapper = await mountView();
+
+    expect(getCollection).toHaveBeenCalledWith(1);
+    expect(wrapper.get(".rom-count").text()).toBe("12");
+  });
+
+  it("re-reads the virtual collection being opened", async () => {
+    routeState.name = "virtual-collection";
+    routeState.params = { collection: "collection-zelda" };
+    storeCollections().setVirtualCollections([virtualCollection(4)]);
+    getVirtualCollection.mockResolvedValue({ data: virtualCollection(5) });
+
+    const wrapper = await mountView();
+
+    expect(getVirtualCollection).toHaveBeenCalledWith("collection-zelda");
+    expect(wrapper.get(".rom-count").text()).toBe("5");
+  });
+
+  // What a finished scan does: the store refetches, and the open page has to
+  // follow or it drifts again until the next visit.
+  it("adopts the store's copy when a refresh replaces it", async () => {
+    routeState.name = "virtual-collection";
+    routeState.params = { collection: "collection-zelda" };
+    const collections = storeCollections();
+    collections.setVirtualCollections([virtualCollection(4)]);
+    getVirtualCollection.mockResolvedValue({ data: virtualCollection(4) });
+
+    const wrapper = await mountView();
+    collections.setVirtualCollections([virtualCollection(5)]);
+    await nextTick();
+
+    expect(wrapper.get(".rom-count").text()).toBe("5");
+  });
+
+  it("falls back to the cached copy when the re-read fails", async () => {
+    getCollection.mockRejectedValue(new Error("offline"));
+
+    const wrapper = await mountView();
+
+    expect(wrapper.get(".rom-count").text()).toBe("9000");
   });
 });

--- a/frontend/src/v2/views/Gallery/Collection.test.ts
+++ b/frontend/src/v2/views/Gallery/Collection.test.ts
@@ -408,6 +408,33 @@ describe("Collection view freshness", () => {
     expect(wrapper.get(".rom-count").text()).toBe("5");
   });
 
+  // Both the route guard and the route watch call the loader per navigation,
+  // and its read can outlive the route, so only the newest may write.
+  it("ignores a read that lands after the route moved on", async () => {
+    let settleFirst!: (value: { data: Collection }) => void;
+    getCollection.mockReturnValueOnce(
+      new Promise((resolve) => {
+        settleFirst = resolve;
+      }),
+    );
+
+    const galleryRoms = storeGalleryRoms();
+    vi.spyOn(galleryRoms, "fetchInitialMetadata").mockResolvedValue();
+    const wrapper = mount(CollectionView);
+
+    routeState.params = { collection: "2" };
+    getCollection.mockResolvedValueOnce({
+      data: { ...collection(2), rom_count: 22 },
+    });
+    await routeGuards[0]?.({ name: "collection", params: { collection: "2" } });
+    await flushPromises();
+
+    settleFirst({ data: { ...collection(1), rom_count: 11 } });
+    await flushPromises();
+
+    expect(wrapper.get(".rom-count").text()).toBe("22");
+  });
+
   it("falls back to the cached copy when the re-read fails", async () => {
     getCollection.mockRejectedValue(new Error("offline"));
 

--- a/frontend/src/v2/views/Gallery/Collection.test.ts
+++ b/frontend/src/v2/views/Gallery/Collection.test.ts
@@ -435,6 +435,19 @@ describe("Collection view freshness", () => {
     expect(wrapper.get(".rom-count").text()).toBe("22");
   });
 
+  // A 404 is the server answering, unlike a failed read, so the cached copy
+  // must not keep a deleted collection on screen.
+  it("shows not-found when the server says the collection is gone", async () => {
+    getCollection.mockRejectedValue(
+      Object.assign(new Error("HTTP 404"), { response: { status: 404 } }),
+    );
+
+    const wrapper = await mountView();
+
+    expect(wrapper.find(".rom-count").exists()).toBe(false);
+    expect(storeCollections().allCollections).toEqual([]);
+  });
+
   it("falls back to the cached copy when the re-read fails", async () => {
     getCollection.mockRejectedValue(new Error("offline"));
 

--- a/frontend/src/v2/views/Gallery/Collection.test.ts
+++ b/frontend/src/v2/views/Gallery/Collection.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable vue/one-component-per-file */
 import { flushPromises, mount } from "@vue/test-utils";
+import { AxiosError } from "axios";
 import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { defineComponent, nextTick, ref } from "vue";
@@ -351,9 +352,8 @@ describe("Collection view random rom", () => {
   });
 });
 
-// The store's lists load once per session, and a virtual collection's ROM count
-// moves with every scan and match, so a cached count disagrees with the gallery
-// below it.
+// The store's lists load once per session, so a cached ROM count disagrees
+// with the gallery below it.
 describe("Collection view freshness", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
@@ -393,7 +393,7 @@ describe("Collection view freshness", () => {
   });
 
   // What a finished scan does: the store refetches, and the open page has to
-  // follow or it drifts again until the next visit.
+  // follow it.
   it("adopts the store's copy when a refresh replaces it", async () => {
     routeState.name = "virtual-collection";
     routeState.params = { collection: "collection-zelda" };
@@ -408,8 +408,6 @@ describe("Collection view freshness", () => {
     expect(wrapper.get(".rom-count").text()).toBe("5");
   });
 
-  // Both the route guard and the route watch call the loader per navigation,
-  // and its read can outlive the route, so only the newest may write.
   it("ignores a read that lands after the route moved on", async () => {
     let settleFirst!: (value: { data: Collection }) => void;
     getCollection.mockReturnValueOnce(
@@ -435,11 +433,11 @@ describe("Collection view freshness", () => {
     expect(wrapper.get(".rom-count").text()).toBe("22");
   });
 
-  // A 404 is the server answering, unlike a failed read, so the cached copy
-  // must not keep a deleted collection on screen.
+  // A 404 answers, unlike a failed read, so the cached copy must not keep a
+  // deleted collection on screen.
   it("shows not-found when the server says the collection is gone", async () => {
     getCollection.mockRejectedValue(
-      Object.assign(new Error("HTTP 404"), { response: { status: 404 } }),
+      Object.assign(new AxiosError("HTTP 404"), { response: { status: 404 } }),
     );
 
     const wrapper = await mountView();

--- a/frontend/src/v2/views/Gallery/Collection.vue
+++ b/frontend/src/v2/views/Gallery/Collection.vue
@@ -169,11 +169,11 @@ const kindLabel = computed(() => {
 });
 
 // Leaving for anything that isn't another gallery keeps `currentCollection`
-// in place, so neither the load flow nor `onRandomGame` can tell from the id
-// alone that the user walked away.
+// in place, so the id alone can't see the user walked away.
 const alive = useIsAlive();
 
-// Only the newest `loadForRoute` may write to the page or drive the gallery.
+// Only the newest `loadForRoute` may write to the page or drive the gallery:
+// the guard and the route watch both call it, and its read outlives the route.
 let loadToken = 0;
 
 function kindFromRoute(
@@ -212,9 +212,8 @@ function findById(kind: CollectionKind, id: string): AnyCollection | undefined {
   return collectionsStore.smartCollections.find((c) => String(c.id) === id);
 }
 
-// The head band renders a ROM count, and the store's lists are loaded once per
-// session, so a cached virtual collection counts whatever it held back then
-// against a gallery that fetches live.
+// The head band renders a ROM count the store's once-per-session lists cannot
+// keep in step with the gallery below it.
 function refreshFromServer(
   kind: CollectionKind,
   id: string,
@@ -227,14 +226,12 @@ function refreshFromServer(
 async function loadForRoute(kind: CollectionKind, id: string) {
   const token = ++loadToken;
   currentKind.value = kind;
-  // The list is still loaded, unused here, for the surfaces reachable from
-  // this page that read it (the add-to-collection dialog).
+  // The list is unused here, but the surfaces reachable from this page read it
+  // (the add-to-collection dialog).
   const [fresh] = await Promise.all([
     refreshFromServer(kind, id),
     ensureLoaded(kind),
   ]);
-  // A newer load owns the page: both the route guard and the route watch call
-  // this per navigation, and the read they wait on can outlive the route.
   if (token !== loadToken || !alive.value) return;
   const collection = fresh ?? findById(kind, id);
   if (!collection) {
@@ -275,9 +272,8 @@ watch(
   },
 );
 
-// Adopt the store's copy when a refresh replaces it, so a scan or a metadata
-// write landing while this page is open corrects the head band as well as the
-// gallery below.
+// Adopt the store's copy when a refresh replaces it, so a scan landing while
+// this page is open corrects the head band too.
 watch(
   () => findById(currentKind.value, String(route.params.collection)),
   (fresh) => {

--- a/frontend/src/v2/views/Gallery/Collection.vue
+++ b/frontend/src/v2/views/Gallery/Collection.vue
@@ -168,6 +168,14 @@ const kindLabel = computed(() => {
   return "Collection";
 });
 
+// Leaving for anything that isn't another gallery keeps `currentCollection`
+// in place, so neither the load flow nor `onRandomGame` can tell from the id
+// alone that the user walked away.
+const alive = useIsAlive();
+
+// Only the newest `loadForRoute` may write to the page or drive the gallery.
+let loadToken = 0;
+
 function kindFromRoute(
   name: string | symbol | null | undefined,
 ): CollectionKind {
@@ -217,6 +225,7 @@ function refreshFromServer(
 }
 
 async function loadForRoute(kind: CollectionKind, id: string) {
+  const token = ++loadToken;
   currentKind.value = kind;
   // The list is still loaded, unused here, for the surfaces reachable from
   // this page that read it (the add-to-collection dialog).
@@ -224,6 +233,9 @@ async function loadForRoute(kind: CollectionKind, id: string) {
     refreshFromServer(kind, id),
     ensureLoaded(kind),
   ]);
+  // A newer load owns the page: both the route guard and the route watch call
+  // this per navigation, and the read they wait on can outlive the route.
+  if (token !== loadToken || !alive.value) return;
   const collection = fresh ?? findById(kind, id);
   if (!collection) {
     notFound.value = true;
@@ -308,10 +320,6 @@ function randomScope(): {
   if (currentKind.value === "smart") return { smartCollectionId: Number(c.id) };
   return { collectionId: Number(c.id) };
 }
-
-// Leaving for anything that isn't another gallery keeps `currentCollection`
-// in place, so the id check in `onRandomGame` can't see the user walked away.
-const alive = useIsAlive();
 
 // `/roms/random` samples the pick server-side, so one request resolves it
 // whatever the collection holds. `null` means the collection holds no roms.

--- a/frontend/src/v2/views/Gallery/Collection.vue
+++ b/frontend/src/v2/views/Gallery/Collection.vue
@@ -204,10 +204,27 @@ function findById(kind: CollectionKind, id: string): AnyCollection | undefined {
   return collectionsStore.smartCollections.find((c) => String(c.id) === id);
 }
 
+// The head band renders a ROM count, and the store's lists are loaded once per
+// session, so a cached virtual collection counts whatever it held back then
+// against a gallery that fetches live.
+function refreshFromServer(
+  kind: CollectionKind,
+  id: string,
+): Promise<AnyCollection | null> {
+  if (kind === "regular") return collectionsStore.refreshCollection(Number(id));
+  if (kind === "virtual") return collectionsStore.refreshVirtualCollection(id);
+  return collectionsStore.refreshSmartCollection(Number(id));
+}
+
 async function loadForRoute(kind: CollectionKind, id: string) {
   currentKind.value = kind;
-  await ensureLoaded(kind);
-  const collection = findById(kind, id);
+  // The list is still loaded, unused here, for the surfaces reachable from
+  // this page that read it (the add-to-collection dialog).
+  const [fresh] = await Promise.all([
+    refreshFromServer(kind, id),
+    ensureLoaded(kind),
+  ]);
+  const collection = fresh ?? findById(kind, id);
   if (!collection) {
     notFound.value = true;
     currentCollection.value = null;
@@ -243,6 +260,16 @@ watch(
   ([name, id]) => {
     if (id == null) return;
     loadForRoute(kindFromRoute(name), String(id));
+  },
+);
+
+// Adopt the store's copy when a refresh replaces it, so a scan or a metadata
+// write landing while this page is open corrects the head band as well as the
+// gallery below.
+watch(
+  () => findById(currentKind.value, String(route.params.collection)),
+  (fresh) => {
+    if (fresh) currentCollection.value = fresh;
   },
 );
 


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

An autogenerated (virtual) collection could show a ROM count that disagreed with the games listed right below it, e.g. "4 GAMES" in the head band over 5 cards in the gallery.

The two numbers come from different places. The head band renders `collection.rom_count` off the collections store, and every fetch site is guarded on the list being empty (`Collection.vue`, `CollectionsIndex.vue`, `Home.vue`), so the store's copy is only ever loaded once per page load and nothing invalidates it. The gallery below, by contrast, re-queries `/api/roms` on every navigation and even refetches itself mid-scan. Virtual collection membership is derived from ROM metadata, so a scan or a metadata match changes it with no collection write to update the cached copy from, and the count silently drifts for the rest of the session.

The data itself was never wrong: the `virtual_collections` view and the membership lookup the gallery filters on agree. I checked that against a real MariaDB 11 with the full migration chain, comparing the view's `rom_count` to the ROMs the gallery filter returns, for ROMs inserted pre-matched, matched later by an `UPDATE` (the scanner path), re-covered after matching, and under name variants that could split a group (case difference, trailing whitespace). Every case agreed.

Two changes, both frontend:

1. **The collection page re-reads the collection it is opening** (`/collections/virtual/{id}`, or the regular / smart equivalent) in parallel with the existing list warm-up, falling back to the cached copy only when that request fails. New store actions `refreshCollection` / `refreshVirtualCollection` / `refreshSmartCollection` do the fetch and refresh the cached copy on the way through, so the tile you came from is corrected too.
2. **The store re-reads its loaded virtual collections when membership can have moved**: on `scan:done`, next to the existing platform reconcile (this also covers "Refresh metadata", single or bulk, which runs through the same scan socket), and in `applyRomWrite`, which is the edit and match dialogs. A watch on the collection page adopts the refreshed copy, so a scan finishing while you are looking at a collection corrects the head band and not just the grid.

`updateVirtualCollection` replaces in place only, never inserts: `virtualCollections` holds one virtual type at a time, and a collection fetched by id carries its own type, so inserting could mix types into the list the index renders.

Worth a reviewer's attention: `loadForRoute` already runs twice per navigation on this view (the route watch and `onBeforeRouteUpdate` both call it), so the gallery requests were already duplicated; this adds one duplicate small GET on that same path. I left the double invocation alone rather than change navigation semantics in a bug fix.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The diagnosis, the implementation, the tests, and the local verification below were all produced in an agent session and reviewed by me.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**Testing**

Static: `npm run typecheck`, `npm run test` (747 pass, 6 new), `npm run build`, Prettier and ESLint clean on the touched files. Each new test was confirmed to fail with its fix reverted.

Manual, against a local backend plus Vite dev server with a seeded virtual collection, on the v2 UI:

- Reproduced the bug with the view change reverted: head band "7 GAMES" over 8 listed games.
- With the fix, the same in-SPA navigation reads 8 GAMES over 8 games; opening a collection whose cached tile said 5 while the server held 6 rendered 6.
- Scan trigger: with the store cached at 8 and the server at 9, running a scan flipped the collections-index tile to "9 games" with no reload.
- Metadata write: saving through the Edit ROM dialog fired `GET /api/collections/virtual?type=collection` (200), no console errors on that path.
- Dark and light both render correctly; no markup or styling changed.
