### PR TITLE
fix(logs): stop a multi-line record painting over the rows after it

### DIFF
--- a/frontend/src/v2/views/Settings/Logs.vue
+++ b/frontend/src/v2/views/Settings/Logs.vue
@@ -34,6 +34,9 @@ interface LogRow extends LogEntry {
   // stable key keeps virtual-scroller rows from re-patching on front
   // eviction.
   seq: number;
+  // The message as emitted, before newline folding. What the tooltip,
+  // the clipboard and the downloaded file use.
+  raw: string;
 }
 
 // Cap the in-memory buffer so a long-lived view holds memory flat.
@@ -58,11 +61,18 @@ const search = ref("");
 // eslint-disable-next-line no-control-regex
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
 
+// A record can carry embedded newlines: a provider logging a formatted JSON
+// body, a traceback. Rows are one line tall, so a message rendered with
+// `white-space: pre` painted over the rows the scroller placed after it.
+const NEWLINE_RE = /\r?\n\s*/g;
+
 let seqCounter = 0;
 function toRow(entry: LogEntry): LogRow {
+  const raw = entry.message.replace(ANSI_RE, "");
   return {
     ...entry,
-    message: entry.message.replace(ANSI_RE, ""),
+    message: raw.trim().replace(NEWLINE_RE, " ⏎ "),
+    raw,
     seq: seqCounter++,
   };
 }
@@ -108,7 +118,7 @@ const filtered = computed<LogRow[]>(() => {
     if (mod !== "ALL" && e.module !== mod) return false;
     if (
       q &&
-      !e.message.toLowerCase().includes(q) &&
+      !e.raw.toLowerCase().includes(q) &&
       !e.module.toLowerCase().includes(q)
     ) {
       return false;
@@ -204,7 +214,7 @@ function formatTime(ts: number) {
 }
 
 function asLine(e: LogRow) {
-  return `[${new Date(e.ts).toISOString()}] ${e.level} [${e.module}] ${e.message}`;
+  return `[${new Date(e.ts).toISOString()}] ${e.level} [${e.module}] ${e.raw}`;
 }
 
 async function copyLogs() {
@@ -334,7 +344,7 @@ function downloadLogs() {
               location="top start"
               max-width="min(80vw, 900px)"
               hint-icon="mdi-content-copy"
-              :text="(item as LogRow).message"
+              :text="(item as LogRow).raw"
               :hint="t('logs.click-to-copy')"
             />
             <span class="r-v2-logs__time">{{
@@ -474,6 +484,9 @@ html[data-bp~="sm-and-down"] .r-v2-logs__spacer {
   font-size: var(--r-font-size-sm);
   line-height: 24px;
   white-space: nowrap;
+  /* Structural guard: the row is one line tall, so anything taller would
+     paint over the rows the scroller placed after it. */
+  overflow: hidden;
   color: var(--r-color-fg-secondary);
   cursor: pointer;
 }


### PR DESCRIPTION
**Description**

A log record can carry embedded newlines. Hasheous logs a pretty-printed JSON rate-limit body, and a traceback does the same. `.r-v2-logs__message` renders with `white-space: pre`, which overrides the row's own `nowrap`, so those became real line breaks inside a row fixed at `height: 24px` while `getItemHeight()` kept returning a constant `ROW_HEIGHT = 24`. The overflow painted over the rows the virtual scroller had already positioned below it: two records sharing one row's pixels, neither readable.

Newlines are folded to a return glyph for display, and the message as emitted is kept alongside it in a new `raw` field, so the tooltip, the clipboard, the downloaded file and the search filter all still see the whole thing. This preserves the invariant the file already states in its comment, "single-line rows keep windowing math exact".

```diff
 let seqCounter = 0;
 function toRow(entry: LogEntry): LogRow {
+  const raw = entry.message.replace(ANSI_RE, "");
   return {
     ...entry,
-    message: entry.message.replace(ANSI_RE, ""),
+    message: raw.replace(NEWLINE_RE, " ⏎ "),
+    raw,
     seq: seqCounter++,
   };
 }
```

The row also gains `overflow: hidden` as a structural guard against anything else growing it. It is `width: max-content`, so that clips vertically without touching the horizontal scroll that reveals long lines.

**Considered and rejected:** variable row heights, via `getItemHeight(item) => (newlineCount + 1) * ROW_HEIGHT`. Windowing would stay exact, since the height comes from the data, but a tailing log whose rows jump between 24px and 200px is not readable either, and the tooltip already surfaces the full text.

**Checklist**

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

**Testing**

`npm run typecheck` (vue-tsc) and `trunk fmt && trunk check` are clean. Adding `raw` to `LogRow` touches several call sites, which is what the typecheck is guarding.

Not yet run: the view itself in a browser against a backend emitting a multi-line record. The two unchecked boxes above are that, and the absence of a unit test. There is no test file for this view and `toRow` is local to `<script setup>`, so covering it would mean extracting it to a module first; happy to do that if a reviewer would rather have the test than the smaller diff.

#### Screenshots (if applicable)

None yet, for the reason above.

**AI assistance disclosure**

This change was written with AI assistance (Claude Opus 5 via Claude Code). The diagnosis, the code and this description were AI-generated. The underlying bug was found and reproduced live while container-testing #4275; the fix has been verified by type checking and linting only, not visually.
