### PR TITLE
chore(deps): upgrade rq to 2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "python-magic ~= 0.4",
   "python-socketio ~= 5.16",
   "redis ~= 6.2",
-  "rq ~= 2.7",
+  "rq ~= 2.11",
   # TODO: Move back to upstream `rq-scheduler`, when support for username and SSL settings is added.
   #       Related PR: https://github.com/rq/rq-scheduler/pull/325
   "rq-scheduler @ git+https://github.com/adamantike/rq-scheduler.git@feat/script-options-username-ssl",
@@ -146,7 +146,10 @@ package = false
 exclude-newer = "7 days"
 # vcrpy >= 8.2.0 is required for aiohttp 3.14 compatibility (the removal of
 # `AsyncStreamReaderMixin`); allow it past the rolling 7-day window.
-exclude-newer-package = { vcrpy = "2026-06-17" }
+# rq 2.11.0 carries the scheduler locking and cron job history the scheduler
+# migration builds on. The rolling window reaches it on 2026-08-24, after which
+# this entry can go.
+exclude-newer-package = { vcrpy = "2026-06-17", rq = "2026-08-17" }
 
 [tool.ty.environment]
 root = ["./backend"]

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
+rq = "2026-08-18T05:00:00Z"
 vcrpy = "2026-06-18T05:00:00Z"
 
 [[package]]
@@ -2319,7 +2320,7 @@ requires-dist = [
     { name = "python-socketio", specifier = "~=5.16" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "redis", specifier = "~=6.2" },
-    { name = "rq", specifier = "~=2.7" },
+    { name = "rq", specifier = "~=2.11" },
     { name = "rq-scheduler", git = "https://github.com/adamantike/rq-scheduler.git?rev=feat%2Fscript-options-username-ssl" },
     { name = "sentry-sdk", specifier = "~=2.32" },
     { name = "sqlalchemy", extras = ["mariadb-connector", "mysql-connector", "postgresql-psycopg"], specifier = "~=2.0" },
@@ -2343,16 +2344,16 @@ provides-extras = ["dev", "test"]
 
 [[package]]
 name = "rq"
-version = "2.9.0"
+version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "croniter" },
     { name = "redis" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/5e/43a7a61f3ebfa79789c72bf442a47fd80bb1a743caeea47b2b833001f388/rq-2.9.0.tar.gz", hash = "sha256:db5dfc1e1fe80ef977fd557d4305107dcf99a80b33d381c9a06e8a2bb11730e5", size = 744959, upload-time = "2026-05-19T15:00:29.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/8a/7fcf759b5b685b26ef029af24575359bf8f5b5b340d92b08bb193a4163b1/rq-2.11.0.tar.gz", hash = "sha256:1ed9db6b685707a7dfd535532a408f1a8f0a5ad720a307be6b844f4142999e78", size = 759304, upload-time = "2026-08-17T02:59:19.695Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/a9/aa38ae2505e5dcb1e898f83a263e703b05829580f75ee86c5e480760ae1a/rq-2.9.0-py3-none-any.whl", hash = "sha256:665b9ad34e36ea15913e60d2a32e1775fef1e9aff907bcae297d6f70dccffed2", size = 120113, upload-time = "2026-05-19T15:00:27.511Z" },
+    { url = "https://files.pythonhosted.org/packages/80/1e/f85cba91fe58c63812b4acce073fc448230381c4785e03832f455305ff82/rq-2.11.0-py3-none-any.whl", hash = "sha256:2f54a31375d7c1b5a1642acef4948809ce6484775b9741fe7edd9399ec9306a9", size = 126654, upload-time = "2026-08-17T02:59:17.112Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Description**

`uv.lock` sat on rq 2.9.0 while `pyproject.toml` allowed anything under 3.0, so the floor now names the version the code is actually tested against.

2.11 is the release the scheduler work ahead needs:

- `RQScheduler` acquires and refreshes its lock before enqueueing, which matters as soon as delayed jobs are released by a worker rather than a separate process.
- Each `CronJob` has a name and keeps the ids of the jobs it created (`cron_job.get_job_ids()`) — the introspection a move to `rq cron` would otherwise cost, since cron state stops living in Redis.
- Calling `create_cron()` more than once no longer duplicates jobs.

2.10 also added webhook notifications and a stable scheduler identity, and 2.9.1 covers `redis-py` >= 8.

The constraint stays under 3.0 deliberately: that release moves `get_current_job()` to `contextvars`, reworks dependency handling behind a `ReadyJobRegistry`, and changes the `Worker.handle_job_success()` signature, which `RomMWorker` subclasses around.

**Note on the quarantine window**

2.11.0 was published on 2026-08-17, so it is still inside the rolling 7-day `exclude-newer` window and needs a per-package exclusion to resolve today. The window reaches it on **2026-08-24**, after which the entry can be deleted and the constraint resolves on its own — happy to drop the override and let it land that way instead, if you would rather not bypass the window at all.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

<sup>No tests added: this is a dependency bump with no behaviour change of its own.</sup>

**Testing**

Full backend suite green (3003 passed, 2 skipped), `trunk fmt && trunk check` clean, and the lockfile diff touches nothing but rq.

Also verified against a real Redis, since the suite's coverage of the scheduler is mostly mocked. Every rq internal the `rq-scheduler` fork reaches into still exists in 2.11 (`rq.utils.backend_class`, `rq.utils.import_attribute`, `rq.logutils.ColorizingStreamHandler`, `Queue.from_queue_key`, `Queue.enqueue_job`, `job.enqueue_at_front`), and each scheduler API RomM uses still behaves: `enqueue_in` and `cron` produce `SCHEDULED` jobs with the expected `func_name`, `get_jobs(with_times=True)` returns due times, a past-due job is queued by `enqueue_jobs()`, and `cancel()` clears the registry entry.

One thing that surfaced while testing, unrelated to this bump: `rq-scheduler` calls `crontab.CronTab.next()` without `default_utc`, which now emits a `FutureWarning` about the coming `utcnow()` change in crontab 0.22+.

**AI assistance disclosure**

This change was written with AI assistance (Claude Opus 5 via Claude Code). The changelog review, the compatibility checks, and this description were AI-generated, then verified by me against the rq sources and a local run of the suite plus the real-Redis checks described above.
