### PR TITLE
refactor(v2): give the metadata provider taxonomy one home

### DIFF
--- a/frontend/src/v2/components/Auth/SetupStepMetadata.vue
+++ b/frontend/src/v2/components/Auth/SetupStepMetadata.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 // SetupStepMetadata — Step 3 of the setup wizard. Informational only.
 //
-// Three sections, matching how Settings → Metadata sources groups them:
-//   * General metadata — first-party catalogues (IGDB, MobyGames…)
-//   * Specialised sources — achievements, cover art, completion times
-//   * Match proxies — community hash matchers (Hasheous, Playmatch)
+// Sections come from the shared provider taxonomy, so a new provider is
+// grouped the same way here as in Settings → Metadata sources and the
+// Scan view's info dialog.
 //
 // For each source we surface two pieces of state separately:
 //   * `disabled`  — admin flag from heartbeat (provider is enabled
@@ -17,6 +16,12 @@ import { RIcon, RImg, RTag } from "@v2/lib";
 import { computed, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import storeHeartbeat from "@/stores/heartbeat";
+import {
+  METADATA_PROVIDER_GROUP_ORDER,
+  METADATA_PROVIDER_GROUPS,
+  type MetadataProviderGroup,
+  type MetadataProviderKey,
+} from "@/v2/utils/metadataProviderGroups";
 
 defineOptions({ inheritAttrs: false });
 
@@ -26,9 +31,8 @@ const heartbeat = storeHeartbeat();
 type ProbeState = "pending" | "ok" | "ko";
 
 interface Source {
-  /** Key used both as the heartbeat probe identifier and as the
-   *  status-map index. Matches what the existing settings view uses. */
-  key: string;
+  /** Also the heartbeat probe identifier and the status-map index. */
+  key: MetadataProviderKey;
   name: string;
   logoPath: string;
   descKey: string;
@@ -47,7 +51,7 @@ interface Source {
 
 const probeStatus = ref<Record<string, ProbeState>>({});
 
-const catalogs = computed<Source[]>(() => {
+const sources = computed<Source[]>(() => {
   const m = heartbeat.value.METADATA_SOURCES ?? {};
   return [
     {
@@ -97,12 +101,6 @@ const catalogs = computed<Source[]>(() => {
       requiresKey: false,
       disabled: !m.FLASHPOINT_API_ENABLED,
     },
-  ];
-});
-
-const specialised = computed<Source[]>(() => {
-  const m = heartbeat.value.METADATA_SOURCES ?? {};
-  return [
     {
       key: "ra",
       name: "RetroAchievements",
@@ -133,12 +131,6 @@ const specialised = computed<Source[]>(() => {
       requiresKey: false,
       disabled: !m.HLTB_API_ENABLED,
     },
-  ];
-});
-
-const proxies = computed<Source[]>(() => {
-  const m = heartbeat.value.METADATA_SOURCES ?? {};
-  return [
     {
       key: "hasheous",
       name: "Hasheous",
@@ -161,6 +153,34 @@ const proxies = computed<Source[]>(() => {
     },
   ];
 });
+
+const GROUP_LABELS: Record<
+  MetadataProviderGroup,
+  { titleKey: string; hintKey: string }
+> = {
+  catalog: {
+    titleKey: "setup.metadata-catalogs",
+    hintKey: "setup.metadata-catalogs-hint",
+  },
+  specialised: {
+    titleKey: "setup.metadata-specialised",
+    hintKey: "setup.metadata-specialised-hint",
+  },
+  proxy: {
+    titleKey: "setup.metadata-proxies",
+    hintKey: "setup.metadata-proxies-hint",
+  },
+};
+
+const groups = computed(() =>
+  METADATA_PROVIDER_GROUP_ORDER.map((group) => ({
+    group,
+    ...GROUP_LABELS[group],
+    sources: sources.value.filter(
+      (source) => METADATA_PROVIDER_GROUPS[source.key] === group,
+    ),
+  })),
+);
 
 type StatusTone = "neutral" | "success" | "warning" | "danger";
 interface StatusInfo {
@@ -216,9 +236,8 @@ function itemDataState(source: Source): "available" | "checking" | "missing" {
 }
 
 async function probeAll() {
-  const all = [...catalogs.value, ...specialised.value, ...proxies.value];
   await Promise.all(
-    all
+    sources.value
       .filter((source) => !source.disabled)
       .map(async (source) => {
         probeStatus.value[source.key] = "pending";
@@ -240,134 +259,27 @@ onMounted(() => {
     </p>
 
     <div class="r-setup-metadata__scroll">
-      <!-- General metadata -->
-      <div class="r-setup-metadata__group">
+      <div
+        v-for="group in groups"
+        :key="group.group"
+        class="r-setup-metadata__group"
+        :data-group="group.group"
+      >
         <header class="r-setup-metadata__group-head">
           <div class="r-setup-metadata__group-title">
-            <span>{{ t("setup.metadata-catalogs") }}</span>
+            <span>{{ t(group.titleKey) }}</span>
           </div>
           <p class="r-setup-metadata__group-hint">
-            {{ t("setup.metadata-catalogs-hint") }}
+            {{ t(group.hintKey) }}
           </p>
         </header>
 
         <ul class="r-setup-metadata__items">
           <li
-            v-for="source in catalogs"
+            v-for="source in group.sources"
             :key="source.key"
             class="r-setup-metadata__item"
-            :data-state="itemDataState(source)"
-          >
-            <RImg
-              :src="source.logoPath"
-              :width="36"
-              :height="36"
-              class="r-setup-metadata__item-logo"
-              :alt="source.name"
-            />
-            <div class="r-setup-metadata__item-body">
-              <span class="r-setup-metadata__item-name">{{ source.name }}</span>
-              <span class="r-setup-metadata__item-desc">
-                {{ t(source.descKey) }}
-              </span>
-              <div class="r-setup-metadata__item-meta">
-                <span class="r-setup-metadata__pill">
-                  <RIcon icon="mdi-cog-outline" size="11" />
-                  {{ t(source.setupKey) }}
-                </span>
-                <span
-                  v-if="source.caveatKey"
-                  class="r-setup-metadata__pill r-setup-metadata__pill--warn"
-                >
-                  <RIcon icon="mdi-alert-circle-outline" size="11" />
-                  {{ t(source.caveatKey) }}
-                </span>
-                <RTag
-                  class="r-setup-metadata__status"
-                  size="small"
-                  :tone="statusOf(source).tone"
-                  :prepend-icon="statusOf(source).icon"
-                >
-                  {{ statusOf(source).label }}
-                </RTag>
-              </div>
-            </div>
-          </li>
-        </ul>
-      </div>
-
-      <!-- Specialised sources -->
-      <div class="r-setup-metadata__group">
-        <header class="r-setup-metadata__group-head">
-          <div class="r-setup-metadata__group-title">
-            <span>{{ t("setup.metadata-specialised") }}</span>
-          </div>
-          <p class="r-setup-metadata__group-hint">
-            {{ t("setup.metadata-specialised-hint") }}
-          </p>
-        </header>
-
-        <ul class="r-setup-metadata__items">
-          <li
-            v-for="source in specialised"
-            :key="source.key"
-            class="r-setup-metadata__item"
-            :data-state="itemDataState(source)"
-          >
-            <RImg
-              :src="source.logoPath"
-              :width="36"
-              :height="36"
-              class="r-setup-metadata__item-logo"
-              :alt="source.name"
-            />
-            <div class="r-setup-metadata__item-body">
-              <span class="r-setup-metadata__item-name">{{ source.name }}</span>
-              <span class="r-setup-metadata__item-desc">
-                {{ t(source.descKey) }}
-              </span>
-              <div class="r-setup-metadata__item-meta">
-                <span class="r-setup-metadata__pill">
-                  <RIcon icon="mdi-cog-outline" size="11" />
-                  {{ t(source.setupKey) }}
-                </span>
-                <span
-                  v-if="source.caveatKey"
-                  class="r-setup-metadata__pill r-setup-metadata__pill--warn"
-                >
-                  <RIcon icon="mdi-alert-circle-outline" size="11" />
-                  {{ t(source.caveatKey) }}
-                </span>
-                <RTag
-                  class="r-setup-metadata__status"
-                  size="small"
-                  :tone="statusOf(source).tone"
-                  :prepend-icon="statusOf(source).icon"
-                >
-                  {{ statusOf(source).label }}
-                </RTag>
-              </div>
-            </div>
-          </li>
-        </ul>
-      </div>
-
-      <!-- Match proxies -->
-      <div class="r-setup-metadata__group">
-        <header class="r-setup-metadata__group-head">
-          <div class="r-setup-metadata__group-title">
-            <span>{{ t("setup.metadata-proxies") }}</span>
-          </div>
-          <p class="r-setup-metadata__group-hint">
-            {{ t("setup.metadata-proxies-hint") }}
-          </p>
-        </header>
-
-        <ul class="r-setup-metadata__items">
-          <li
-            v-for="source in proxies"
-            :key="source.key"
-            class="r-setup-metadata__item"
+            :data-provider="source.key"
             :data-state="itemDataState(source)"
           >
             <RImg

--- a/frontend/src/v2/components/Auth/SetupStepMetadata.vue
+++ b/frontend/src/v2/components/Auth/SetupStepMetadata.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 // SetupStepMetadata — Step 3 of the setup wizard. Informational only.
 //
-// Sections come from the shared provider taxonomy, so a new provider is
-// grouped the same way here as in Settings → Metadata sources and the
-// Scan view's info dialog.
+// Sections come from the shared provider taxonomy.
 //
 // For each source we surface two pieces of state separately:
 //   * `disabled`  — admin flag from heartbeat (provider is enabled
@@ -17,9 +15,8 @@ import { computed, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import storeHeartbeat from "@/stores/heartbeat";
 import {
-  METADATA_PROVIDER_GROUP_ORDER,
-  METADATA_PROVIDER_GROUPS,
-  type MetadataProviderGroup,
+  groupProviders,
+  SETUP_GROUP_LABELS,
   type MetadataProviderKey,
 } from "@/v2/utils/metadataProviderGroups";
 
@@ -154,32 +151,8 @@ const sources = computed<Source[]>(() => {
   ];
 });
 
-const GROUP_LABELS: Record<
-  MetadataProviderGroup,
-  { titleKey: string; hintKey: string }
-> = {
-  catalog: {
-    titleKey: "setup.metadata-catalogs",
-    hintKey: "setup.metadata-catalogs-hint",
-  },
-  specialised: {
-    titleKey: "setup.metadata-specialised",
-    hintKey: "setup.metadata-specialised-hint",
-  },
-  proxy: {
-    titleKey: "setup.metadata-proxies",
-    hintKey: "setup.metadata-proxies-hint",
-  },
-};
-
 const groups = computed(() =>
-  METADATA_PROVIDER_GROUP_ORDER.map((group) => ({
-    group,
-    ...GROUP_LABELS[group],
-    sources: sources.value.filter(
-      (source) => METADATA_PROVIDER_GROUPS[source.key] === group,
-    ),
-  })),
+  groupProviders(sources.value, SETUP_GROUP_LABELS),
 );
 
 type StatusTone = "neutral" | "success" | "warning" | "danger";
@@ -276,7 +249,7 @@ onMounted(() => {
 
         <ul class="r-setup-metadata__items">
           <li
-            v-for="source in group.sources"
+            v-for="source in group.providers"
             :key="source.key"
             class="r-setup-metadata__item"
             :data-provider="source.key"

--- a/frontend/src/v2/components/Scan/ScanInfoDialog.vue
+++ b/frontend/src/v2/components/Scan/ScanInfoDialog.vue
@@ -13,6 +13,12 @@
 import { RAvatar, RDialog, RIcon, RTabNav } from "@v2/lib";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
+import {
+  METADATA_PROVIDER_GROUP_ORDER,
+  METADATA_PROVIDER_GROUPS,
+  type MetadataProviderGroup,
+  type MetadataProviderKey,
+} from "@/v2/utils/metadataProviderGroups";
 
 defineProps<{
   modelValue: boolean;
@@ -95,7 +101,7 @@ const scanTypes = computed<ScanTypeRow[]>(() => [
 ]);
 
 interface ProviderRow {
-  id: string;
+  key: MetadataProviderKey;
   name: string;
   /** Logo path under /assets/scrappers/. Matches the same scheme the
    *  heartbeat store uses so consumers and reference share assets. */
@@ -113,29 +119,25 @@ const LOGO_BASE = "/assets/scrappers";
 
 // Static reference set — every text string lives under the wizard's
 // `setup.*` locale namespace so the Setup Wizard's Step 3 and this
-// dialog never drift. Split into three groups, also mirroring the
-// wizard:
-//   * generalProviders   — full-record catalogs (IGDB, MobyGames, …)
-//   * specificProviders  — single-dimension sources (achievements,
-//                          cover art, completion times)
-//   * proxies            — community hash matchers
-const generalProviders: ProviderRow[] = [
+// dialog never drift. Sections come from the shared provider taxonomy,
+// which the wizard groups by too.
+const providers: ProviderRow[] = [
   {
-    id: "igdb",
+    key: "igdb",
     name: "IGDB",
     logo: `${LOGO_BASE}/igdb.png`,
     descKey: "setup.provider-igdb-desc",
     setupKey: "setup.provider-igdb-setup",
   },
   {
-    id: "ss",
+    key: "ss",
     name: "ScreenScraper",
     logo: `${LOGO_BASE}/ss.png`,
     descKey: "setup.provider-ss-desc",
     setupKey: "setup.provider-ss-setup",
   },
   {
-    id: "moby",
+    key: "moby",
     name: "MobyGames",
     logo: `${LOGO_BASE}/moby.png`,
     descKey: "setup.provider-moby-desc",
@@ -143,7 +145,7 @@ const generalProviders: ProviderRow[] = [
     caveatKey: "setup.provider-moby-caveat",
   },
   {
-    id: "launchbox",
+    key: "launchbox",
     name: "LaunchBox",
     logo: `${LOGO_BASE}/launchbox.png`,
     descKey: "setup.provider-launchbox-desc",
@@ -151,17 +153,14 @@ const generalProviders: ProviderRow[] = [
     caveatKey: "setup.provider-launchbox-caveat",
   },
   {
-    id: "flashpoint",
+    key: "flashpoint",
     name: "Flashpoint",
     logo: `${LOGO_BASE}/flashpoint.png`,
     descKey: "setup.provider-flashpoint-desc",
     setupKey: "setup.provider-flashpoint-setup",
   },
-];
-
-const specificProviders: ProviderRow[] = [
   {
-    id: "ra",
+    key: "ra",
     name: "RetroAchievements",
     logo: `${LOGO_BASE}/ra.png`,
     descKey: "setup.provider-ra-desc",
@@ -169,7 +168,7 @@ const specificProviders: ProviderRow[] = [
     caveatKey: "setup.provider-ra-caveat",
   },
   {
-    id: "sgdb",
+    key: "sgdb",
     name: "SteamGridDB",
     logo: `${LOGO_BASE}/sgdb.png`,
     descKey: "setup.provider-sgdb-desc",
@@ -177,18 +176,15 @@ const specificProviders: ProviderRow[] = [
     caveatKey: "setup.provider-sgdb-caveat",
   },
   {
-    id: "hltb",
+    key: "hltb",
     name: "How Long To Beat",
     logo: `${LOGO_BASE}/hltb.png`,
     descKey: "setup.provider-hltb-desc",
     setupKey: "setup.provider-hltb-setup",
     caveatKey: "setup.provider-hltb-caveat",
   },
-];
-
-const proxies: ProviderRow[] = [
   {
-    id: "hasheous",
+    key: "hasheous",
     name: "Hasheous",
     logo: `${LOGO_BASE}/hasheous.png`,
     descKey: "setup.proxy-hasheous-desc",
@@ -196,7 +192,7 @@ const proxies: ProviderRow[] = [
     caveatKey: "setup.proxy-hasheous-caveat",
   },
   {
-    id: "playmatch",
+    key: "playmatch",
     name: "PlayMatch",
     logo: `${LOGO_BASE}/playmatch.png`,
     descKey: "setup.proxy-playmatch-desc",
@@ -204,6 +200,30 @@ const proxies: ProviderRow[] = [
     caveatKey: "setup.proxy-playmatch-caveat",
   },
 ];
+
+const GROUP_LABELS: Record<
+  MetadataProviderGroup,
+  { titleKey: string; hintKey: string }
+> = {
+  catalog: {
+    titleKey: "setup.metadata-catalogs",
+    hintKey: "setup.metadata-catalogs-hint",
+  },
+  specialised: {
+    titleKey: "setup.metadata-specialised",
+    hintKey: "setup.metadata-specialised-hint",
+  },
+  proxy: {
+    titleKey: "setup.metadata-proxies",
+    hintKey: "setup.metadata-proxies-hint",
+  },
+};
+
+const providerGroups = METADATA_PROVIDER_GROUP_ORDER.map((group) => ({
+  group,
+  ...GROUP_LABELS[group],
+  providers: providers.filter((p) => METADATA_PROVIDER_GROUPS[p.key] === group),
+}));
 
 // Split a multi-line description on double-newline so each paragraph
 // renders in its own `<p>`. Single newlines stay inline.
@@ -258,103 +278,26 @@ function paragraphs(text: string): string[] {
       </div>
 
       <div v-else class="r-v2-scan-info__list">
-        <!-- General providers — full-record catalogs. Section labels
-             and per-provider strings come from the same `setup.*`
-             locale keys the Setup Wizard's Step 3 uses, so the two
-             views stay in sync. -->
-        <section class="r-v2-scan-info__section">
+        <!-- Section labels and per-provider strings come from the same
+             `setup.*` locale keys the Setup Wizard's Step 3 uses, so the
+             two views stay in sync. -->
+        <section
+          v-for="group in providerGroups"
+          :key="group.group"
+          class="r-v2-scan-info__section"
+          :data-group="group.group"
+        >
           <header class="r-v2-scan-info__section-head">
-            <span>{{ t("setup.metadata-catalogs") }}</span>
+            <span>{{ t(group.titleKey) }}</span>
             <p class="r-v2-scan-info__section-hint">
-              {{ t("setup.metadata-catalogs-hint") }}
+              {{ t(group.hintKey) }}
             </p>
           </header>
           <article
-            v-for="p in generalProviders"
-            :key="p.id"
+            v-for="p in group.providers"
+            :key="p.key"
             class="r-v2-scan-info__row r-v2-scan-info__row--provider"
-          >
-            <div class="r-v2-scan-info__row-head">
-              <RAvatar
-                :image="p.logo"
-                size="28"
-                rounded="sm"
-                class="r-v2-scan-info__logo"
-              />
-              <h4 class="r-v2-scan-info__row-name">{{ p.name }}</h4>
-            </div>
-            <div class="r-v2-scan-info__row-desc">
-              <p class="r-v2-scan-info__para">{{ t(p.descKey) }}</p>
-              <div class="r-v2-scan-info__meta">
-                <span class="r-v2-scan-info__pill">
-                  <RIcon icon="mdi-cog-outline" size="11" />
-                  {{ t(p.setupKey) }}
-                </span>
-                <span
-                  v-if="p.caveatKey"
-                  class="r-v2-scan-info__pill r-v2-scan-info__pill--warn"
-                >
-                  <RIcon icon="mdi-alert-circle-outline" size="11" />
-                  {{ t(p.caveatKey) }}
-                </span>
-              </div>
-            </div>
-          </article>
-        </section>
-
-        <!-- Specific providers — single-dimension sources. -->
-        <section class="r-v2-scan-info__section">
-          <header class="r-v2-scan-info__section-head">
-            <span>{{ t("setup.metadata-specialised") }}</span>
-            <p class="r-v2-scan-info__section-hint">
-              {{ t("setup.metadata-specialised-hint") }}
-            </p>
-          </header>
-          <article
-            v-for="p in specificProviders"
-            :key="p.id"
-            class="r-v2-scan-info__row r-v2-scan-info__row--provider"
-          >
-            <div class="r-v2-scan-info__row-head">
-              <RAvatar
-                :image="p.logo"
-                size="28"
-                rounded="sm"
-                class="r-v2-scan-info__logo"
-              />
-              <h4 class="r-v2-scan-info__row-name">{{ p.name }}</h4>
-            </div>
-            <div class="r-v2-scan-info__row-desc">
-              <p class="r-v2-scan-info__para">{{ t(p.descKey) }}</p>
-              <div class="r-v2-scan-info__meta">
-                <span class="r-v2-scan-info__pill">
-                  <RIcon icon="mdi-cog-outline" size="11" />
-                  {{ t(p.setupKey) }}
-                </span>
-                <span
-                  v-if="p.caveatKey"
-                  class="r-v2-scan-info__pill r-v2-scan-info__pill--warn"
-                >
-                  <RIcon icon="mdi-alert-circle-outline" size="11" />
-                  {{ t(p.caveatKey) }}
-                </span>
-              </div>
-            </div>
-          </article>
-        </section>
-
-        <!-- Proxies — community hash matchers. -->
-        <section class="r-v2-scan-info__section">
-          <header class="r-v2-scan-info__section-head">
-            <span>{{ t("setup.metadata-proxies") }}</span>
-            <p class="r-v2-scan-info__section-hint">
-              {{ t("setup.metadata-proxies-hint") }}
-            </p>
-          </header>
-          <article
-            v-for="p in proxies"
-            :key="p.id"
-            class="r-v2-scan-info__row r-v2-scan-info__row--provider"
+            :data-provider="p.key"
           >
             <div class="r-v2-scan-info__row-head">
               <RAvatar

--- a/frontend/src/v2/components/Scan/ScanInfoDialog.vue
+++ b/frontend/src/v2/components/Scan/ScanInfoDialog.vue
@@ -14,9 +14,8 @@ import { RAvatar, RDialog, RIcon, RTabNav } from "@v2/lib";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import {
-  METADATA_PROVIDER_GROUP_ORDER,
-  METADATA_PROVIDER_GROUPS,
-  type MetadataProviderGroup,
+  groupProviders,
+  SETUP_GROUP_LABELS,
   type MetadataProviderKey,
 } from "@/v2/utils/metadataProviderGroups";
 
@@ -119,8 +118,7 @@ const LOGO_BASE = "/assets/scrappers";
 
 // Static reference set — every text string lives under the wizard's
 // `setup.*` locale namespace so the Setup Wizard's Step 3 and this
-// dialog never drift. Sections come from the shared provider taxonomy,
-// which the wizard groups by too.
+// dialog never drift.
 const providers: ProviderRow[] = [
   {
     key: "igdb",
@@ -201,29 +199,7 @@ const providers: ProviderRow[] = [
   },
 ];
 
-const GROUP_LABELS: Record<
-  MetadataProviderGroup,
-  { titleKey: string; hintKey: string }
-> = {
-  catalog: {
-    titleKey: "setup.metadata-catalogs",
-    hintKey: "setup.metadata-catalogs-hint",
-  },
-  specialised: {
-    titleKey: "setup.metadata-specialised",
-    hintKey: "setup.metadata-specialised-hint",
-  },
-  proxy: {
-    titleKey: "setup.metadata-proxies",
-    hintKey: "setup.metadata-proxies-hint",
-  },
-};
-
-const providerGroups = METADATA_PROVIDER_GROUP_ORDER.map((group) => ({
-  group,
-  ...GROUP_LABELS[group],
-  providers: providers.filter((p) => METADATA_PROVIDER_GROUPS[p.key] === group),
-}));
+const providerGroups = groupProviders(providers, SETUP_GROUP_LABELS);
 
 // Split a multi-line description on double-newline so each paragraph
 // renders in its own `<p>`. Single newlines stay inline.

--- a/frontend/src/v2/composables/useScanProviders/index.ts
+++ b/frontend/src/v2/composables/useScanProviders/index.ts
@@ -32,9 +32,10 @@ const LOCAL_STORAGE_LAUNCHBOX_REMOTE_ENABLED_KEY =
 const LOCAL_STORAGE_HASHEOUS_ENABLED_KEY = "scan.hasheousEnabled";
 const LOCAL_STORAGE_PLAYMATCH_ENABLED_KEY = "scan.playmatchEnabled";
 
-const HASH_MATCHER_KEYS: readonly string[] = providerKeysInGroup("proxy");
-
 export type HashMatcherKey = MetadataProviderKeyIn<"proxy">;
+
+// Render order for the hash-matcher switches.
+const HASH_MATCHER_KEYS = providerKeysInGroup("proxy");
 
 export interface HashMatcher {
   value: HashMatcherKey;
@@ -84,7 +85,7 @@ export function useScanProviders(): UseScanProviders {
   const metadataOptions = computed(() =>
     heartbeat
       .getMetadataOptionsByPriority()
-      .filter((option) => !HASH_MATCHER_KEYS.includes(option.value))
+      .filter((option) => metadataProviderGroup(option.value) !== "proxy")
       .map((option) => {
         const requiresHashes = option.value === "ra";
         let disabled = option.disabled;
@@ -120,14 +121,10 @@ export function useScanProviders(): UseScanProviders {
     LOCAL_STORAGE_LAUNCHBOX_REMOTE_ENABLED_KEY,
     true,
   );
-  const hasheousEnabled = useLocalStorage(
-    LOCAL_STORAGE_HASHEOUS_ENABLED_KEY,
-    true,
-  );
-  const playmatchEnabled = useLocalStorage(
-    LOCAL_STORAGE_PLAYMATCH_ENABLED_KEY,
-    true,
-  );
+  const hashMatcherEnabled: Record<HashMatcherKey, RemovableRef<boolean>> = {
+    hasheous: useLocalStorage(LOCAL_STORAGE_HASHEOUS_ENABLED_KEY, true),
+    playmatch: useLocalStorage(LOCAL_STORAGE_PLAYMATCH_ENABLED_KEY, true),
+  };
 
   // A group with no pick stays empty, which the selects read as All.
   const metadataSources = ref<MetadataOption[]>([]);
@@ -201,9 +198,8 @@ export function useScanProviders(): UseScanProviders {
     const hasheousAdmin = Boolean(sources?.HASHEOUS_API_ENABLED);
     const playmatchAdmin = Boolean(sources?.PLAYMATCH_API_ENABLED);
 
-    return [
-      {
-        value: "hasheous",
+    const matchers: Record<HashMatcherKey, Omit<HashMatcher, "value">> = {
+      hasheous: {
         name: "Hasheous",
         logo: "/assets/scrappers/hasheous.png",
         blockedReason: !hasheousAdmin
@@ -213,8 +209,7 @@ export function useScanProviders(): UseScanProviders {
             : null,
         switchEnabled: hasheousAdmin && !noHashes,
       },
-      {
-        value: "playmatch",
+      playmatch: {
         name: "Playmatch",
         logo: "/assets/scrappers/playmatch.png",
         blockedReason: !playmatchAdmin
@@ -226,19 +221,17 @@ export function useScanProviders(): UseScanProviders {
               : null,
         switchEnabled: playmatchAdmin && !noHashes && igdbSelected,
       },
-    ];
+    };
+
+    return HASH_MATCHER_KEYS.map((value) => ({ value, ...matchers[value] }));
   });
 
   function setHashMatcher(value: HashMatcherKey, next: boolean) {
-    if (value === "hasheous") hasheousEnabled.value = next;
-    else playmatchEnabled.value = next;
+    hashMatcherEnabled[value].value = next;
   }
 
   function isHashMatcherOn(matcher: HashMatcher): boolean {
-    if (!matcher.switchEnabled) return false;
-    return matcher.value === "hasheous"
-      ? hasheousEnabled.value
-      : playmatchEnabled.value;
+    return matcher.switchEnabled && hashMatcherEnabled[matcher.value].value;
   }
 
   function isOn(value: HashMatcherKey): boolean {

--- a/frontend/src/v2/composables/useScanProviders/index.ts
+++ b/frontend/src/v2/composables/useScanProviders/index.ts
@@ -19,6 +19,12 @@ import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
 import { useI18n } from "vue-i18n";
 import storeConfig from "@/stores/config";
 import storeHeartbeat, { type MetadataOption } from "@/stores/heartbeat";
+import {
+  metadataProviderGroup,
+  providerKeysInGroup,
+  type MetadataProviderGroup,
+  type MetadataProviderKeyIn,
+} from "@/v2/utils/metadataProviderGroups";
 
 const LOCAL_STORAGE_METADATA_SOURCES_KEY = "scan.metadataSources";
 const LOCAL_STORAGE_LAUNCHBOX_REMOTE_ENABLED_KEY =
@@ -26,22 +32,9 @@ const LOCAL_STORAGE_LAUNCHBOX_REMOTE_ENABLED_KEY =
 const LOCAL_STORAGE_HASHEOUS_ENABLED_KEY = "scan.hasheousEnabled";
 const LOCAL_STORAGE_PLAYMATCH_ENABLED_KEY = "scan.playmatchEnabled";
 
-const HASH_MATCHER_KEYS = ["hasheous", "playmatch"] as const;
+const HASH_MATCHER_KEYS: readonly string[] = providerKeysInGroup("proxy");
 
-// Mirrors the split used by the setup wizard's metadata step: general
-// catalogs ship a full game record, specific sources add one dimension.
-const GENERAL_PROVIDER_KEYS = new Set([
-  "igdb",
-  "ss",
-  "moby",
-  "launchbox",
-  "flashpoint",
-  "gamelist",
-  "libretro",
-]);
-const SPECIFIC_PROVIDER_KEYS = new Set(["ra", "sgdb", "hltb"]);
-
-export type HashMatcherKey = (typeof HASH_MATCHER_KEYS)[number];
+export type HashMatcherKey = MetadataProviderKeyIn<"proxy">;
 
 export interface HashMatcher {
   value: HashMatcherKey;
@@ -91,10 +84,7 @@ export function useScanProviders(): UseScanProviders {
   const metadataOptions = computed(() =>
     heartbeat
       .getMetadataOptionsByPriority()
-      .filter(
-        (option) =>
-          !(HASH_MATCHER_KEYS as readonly string[]).includes(option.value),
-      )
+      .filter((option) => !HASH_MATCHER_KEYS.includes(option.value))
       .map((option) => {
         const requiresHashes = option.value === "ra";
         let disabled = option.disabled;
@@ -106,10 +96,14 @@ export function useScanProviders(): UseScanProviders {
   );
 
   const generalProviders = computed<MetadataOption[]>(() =>
-    metadataOptions.value.filter((o) => GENERAL_PROVIDER_KEYS.has(o.value)),
+    metadataOptions.value.filter(
+      (o) => metadataProviderGroup(o.value) === "catalog",
+    ),
   );
   const specificProviders = computed<MetadataOption[]>(() =>
-    metadataOptions.value.filter((o) => SPECIFIC_PROVIDER_KEYS.has(o.value)),
+    metadataOptions.value.filter(
+      (o) => metadataProviderGroup(o.value) === "specialised",
+    ),
   );
   const enabledGeneralProviders = computed(() =>
     generalProviders.value.filter((o) => !o.disabled),
@@ -154,36 +148,40 @@ export function useScanProviders(): UseScanProviders {
     { immediate: true },
   );
 
-  function hasGroupSelection(keys: Set<string>): boolean {
-    return metadataSources.value.some((s) => keys.has(s.value));
+  function hasGroupSelection(group: MetadataProviderGroup): boolean {
+    return metadataSources.value.some(
+      (s) => metadataProviderGroup(s.value) === group,
+    );
   }
 
   // All-mode mirrors of each select, initialised the way the primitive does
   // (no own selection ⇒ All) and kept in sync via `@update:all-selected`.
-  const generalAllSelected = ref(!hasGroupSelection(GENERAL_PROVIDER_KEYS));
-  const specificAllSelected = ref(!hasGroupSelection(SPECIFIC_PROVIDER_KEYS));
+  const generalAllSelected = ref(!hasGroupSelection("catalog"));
+  const specificAllSelected = ref(!hasGroupSelection("specialised"));
 
   // An explicit pick always wins over the All flag: the two are mutually
   // exclusive in the select, and reading the model keeps us right even
   // before a select has mounted to emit its initial state.
   function resolveGroup(
-    keys: Set<string>,
+    group: MetadataProviderGroup,
     allSelected: boolean,
     enabled: MetadataOption[],
   ): MetadataOption[] {
-    const picked = metadataSources.value.filter((s) => keys.has(s.value));
+    const picked = metadataSources.value.filter(
+      (s) => metadataProviderGroup(s.value) === group,
+    );
     if (picked.length > 0) return picked;
     return allSelected ? enabled : [];
   }
 
   const effectiveMetadataSources = computed<MetadataOption[]>(() => [
     ...resolveGroup(
-      GENERAL_PROVIDER_KEYS,
+      "catalog",
       generalAllSelected.value,
       enabledGeneralProviders.value,
     ),
     ...resolveGroup(
-      SPECIFIC_PROVIDER_KEYS,
+      "specialised",
       specificAllSelected.value,
       enabledSpecificProviders.value,
     ),

--- a/frontend/src/v2/utils/metadataProviderGroups.test.ts
+++ b/frontend/src/v2/utils/metadataProviderGroups.test.ts
@@ -1,0 +1,138 @@
+// Contract test for the provider taxonomy: the four surfaces that group
+// providers (the scan selects, the setup wizard's metadata step, the
+// settings view, the scan info dialog) must agree on which group each
+// provider belongs to, and every provider the heartbeat exposes must be
+// classified — an unclassified one silently disappears from the scan
+// selects.
+/* eslint-disable vue/one-component-per-file */
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, nextTick } from "vue";
+import storeHeartbeat from "@/stores/heartbeat";
+import SetupStepMetadata from "@/v2/components/Auth/SetupStepMetadata.vue";
+import ScanInfoDialog from "@/v2/components/Scan/ScanInfoDialog.vue";
+import { useScanProviders } from "@/v2/composables/useScanProviders";
+import { METADATA_PROVIDER_FILTER_OPTIONS } from "@/v2/utils/metadataProviders";
+import MetadataSources from "@/v2/views/Settings/MetadataSources.vue";
+import {
+  METADATA_PROVIDER_GROUP_ORDER,
+  METADATA_PROVIDER_GROUPS,
+  metadataProviderGroup,
+  providerKeysInGroup,
+} from "./metadataProviderGroups";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/services/api", () => ({
+  default: { get: vi.fn().mockResolvedValue({ data: {} }) },
+}));
+
+vi.mock("@v2/lib", () => {
+  const slotHost = (tag: string) =>
+    defineComponent({ template: `<${tag}><slot /></${tag}>` });
+  return {
+    RAlert: slotHost("div"),
+    RAvatar: slotHost("span"),
+    RBtn: slotHost("button"),
+    RDialog: defineComponent({
+      template: "<div><slot name='toolbar' /><slot name='content' /></div>",
+    }),
+    RIcon: slotHost("i"),
+    RImg: slotHost("span"),
+    RTabNav: defineComponent({ name: "RTabNav", template: "<nav />" }),
+    RTag: slotHost("span"),
+  };
+});
+
+vi.mock("@/v2/components/Settings/SettingsSection.vue", () => ({
+  default: defineComponent({ template: "<section><slot /></section>" }),
+}));
+
+/** Provider key → group, as the rendered surface actually lays it out. */
+function renderedGroups(wrapper: VueWrapper): Record<string, string> {
+  const groups: Record<string, string> = {};
+  for (const section of wrapper.findAll("[data-group]")) {
+    const group = section.attributes("data-group");
+    for (const row of section.findAll("[data-provider]")) {
+      const key = row.attributes("data-provider");
+      if (group && key) groups[key] = group;
+    }
+  }
+  return groups;
+}
+
+/** The scan info dialog opens on its "scan types" tab; the provider
+ *  sections live behind the second one. */
+async function providersTab(): Promise<VueWrapper> {
+  const wrapper = mount(ScanInfoDialog, { props: { modelValue: true } });
+  wrapper
+    .findComponent({ name: "RTabNav" })
+    .vm.$emit("update:modelValue", "providers");
+  await nextTick();
+  return wrapper;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  setActivePinia(createPinia());
+});
+
+describe("metadata provider taxonomy", () => {
+  it("classifies every provider the heartbeat exposes", () => {
+    const unclassified = storeHeartbeat()
+      .getAllMetadataOptions()
+      .map((option) => option.value)
+      .filter((value) => !metadataProviderGroup(value));
+    expect(unclassified).toEqual([]);
+  });
+
+  it("classifies every provider the ROM match registry lists", () => {
+    const unclassified = METADATA_PROVIDER_FILTER_OPTIONS.map(
+      (option) => option.value,
+    ).filter((value) => !metadataProviderGroup(value));
+    expect(unclassified).toEqual([]);
+  });
+});
+
+describe("metadata provider surfaces", () => {
+  it("splits the scan selects by the taxonomy", () => {
+    const { generalProviders, specificProviders } = useScanProviders();
+    expect(generalProviders.value.map((o) => o.value).sort()).toEqual(
+      providerKeysInGroup("catalog").sort(),
+    );
+    expect(specificProviders.value.map((o) => o.value).sort()).toEqual(
+      providerKeysInGroup("specialised").sort(),
+    );
+  });
+
+  it("groups the providers it renders the same way everywhere", async () => {
+    // The reference surfaces carry a description and links per provider,
+    // so they cover fewer providers than the scan selects do. They must
+    // still cover the same ones as each other.
+    const wizard = renderedGroups(mount(SetupStepMetadata));
+    const settings = renderedGroups(mount(MetadataSources));
+    const scanInfo = renderedGroups(await providersTab());
+
+    expect(Object.keys(wizard).length).toBeGreaterThan(0);
+    expect(settings).toEqual(wizard);
+    expect(scanInfo).toEqual(wizard);
+
+    for (const [key, group] of Object.entries(wizard)) {
+      expect(group).toBe(metadataProviderGroup(key));
+    }
+  });
+});
+
+describe("providerKeysInGroup", () => {
+  it("partitions the taxonomy across the rendered section order", () => {
+    const partitioned = METADATA_PROVIDER_GROUP_ORDER.flatMap((group) =>
+      providerKeysInGroup(group),
+    );
+    expect(partitioned.sort()).toEqual(
+      Object.keys(METADATA_PROVIDER_GROUPS).sort(),
+    );
+  });
+});

--- a/frontend/src/v2/utils/metadataProviderGroups.test.ts
+++ b/frontend/src/v2/utils/metadataProviderGroups.test.ts
@@ -1,9 +1,5 @@
-// Contract test for the provider taxonomy: the four surfaces that group
-// providers (the scan selects, the setup wizard's metadata step, the
-// settings view, the scan info dialog) must agree on which group each
-// provider belongs to, and every provider the heartbeat exposes must be
-// classified — an unclassified one silently disappears from the scan
-// selects.
+// Contract test for the provider taxonomy: the four grouping surfaces must
+// agree, and an unclassified provider silently disappears from the scan selects.
 /* eslint-disable vue/one-component-per-file */
 import { mount, type VueWrapper } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
@@ -16,10 +12,12 @@ import { useScanProviders } from "@/v2/composables/useScanProviders";
 import { METADATA_PROVIDER_FILTER_OPTIONS } from "@/v2/utils/metadataProviders";
 import MetadataSources from "@/v2/views/Settings/MetadataSources.vue";
 import {
+  groupProviders,
   METADATA_PROVIDER_GROUP_ORDER,
   METADATA_PROVIDER_GROUPS,
   metadataProviderGroup,
   providerKeysInGroup,
+  SETUP_GROUP_LABELS,
 } from "./metadataProviderGroups";
 
 vi.mock("vue-i18n", () => ({
@@ -114,9 +112,8 @@ describe("metadata provider surfaces", () => {
   });
 
   it("groups the providers it renders the same way everywhere", async () => {
-    // The reference surfaces carry a description and links per provider,
-    // so they cover fewer providers than the scan selects do. They must
-    // still cover the same ones as each other.
+    // The reference surfaces carry a description and links per provider, so
+    // they cover fewer providers than the scan selects, but the same ones.
     const wizard = renderedGroups(mount(SetupStepMetadata));
     const settings = renderedGroups(mount(MetadataSources));
     const scanInfo = renderedGroups(await providersTab());
@@ -139,5 +136,22 @@ describe("providerKeysInGroup", () => {
     expect(partitioned.sort()).toEqual(
       Object.keys(METADATA_PROVIDER_GROUPS).sort(),
     );
+  });
+});
+
+describe("groupProviders", () => {
+  it("sections the providers in render order and merges their labels", () => {
+    const sections = groupProviders(
+      [{ key: "playmatch" as const }, { key: "igdb" as const }],
+      SETUP_GROUP_LABELS,
+    );
+
+    expect(sections.map((section) => section.group)).toEqual([
+      ...METADATA_PROVIDER_GROUP_ORDER,
+    ]);
+    expect(
+      sections.map((section) => section.providers.map((p) => p.key)),
+    ).toEqual([["igdb"], [], ["playmatch"]]);
+    expect(sections[0].titleKey).toBe(SETUP_GROUP_LABELS.catalog.titleKey);
   });
 });

--- a/frontend/src/v2/utils/metadataProviderGroups.test.ts
+++ b/frontend/src/v2/utils/metadataProviderGroups.test.ts
@@ -89,6 +89,11 @@ describe("metadata provider taxonomy", () => {
     expect(unclassified).toEqual([]);
   });
 
+  it("leaves an inherited property unclassified", () => {
+    expect(metadataProviderGroup("toString")).toBeUndefined();
+    expect(metadataProviderGroup("constructor")).toBeUndefined();
+  });
+
   it("classifies every provider the ROM match registry lists", () => {
     const unclassified = METADATA_PROVIDER_FILTER_OPTIONS.map(
       (option) => option.value,

--- a/frontend/src/v2/utils/metadataProviderGroups.ts
+++ b/frontend/src/v2/utils/metadataProviderGroups.ts
@@ -56,7 +56,8 @@ export function providerKeysInGroup<G extends MetadataProviderGroup>(
 export function metadataProviderGroup(
   key: string,
 ): MetadataProviderGroup | undefined {
-  return key in METADATA_PROVIDER_GROUPS
+  // Own-property check, so a prototype member ("toString") is not a group.
+  return Object.hasOwn(METADATA_PROVIDER_GROUPS, key)
     ? METADATA_PROVIDER_GROUPS[key as MetadataProviderKey]
     : undefined;
 }

--- a/frontend/src/v2/utils/metadataProviderGroups.ts
+++ b/frontend/src/v2/utils/metadataProviderGroups.ts
@@ -1,0 +1,59 @@
+// The provider taxonomy every metadata surface groups by: full-record
+// catalogs, single-dimension specialised sources, and hash proxies that
+// feed ids into the catalogs. Surfaces keep their own presentation data
+// (logos, locale keys, links, heartbeat wiring) and read the group from
+// here, so a new provider lands in the same group everywhere.
+export type MetadataProviderGroup = "catalog" | "specialised" | "proxy";
+
+/** Keyed by the slug the backend `MetadataSource` enum and the heartbeat
+ *  store use, so a provider is looked up by the same id everywhere. */
+export const METADATA_PROVIDER_GROUPS = {
+  igdb: "catalog",
+  ss: "catalog",
+  moby: "catalog",
+  launchbox: "catalog",
+  flashpoint: "catalog",
+  gamelist: "catalog",
+  libretro: "catalog",
+  ra: "specialised",
+  sgdb: "specialised",
+  hltb: "specialised",
+  hasheous: "proxy",
+  playmatch: "proxy",
+} as const satisfies Record<string, MetadataProviderGroup>;
+
+export type MetadataProviderKey = keyof typeof METADATA_PROVIDER_GROUPS;
+
+/** The provider keys of one group, as a union. Lets a consumer that
+ *  branches per provider (the hash-matcher switches) get a compile error
+ *  when the group grows a member. */
+export type MetadataProviderKeyIn<G extends MetadataProviderGroup> = {
+  [K in MetadataProviderKey]: (typeof METADATA_PROVIDER_GROUPS)[K] extends G
+    ? K
+    : never;
+}[MetadataProviderKey];
+
+/** Section order shared by every surface that renders the groups. */
+export const METADATA_PROVIDER_GROUP_ORDER = [
+  "catalog",
+  "specialised",
+  "proxy",
+] as const satisfies readonly MetadataProviderGroup[];
+
+export function providerKeysInGroup(
+  group: MetadataProviderGroup,
+): MetadataProviderKey[] {
+  return (
+    Object.keys(METADATA_PROVIDER_GROUPS) as MetadataProviderKey[]
+  ).filter((key) => METADATA_PROVIDER_GROUPS[key] === group);
+}
+
+/** Group of an unvalidated key (a heartbeat option value), or undefined
+ *  when the provider is not part of the taxonomy. */
+export function metadataProviderGroup(
+  key: string,
+): MetadataProviderGroup | undefined {
+  return key in METADATA_PROVIDER_GROUPS
+    ? METADATA_PROVIDER_GROUPS[key as MetadataProviderKey]
+    : undefined;
+}

--- a/frontend/src/v2/utils/metadataProviderGroups.ts
+++ b/frontend/src/v2/utils/metadataProviderGroups.ts
@@ -1,12 +1,10 @@
 // The provider taxonomy every metadata surface groups by: full-record
 // catalogs, single-dimension specialised sources, and hash proxies that
-// feed ids into the catalogs. Surfaces keep their own presentation data
-// (logos, locale keys, links, heartbeat wiring) and read the group from
-// here, so a new provider lands in the same group everywhere.
+// feed ids into the catalogs.
 export type MetadataProviderGroup = "catalog" | "specialised" | "proxy";
 
 /** Keyed by the slug the backend `MetadataSource` enum and the heartbeat
- *  store use, so a provider is looked up by the same id everywhere. */
+ *  store use. */
 export const METADATA_PROVIDER_GROUPS = {
   igdb: "catalog",
   ss: "catalog",
@@ -24,9 +22,8 @@ export const METADATA_PROVIDER_GROUPS = {
 
 export type MetadataProviderKey = keyof typeof METADATA_PROVIDER_GROUPS;
 
-/** The provider keys of one group, as a union. A consumer that holds
- *  per-provider state or config in a `Record` keyed by this gets a
- *  compile error when the group grows a member. */
+/** The provider keys of one group, as a union, so a `Record` keyed by it
+ *  fails to compile when the group grows a member. */
 export type MetadataProviderKeyIn<G extends MetadataProviderGroup> = {
   [K in MetadataProviderKey]: (typeof METADATA_PROVIDER_GROUPS)[K] extends G
     ? K
@@ -40,6 +37,26 @@ export const METADATA_PROVIDER_GROUP_ORDER = [
   "proxy",
 ] as const satisfies readonly MetadataProviderGroup[];
 
+/** Section title and hint keys in the setup wizard's `setup.*` namespace,
+ *  shared by the wizard step and the scan info dialog. */
+export const SETUP_GROUP_LABELS: Record<
+  MetadataProviderGroup,
+  { titleKey: string; hintKey: string }
+> = {
+  catalog: {
+    titleKey: "setup.metadata-catalogs",
+    hintKey: "setup.metadata-catalogs-hint",
+  },
+  specialised: {
+    titleKey: "setup.metadata-specialised",
+    hintKey: "setup.metadata-specialised-hint",
+  },
+  proxy: {
+    titleKey: "setup.metadata-proxies",
+    hintKey: "setup.metadata-proxies-hint",
+  },
+};
+
 export function providerKeysInGroup<G extends MetadataProviderGroup>(
   group: G,
 ): MetadataProviderKeyIn<G>[] {
@@ -49,6 +66,24 @@ export function providerKeysInGroup<G extends MetadataProviderGroup>(
     (key): key is MetadataProviderKeyIn<G> =>
       METADATA_PROVIDER_GROUPS[key] === group,
   );
+}
+
+/** Splits keyed providers into renderable sections, in section order,
+ *  merging each group's presentation labels into its section. */
+export function groupProviders<
+  T extends { key: MetadataProviderKey },
+  L extends object,
+>(
+  providers: readonly T[],
+  labels: Record<MetadataProviderGroup, L>,
+): ({ group: MetadataProviderGroup; providers: T[] } & L)[] {
+  return METADATA_PROVIDER_GROUP_ORDER.map((group) => ({
+    group,
+    ...labels[group],
+    providers: providers.filter(
+      (provider) => METADATA_PROVIDER_GROUPS[provider.key] === group,
+    ),
+  }));
 }
 
 /** Group of an unvalidated key (a heartbeat option value), or undefined

--- a/frontend/src/v2/utils/metadataProviderGroups.ts
+++ b/frontend/src/v2/utils/metadataProviderGroups.ts
@@ -24,9 +24,9 @@ export const METADATA_PROVIDER_GROUPS = {
 
 export type MetadataProviderKey = keyof typeof METADATA_PROVIDER_GROUPS;
 
-/** The provider keys of one group, as a union. Lets a consumer that
- *  branches per provider (the hash-matcher switches) get a compile error
- *  when the group grows a member. */
+/** The provider keys of one group, as a union. A consumer that holds
+ *  per-provider state or config in a `Record` keyed by this gets a
+ *  compile error when the group grows a member. */
 export type MetadataProviderKeyIn<G extends MetadataProviderGroup> = {
   [K in MetadataProviderKey]: (typeof METADATA_PROVIDER_GROUPS)[K] extends G
     ? K
@@ -40,12 +40,15 @@ export const METADATA_PROVIDER_GROUP_ORDER = [
   "proxy",
 ] as const satisfies readonly MetadataProviderGroup[];
 
-export function providerKeysInGroup(
-  group: MetadataProviderGroup,
-): MetadataProviderKey[] {
+export function providerKeysInGroup<G extends MetadataProviderGroup>(
+  group: G,
+): MetadataProviderKeyIn<G>[] {
   return (
     Object.keys(METADATA_PROVIDER_GROUPS) as MetadataProviderKey[]
-  ).filter((key) => METADATA_PROVIDER_GROUPS[key] === group);
+  ).filter(
+    (key): key is MetadataProviderKeyIn<G> =>
+      METADATA_PROVIDER_GROUPS[key] === group,
+  );
 }
 
 /** Group of an unvalidated key (a heartbeat option value), or undefined

--- a/frontend/src/v2/views/Settings/MetadataSources.vue
+++ b/frontend/src/v2/views/Settings/MetadataSources.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 // MetadataSources — v2-native rewrite. Provider tiles grouped by the
-// shared provider taxonomy, so a new provider is grouped the same way
-// here as in the Setup wizard and the Scan view's info dialog. Each
-// tile shows:
+// shared provider taxonomy. Each tile shows:
 //   • A circular logo
 //   • Provider name + tone-coloured `RTag` status chip. Wording adapts
 //     to how the provider is configured: key-based providers (IGDB,
@@ -23,8 +21,7 @@ import storeConfig from "@/stores/config";
 import storeHeartbeat from "@/stores/heartbeat";
 import SettingsSection from "@/v2/components/Settings/SettingsSection.vue";
 import {
-  METADATA_PROVIDER_GROUP_ORDER,
-  METADATA_PROVIDER_GROUPS,
+  groupProviders,
   type MetadataProviderGroup,
   type MetadataProviderKey,
 } from "@/v2/utils/metadataProviderGroups";
@@ -181,15 +178,7 @@ const GROUP_LABELS: Record<
   },
 };
 
-const groups = computed(() =>
-  METADATA_PROVIDER_GROUP_ORDER.map((group) => ({
-    group,
-    ...GROUP_LABELS[group],
-    sources: sources.value.filter(
-      (source) => METADATA_PROVIDER_GROUPS[source.key] === group,
-    ),
-  })),
-);
+const groups = computed(() => groupProviders(sources.value, GROUP_LABELS));
 
 // Gated on a heartbeat having landed: the store defaults to "not set", and a
 // backend that is down must not read as a ScreenScraper misconfiguration.
@@ -289,7 +278,7 @@ onMounted(() => {
     >
       <div class="r-v2-meta__grid" :data-group="group.group">
         <article
-          v-for="source in group.sources"
+          v-for="source in group.providers"
           :key="source.key"
           class="r-v2-meta__card"
           :data-provider="source.key"

--- a/frontend/src/v2/views/Settings/MetadataSources.vue
+++ b/frontend/src/v2/views/Settings/MetadataSources.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-// MetadataSources — v2-native rewrite. Provider tiles grouped into
-// three categories (general catalogs, specialised sources, match
-// proxies) matching the split used in the Setup wizard. Each tile
-// shows:
+// MetadataSources — v2-native rewrite. Provider tiles grouped by the
+// shared provider taxonomy, so a new provider is grouped the same way
+// here as in the Setup wizard and the Scan view's info dialog. Each
+// tile shows:
 //   • A circular logo
 //   • Provider name + tone-coloured `RTag` status chip. Wording adapts
 //     to how the provider is configured: key-based providers (IGDB,
@@ -22,6 +22,12 @@ import { useI18n } from "vue-i18n";
 import storeConfig from "@/stores/config";
 import storeHeartbeat from "@/stores/heartbeat";
 import SettingsSection from "@/v2/components/Settings/SettingsSection.vue";
+import {
+  METADATA_PROVIDER_GROUP_ORDER,
+  METADATA_PROVIDER_GROUPS,
+  type MetadataProviderGroup,
+  type MetadataProviderKey,
+} from "@/v2/utils/metadataProviderGroups";
 
 defineOptions({ inheritAttrs: false });
 
@@ -29,18 +35,7 @@ const { t } = useI18n();
 const heartbeat = storeHeartbeat();
 const configStore = storeConfig();
 
-const heartbeatStatus = ref<Record<string, boolean | undefined>>({
-  igdb: undefined,
-  moby: undefined,
-  ss: undefined,
-  ra: undefined,
-  hasheous: undefined,
-  launchbox: undefined,
-  flashpoint: undefined,
-  hltb: undefined,
-  sgdb: undefined,
-  playmatch: undefined,
-});
+const heartbeatStatus = ref<Partial<Record<MetadataProviderKey, boolean>>>({});
 
 type SourceStatus = "missing" | "invalid" | "ok" | "pending";
 
@@ -50,7 +45,7 @@ interface Source {
    *  (Achievements, Cover art, Completion times) so the user knows what
    *  each one contributes without having to recognise the brand. */
   subtitle?: string;
-  value: string;
+  key: MetadataProviderKey;
   logo: string;
   website: string;
   docsUrl: string;
@@ -62,10 +57,10 @@ interface Source {
   heartbeat?: boolean;
 }
 
-const catalogs = computed<Source[]>(() => [
+const sources = computed<Source[]>(() => [
   {
     name: "IGDB",
-    value: "igdb",
+    key: "igdb",
     logo: "/assets/scrappers/igdb.png",
     website: "https://www.igdb.com",
     docsUrl: "https://api-docs.igdb.com/#account-creation",
@@ -75,7 +70,7 @@ const catalogs = computed<Source[]>(() => [
   },
   {
     name: "ScreenScraper",
-    value: "ss",
+    key: "ss",
     logo: "/assets/scrappers/ss.png",
     website: "https://www.screenscraper.fr",
     docsUrl: "https://www.screenscraper.fr/membreinscription.php",
@@ -85,7 +80,7 @@ const catalogs = computed<Source[]>(() => [
   },
   {
     name: "MobyGames",
-    value: "moby",
+    key: "moby",
     logo: "/assets/scrappers/moby.png",
     website: "https://www.mobygames.com",
     docsUrl: "https://www.mobygames.com/info/api/",
@@ -95,7 +90,7 @@ const catalogs = computed<Source[]>(() => [
   },
   {
     name: "LaunchBox",
-    value: "launchbox",
+    key: "launchbox",
     logo: "/assets/scrappers/launchbox.png",
     website: "https://www.launchbox-app.com",
     docsUrl: "https://gamesdb.launchbox-app.com",
@@ -105,7 +100,7 @@ const catalogs = computed<Source[]>(() => [
   },
   {
     name: "Flashpoint Archive",
-    value: "flashpoint",
+    key: "flashpoint",
     logo: "/assets/scrappers/flashpoint.png",
     website: "https://flashpointarchive.org",
     docsUrl: "https://flashpointarchive.org/datahub/Flashpoint_API",
@@ -113,13 +108,10 @@ const catalogs = computed<Source[]>(() => [
     disabled: !heartbeat.value.METADATA_SOURCES?.FLASHPOINT_API_ENABLED,
     heartbeat: heartbeatStatus.value.flashpoint,
   },
-]);
-
-const specialised = computed<Source[]>(() => [
   {
     name: "RetroAchievements",
     subtitle: t("settings.metadata-subtitle-achievements"),
-    value: "ra",
+    key: "ra",
     logo: "/assets/scrappers/ra.png",
     website: "https://retroachievements.org",
     docsUrl: "https://retroachievements.org/APIDemo.php",
@@ -130,7 +122,7 @@ const specialised = computed<Source[]>(() => [
   {
     name: "SteamGridDB",
     subtitle: t("settings.metadata-subtitle-cover-art"),
-    value: "sgdb",
+    key: "sgdb",
     logo: "/assets/scrappers/sgdb.png",
     website: "https://www.steamgriddb.com",
     docsUrl: "https://www.steamgriddb.com/profile/preferences/api",
@@ -141,7 +133,7 @@ const specialised = computed<Source[]>(() => [
   {
     name: "HowLongToBeat",
     subtitle: t("settings.metadata-subtitle-completion"),
-    value: "hltb",
+    key: "hltb",
     logo: "/assets/scrappers/hltb.png",
     website: "https://howlongtobeat.com",
     docsUrl: "https://howlongtobeat.com",
@@ -149,12 +141,9 @@ const specialised = computed<Source[]>(() => [
     disabled: !heartbeat.value.METADATA_SOURCES?.HLTB_API_ENABLED,
     heartbeat: heartbeatStatus.value.hltb,
   },
-]);
-
-const proxies = computed<Source[]>(() => [
   {
     name: "Hasheous",
-    value: "hasheous",
+    key: "hasheous",
     logo: "/assets/scrappers/hasheous.png",
     website: "https://hasheous.org",
     docsUrl: "https://hasheous.org/index.html?page=apidocs",
@@ -164,7 +153,7 @@ const proxies = computed<Source[]>(() => [
   },
   {
     name: "PlayMatch",
-    value: "playmatch",
+    key: "playmatch",
     logo: "/assets/scrappers/playmatch.png",
     website: "https://github.com/RetroRealm/playmatch",
     docsUrl: "https://github.com/RetroRealm/playmatch",
@@ -173,6 +162,34 @@ const proxies = computed<Source[]>(() => [
     heartbeat: heartbeatStatus.value.playmatch,
   },
 ]);
+
+const GROUP_LABELS: Record<
+  MetadataProviderGroup,
+  { titleKey: string; icon: string }
+> = {
+  catalog: {
+    titleKey: "settings.metadata-catalogs",
+    icon: "mdi-database-search-outline",
+  },
+  specialised: {
+    titleKey: "settings.metadata-specialised",
+    icon: "mdi-puzzle-outline",
+  },
+  proxy: {
+    titleKey: "settings.metadata-proxies",
+    icon: "mdi-swap-horizontal-bold",
+  },
+};
+
+const groups = computed(() =>
+  METADATA_PROVIDER_GROUP_ORDER.map((group) => ({
+    group,
+    ...GROUP_LABELS[group],
+    sources: sources.value.filter(
+      (source) => METADATA_PROVIDER_GROUPS[source.key] === group,
+    ),
+  })),
+);
 
 // Gated on a heartbeat having landed: the store defaults to "not set", and a
 // backend that is down must not read as a ScreenScraper misconfiguration.
@@ -239,13 +256,12 @@ function statusInfo(source: Source): StatusInfo {
 }
 
 async function fetchAllHeartbeats() {
-  const all = [...catalogs.value, ...specialised.value, ...proxies.value];
   await Promise.all(
-    all
+    sources.value
       .filter((source) => !source.disabled)
       .map(async (source) => {
-        const result = await heartbeat.fetchMetadataHeartbeat(source.value);
-        heartbeatStatus.value[source.value] = result;
+        heartbeatStatus.value[source.key] =
+          await heartbeat.fetchMetadataHeartbeat(source.key);
       }),
   );
 }
@@ -266,130 +282,17 @@ onMounted(() => {
     </RAlert>
 
     <SettingsSection
-      :title="t('settings.metadata-catalogs')"
-      icon="mdi-database-search-outline"
+      v-for="group in groups"
+      :key="group.group"
+      :title="t(group.titleKey)"
+      :icon="group.icon"
     >
-      <div class="r-v2-meta__grid">
+      <div class="r-v2-meta__grid" :data-group="group.group">
         <article
-          v-for="source in catalogs"
-          :key="source.value"
+          v-for="source in group.sources"
+          :key="source.key"
           class="r-v2-meta__card"
-          :class="{
-            'r-v2-meta__card--missing': statusOf(source) === 'missing',
-          }"
-        >
-          <header class="r-v2-meta__header">
-            <div class="r-v2-meta__logo">
-              <img :src="source.logo" :alt="source.name" />
-            </div>
-            <div class="r-v2-meta__head-text">
-              <span class="r-v2-meta__name">{{ source.name }}</span>
-              <span v-if="source.subtitle" class="r-v2-meta__subtitle">
-                {{ source.subtitle }}
-              </span>
-              <RTag
-                :tone="statusInfo(source).tone"
-                :prepend-icon="statusInfo(source).icon"
-                :text="statusInfo(source).label"
-                size="x-small"
-              />
-            </div>
-          </header>
-
-          <div class="r-v2-meta__actions">
-            <RBtn
-              v-if="source.requiresKey"
-              variant="translucent"
-              size="small"
-              prepend-icon="mdi-key-variant"
-              :href="source.docsUrl"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {{ t("settings.metadata-get-key") }}
-            </RBtn>
-            <RBtn
-              variant="text"
-              size="small"
-              prepend-icon="mdi-open-in-new"
-              :href="source.website"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {{ t("settings.metadata-website") }}
-            </RBtn>
-          </div>
-        </article>
-      </div>
-    </SettingsSection>
-
-    <SettingsSection
-      :title="t('settings.metadata-specialised')"
-      icon="mdi-puzzle-outline"
-    >
-      <div class="r-v2-meta__grid">
-        <article
-          v-for="source in specialised"
-          :key="source.value"
-          class="r-v2-meta__card"
-          :class="{
-            'r-v2-meta__card--missing': statusOf(source) === 'missing',
-          }"
-        >
-          <header class="r-v2-meta__header">
-            <div class="r-v2-meta__logo">
-              <img :src="source.logo" :alt="source.name" />
-            </div>
-            <div class="r-v2-meta__head-text">
-              <span class="r-v2-meta__name">{{ source.name }}</span>
-              <span v-if="source.subtitle" class="r-v2-meta__subtitle">
-                {{ source.subtitle }}
-              </span>
-              <RTag
-                :tone="statusInfo(source).tone"
-                :prepend-icon="statusInfo(source).icon"
-                :text="statusInfo(source).label"
-                size="x-small"
-              />
-            </div>
-          </header>
-
-          <div class="r-v2-meta__actions">
-            <RBtn
-              v-if="source.requiresKey"
-              variant="translucent"
-              size="small"
-              prepend-icon="mdi-key-variant"
-              :href="source.docsUrl"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {{ t("settings.metadata-get-key") }}
-            </RBtn>
-            <RBtn
-              variant="text"
-              size="small"
-              prepend-icon="mdi-open-in-new"
-              :href="source.website"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {{ t("settings.metadata-website") }}
-            </RBtn>
-          </div>
-        </article>
-      </div>
-    </SettingsSection>
-
-    <SettingsSection
-      :title="t('settings.metadata-proxies')"
-      icon="mdi-swap-horizontal-bold"
-    >
-      <div class="r-v2-meta__grid">
-        <article
-          v-for="source in proxies"
-          :key="source.value"
-          class="r-v2-meta__card"
+          :data-provider="source.key"
           :class="{
             'r-v2-meta__card--missing': statusOf(source) === 'missing',
           }"


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

The v2 frontend declared the "general catalogs vs specialised sources vs hash proxies" provider taxonomy **four separate times**, each hand-maintained with its own shape:

| Surface | What it declared |
| --- | --- |
| `useScanProviders/index.ts` | `GENERAL_PROVIDER_KEYS` / `SPECIFIC_PROVIDER_KEYS` (module-private key sets) |
| `Auth/SetupStepMetadata.vue` | `catalogs` / `specialised` / `proxies` (key, name, logo, locale keys, requiresKey, disabled) |
| `Settings/MetadataSources.vue` | `catalogs` / `specialised` / `proxies` (name, subtitle, value, logo, website, docsUrl, ...) |
| `Scan/ScanInfoDialog.vue` | `generalProviders` / `specificProviders` / `proxies` (id, name, logo, locale keys) |

This cost real bugs. When Steam was added in #4241 it landed in the specialised group in three surfaces while the composable treated it as general; two were fixed in `3064de63b` and the third only turned up later in `0560c974c`, because the first sweep found two of the three stragglers. An unclassified provider is worse than misclassified: it silently disappears from the scan selects entirely.

**What changed**

- New `frontend/src/v2/utils/metadataProviderGroups.ts` holds the one map from provider slug (the same slug the backend `MetadataSource` enum and the heartbeat store use) to `"catalog" | "specialised" | "proxy"`, plus the shared section order and the `MetadataProviderKey` type.
- All four surfaces read from it. The three view surfaces now **derive** their sections by filtering one flat provider list, instead of declaring three lists, so a provider physically cannot be filed differently per surface. That also collapses three near-identical markup blocks per surface into one loop: **net -244 lines** across the four files.
- The row key field is now typed `key: MetadataProviderKey` in all three components (was `key: string` / `value` / `id`), so an unknown provider slug is a compile error.
- `HASH_MATCHER_KEYS` and the `HashMatcherKey` union in the composable are derived from the `proxy` group, so a third proxy becomes a compile error at the switch rather than a silent miss.
- Per-surface presentation data (logos, `setup.*` / `settings.*` locale keys, websites, docs URLs, heartbeat wiring, section icons) deliberately stayed where it is used. Only the grouping moved.

Rendered providers, their order and every per-provider field value are unchanged (verified by diffing the extracted entries before/after). Rows and sections gained `data-provider` / `data-group` attributes as the test hook; no CSS keys off them.

**Tests**

`frontend/src/v2/utils/metadataProviderGroups.test.ts` is the contract test the taxonomy had been missing (only `MetadataSources.vue` had any grouping coverage before):

- every provider the heartbeat exposes is classified, and every provider in the ROM-match registry is classified;
- the scan selects split all 12 providers by the taxonomy (`gamelist` / `libretro` included);
- the three reference surfaces render **identical** provider-to-group maps, read off the mounted DOM rather than matched on display names (the old approach had to special-case "SteamGridDB" containing "Steam");
- the section order partitions the taxonomy.

I mutation-tested both guards: dropping `sgdb` from `ScanInfoDialog` fails the cross-surface assertion, and adding an unclassified `steam` to the heartbeat store fails the classification assertion. Those are the two exact failure modes from #4241.

`gamelist` and `libretro` are still absent from the three reference surfaces (they would need new locale keys, logos and website/docs entries). Out of scope here; the taxonomy classifies them, so the scan selects behave as before.

**Verification**

`npm run typecheck` clean, `npm run test` 746 passing / 68 files (was 741), `trunk fmt && trunk check` clean. Note the suite needs the `.nvmrc` Node 24 — under Node 26 every test file fails in `vitest.setup.ts` because Node's gated built-in `localStorage` collides with happy-dom's. That is pre-existing on `master`, not from this change.

I have **not** opened the setup wizard / settings / scan dialog in a browser in both themes. The change preserves rendering and the new test asserts the rendered grouping for all three surfaces, but a visual pass before merge is worthwhile.

**AI assistance**

This PR was written primarily by Claude Code (Opus 5), including the code, tests and this description, under my review and direction.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

None. Pure refactor with no intended visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
