### PR TITLE
feat(hasheous): make the Hasheous API URL configurable

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -124,6 +124,11 @@ PLAYMATCH_API_URL: Final[str] = _get_env(
 
 # HASHEOUS
 HASHEOUS_API_ENABLED: Final[bool] = safe_str_to_bool(_get_env("HASHEOUS_API_ENABLED"))
+# Base URL of the Hasheous API, overridable to point at a self-hosted instance.
+HASHEOUS_API_URL: Final[str] = _get_env(
+    "HASHEOUS_API_URL",
+    "https://beta.hasheous.org/api/v1" if DEV_MODE else "https://hasheous.org/api/v1",
+).rstrip("/")
 
 # THEGAMESDB
 TGDB_API_ENABLED: Final[bool] = safe_str_to_bool(_get_env("TGDB_API_ENABLED"))

--- a/backend/handler/metadata/hasheous_handler.py
+++ b/backend/handler/metadata/hasheous_handler.py
@@ -4,9 +4,10 @@ from typing import Any, NotRequired, TypedDict
 
 import httpx
 import pydash
+import yarl
 from fastapi import HTTPException, status
 
-from config import DEV_MODE, HASHEOUS_API_ENABLED
+from config import DEV_MODE, HASHEOUS_API_ENABLED, HASHEOUS_API_URL
 from logger.logger import log
 from models.rom import RomFile
 from utils import get_version
@@ -127,11 +128,9 @@ def extract_metadata_from_igdb_rom(rom: dict[str, Any]) -> IGDBMetadata:
 
 class HasheousHandler(MetadataHandler):
     def __init__(self) -> None:
-        self.BASE_URL = (
-            "https://beta.hasheous.org/api/v1"
-            if DEV_MODE
-            else "https://hasheous.org/api/v1"
-        )
+        self.BASE_URL = HASHEOUS_API_URL
+        # Cover art is linked relative to the site root, not the API path.
+        self.BASE_ORIGIN = str(yarl.URL(self.BASE_URL).origin())
         self.healthcheck_endpoint = f"{self.BASE_URL}/HealthCheck"
         self.platform_endpoint = f"{self.BASE_URL}/Lookup/Platforms"
         self.games_endpoint = f"{self.BASE_URL}/Lookup/ByHash"
@@ -345,7 +344,7 @@ class HasheousHandler(MetadataHandler):
         url_cover = ""
         for attr in attributes:
             if attr["attributeName"] == "Logo":
-                url_cover = f"https://hasheous.org{attr['link']}"
+                url_cover = f"{self.BASE_ORIGIN}{attr['link']}"
                 break
 
         return (

--- a/backend/handler/metadata/hasheous_handler.py
+++ b/backend/handler/metadata/hasheous_handler.py
@@ -130,7 +130,14 @@ class HasheousHandler(MetadataHandler):
     def __init__(self) -> None:
         self.BASE_URL = HASHEOUS_API_URL
         # Cover art is linked relative to the site root, not the API path.
-        self.BASE_ORIGIN = str(yarl.URL(self.BASE_URL).origin())
+        try:
+            self.BASE_ORIGIN = str(yarl.URL(self.BASE_URL).origin())
+        except ValueError:
+            log.warning(
+                "Invalid HASHEOUS_API_URL %r, cover art URLs may be wrong",
+                self.BASE_URL,
+            )
+            self.BASE_ORIGIN = ""
         self.healthcheck_endpoint = f"{self.BASE_URL}/HealthCheck"
         self.platform_endpoint = f"{self.BASE_URL}/Lookup/Platforms"
         self.games_endpoint = f"{self.BASE_URL}/Lookup/ByHash"

--- a/backend/utils/ssrf.py
+++ b/backend/utils/ssrf.py
@@ -42,7 +42,7 @@ from httpcore._backends.base import (
 )
 from httpcore._backends.sync import SyncBackend
 
-from config import PLAYMATCH_API_URL
+from config import HASHEOUS_API_URL, PLAYMATCH_API_URL
 from logger.logger import log
 from utils.validation import ValidationError
 
@@ -118,7 +118,7 @@ def _parse_origin(origin: str) -> tuple[str, int] | None:
 # Origins the admin explicitly configured are trusted to reach private addresses.
 # Matched by exact host and port so the exception stays as narrow as possible.
 INTERNAL_ORIGIN_ALLOWLIST: frozenset[tuple[str, int]] = frozenset(
-    pydash.compact([_parse_origin(PLAYMATCH_API_URL)])
+    pydash.compact([_parse_origin(PLAYMATCH_API_URL), _parse_origin(HASHEOUS_API_URL)])
 )
 
 

--- a/env.template
+++ b/env.template
@@ -70,6 +70,7 @@ PLAYMATCH_API_ENABLED=false  # Enable PlayMatch API integration
 # PLAYMATCH_API_URL=https://playmatch.retrorealm.dev/api/v2  # Point at a self-hosted PlayMatch instance
 LAUNCHBOX_API_ENABLED=false  # Enable LaunchBox API integration
 HASHEOUS_API_ENABLED=false  # Enable Hasheous API integration
+# HASHEOUS_API_URL=https://hasheous.org/api/v1  # Point at a self-hosted Hasheous instance
 FLASHPOINT_API_ENABLED=false  # Enable Flashpoint API integration
 HLTB_API_ENABLED=false  # Enable HowLongToBeat API integration
 TGDB_API_ENABLED=false  # Enable TheGamesDB API integration


### PR DESCRIPTION
Closes #4288.

`HasheousHandler` hardcodes `https://hasheous.org/api/v1`, so a self-hosted Hasheous instance is unreachable. This adds `HASHEOUS_API_URL`, shaped exactly like the existing `PLAYMATCH_API_URL`: a full base URL, defaulting to the current value and still selecting the beta host under `DEV_MODE`. Leaving it unset changes nothing.

Two things beyond swapping the constant turned out to be necessary:

**Cover art.** Logo links come back relative to the site root rather than the API path, so `lookup_rom` built them from a second hardcoded `https://hasheous.org`. That origin is now derived from the configured URL with `yarl`, which the codebase already uses for URLs elsewhere.

**SSRF allowlist.** A self-hosted instance usually sits on a private address — a LAN host, or a container on the same Docker network — and `_pick_safe_address` rejects those. `INTERNAL_ORIGIN_ALLOWLIST` exists for exactly this case ("origins the admin explicitly configured are trusted to reach private addresses"), so the Hasheous origin joins Playmatch's there. Without this, setting the variable to anything private connects and then fails, which would be a confusing thing to debug.

### Note on the client API key

This PR covers the URL only, which is what #4288 asked for. Worth knowing for anyone self-hosting: Hasheous puts `[ClientApiKey()]` on `MetadataProxyController` but not on `LookupController`, so hash lookups work against a self-hosted instance with the key RomM already sends, while the IGDB/RA proxy calls will 401 unless that instance has RomM's key registered. If you would like `HASHEOUS_API_KEY` as a follow-up, I am happy to add it — I left it out to keep this change to what was requested.

### Testing

- `ruff`, `black` and `isort` clean using the repo's `.trunk/configs`.
- Verified `yarl.URL(...).origin()` returns the expected origin for both the default and a container-name URL.
- Verified `_parse_origin` yields the right `(host, port)` for the default, a container name with and without an explicit port, a Tailscale hostname and a LAN address.
- I could not run the pytest suite locally: `uv sync` fails to build the `mariadb` package without MariaDB Connector/C on this machine. The SSRF tests pass an explicit `allowlist` into the backends rather than exercising `INTERNAL_ORIGIN_ALLOWLIST`, so this change is not covered by them; I did not add a test because the Playmatch entry it mirrors has none either, but say the word and I will.

### AI assistance disclosure

This PR was written primarily by Claude Code, including the code, this description and the investigation behind them. I reviewed the result and it is running against a self-hosted Hasheous instance on my own setup. Any replies from me on this PR may also be drafted by Claude Code.
