### PR TITLE
fix: Preserve nested arcade ROM filenames

### DIFF
--- a/frontend/src/utils/index.test.ts
+++ b/frontend/src/utils/index.test.ts
@@ -12,11 +12,41 @@ function makeRom(overrides: Partial<SimpleRom>): SimpleRom {
 }
 
 describe("getDownloadPath", () => {
-  it("uses fs_name when no file is selected", () => {
-    const rom = makeRom({ id: 14, fs_name: "Maniac Mansion (1989).adf" });
+  it("uses fs_name for a flat single-file rom", () => {
+    const rom = makeRom({
+      id: 14,
+      fs_name: "Maniac Mansion (1989).adf",
+      has_nested_single_file: false,
+      files: [
+        { id: 19, file_name: "Maniac Mansion (1989).adf" },
+      ] as SimpleRom["files"],
+    });
     expect(getDownloadPath({ rom })).toBe(
       "/api/roms/14/content/Maniac Mansion (1989).adf",
     );
+  });
+
+  it("uses the file name for a nested single-file rom", () => {
+    const rom = makeRom({
+      id: 21,
+      fs_name: "Art Of Fighting",
+      has_nested_single_file: true,
+      files: [{ id: 26, file_name: "aof.zip" }] as SimpleRom["files"],
+    });
+    expect(getDownloadPath({ rom })).toBe("/api/roms/21/content/aof.zip");
+  });
+
+  it("uses fs_name for an unselected multi-file rom", () => {
+    const rom = makeRom({
+      id: 24,
+      fs_name: "B.A.T.",
+      has_nested_single_file: false,
+      files: [
+        { id: 29, file_name: "B.A.T. Disk1.adf" },
+        { id: 30, file_name: "B.A.T. Disk2.adf" },
+      ] as SimpleRom["files"],
+    });
+    expect(getDownloadPath({ rom })).toBe("/api/roms/24/content/B.A.T.");
   });
 
   it("uses the selected file name (with extension) for a single file", () => {

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -132,8 +132,15 @@ export function getDownloadPath({
     fileIDs.length === 1
       ? rom.files?.find((f) => f.id === fileIDs[0])
       : undefined;
-  const contentName = selectedFile
-    ? encodeURIComponent(selectedFile.file_name)
+  const nestedFile =
+    fileIDs.length === 0 &&
+    rom.has_nested_single_file &&
+    rom.files?.length === 1
+      ? rom.files[0]
+      : undefined;
+  const contentFile = selectedFile ?? nestedFile;
+  const contentName = contentFile
+    ? encodeURIComponent(contentFile.file_name)
     : rom.fs_name;
 
   return `/api/roms/${rom.id}/content/${contentName}${


### PR DESCRIPTION
**Description**

`getDownloadPath` derived the content path segment from `rom.fs_name` whenever
no explicit file selection was supplied. For a nested single-file ROM — an
arcade entry whose directory holds exactly one file — that produced the
directory name rather than the real filename, so the download arrived named
after the folder (`.../content/Art Of Fighting` instead of `.../content/aof.zip`).

This adds a `nestedFile` branch: when no `file_ids` were selected, the ROM is
flagged `has_nested_single_file`, and it has exactly one entry in `files`, that
entry's `file_name` becomes the content segment. Every other branch is
untouched — flat single-file ROMs, explicitly selected discs, multi-file ZIP
downloads, and unknown file IDs all resolve exactly as before.

The decision stays in the shared helper rather than adding player-specific
configuration, so the existing EmulatorJS, console, Ruffle, and download call
sites all receive a correctly named payload with no new wiring.

**Checklist**

- [ ] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Unit tests in `frontend/src/utils/index.test.ts` cover the new nested
single-file case and pin the unchanged flat single-file and multi-file
behaviors. The other boxes are left unchecked because those steps were not
performed.

#### Screenshots (if applicable)

Not applicable — this changes a download URL path, with no UI surface.

Fixes #1893

AI was used for assistance.
