### PR TITLE
refactor(v2): extract a shared player shell

### DIFF
--- a/frontend/src/v2/components/Player/PlayerShell.test.ts
+++ b/frontend/src/v2/components/Player/PlayerShell.test.ts
@@ -1,0 +1,136 @@
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SimpleRom } from "@/stores/roms";
+import PlayerShell from "./PlayerShell.vue";
+
+const mocks = vi.hoisted(() => ({ push: vi.fn() }));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock("@/plugins/router", () => ({
+  ROUTES: { ROM: "rom", PLATFORM: "platform" },
+}));
+
+vi.mock("@/v2/components/shared/GameCover.vue", () => ({
+  default: { template: "<div class='game-cover' />" },
+}));
+
+const heroRom = { id: 1, platform_id: 2 } as unknown as SimpleRom;
+
+function mountShell(
+  props: Partial<{
+    heroRom: SimpleRom | null;
+    ready: boolean;
+    running: boolean;
+    quitting: boolean;
+  }> = {},
+): VueWrapper {
+  return mount(PlayerShell, {
+    props: {
+      heroRom,
+      title: "Game",
+      platformLabel: "Platform",
+      romId: 1,
+      ready: true,
+      running: false,
+      ...props,
+    },
+    slots: { stage: "<div class='stage' />" },
+    global: {
+      stubs: {
+        RBtn: {
+          props: ["disabled"],
+          emits: ["click"],
+          template:
+            '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+        },
+        RCard: { template: "<div><slot /></div>" },
+        RSpinner: true,
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  mocks.push.mockReset();
+});
+
+describe("PlayerShell", () => {
+  it("waits on a spinner until a hero is available", () => {
+    const wrapper = mountShell({ heroRom: null });
+
+    expect(wrapper.findComponent({ name: "RSpinner" }).exists()).toBe(true);
+    expect(wrapper.find(".r-v2-player__play").exists()).toBe(false);
+  });
+
+  it("blocks play until the full payload has landed", async () => {
+    const wrapper = mountShell({ ready: false });
+
+    const play = wrapper.get(".r-v2-player__play");
+    expect(play.attributes("disabled")).toBeDefined();
+
+    await play.trigger("click");
+    expect(wrapper.emitted("play")).toBeUndefined();
+  });
+
+  it("emits play once the payload is ready", async () => {
+    const wrapper = mountShell();
+
+    await wrapper.get(".r-v2-player__play").trigger("click");
+
+    expect(wrapper.emitted("play")).toHaveLength(1);
+  });
+
+  it("navigates back to the game and to its platform", async () => {
+    const wrapper = mountShell();
+
+    const buttons = wrapper.findAll("button");
+    await buttons[1]!.trigger("click");
+    await buttons[2]!.trigger("click");
+
+    expect(mocks.push).toHaveBeenNthCalledWith(1, {
+      name: "rom",
+      params: { rom: 1 },
+    });
+    expect(mocks.push).toHaveBeenNthCalledWith(2, {
+      name: "platform",
+      params: { platform: 2 },
+    });
+  });
+
+  it("skips the gallery link when the hero carries no platform", async () => {
+    const wrapper = mountShell({
+      heroRom: { id: 1 } as unknown as SimpleRom,
+    });
+
+    await wrapper.findAll("button")[2]!.trigger("click");
+
+    expect(mocks.push).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: "platform" }),
+    );
+  });
+
+  it("swaps the config panel for the stage while running", async () => {
+    const wrapper = mountShell({ running: true });
+
+    expect(wrapper.find(".stage").exists()).toBe(true);
+    expect(wrapper.find(".r-v2-player__play").exists()).toBe(false);
+
+    await wrapper.get(".r-v2-player__quit").trigger("click");
+    expect(wrapper.emitted("quit")).toHaveLength(1);
+  });
+
+  it("keeps the quit button busy while an exit is still saving", () => {
+    const wrapper = mountShell({ running: true, quitting: true });
+
+    expect(
+      wrapper.get(".r-v2-player__quit").attributes("disabled"),
+    ).toBeDefined();
+  });
+});

--- a/frontend/src/v2/components/Player/PlayerShell.vue
+++ b/frontend/src/v2/components/Player/PlayerShell.vue
@@ -3,28 +3,21 @@
 // settings card, play and back buttons, and the full-bleed running stage. A
 // player supplies only the controls above the Play button and whatever it
 // mounts as a stage, through the `settings` and `stage` slots.
-//
-// EmulatorJS deliberately does not use this: its hero lives inside a card with
-// an alt-art glow and it lays out three panels on its own breakpoints. It takes
-// `usePlayerHero` instead.
 import { RBtn, RCard, RSpinner } from "@v2/lib";
 import { useI18n } from "vue-i18n";
-import { useRouter } from "vue-router";
-import { ROUTES } from "@/plugins/router";
 import type { DetailedRom, SimpleRom } from "@/stores/roms";
 import GameCover from "@/v2/components/shared/GameCover.vue";
+import { usePlayerNav } from "@/v2/composables/usePlayerNav";
 
 interface Props {
   /** Full rom once loaded, else the cover-only seed during the morph-in. */
   heroRom: DetailedRom | SimpleRom | null;
   title: string;
   platformLabel: string;
-  /** Route rom id, bound before `heroRom` resolves so the morph tag paints. */
+  /** Route rom id, so the morph tag matches even while the hero is a seed. */
   romId: number;
-  /** The full payload has landed, so the game can actually boot. */
   ready: boolean;
   running: boolean;
-  /** Keeps the quit button busy while an exit is still saving. */
   quitting?: boolean;
 }
 
@@ -36,17 +29,10 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-const router = useRouter();
-
-function backToRom() {
-  router.push({ name: ROUTES.ROM, params: { rom: props.romId } });
-}
-
-function backToPlatform() {
-  const platformId = props.heroRom?.platform_id;
-  if (platformId == null) return;
-  router.push({ name: ROUTES.PLATFORM, params: { platform: platformId } });
-}
+const { backToRom, backToPlatform } = usePlayerNav(
+  props.romId,
+  () => props.heroRom?.platform_id,
+);
 </script>
 
 <template>
@@ -110,7 +96,9 @@ function backToPlatform() {
         </div>
       </RCard>
 
-      <slot name="brand" />
+      <div v-if="$slots.brand" class="r-v2-player__brand">
+        <slot name="brand" />
+      </div>
     </div>
 
     <div v-else class="r-v2-player__stage-wrap">
@@ -196,6 +184,11 @@ function backToPlatform() {
 
 .r-v2-player__play {
   margin-top: 8px;
+}
+
+.r-v2-player__brand {
+  grid-column: 1 / -1;
+  margin-top: 12px;
 }
 
 .r-v2-player__stage-wrap {

--- a/frontend/src/v2/components/Player/PlayerShell.vue
+++ b/frontend/src/v2/components/Player/PlayerShell.vue
@@ -1,0 +1,227 @@
+<script setup lang="ts">
+// PlayerShell — the pre-game chrome a simple v2 player needs: cover column,
+// settings card, play and back buttons, and the full-bleed running stage. A
+// player supplies only the controls above the Play button and whatever it
+// mounts as a stage, through the `settings` and `stage` slots.
+//
+// EmulatorJS deliberately does not use this: its hero lives inside a card with
+// an alt-art glow and it lays out three panels on its own breakpoints. It takes
+// `usePlayerHero` instead.
+import { RBtn, RCard, RSpinner } from "@v2/lib";
+import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
+import { ROUTES } from "@/plugins/router";
+import type { DetailedRom, SimpleRom } from "@/stores/roms";
+import GameCover from "@/v2/components/shared/GameCover.vue";
+
+interface Props {
+  /** Full rom once loaded, else the cover-only seed during the morph-in. */
+  heroRom: DetailedRom | SimpleRom | null;
+  title: string;
+  platformLabel: string;
+  /** Route rom id, bound before `heroRom` resolves so the morph tag paints. */
+  romId: number;
+  /** The full payload has landed, so the game can actually boot. */
+  ready: boolean;
+  running: boolean;
+  /** Keeps the quit button busy while an exit is still saving. */
+  quitting?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), { quitting: false });
+
+const emit = defineEmits<{
+  play: [];
+  quit: [];
+}>();
+
+const { t } = useI18n();
+const router = useRouter();
+
+function backToRom() {
+  router.push({ name: ROUTES.ROM, params: { rom: props.romId } });
+}
+
+function backToPlatform() {
+  const platformId = props.heroRom?.platform_id;
+  if (platformId == null) return;
+  router.push({ name: ROUTES.PLATFORM, params: { platform: platformId } });
+}
+</script>
+
+<template>
+  <section v-if="heroRom" class="r-v2-player">
+    <div v-if="!running" class="r-v2-player__config">
+      <aside class="r-v2-player__cover">
+        <GameCover
+          class="r-v2-player__cover-box"
+          :rom="heroRom"
+          :title="title"
+          :identified="heroRom?.is_identified ?? true"
+          :morph-id="romId"
+          style-context="player"
+          morph-static
+          hover-motion
+        />
+        <h1 class="r-v2-player__title">
+          {{ title }}
+        </h1>
+        <p class="r-v2-player__subtitle">
+          {{ platformLabel }}
+        </p>
+      </aside>
+
+      <RCard class="r-v2-player__panel" variant="flat">
+        <div class="r-v2-player__settings">
+          <slot name="settings" />
+
+          <RBtn
+            size="large"
+            variant="flat"
+            color="primary"
+            block
+            prepend-icon="mdi-play-circle"
+            class="r-v2-player__play"
+            :loading="!ready"
+            :disabled="!ready"
+            @click="emit('play')"
+          >
+            {{ t("play.play") }}
+          </RBtn>
+
+          <RBtn
+            block
+            variant="text"
+            size="small"
+            prepend-icon="mdi-arrow-left"
+            @click="backToRom"
+          >
+            {{ t("play.back-to-game-details") }}
+          </RBtn>
+          <RBtn
+            block
+            variant="text"
+            size="small"
+            prepend-icon="mdi-view-grid-outline"
+            @click="backToPlatform"
+          >
+            {{ t("play.back-to-gallery") }}
+          </RBtn>
+        </div>
+      </RCard>
+
+      <slot name="brand" />
+    </div>
+
+    <div v-else class="r-v2-player__stage-wrap">
+      <slot name="stage" />
+      <RBtn
+        class="r-v2-player__quit"
+        variant="translucent"
+        prepend-icon="mdi-exit-to-app"
+        :loading="quitting"
+        :disabled="quitting"
+        @click="emit('quit')"
+      >
+        {{ t("play.quit") }}
+      </RBtn>
+    </div>
+  </section>
+
+  <section v-else class="r-v2-player__loading">
+    <RSpinner :size="40" :aria-label="t('common.loading')" />
+  </section>
+</template>
+
+<style scoped>
+.r-v2-player {
+  position: relative;
+  min-height: calc(100vh - var(--r-nav-h));
+  padding: 24px var(--r-row-pad) 48px;
+}
+
+.r-v2-player__config {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 24px;
+  max-width: 820px;
+  margin: 0 auto;
+}
+
+.r-v2-player__cover {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 8px;
+}
+
+.r-v2-player__cover-box {
+  --r-cover-radius: var(--r-radius-lg);
+}
+/* 2D box art keeps a drop shadow; alt-art floats frame-free. */
+.r-v2-player__cover-box:not(.game-cover--alt) {
+  box-shadow: 0 18px 36px color-mix(in srgb, black 55%, transparent);
+}
+
+.r-v2-player__title {
+  margin: 10px 0 0;
+  font-size: var(--r-font-size-xl);
+  font-weight: var(--r-font-weight-bold);
+  line-height: 1.2;
+}
+
+.r-v2-player__subtitle {
+  margin: 0;
+  font-size: var(--r-font-size-sm);
+  color: var(--r-color-fg-muted);
+}
+
+.r-v2-player__panel {
+  background: var(--r-color-bg-elevated) !important;
+  border: 1px solid var(--r-color-border) !important;
+  border-radius: var(--r-radius-lg) !important;
+  backdrop-filter: blur(18px);
+  display: flex !important;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.r-v2-player__settings {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.r-v2-player__play {
+  margin-top: 8px;
+}
+
+.r-v2-player__stage-wrap {
+  position: fixed;
+  inset: var(--r-nav-h) 0 0 0;
+  background: var(--r-color-canvas-bg);
+  z-index: 1;
+}
+.r-v2-player__quit {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 2;
+}
+
+.r-v2-player__loading {
+  min-height: calc(100vh - var(--r-nav-h));
+  display: grid;
+  place-items: center;
+}
+
+html[data-bp~="xs"] .r-v2-player__config {
+  grid-template-columns: 1fr;
+}
+html[data-bp~="xs"] .r-v2-player__cover {
+  max-width: 240px;
+  margin: 0 auto;
+}
+</style>

--- a/frontend/src/v2/composables/usePlayerHero/index.ts
+++ b/frontend/src/v2/composables/usePlayerHero/index.ts
@@ -1,14 +1,10 @@
 // usePlayerHero — the seed / hero / title block a v2 player view opens with.
-// EmulatorJS and Ruffle both refetch the full ROM on mount but need a cover in
-// the DOM *before* that resolves, so the shared-element morph from the gallery
-// or details cover pairs on entry.
+// A player refetches the full ROM on mount, so the seed is synchronous: it puts
+// a cover in the DOM before that resolves, which is what the shared-element
+// morph from the gallery or details cover pairs with on entry.
 //
-// Seeding is synchronous: from GameDetails the full DetailedRom is already in
-// `currentRom`; on a direct gallery→play only a SimpleRom exists, so a
-// cover-only `heroSeed` stands in until the view's own fetch lands.
-//
-// The caller owns the `rom` ref — EmulatorJS needs a deep one for the save and
-// state lists it mutates — and this seeds into it.
+// The `rom` ref is passed in rather than created here so each caller picks its
+// own depth (JsDos and Ruffle want a shallow one, EmulatorJS a deep one).
 import { computed, type ComputedRef, type Ref, shallowRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
@@ -19,7 +15,6 @@ import storeGalleryRoms from "@/v2/stores/galleryRoms";
 
 export function usePlayerHero(rom: Ref<DetailedRom | null>): {
   romId: number;
-  heroSeed: Ref<SimpleRom | null>;
   heroRom: ComputedRef<DetailedRom | SimpleRom | null>;
   title: ComputedRef<string>;
   platformLabel: ComputedRef<string>;
@@ -72,5 +67,5 @@ export function usePlayerHero(rom: Ref<DetailedRom | null>): {
     { immediate: true },
   );
 
-  return { romId, heroSeed, heroRom, title, platformLabel };
+  return { romId, heroRom, title, platformLabel };
 }

--- a/frontend/src/v2/composables/usePlayerHero/index.ts
+++ b/frontend/src/v2/composables/usePlayerHero/index.ts
@@ -1,0 +1,76 @@
+// usePlayerHero — the seed / hero / title block a v2 player view opens with.
+// EmulatorJS and Ruffle both refetch the full ROM on mount but need a cover in
+// the DOM *before* that resolves, so the shared-element morph from the gallery
+// or details cover pairs on entry.
+//
+// Seeding is synchronous: from GameDetails the full DetailedRom is already in
+// `currentRom`; on a direct gallery→play only a SimpleRom exists, so a
+// cover-only `heroSeed` stands in until the view's own fetch lands.
+//
+// The caller owns the `rom` ref — EmulatorJS needs a deep one for the save and
+// state lists it mutates — and this seeds into it.
+import { computed, type ComputedRef, type Ref, shallowRef, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRoute } from "vue-router";
+import storeRoms, { type DetailedRom, type SimpleRom } from "@/stores/roms";
+import { useBackgroundArt } from "@/v2/composables/useBackgroundArt";
+import { usePageTitle } from "@/v2/composables/usePageTitle";
+import storeGalleryRoms from "@/v2/stores/galleryRoms";
+
+export function usePlayerHero(rom: Ref<DetailedRom | null>): {
+  romId: number;
+  heroSeed: Ref<SimpleRom | null>;
+  heroRom: ComputedRef<DetailedRom | SimpleRom | null>;
+  title: ComputedRef<string>;
+  platformLabel: ComputedRef<string>;
+} {
+  const { t } = useI18n();
+  const route = useRoute();
+  const setBgArt = useBackgroundArt();
+
+  const romId = Number(route.params.rom);
+
+  const seededRom = storeRoms().currentRom;
+  if (seededRom?.id === romId) {
+    rom.value = seededRom;
+  }
+  const heroSeed = shallowRef<SimpleRom | null>(null);
+  if (!rom.value) {
+    heroSeed.value = storeGalleryRoms().getRomById(romId);
+  }
+
+  const heroRom = computed<DetailedRom | SimpleRom | null>(
+    () => rom.value ?? heroSeed.value,
+  );
+
+  const title = computed(
+    () => heroRom.value?.name || heroRom.value?.fs_name_no_ext || "",
+  );
+
+  usePageTitle(() =>
+    title.value ? t("play.page-title", { name: title.value }) : null,
+  );
+
+  const platformLabel = computed(
+    () =>
+      heroRom.value?.platform_custom_name ||
+      heroRom.value?.platform_display_name ||
+      "",
+  );
+
+  // Background art keeps the plain 2D cover — a blurred disc or cartridge
+  // reads poorly as a full-bleed backdrop.
+  watch(
+    () => {
+      const r = rom.value;
+      if (!r) return null;
+      return r.path_cover_large ?? r.path_cover_small ?? r.url_cover ?? null;
+    },
+    (url) => {
+      if (url) setBgArt(url);
+    },
+    { immediate: true },
+  );
+
+  return { romId, heroSeed, heroRom, title, platformLabel };
+}

--- a/frontend/src/v2/composables/usePlayerNav/index.ts
+++ b/frontend/src/v2/composables/usePlayerNav/index.ts
@@ -1,0 +1,26 @@
+// usePlayerNav — the two back links every v2 player view carries. The route id
+// is used rather than the hero's, so the links work during the seed window.
+import { useRouter } from "vue-router";
+import { ROUTES } from "@/plugins/router";
+
+export function usePlayerNav(
+  romId: number,
+  platformId: () => number | null | undefined,
+): {
+  backToRom: () => void;
+  backToPlatform: () => void;
+} {
+  const router = useRouter();
+
+  function backToRom() {
+    router.push({ name: ROUTES.ROM, params: { rom: romId } });
+  }
+
+  function backToPlatform() {
+    const platform = platformId();
+    if (platform == null) return;
+    router.push({ name: ROUTES.PLATFORM, params: { platform } });
+  }
+
+  return { backToRom, backToPlatform };
+}

--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -13,7 +13,15 @@
 // The running state mounts the v1 <Player> component (600 lines of EJS
 // wiring — not worth rewriting). The v1 SelectSaveDialog / SelectStateDialog
 // + CacheDialog are mounted in GlobalDialogs so the emitter bridge works.
-import { RBtn, RCard, RIcon, RSelect, RSliderBtnGroup, RSwitch } from "@v2/lib";
+import {
+  RBtn,
+  RCard,
+  RIcon,
+  RSelect,
+  RSliderBtnGroup,
+  RSpinner,
+  RSwitch,
+} from "@v2/lib";
 import { useEventListener, useLocalStorage } from "@vueuse/core";
 import type { Emitter } from "mitt";
 import { storeToRefs } from "pinia";
@@ -28,9 +36,7 @@ import {
   watch,
 } from "vue";
 import { useI18n } from "vue-i18n";
-import { useRouter } from "vue-router";
 import type { FirmwareSchema, SaveSchema, StateSchema } from "@/__generated__";
-import { ROUTES } from "@/plugins/router";
 import firmwareApi from "@/services/api/firmware";
 import romApi from "@/services/api/rom";
 import socket from "@/services/socket";
@@ -49,6 +55,7 @@ import { useFullscreenPref } from "@/v2/composables/useFullscreenPref";
 import { useInputModality } from "@/v2/composables/useInputModality";
 import { usePlaySession } from "@/v2/composables/usePlaySession";
 import { usePlayerHero } from "@/v2/composables/usePlayerHero";
+import { usePlayerNav } from "@/v2/composables/usePlayerNav";
 import type { SliderBtnGroupItem } from "@/v2/lib/primitives/RSliderBtnGroup/types";
 import {
   resolveBezelHost,
@@ -73,7 +80,6 @@ const Player = defineAsyncComponent(
 );
 
 const { t } = useI18n();
-const router = useRouter();
 const emitter = inject<Emitter<Events>>("emitter");
 const auth = storeAuth();
 const playingStore = storePlaying();
@@ -96,7 +102,11 @@ const rom = ref<DetailedRom | null>(null);
 const firmwareOptions = ref<FirmwareSchema[]>([]);
 const selectedSave = ref<SaveSchema | null>(null);
 
-const { romId, heroSeed, heroRom, title, platformLabel } = usePlayerHero(rom);
+const { romId, heroRom, title, platformLabel } = usePlayerHero(rom);
+const { backToRom, backToPlatform } = usePlayerNav(
+  romId,
+  () => heroRom.value?.platform_id,
+);
 const isSavesTabSelected = ref(true);
 const selectedState = ref<StateSchema | null>(null);
 const selectedDisc = ref<DiscSelection>(null);
@@ -441,16 +451,6 @@ function openCacheDialog() {
   emitter?.emit("openEmulatorJSCacheDialog", null);
 }
 
-function backToRom() {
-  router.push({ name: ROUTES.ROM, params: { rom: rom.value?.id } });
-}
-function backToPlatform() {
-  router.push({
-    name: ROUTES.PLATFORM,
-    params: { platform: rom.value?.platform_id },
-  });
-}
-
 type AssetTab = "save" | "state";
 const activeAssetTab = computed<AssetTab>(() =>
   isSavesTabSelected.value ? "save" : "state",
@@ -503,7 +503,7 @@ const selectedAsset = computed<SaveSchema | StateSchema | null>(() =>
 </script>
 
 <template>
-  <section v-if="rom || heroSeed" class="r-v2-ejs">
+  <section v-if="heroRom" class="r-v2-ejs">
     <!-- Pre-game configuration -->
     <div v-if="!gameRunning" class="r-v2-ejs__config">
       <!-- Hero: cover + title + Play CTA -->
@@ -715,7 +715,7 @@ const selectedAsset = computed<SaveSchema | StateSchema | null>(() =>
   </section>
 
   <section v-else class="r-v2-ejs__loading">
-    <div class="r-v2-ejs__spinner" :aria-label="t('common.loading')" />
+    <RSpinner :size="40" :aria-label="t('common.loading')" />
   </section>
 </template>
 
@@ -940,19 +940,6 @@ const selectedAsset = computed<SaveSchema | StateSchema | null>(() =>
   min-height: calc(100vh - var(--r-nav-h));
   display: grid;
   place-items: center;
-}
-.r-v2-ejs__spinner {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  border: 2px solid var(--r-color-surface-hover);
-  border-top-color: var(--r-color-brand-primary);
-  animation: r-ejs-spin 0.8s linear infinite;
-}
-@keyframes r-ejs-spin {
-  to {
-    transform: rotate(360deg);
-  }
 }
 
 /* ── Responsive ──────────────────────────────────────────── */

--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -28,7 +28,7 @@ import {
   watch,
 } from "vue";
 import { useI18n } from "vue-i18n";
-import { useRoute, useRouter } from "vue-router";
+import { useRouter } from "vue-router";
 import type { FirmwareSchema, SaveSchema, StateSchema } from "@/__generated__";
 import { ROUTES } from "@/plugins/router";
 import firmwareApi from "@/services/api/firmware";
@@ -37,21 +37,19 @@ import socket from "@/services/socket";
 import storeAuth from "@/stores/auth";
 import storeConfig from "@/stores/config";
 import storePlaying from "@/stores/playing";
-import storeRoms, { type DetailedRom, type SimpleRom } from "@/stores/roms";
+import type { DetailedRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import { getSupportedEJSCores } from "@/utils";
 import AssetPreview from "@/v2/components/Player/AssetPreview.vue";
 import AssetList from "@/v2/components/shared/AssetList.vue";
 import AssetStrip from "@/v2/components/shared/AssetStrip.vue";
 import GameCover from "@/v2/components/shared/GameCover.vue";
-import { useBackgroundArt } from "@/v2/composables/useBackgroundArt";
 import { useCoverArt } from "@/v2/composables/useCoverArt";
 import { useFullscreenPref } from "@/v2/composables/useFullscreenPref";
 import { useInputModality } from "@/v2/composables/useInputModality";
-import { usePageTitle } from "@/v2/composables/usePageTitle";
 import { usePlaySession } from "@/v2/composables/usePlaySession";
+import { usePlayerHero } from "@/v2/composables/usePlayerHero";
 import type { SliderBtnGroupItem } from "@/v2/lib/primitives/RSliderBtnGroup/types";
-import storeGalleryRoms from "@/v2/stores/galleryRoms";
 import {
   resolveBezelHost,
   resolveBezelUrl,
@@ -75,7 +73,6 @@ const Player = defineAsyncComponent(
 );
 
 const { t } = useI18n();
-const route = useRoute();
 const router = useRouter();
 const emitter = inject<Emitter<Events>>("emitter");
 const auth = storeAuth();
@@ -99,34 +96,7 @@ const rom = ref<DetailedRom | null>(null);
 const firmwareOptions = ref<FirmwareSchema[]>([]);
 const selectedSave = ref<SaveSchema | null>(null);
 
-// Rom id straight from the route param (available before `rom` resolves),
-// so the hero cover paints its `view-transition-name` immediately and the
-// shared-element morph from the gallery / details cover pairs on entry.
-const morphRomId = computed(() => {
-  const r = route.params.rom;
-  return typeof r === "string" ? r : null;
-});
-
-// Seed synchronously so the hero cover is already in the DOM when the view
-// transition captures this view — the morph from the details / gallery cover
-// then pairs on entry. `onMounted` refetches the full payload.
-//   * From GameDetails: `currentRom` is the full DetailedRom → seed `rom`.
-//   * Direct gallery→play: only a SimpleRom exists (the gallery card) → seed a
-//     cover-only `heroSeed` so the cover still paints its morph tag. `rom`
-//     stays null (its DetailedRom-only fields are read guarded) until mount.
-const seededRom = storeRoms().currentRom;
-if (seededRom && String(seededRom.id) === morphRomId.value) {
-  rom.value = seededRom;
-}
-const heroSeed = ref<SimpleRom | null>(null);
-if (!rom.value && morphRomId.value != null) {
-  heroSeed.value = storeGalleryRoms().getRomById(Number(morphRomId.value));
-}
-// What the hero cover / title / glow read: the full rom once loaded, else the
-// lightweight seed during the morph-in window.
-const heroRom = computed<DetailedRom | SimpleRom | null>(
-  () => rom.value ?? heroSeed.value,
-);
+const { romId, heroSeed, heroRom, title, platformLabel } = usePlayerHero(rom);
 const isSavesTabSelected = ref(true);
 const selectedState = ref<StateSchema | null>(null);
 const selectedDisc = ref<DiscSelection>(null);
@@ -207,8 +177,6 @@ const discItems = computed<{ title: string; value: DiscSelection }[]>(() => [
   })),
 ]);
 
-const setBgArt = useBackgroundArt();
-
 // The hero cover is the shared GameCover (same component as gallery +
 // details). We keep a lightweight `useCoverArt` here only to know whether
 // the active style is alt-art, so the purple glow can be dropped for a
@@ -233,7 +201,7 @@ const bezelUrl = computed(() =>
 // the route param so it binds before `rom` resolves; stored as the compact "0"
 // hidden / "1" shown marker (anything else fails safe to shown), and defaults
 // are not written so merely opening a game leaves storage untouched.
-const showBezel = useLocalStorage(`player:${morphRomId.value}:bezel`, true, {
+const showBezel = useLocalStorage(`player:${romId}:bezel`, true, {
   writeDefaults: false,
   serializer: {
     read: resolveStoredBezelVisible,
@@ -248,22 +216,6 @@ const bezelHost = ref<HTMLElement | null>(null);
 useEventListener(document, "fullscreenchange", () => {
   bezelHost.value = resolveBezelHost(document.fullscreenElement);
 });
-
-// Background art keeps the plain 2D cover — a blurred disc / cartridge
-// reads poorly as a full-bleed backdrop.
-const bgCoverUrl = computed(() => {
-  const r = rom.value;
-  if (!r) return null;
-  return r.path_cover_large ?? r.path_cover_small ?? r.url_cover ?? null;
-});
-
-watch(
-  bgCoverUrl,
-  (url) => {
-    if (url) setBgArt(url);
-  },
-  { immediate: true },
-);
 
 async function onPlay() {
   // Launch flourish on the visible cover (disc drop+spin / cartridge
@@ -357,7 +309,7 @@ watch(selectedCore, (newSelectedCore) => {
 
 onMounted(async () => {
   const romResponse = await romApi.getRom({
-    romId: parseInt(route.params.rom as string),
+    romId,
   });
   rom.value = romResponse.data;
 
@@ -499,21 +451,6 @@ function backToPlatform() {
   });
 }
 
-const title = computed(
-  () => heroRom.value?.name || heroRom.value?.fs_name_no_ext || "",
-);
-
-usePageTitle(() =>
-  title.value ? t("play.page-title", { name: title.value }) : null,
-);
-
-const platformLabel = computed(
-  () =>
-    heroRom.value?.platform_custom_name ||
-    heroRom.value?.platform_display_name ||
-    "",
-);
-
 type AssetTab = "save" | "state";
 const activeAssetTab = computed<AssetTab>(() =>
   isSavesTabSelected.value ? "save" : "state",
@@ -581,7 +518,7 @@ const selectedAsset = computed<SaveSchema | StateSchema | null>(() =>
             :rom="heroRom"
             :title="title"
             :identified="heroRom?.is_identified ?? true"
-            :morph-id="morphRomId"
+            :morph-id="romId"
             style-context="player"
             morph-static
             hover-motion

--- a/frontend/src/v2/views/Player/JsDos.test.ts
+++ b/frontend/src/v2/views/Player/JsDos.test.ts
@@ -187,7 +187,7 @@ async function mountPlayer(handle: JsDosProps): Promise<VueWrapper> {
   );
   const wrapper = mountView();
   await flushPromises();
-  await wrapper.get(".r-v2-jsdos__play").trigger("click");
+  await wrapper.get(".r-v2-player__play").trigger("click");
   await nextTick();
   return wrapper;
 }
@@ -242,7 +242,7 @@ describe("JsDos player exit", () => {
     const wrapper = mountView();
     await flushPromises();
 
-    await wrapper.get(".r-v2-jsdos__play").trigger("click");
+    await wrapper.get(".r-v2-player__play").trigger("click");
 
     expect(mocks.snackbarError).toHaveBeenCalledWith(
       "play.stream-error-generic",
@@ -276,7 +276,7 @@ describe("JsDos player exit", () => {
     const handle = makeHandle();
     const wrapper = await mountPlayer(handle);
 
-    await wrapper.get(".r-v2-jsdos__quit").trigger("click");
+    await wrapper.get(".r-v2-player__quit").trigger("click");
     await flushPromises();
 
     expect(handle.save).toHaveBeenCalledOnce();
@@ -292,7 +292,7 @@ describe("JsDos player exit", () => {
     const handle = makeHandle(false);
     const wrapper = await mountPlayer(handle);
 
-    await wrapper.get(".r-v2-jsdos__quit").trigger("click");
+    await wrapper.get(".r-v2-player__quit").trigger("click");
     await flushPromises();
 
     expect(mocks.snackbarError).toHaveBeenCalledWith(
@@ -303,7 +303,7 @@ describe("JsDos player exit", () => {
     expect(mocks.flushPlaySession).not.toHaveBeenCalled();
     expect(mocks.setPlaying).not.toHaveBeenCalledWith(false);
     expect(
-      wrapper.get(".r-v2-jsdos__quit").attributes("disabled"),
+      wrapper.get(".r-v2-player__quit").attributes("disabled"),
     ).toBeUndefined();
     wrapper.unmount();
   });
@@ -313,7 +313,7 @@ describe("JsDos player exit", () => {
     const handle = makeHandle(false);
     const wrapper = await mountPlayer(handle);
 
-    await wrapper.get(".r-v2-jsdos__quit").trigger("click");
+    await wrapper.get(".r-v2-player__quit").trigger("click");
     await flushPromises();
 
     expect(handle.stop).toHaveBeenCalledOnce();
@@ -328,7 +328,7 @@ describe("JsDos player exit", () => {
     handle.save.mockRejectedValue(new Error("save failed"));
     const wrapper = await mountPlayer(handle);
 
-    await wrapper.get(".r-v2-jsdos__quit").trigger("click");
+    await wrapper.get(".r-v2-player__quit").trigger("click");
     await flushPromises();
 
     expect(mocks.snackbarError).toHaveBeenCalledWith(
@@ -349,8 +349,8 @@ describe("JsDos player exit", () => {
     );
     const wrapper = await mountPlayer(handle);
 
-    await wrapper.get(".r-v2-jsdos__quit").trigger("click");
-    await wrapper.get(".r-v2-jsdos__quit").trigger("click");
+    await wrapper.get(".r-v2-player__quit").trigger("click");
+    await wrapper.get(".r-v2-player__quit").trigger("click");
     expect(handle.save).toHaveBeenCalledOnce();
 
     finishSave?.(true);
@@ -369,7 +369,7 @@ describe("JsDos player exit", () => {
     );
     const wrapper = await mountPlayer(handle);
 
-    await wrapper.get(".r-v2-jsdos__quit").trigger("click");
+    await wrapper.get(".r-v2-player__quit").trigger("click");
     expect(mocks.routeLeaveGuard?.({ fullPath: "/platform/2" })).toBe(false);
     expect(handle.save).toHaveBeenCalledOnce();
 

--- a/frontend/src/v2/views/Player/JsDos.vue
+++ b/frontend/src/v2/views/Player/JsDos.vue
@@ -1,30 +1,20 @@
 <script setup lang="ts">
-import { RBtn, RCard, RSpinner, RSwitch } from "@v2/lib";
-import {
-  computed,
-  nextTick,
-  onBeforeUnmount,
-  onMounted,
-  ref,
-  shallowRef,
-} from "vue";
+import { RSwitch } from "@v2/lib";
+import { nextTick, onBeforeUnmount, onMounted, ref, shallowRef } from "vue";
 import { useI18n } from "vue-i18n";
-import { onBeforeRouteLeave, useRoute, useRouter } from "vue-router";
-import { ROUTES } from "@/plugins/router";
+import { onBeforeRouteLeave } from "vue-router";
 import romApi from "@/services/api/rom";
 import storeAuth from "@/stores/auth";
 import storePlaying from "@/stores/playing";
-import storeRoms, { type DetailedRom, type SimpleRom } from "@/stores/roms";
+import type { DetailedRom } from "@/stores/roms";
 import type { JsDosProps } from "@/types/js-dos";
 import { getDownloadPath } from "@/utils";
-import GameCover from "@/v2/components/shared/GameCover.vue";
-import { useBackgroundArt } from "@/v2/composables/useBackgroundArt";
+import PlayerShell from "@/v2/components/Player/PlayerShell.vue";
 import { useConfirm } from "@/v2/composables/useConfirm";
 import { useFullscreenPref } from "@/v2/composables/useFullscreenPref";
-import { usePageTitle } from "@/v2/composables/usePageTitle";
 import { usePlaySession } from "@/v2/composables/usePlaySession";
+import { usePlayerHero } from "@/v2/composables/usePlayerHero";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
-import storeGalleryRoms from "@/v2/stores/galleryRoms";
 import { isJsResource, loadScript } from "./scriptLoader";
 
 const JSDOS_LOCAL_BASE = "/assets/jsdos";
@@ -36,8 +26,6 @@ const JSDOS_CDN_BASE = "https://cdn.jsdelivr.net/npm/js-dos@8.4.1/dist";
 let jsDosAssetBase = JSDOS_LOCAL_BASE;
 
 const { t } = useI18n();
-const route = useRoute();
-const router = useRouter();
 const authStore = storeAuth();
 const playingStore = storePlaying();
 const { fullscreenOnPlay } = useFullscreenPref();
@@ -52,38 +40,7 @@ const stage = ref<HTMLDivElement | null>(null);
 
 let dos: JsDosProps | null = null;
 
-const romId = Number(route.params.rom);
-
-// Seed the cover before the full ROM request resolves so the view transition
-// has an element to morph onto.
-const seededRom = storeRoms().currentRom;
-if (seededRom?.id === romId) {
-  rom.value = seededRom;
-}
-const heroSeed = shallowRef<SimpleRom | null>(null);
-if (!rom.value) {
-  heroSeed.value = storeGalleryRoms().getRomById(romId);
-}
-const heroRom = computed<DetailedRom | SimpleRom | null>(
-  () => rom.value ?? heroSeed.value,
-);
-
-const setBgArt = useBackgroundArt();
-
-const title = computed(
-  () => heroRom.value?.name || heroRom.value?.fs_name_no_ext || "",
-);
-
-usePageTitle(() =>
-  title.value ? t("play.page-title", { name: title.value }) : null,
-);
-
-const platformLabel = computed(
-  () =>
-    heroRom.value?.platform_custom_name ||
-    heroRom.value?.platform_display_name ||
-    "",
-);
+const { romId, heroRom, title, platformLabel } = usePlayerHero(rom);
 
 async function loadRuntime() {
   jsDosAssetBase = (await isJsResource(`${JSDOS_LOCAL_BASE}/js-dos.js`))
@@ -193,17 +150,6 @@ async function leavePlayer(destination: string) {
 function onlyQuit() {
   void leavePlayer(`/rom/${romId}`);
 }
-function backToRom() {
-  router.push({ name: ROUTES.ROM, params: { rom: romId } });
-}
-function backToPlatform() {
-  const platformId = heroRom.value?.platform_id;
-  if (platformId == null) return;
-  router.push({
-    name: ROUTES.PLATFORM,
-    params: { platform: platformId },
-  });
-}
 
 function onBeforeUnload(event: BeforeUnloadEvent) {
   if (!dos || quitting.value) return;
@@ -220,10 +166,6 @@ onMounted(async () => {
 
   const romResponse = await romApi.getRom({ romId });
   rom.value = romResponse.data;
-
-  const { path_cover_large, path_cover_small, url_cover } = romResponse.data;
-  const cover = path_cover_large ?? path_cover_small ?? url_cover;
-  if (cover) setBgArt(cover);
 });
 
 onBeforeRouteLeave((to) => {
@@ -238,189 +180,40 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <section v-if="rom || heroSeed" class="r-v2-jsdos">
-    <div v-if="!gameRunning" class="r-v2-jsdos__config">
-      <aside class="r-v2-jsdos__cover">
-        <GameCover
-          class="r-v2-jsdos__cover-box"
-          :rom="heroRom"
-          :title="title"
-          :identified="heroRom?.is_identified ?? true"
-          :morph-id="romId"
-          style-context="player"
-          morph-static
-          hover-motion
-        />
-        <h1 class="r-v2-jsdos__title">
-          {{ title }}
-        </h1>
-        <p class="r-v2-jsdos__subtitle">
-          {{ platformLabel }}
-        </p>
-      </aside>
+  <PlayerShell
+    :hero-rom="heroRom"
+    :title="title"
+    :platform-label="platformLabel"
+    :rom-id="romId"
+    :ready="!!rom"
+    :running="gameRunning"
+    :quitting="quitting"
+    @play="onPlay"
+    @quit="onlyQuit"
+  >
+    <template #settings>
+      <RSwitch v-model="fullscreenOnPlay" :label="t('play.full-screen')" />
 
-      <RCard class="r-v2-jsdos__panel" variant="flat">
-        <div class="r-v2-jsdos__settings">
-          <RSwitch v-model="fullscreenOnPlay" :label="t('play.full-screen')" />
+      <p class="r-v2-jsdos__save-note">
+        {{ t("play.jsdos-browser-save-warning") }}
+      </p>
+    </template>
 
-          <p class="r-v2-jsdos__save-note">
-            {{ t("play.jsdos-browser-save-warning") }}
-          </p>
-
-          <RBtn
-            size="large"
-            variant="flat"
-            color="primary"
-            block
-            prepend-icon="mdi-play-circle"
-            class="r-v2-jsdos__play"
-            :loading="!rom"
-            :disabled="!rom"
-            @click="onPlay"
-          >
-            {{ t("play.play") }}
-          </RBtn>
-
-          <RBtn
-            block
-            variant="text"
-            size="small"
-            prepend-icon="mdi-arrow-left"
-            @click="backToRom"
-          >
-            {{ t("play.back-to-game-details") }}
-          </RBtn>
-          <RBtn
-            block
-            variant="text"
-            size="small"
-            prepend-icon="mdi-view-grid-outline"
-            @click="backToPlatform"
-          >
-            {{ t("play.back-to-gallery") }}
-          </RBtn>
-        </div>
-      </RCard>
-    </div>
-
-    <div v-else class="r-v2-jsdos__stage-wrap">
+    <template #stage>
       <div ref="stage" class="r-v2-jsdos__stage" />
-      <RBtn
-        class="r-v2-jsdos__quit"
-        variant="translucent"
-        prepend-icon="mdi-exit-to-app"
-        :loading="quitting"
-        :disabled="quitting"
-        @click="onlyQuit"
-      >
-        {{ t("play.quit") }}
-      </RBtn>
-    </div>
-  </section>
-
-  <section v-else class="r-v2-jsdos__loading">
-    <RSpinner :size="40" :aria-label="t('common.loading')" />
-  </section>
+    </template>
+  </PlayerShell>
 </template>
 
 <style scoped>
-.r-v2-jsdos {
-  position: relative;
-  min-height: calc(100vh - var(--r-nav-h));
-  padding: 24px var(--r-row-pad) 48px;
-}
-
-.r-v2-jsdos__config {
-  display: grid;
-  grid-template-columns: 240px 1fr;
-  gap: 24px;
-  max-width: 820px;
-  margin: 0 auto;
-}
-
-.r-v2-jsdos__cover {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  gap: 8px;
-}
-
-.r-v2-jsdos__cover-box {
-  --r-cover-radius: var(--r-radius-lg);
-}
-.r-v2-jsdos__cover-box:not(.game-cover--alt) {
-  box-shadow: 0 18px 36px color-mix(in srgb, black 55%, transparent);
-}
-
-.r-v2-jsdos__title {
-  margin: 10px 0 0;
-  font-size: var(--r-font-size-xl);
-  font-weight: var(--r-font-weight-bold);
-  line-height: 1.2;
-}
-
-.r-v2-jsdos__subtitle {
-  margin: 0;
-  font-size: var(--r-font-size-sm);
-  color: var(--r-color-fg-muted);
-}
-
-.r-v2-jsdos__panel {
-  background: var(--r-color-bg-elevated) !important;
-  border: 1px solid var(--r-color-border) !important;
-  border-radius: var(--r-radius-lg) !important;
-  backdrop-filter: blur(18px);
-  display: flex !important;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.r-v2-jsdos__settings {
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.r-v2-jsdos__play {
-  margin-top: 8px;
-}
-
 .r-v2-jsdos__save-note {
   margin: 0;
   color: var(--r-color-fg-muted);
   font-size: var(--r-font-size-sm);
 }
 
-.r-v2-jsdos__stage-wrap {
-  position: fixed;
-  inset: var(--r-nav-h) 0 0 0;
-  background: var(--r-color-canvas-bg);
-  z-index: 1;
-}
 .r-v2-jsdos__stage {
   width: 100%;
   height: 100%;
-}
-.r-v2-jsdos__quit {
-  position: absolute;
-  top: 16px;
-  right: 16px;
-  z-index: 2;
-}
-
-.r-v2-jsdos__loading {
-  min-height: calc(100vh - var(--r-nav-h));
-  display: grid;
-  place-items: center;
-}
-
-html[data-bp~="xs"] .r-v2-jsdos__config {
-  grid-template-columns: 1fr;
-}
-html[data-bp~="xs"] .r-v2-jsdos__cover {
-  max-width: 240px;
-  margin: 0 auto;
 }
 </style>

--- a/frontend/src/v2/views/Player/Ruffle.vue
+++ b/frontend/src/v2/views/Player/Ruffle.vue
@@ -3,37 +3,24 @@
 // createPlayer, fullscreen) is ported verbatim from
 // `src/views/Player/RuffleRS/Base.vue` so playback stays identical; only the
 // chrome is v2. No shared state with EJS — Flash has its own config.
-import { RBtn, RCard, RIcon, RSwitch } from "@v2/lib";
-import {
-  computed,
-  nextTick,
-  onBeforeUnmount,
-  onMounted,
-  ref,
-  watch,
-} from "vue";
+import { RIcon, RSwitch } from "@v2/lib";
+import { nextTick, onBeforeUnmount, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
-import { useRoute, useRouter } from "vue-router";
-import { ROUTES } from "@/plugins/router";
 import romApi from "@/services/api/rom";
 import storePlaying from "@/stores/playing";
-import storeRoms, { type DetailedRom, type SimpleRom } from "@/stores/roms";
+import type { DetailedRom } from "@/stores/roms";
 import type { RuffleSourceAPI } from "@/types/ruffle";
 import { getDownloadPath } from "@/utils";
-import GameCover from "@/v2/components/shared/GameCover.vue";
-import { useBackgroundArt } from "@/v2/composables/useBackgroundArt";
+import PlayerShell from "@/v2/components/Player/PlayerShell.vue";
 import { useFullscreenPref } from "@/v2/composables/useFullscreenPref";
-import { usePageTitle } from "@/v2/composables/usePageTitle";
 import { usePlaySession } from "@/v2/composables/usePlaySession";
-import storeGalleryRoms from "@/v2/stores/galleryRoms";
+import { usePlayerHero } from "@/v2/composables/usePlayerHero";
 import { colorCanvas } from "@/v2/tokens";
 
 const RUFFLE_VERSION = "0.2.0-nightly.2025.8.14";
 const DEFAULT_BACKGROUND_COLOR = colorCanvas.bgDeep;
 
 const { t } = useI18n();
-const route = useRoute();
-const router = useRouter();
 const { fullscreenOnPlay } = useFullscreenPref();
 const playingStore = storePlaying();
 const playSession = usePlaySession();
@@ -41,31 +28,6 @@ const playSession = usePlaySession();
 const rom = ref<DetailedRom | null>(null);
 const gameRunning = ref(false);
 const backgroundColor = ref<string>(DEFAULT_BACKGROUND_COLOR);
-
-// Rom id from the route param (available before `rom` resolves) so the hero
-// cover paints its `view-transition-name` immediately and the shared-element
-// morph from the gallery / details cover pairs on entry.
-const morphRomId = computed(() => {
-  const r = route.params.rom;
-  return typeof r === "string" ? r : null;
-});
-
-// Seed synchronously so the hero cover is in the DOM when the view transition
-// captures this view and the morph pairs on entry. From GameDetails the full
-// DetailedRom is in `currentRom`; on a direct gallery→play only a SimpleRom
-// exists, so seed a cover-only `heroSeed` (`rom` stays null until `onMounted`
-// refetches). See EmulatorJS for the same pattern.
-const seededRom = storeRoms().currentRom;
-if (seededRom && String(seededRom.id) === morphRomId.value) {
-  rom.value = seededRom;
-}
-const heroSeed = ref<SimpleRom | null>(null);
-if (!rom.value && morphRomId.value != null) {
-  heroSeed.value = storeGalleryRoms().getRomById(Number(morphRomId.value));
-}
-const heroRom = computed<DetailedRom | SimpleRom | null>(
-  () => rom.value ?? heroSeed.value,
-);
 
 declare global {
   interface Window {
@@ -84,41 +46,7 @@ declare global {
 
 window.RufflePlayer = window.RufflePlayer || {};
 
-const setBgArt = useBackgroundArt();
-
-// The cover is the shared GameCover (same component as gallery + details +
-// EmulatorJS) — it owns style/ratio/placeholder. Flash has no disc /
-// cartridge metadata, so it's effectively always 2D box art here.
-
-// Background art keeps the plain 2D cover.
-const bgCoverUrl = computed(() => {
-  const r = rom.value;
-  if (!r) return null;
-  return r.path_cover_large ?? r.path_cover_small ?? r.url_cover ?? null;
-});
-
-watch(
-  bgCoverUrl,
-  (url) => {
-    if (url) setBgArt(url);
-  },
-  { immediate: true },
-);
-
-const title = computed(
-  () => heroRom.value?.name || heroRom.value?.fs_name_no_ext || "",
-);
-
-usePageTitle(() =>
-  title.value ? t("play.page-title", { name: title.value }) : null,
-);
-
-const platformLabel = computed(
-  () =>
-    heroRom.value?.platform_custom_name ||
-    heroRom.value?.platform_display_name ||
-    "",
-);
+const { romId, heroRom, title, platformLabel } = usePlayerHero(rom);
 
 function onPlay() {
   gameRunning.value = true;
@@ -173,20 +101,8 @@ function onlyQuit() {
   window.history.back();
 }
 
-function backToRom() {
-  router.push({ name: ROUTES.ROM, params: { rom: rom.value?.id } });
-}
-function backToPlatform() {
-  router.push({
-    name: ROUTES.PLATFORM,
-    params: { platform: rom.value?.platform_id },
-  });
-}
-
 onMounted(async () => {
-  const romResponse = await romApi.getRom({
-    romId: parseInt(route.params.rom as string),
-  });
+  const romResponse = await romApi.getRom({ romId });
   rom.value = romResponse.data;
 
   if (rom.value) {
@@ -216,173 +132,52 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <section v-if="rom || heroSeed" class="r-v2-ruffle">
-    <!-- Pre-game configuration -->
-    <div v-if="!gameRunning" class="r-v2-ruffle__config">
-      <!-- Cover column -->
-      <aside class="r-v2-ruffle__cover">
-        <GameCover
-          class="r-v2-ruffle__cover-box"
-          :rom="heroRom"
-          :title="title"
-          :identified="heroRom?.is_identified ?? true"
-          :morph-id="morphRomId"
-          style-context="player"
-          morph-static
-          hover-motion
+  <PlayerShell
+    :hero-rom="heroRom"
+    :title="title"
+    :platform-label="platformLabel"
+    :rom-id="romId"
+    :ready="!!rom"
+    :running="gameRunning"
+    @play="onPlay"
+    @quit="onlyQuit"
+  >
+    <template #settings>
+      <div class="r-v2-ruffle__section-label">
+        <RIcon icon="mdi-palette" size="16" />
+        <span>{{ t("play.select-background-color") }}</span>
+      </div>
+      <div class="r-v2-ruffle__color-row">
+        <input
+          v-model="backgroundColor"
+          type="color"
+          class="r-v2-ruffle__color-input"
+          :aria-label="t('play.select-background-color')"
+          :title="t('play.select-background-color')"
+          @change="onBackgroundColorChange"
         />
-        <h1 class="r-v2-ruffle__title">
-          {{ title }}
-        </h1>
-        <p class="r-v2-ruffle__subtitle">
-          {{ platformLabel }}
-        </p>
-      </aside>
+        <code class="r-v2-ruffle__color-code">
+          {{ backgroundColor.toUpperCase() }}
+        </code>
+      </div>
 
-      <!-- Settings panel -->
-      <RCard class="r-v2-ruffle__panel" variant="flat">
-        <div class="r-v2-ruffle__settings">
-          <div class="r-v2-ruffle__section-label">
-            <RIcon icon="mdi-palette" size="16" />
-            <span>{{ t("play.select-background-color") }}</span>
-          </div>
-          <div class="r-v2-ruffle__color-row">
-            <input
-              v-model="backgroundColor"
-              type="color"
-              class="r-v2-ruffle__color-input"
-              :aria-label="t('play.select-background-color')"
-              :title="t('play.select-background-color')"
-              @change="onBackgroundColorChange"
-            />
-            <code class="r-v2-ruffle__color-code">
-              {{ backgroundColor.toUpperCase() }}
-            </code>
-          </div>
+      <RSwitch v-model="fullscreenOnPlay" :label="t('play.full-screen')" />
+    </template>
 
-          <RSwitch v-model="fullscreenOnPlay" :label="t('play.full-screen')" />
-
-          <RBtn
-            size="large"
-            variant="flat"
-            color="primary"
-            block
-            prepend-icon="mdi-play-circle"
-            class="r-v2-ruffle__play"
-            :loading="!rom"
-            :disabled="!rom"
-            @click="onPlay"
-          >
-            {{ t("play.play") }}
-          </RBtn>
-
-          <RBtn
-            block
-            variant="text"
-            size="small"
-            prepend-icon="mdi-arrow-left"
-            @click="backToRom"
-          >
-            {{ t("play.back-to-game-details") }}
-          </RBtn>
-          <RBtn
-            block
-            variant="text"
-            size="small"
-            prepend-icon="mdi-view-grid-outline"
-            @click="backToPlatform"
-          >
-            {{ t("play.back-to-gallery") }}
-          </RBtn>
-        </div>
-      </RCard>
-
+    <template #brand>
       <div class="r-v2-ruffle__brand">
         <span>{{ t("play.powered-by") }}</span>
         <img src="/assets/ruffle/ruffle.svg" alt="Ruffle" />
       </div>
-    </div>
+    </template>
 
-    <!-- Running state — full bleed minus nav -->
-    <div v-else class="r-v2-ruffle__stage-wrap">
+    <template #stage>
       <div id="r-v2-ruffle-stage" class="r-v2-ruffle__stage" />
-      <RBtn
-        class="r-v2-ruffle__quit"
-        variant="translucent"
-        prepend-icon="mdi-exit-to-app"
-        @click="onlyQuit"
-      >
-        {{ t("play.quit") }}
-      </RBtn>
-    </div>
-  </section>
-
-  <section v-else class="r-v2-ruffle__loading">
-    <div class="r-v2-ruffle__spinner" :aria-label="t('common.loading')" />
-  </section>
+    </template>
+  </PlayerShell>
 </template>
 
 <style scoped>
-.r-v2-ruffle {
-  position: relative;
-  min-height: calc(100vh - var(--r-nav-h));
-  padding: 24px var(--r-row-pad) 48px;
-}
-
-.r-v2-ruffle__config {
-  display: grid;
-  grid-template-columns: 240px 1fr;
-  gap: 24px;
-  max-width: 820px;
-  margin: 0 auto;
-}
-
-.r-v2-ruffle__cover {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  gap: 8px;
-}
-
-.r-v2-ruffle__cover-box {
-  --r-cover-radius: var(--r-radius-lg);
-}
-/* 2D box art keeps a drop shadow; alt-art (rare for Flash) floats frame-free. */
-.r-v2-ruffle__cover-box:not(.game-cover--alt) {
-  box-shadow: 0 18px 36px color-mix(in srgb, black 55%, transparent);
-}
-
-.r-v2-ruffle__title {
-  margin: 10px 0 0;
-  font-size: var(--r-font-size-xl);
-  font-weight: var(--r-font-weight-bold);
-  line-height: 1.2;
-}
-
-.r-v2-ruffle__subtitle {
-  margin: 0;
-  font-size: var(--r-font-size-sm);
-  color: var(--r-color-fg-muted);
-}
-
-.r-v2-ruffle__panel {
-  background: var(--r-color-bg-elevated) !important;
-  border: 1px solid var(--r-color-border) !important;
-  border-radius: var(--r-radius-lg) !important;
-  backdrop-filter: blur(18px);
-  display: flex !important;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.r-v2-ruffle__settings {
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
 .r-v2-ruffle__section-label {
   display: inline-flex;
   align-items: center;
@@ -423,10 +218,6 @@ onBeforeUnmount(() => {
   letter-spacing: 0.04em;
 }
 
-.r-v2-ruffle__play {
-  margin-top: 8px;
-}
-
 .r-v2-ruffle__brand {
   grid-column: 1 / -1;
   display: flex;
@@ -442,49 +233,9 @@ onBeforeUnmount(() => {
   height: 22px;
 }
 
-/* Running state */
-.r-v2-ruffle__stage-wrap {
-  position: fixed;
-  inset: var(--r-nav-h) 0 0 0;
-  background: var(--r-color-canvas-bg);
-  z-index: 1;
-}
 .r-v2-ruffle__stage {
   width: 100%;
   height: 100%;
   --splash-screen-background: none;
-}
-.r-v2-ruffle__quit {
-  position: absolute;
-  top: 16px;
-  right: 16px;
-  z-index: 2;
-}
-
-.r-v2-ruffle__loading {
-  min-height: calc(100vh - var(--r-nav-h));
-  display: grid;
-  place-items: center;
-}
-.r-v2-ruffle__spinner {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  border: 2px solid var(--r-color-surface-hover);
-  border-top-color: var(--r-color-brand-primary);
-  animation: r-v2-ruffle-spin 0.8s linear infinite;
-}
-@keyframes r-v2-ruffle-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-html[data-bp~="xs"] .r-v2-ruffle__config {
-  grid-template-columns: 1fr;
-}
-html[data-bp~="xs"] .r-v2-ruffle__cover {
-  max-width: 240px;
-  margin: 0 auto;
 }
 </style>

--- a/frontend/src/v2/views/Player/Ruffle.vue
+++ b/frontend/src/v2/views/Player/Ruffle.vue
@@ -4,7 +4,7 @@
 // `src/views/Player/RuffleRS/Base.vue` so playback stays identical; only the
 // chrome is v2. No shared state with EJS — Flash has its own config.
 import { RIcon, RSwitch } from "@v2/lib";
-import { nextTick, onBeforeUnmount, onMounted, ref } from "vue";
+import { nextTick, onBeforeUnmount, onMounted, ref, shallowRef } from "vue";
 import { useI18n } from "vue-i18n";
 import romApi from "@/services/api/rom";
 import storePlaying from "@/stores/playing";
@@ -25,7 +25,7 @@ const { fullscreenOnPlay } = useFullscreenPref();
 const playingStore = storePlaying();
 const playSession = usePlaySession();
 
-const rom = ref<DetailedRom | null>(null);
+const rom = shallowRef<DetailedRom | null>(null);
 const gameRunning = ref(false);
 const backgroundColor = ref<string>(DEFAULT_BACKGROUND_COLOR);
 
@@ -219,12 +219,10 @@ onBeforeUnmount(() => {
 }
 
 .r-v2-ruffle__brand {
-  grid-column: 1 / -1;
   display: flex;
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
-  margin-top: 12px;
   font-size: var(--r-font-size-xs);
   color: var(--r-color-fg-faint);
   font-style: italic;

--- a/frontend/src/v2/views/Player/Stream.vue
+++ b/frontend/src/v2/views/Player/Stream.vue
@@ -73,8 +73,9 @@ const romId = computed(() => Number(route.params.rom));
 // transition captures this view and the morph pairs on entry. From
 // GameDetails the full DetailedRom is in `currentRom`; on a direct
 // gallery→play only a SimpleRom exists, so seed a cover-only `heroSeed`
-// (`rom` stays null until `onMounted` refetches). See EmulatorJS / Ruffle
-// for the same pattern.
+// (`rom` stays null until `onMounted` refetches). `usePlayerHero` does this
+// for the other players; Stream keeps its own copy because its label comes
+// from the streaming container and it clears the background art while playing.
 if (romsStore.currentRom && romsStore.currentRom.id === romId.value) {
   rom.value = romsStore.currentRom;
 }


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The v2 player views duplicate their chrome. `EmulatorJS.vue`, `Ruffle.vue` and `JsDos.vue` each carry their own copy of the block every player opens with (synchronous hero seeding, title, platform label, background-art watch), and `Ruffle.vue` and `JsDos.vue` additionally hand-roll the cover column, settings card, back buttons and loading spinner that any simple player needs.

This extracts three seams:

- **`usePlayerHero`** (`src/v2/composables/usePlayerHero/`) — the seed / hero / title / platform-label block plus the background-art watch. Adopted by all three players. The caller keeps ownership of the `rom` ref, because EmulatorJS needs a deep one for the save and state lists it mutates.
- **`PlayerShell`** (`src/v2/components/Player/PlayerShell.vue`) — the cover column, settings card, play and back buttons, the full-bleed running stage and the loading state, with `settings`, `stage` and `brand` slots. Ruffle keeps only its colour picker, brand strip and stage; js-dos keeps only its fullscreen switch, browser-save note and stage.
- **`usePlayerNav`** (`src/v2/composables/usePlayerNav/`) — the two back links, shared by the shell and by EmulatorJS. EmulatorJS's copy navigated off `rom.value?.id`, so it pushed `undefined` params during exactly the seed window the hero seeding exists to cover; it now uses the route id like the shell does.

`EmulatorJS.vue` deliberately opts out of `PlayerShell`: its hero sits inside a card with an alt-art glow and it lays out three panels on its own breakpoints. It takes the composables alone, and while it was open it also drops its hand-rolled `@keyframes` spinner for `RSpinner`.

`Stream.vue` is left alone: its label comes from the streaming container, its background art clears while playing, and it has its own back route.

Net **-638 / +558** across nine files, and the duplication is gone rather than moved.

**Why now:** this fell out of a cleanup pass on #4061 (js-dos player), which landed as a *third* near-verbatim copy of the same chrome — `JsDos.vue` and `Ruffle.vue` shared ~245 lines. Now that #4061 is on `master`, this PR is rebased on it and converts `JsDos.vue` too, so `PlayerShell` gains its second consumer here.

**Behaviour:** no intended change. The one visible difference is that Ruffle's hand-rolled loading spinner is now `RSpinner`, matching the other players (same 40px / 2px / brand-coloured arc, and it drops a bespoke `@keyframes`). The js-dos view keeps its own quit/save flow, route-leave guard and `beforeunload` warning; only its chrome moves into the shell.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

<sup>Verified: `npm run typecheck`, `npm run test` (838 tests / 74 files), `npm run build` and `trunk fmt && trunk check` all pass. `PlayerShell.test.ts` is new and covers the play/quit emits, the missing-platform guard and the loading branch; `JsDos.test.ts`'s 15 existing cases move their selectors onto the shell's classes. **Not yet exercised in a browser**, and since the change moves scoped CSS into a child component that is where a regression would hide: the Ruffle and js-dos pre-game panels and running stages want a look in both themes before merge.</sup>

#### Screenshots (if applicable)

n/a

---

<sup>AI assistance: this PR was written with Claude Code (Opus 5). The duplication was identified by an automated review pass over #4061; the extraction, the decision on which views adopt which seam, and the verification above were carried out by the agent under my direction and reviewed by me.</sup>
