### PR TITLE
fix: map Neo Geo MVS/AES to the RetroAchievements Arcade console

### DIFF
--- a/backend/handler/metadata/ra_handler.py
+++ b/backend/handler/metadata/ra_handler.py
@@ -430,6 +430,8 @@ RA_PLATFORM_LIST: dict[UPS, SlugToRAId] = {
     UPS.FAMICOM: {"id": 7, "name": "Family Computer"},
     UPS.FDS: {"id": 81, "name": "Famicom Disk System"},
     UPS.NEO_GEO_CD: {"id": 56, "name": "Neo Geo CD"},
+    UPS.NEOGEOAES: {"id": 27, "name": "Neo Geo AES"},
+    UPS.NEOGEOMVS: {"id": 27, "name": "Neo Geo MVS"},
     UPS.NEO_GEO_POCKET: {"id": 14, "name": "Neo Geo Pocket"},
     UPS.NEO_GEO_POCKET_COLOR: {
         "id": 14,


### PR DESCRIPTION
**Description**

Neo Geo MVS/AES ROMs never matched on RetroAchievements, even with a valid RA hash.

`RA_PLATFORM_LIST` had no entry for the `neogeomvs` / `neogeoaes` slugs, so `RAHandler.get_platform()` returned `ra_id=None`, the platform was stored without an RA id, and the scan skipped RAHasher entirely: no `ra_hash` was ever computed, so there was nothing to look up.

RetroAchievements files Neo Geo cartridge games under the **Arcade** console (ID 27), hashed by FBNeo. Confirmed against the API for the game linked in the issue:

```
API_GetGame.php?i=11758 -> {"Title":"Art of Fighting","ConsoleID":27,"ConsoleName":"Arcade"}
API_GetGameHashes.php?i=11758 -> "aof.7z ...", MD5 df4a8b32238c36921a260ed6ab784850, Labels ["fbneo"]
```

That hash is `md5("aof")`, i.e. the Arcade basename hash RomM already computes, so mapping both slugs to console 27 is all that is needed. The existing Arcade special-cases in `RAHasherService` key off the RA id, so archived MVS ROMs correctly bypass extraction (which would rename the file and break the basename hash).

The display names stay platform-specific ("Neo Geo MVS" / "Neo Geo AES") rather than "Arcade", matching how the other aliases in this table are handled (SuperGrafx, Super Famicom, MSX2).

Existing libraries need a rescan of the platform for the RA id to be stored.

Fixes #4279

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

**AI assistance disclosure**

This change was written with AI assistance (Claude Code): the investigation and the fix were AI-authored and reviewed by me before submitting.