### PR TITLE
fix(auth): send PKCE on the OIDC authorization request

### DIFF
--- a/backend/decorators/auth.py
+++ b/backend/decorators/auth.py
@@ -65,6 +65,15 @@ oauth.register(
     client_kwargs={
         "scope": f"openid profile email {OIDC_CLAIM_ROLES}".strip(),
         "verify": OIDC_TLS_CACERTFILE,
+        # PKCE (RFC 7636). Authlib only derives a code_verifier when
+        # code_challenge_method is set, so without this the authorization
+        # request carries no code_challenge at all. Providers that mandate
+        # PKCE then refuse to issue the code: the user authenticates fine and
+        # is redirected back without a `code`, surfacing as a generic login
+        # failure. Providers that don't support PKCE ignore the extra
+        # parameters (OIDC Core 3.1.2.1), so sending it unconditionally is
+        # backwards-compatible -- and OAuth 2.1 requires it of every client.
+        "code_challenge_method": "S256",
     },
 )
 

--- a/backend/decorators/auth.py
+++ b/backend/decorators/auth.py
@@ -65,14 +65,8 @@ oauth.register(
     client_kwargs={
         "scope": f"openid profile email {OIDC_CLAIM_ROLES}".strip(),
         "verify": OIDC_TLS_CACERTFILE,
-        # PKCE (RFC 7636). Authlib only derives a code_verifier when
-        # code_challenge_method is set, so without this the authorization
-        # request carries no code_challenge at all. Providers that mandate
-        # PKCE then refuse to issue the code: the user authenticates fine and
-        # is redirected back without a `code`, surfacing as a generic login
-        # failure. Providers that don't support PKCE ignore the extra
-        # parameters (OIDC Core 3.1.2.1), so sending it unconditionally is
-        # backwards-compatible -- and OAuth 2.1 requires it of every client.
+        # Authlib only derives a code_verifier when code_challenge_method is set,
+        # so providers that mandate PKCE refuse the code without it.
         "code_challenge_method": "S256",
     },
 )

--- a/backend/tests/decorators/test_auth.py
+++ b/backend/tests/decorators/test_auth.py
@@ -6,21 +6,12 @@ from decorators.auth import oauth
 
 
 def test_oidc_client_is_configured_for_pkce():
-    """The OIDC client must ask Authlib for PKCE.
-
-    Authlib only derives a code_verifier when code_challenge_method is set on
-    the client, so this kwarg is what makes the whole flow PKCE-capable.
-    """
+    """Authlib only derives a code_verifier when this kwarg is set."""
     assert oauth.openid.client_kwargs["code_challenge_method"] == "S256"
 
 
 def test_authorization_url_carries_a_code_challenge():
-    """The configured method must actually yield PKCE parameters.
-
-    Guards the end of the chain: providers that mandate PKCE reject an
-    authorization request with no code_challenge, so asserting the kwarg
-    alone would not prove the request is well-formed.
-    """
+    """The configured method must reach the authorization URL itself."""
     client = AsyncOAuth2Client(
         client_id="romm",
         code_challenge_method=oauth.openid.client_kwargs["code_challenge_method"],

--- a/backend/tests/decorators/test_auth.py
+++ b/backend/tests/decorators/test_auth.py
@@ -1,8 +1,16 @@
+import hashlib
+from base64 import urlsafe_b64encode
+from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
 
-from authlib.integrations.httpx_client import AsyncOAuth2Client
+import pytest
 
 from decorators.auth import oauth
+
+
+def _s256(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
 
 def test_oidc_client_is_configured_for_pkce():
@@ -10,17 +18,27 @@ def test_oidc_client_is_configured_for_pkce():
     assert oauth.openid.client_kwargs["code_challenge_method"] == "S256"
 
 
-def test_authorization_url_carries_a_code_challenge():
-    """The configured method must reach the authorization URL itself."""
-    client = AsyncOAuth2Client(
-        client_id="romm",
-        code_challenge_method=oauth.openid.client_kwargs["code_challenge_method"],
+@pytest.mark.asyncio
+async def test_authorize_redirect_sends_a_challenge_matching_the_stored_verifier(
+    monkeypatch,
+):
+    """The callback can only redeem the code if these two halves agree."""
+    monkeypatch.setitem(
+        oauth.openid.server_metadata,
+        "authorization_endpoint",
+        "https://idp.example.com/authorize",
+    )
+    monkeypatch.setitem(oauth.openid.server_metadata, "_loaded_at", 0.0)
+    request = SimpleNamespace(session={})
+
+    response = await oauth.openid.authorize_redirect(
+        request, "https://romm.example.com/api/oauth/openid"
     )
 
-    url, _state = client.create_authorization_url(
-        "https://idp.example.com/authorize", code_verifier="a" * 48
-    )
-
-    params = parse_qs(urlparse(url).query)
+    params = parse_qs(urlparse(response.headers["location"]).query)
     assert params["code_challenge_method"] == ["S256"]
-    assert params["code_challenge"]
+
+    state_data = await oauth.openid.framework.get_state_data(
+        request.session, params["state"][0]
+    )
+    assert params["code_challenge"] == [_s256(state_data["code_verifier"])]

--- a/backend/tests/decorators/test_auth.py
+++ b/backend/tests/decorators/test_auth.py
@@ -1,0 +1,35 @@
+from urllib.parse import parse_qs, urlparse
+
+from authlib.integrations.httpx_client import AsyncOAuth2Client
+
+from decorators.auth import oauth
+
+
+def test_oidc_client_is_configured_for_pkce():
+    """The OIDC client must ask Authlib for PKCE.
+
+    Authlib only derives a code_verifier when code_challenge_method is set on
+    the client, so this kwarg is what makes the whole flow PKCE-capable.
+    """
+    assert oauth.openid.client_kwargs["code_challenge_method"] == "S256"
+
+
+def test_authorization_url_carries_a_code_challenge():
+    """The configured method must actually yield PKCE parameters.
+
+    Guards the end of the chain: providers that mandate PKCE reject an
+    authorization request with no code_challenge, so asserting the kwarg
+    alone would not prove the request is well-formed.
+    """
+    client = AsyncOAuth2Client(
+        client_id="romm",
+        code_challenge_method=oauth.openid.client_kwargs["code_challenge_method"],
+    )
+
+    url, _state = client.create_authorization_url(
+        "https://idp.example.com/authorize", code_verifier="a" * 48
+    )
+
+    params = parse_qs(urlparse(url).query)
+    assert params["code_challenge_method"] == ["S256"]
+    assert params["code_challenge"]


### PR DESCRIPTION
**Description**

RomM's OIDC client never sends a PKCE `code_challenge`, so it cannot authenticate against any provider that requires PKCE.

Authlib only derives a `code_verifier` when `code_challenge_method` is set on the client. `backend/decorators/auth.py` doesn't set it, so `create_authorization_url()` emits no `code_challenge` or `code_challenge_method` at all. That one kwarg is what makes the flow PKCE-capable:

```python
client_kwargs={
    "scope": f"openid profile email {OIDC_CLAIM_ROLES}".strip(),
    "verify": OIDC_TLS_CACERTFILE,
    "code_challenge_method": "S256",   # added
},
```

**Why this matters**

Providers that mandate PKCE accept the login, then refuse to issue the authorization code and redirect back to `/api/oauth/openid` with an error and no `code`. To the user it looks like a generic login failure. The RomM logs show a successful discovery fetch and a clean 302, so there is nothing obviously wrong to point at, which makes it an unpleasant one to debug.

This is not a niche configuration. PKCE for confidential clients is required by OAuth 2.1 (draft-ietf-oauth-v2-1, section 4.1.1), and [OAuth 2.0 Security Best Current Practice](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics) has recommended it for years. Providers are steadily making it non-optional.

**Compatibility**

Safe to send unconditionally. Under OIDC Core section 3.1.2.1, unrecognized authorization-request parameters are ignored, so providers without PKCE support are unaffected. That is why this is a plain default rather than a new env var: nothing to configure, and no behaviour change for anyone whose login works today.

**Testing**

Verified against a real PKCE-mandating provider (a self-hosted OIDC IdP), not only in unit tests.

Before the change, the provider rejects RomM's authorization request outright:

```
error=invalid_request&error_description=code_challenge_method+must+be+S256
```

After, RomM's own `/api/login/openid` redirect carries valid parameters and the provider serves the login challenge:

```
client_id: romm
response_type: code
scope: openid profile email groups
code_challenge_method: S256
code_challenge: present (43 chars)
```

43 characters is the expected length for a base64url-encoded SHA-256 digest.

`backend/tests/decorators/test_auth.py` adds two tests: one asserting the client kwarg, one asserting that a generated authorization URL actually carries `code_challenge` and `code_challenge_method`. The second covers the end of the chain, since asserting the kwarg alone would not prove the resulting request is well-formed. Both fail without the fix. The auth suite (172 tests) passes, and `trunk fmt` / `trunk check` are clean.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

---

**AI assistance disclosure**

Per CONTRIBUTING.md: this PR was written with AI assistance (Claude), covering the code change, the tests, and this description. I directed the work and reviewed the result. The root cause was confirmed by reading Authlib's source to establish that `code_challenge_method` is what gates verifier derivation, and the fix was validated against a live PKCE-mandating provider as described above before submitting. The patched build has been running in my homelab since.
