### PR TITLE
feat(saves): scope save discovery to a set of ROM IDs

### DIFF
--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -105,7 +105,7 @@ from utils.m3u import generate_m3u_content
 from utils.nginx import FileRedirectResponse, ZipContentLine, ZipResponse
 from utils.router import APIRouter
 from utils.screenshots import continue_playing_screenshot
-from utils.validation import ValidationError
+from utils.validation import ValidationError, parse_comma_separated_ids
 from utils.zip_cache import (
     BULK_CACHE_MAX_ROMS,
     ZipFileEntry,
@@ -1107,13 +1107,11 @@ async def download_roms(
         )
         rom_id_list = list(dict.fromkeys(rom.id for rom in rom_rows))
     elif rom_ids:
-        # Parse comma-separated string into list of integers
         try:
-            rom_id_list = [int(id.strip()) for id in rom_ids.split(",") if id.strip()]
-        except ValueError as e:
+            rom_id_list = parse_comma_separated_ids(rom_ids, "ROM ID")
+        except ValidationError as e:
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid ROM ID format. Must be comma-separated integers.",
+                status_code=status.HTTP_400_BAD_REQUEST, detail=e.message
             ) from e
     else:
         raise HTTPException(

--- a/backend/endpoints/saves.py
+++ b/backend/endpoints/saves.py
@@ -35,12 +35,7 @@ from utils.datetime import to_utc
 from utils.filesystem import sanitize_filename
 from utils.router import APIRouter
 from utils.uploads import check_asset_upload_size
-from utils.validation import (
-    MAX_ROM_IDS_PER_QUERY,
-    ValidationError,
-    normalize_rom_id_scope,
-    parse_comma_separated_ids,
-)
+from utils.validation import RomIdScope
 
 
 def _build_save_schema(
@@ -403,30 +398,17 @@ async def add_save(
     return _build_save_schema(db_save, _syncs_for_save(db_save.id, device), device)
 
 
-def _parse_rom_ids(rom_ids: str | None) -> list[int] | None:
-    if rom_ids is None:
-        return None
-
-    try:
-        return normalize_rom_id_scope(parse_comma_separated_ids(rom_ids, "ROM ID"))
-    except ValidationError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail=exc.message
-        ) from exc
-
-
 @protected_route(router.get, "", [Scope.ASSETS_READ])
 def get_saves(
     request: Request,
     rom_id: int | None = None,
     rom_ids: Annotated[
-        str | None,
+        RomIdScope,
         Query(
             description=(
-                "Comma-separated list of ROM IDs to scope the results to, for "
-                "clients syncing a known set of ROMs. At most "
-                f"{MAX_ROM_IDS_PER_QUERY} IDs per request; an empty value "
-                "returns no saves. Combined with `rom_id` when both are given."
+                "ROM IDs to scope the results to, for clients syncing a known "
+                "set of ROMs. Multiple values are allowed by repeating the "
+                "parameter. Combined with `rom_id` when both are given."
             ),
         ),
     ] = None,
@@ -442,7 +424,7 @@ def get_saves(
     saves = db_save_handler.get_saves(
         user_id=request.user.id,
         rom_id=rom_id,
-        rom_ids=_parse_rom_ids(rom_ids),
+        rom_ids=rom_ids,
         platform_id=platform_id,
         slot=slot,
     )

--- a/backend/endpoints/saves.py
+++ b/backend/endpoints/saves.py
@@ -23,10 +23,6 @@ from handler.database import (
     db_screenshot_handler,
     db_sync_session_handler,
 )
-from handler.database.saves_handler import (
-    MAX_ROM_IDS_PER_QUERY,
-    normalize_rom_id_scope,
-)
 from handler.filesystem import fs_asset_handler
 from handler.scan_handler import scan_save, scan_screenshot
 from logger.formatter import BLUE
@@ -39,6 +35,12 @@ from utils.datetime import to_utc
 from utils.filesystem import sanitize_filename
 from utils.router import APIRouter
 from utils.uploads import check_asset_upload_size
+from utils.validation import (
+    MAX_ROM_IDS_PER_QUERY,
+    ValidationError,
+    normalize_rom_id_scope,
+    parse_comma_separated_ids,
+)
 
 
 def _build_save_schema(
@@ -401,22 +403,15 @@ async def add_save(
     return _build_save_schema(db_save, _syncs_for_save(db_save.id, device), device)
 
 
-def _parse_rom_ids(rom_ids: str) -> list[int]:
-    try:
-        parsed = [
-            int(part) for part in (raw.strip() for raw in rom_ids.split(",")) if part
-        ]
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid ROM ID format. Must be comma-separated integers.",
-        ) from exc
+def _parse_rom_ids(rom_ids: str | None) -> list[int] | None:
+    if rom_ids is None:
+        return None
 
     try:
-        return normalize_rom_id_scope(parsed)
-    except ValueError as exc:
+        return normalize_rom_id_scope(parse_comma_separated_ids(rom_ids, "ROM ID"))
+    except ValidationError as exc:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            status_code=status.HTTP_400_BAD_REQUEST, detail=exc.message
         ) from exc
 
 
@@ -447,7 +442,7 @@ def get_saves(
     saves = db_save_handler.get_saves(
         user_id=request.user.id,
         rom_id=rom_id,
-        rom_ids=_parse_rom_ids(rom_ids) if rom_ids is not None else None,
+        rom_ids=_parse_rom_ids(rom_ids),
         platform_id=platform_id,
         slot=slot,
     )

--- a/backend/endpoints/saves.py
+++ b/backend/endpoints/saves.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Annotated
 
-from fastapi import Body, File, HTTPException, Request, UploadFile, status
+from fastapi import Body, File, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import FileResponse
 
 from config import MAX_AUTOCLEANUP_LIMIT
@@ -22,6 +22,10 @@ from handler.database import (
     db_save_handler,
     db_screenshot_handler,
     db_sync_session_handler,
+)
+from handler.database.saves_handler import (
+    MAX_ROM_IDS_PER_QUERY,
+    normalize_rom_id_scope,
 )
 from handler.filesystem import fs_asset_handler
 from handler.scan_handler import scan_save, scan_screenshot
@@ -397,10 +401,40 @@ async def add_save(
     return _build_save_schema(db_save, _syncs_for_save(db_save.id, device), device)
 
 
+def _parse_rom_ids(rom_ids: str) -> list[int]:
+    try:
+        parsed = [
+            int(part) for part in (raw.strip() for raw in rom_ids.split(",")) if part
+        ]
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid ROM ID format. Must be comma-separated integers.",
+        ) from exc
+
+    try:
+        return normalize_rom_id_scope(parsed)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+
+
 @protected_route(router.get, "", [Scope.ASSETS_READ])
 def get_saves(
     request: Request,
     rom_id: int | None = None,
+    rom_ids: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Comma-separated list of ROM IDs to scope the results to, for "
+                "clients syncing a known set of ROMs. At most "
+                f"{MAX_ROM_IDS_PER_QUERY} IDs per request; an empty value "
+                "returns no saves. Combined with `rom_id` when both are given."
+            ),
+        ),
+    ] = None,
     platform_id: int | None = None,
     device_id: str | None = None,
     slot: str | None = None,
@@ -411,7 +445,11 @@ def get_saves(
     )
 
     saves = db_save_handler.get_saves(
-        user_id=request.user.id, rom_id=rom_id, platform_id=platform_id, slot=slot
+        user_id=request.user.id,
+        rom_id=rom_id,
+        rom_ids=_parse_rom_ids(rom_ids) if rom_ids is not None else None,
+        platform_id=platform_id,
+        slot=slot,
     )
 
     if not device:

--- a/backend/endpoints/sync.py
+++ b/backend/endpoints/sync.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from fastapi import HTTPException, Request, status
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from config import TASK_TIMEOUT
 from decorators.auth import protected_route
@@ -22,6 +22,10 @@ from handler.database import (
     db_device_save_sync_handler,
     db_save_handler,
     db_sync_session_handler,
+)
+from handler.database.saves_handler import (
+    MAX_ROM_IDS_PER_QUERY,
+    normalize_rom_id_scope,
 )
 from handler.play_session_handler import ingest_play_sessions
 from handler.redis_handler import high_prio_queue
@@ -79,6 +83,21 @@ class SyncNegotiatePayload(BaseModel):
     saves: list[ClientSaveState] = Field(
         description="Current save state on the client."
     )
+    rom_ids: list[int] | None = Field(
+        default=None,
+        description=(
+            "IDs of the ROMs installed on the device. When provided, downloads "
+            "are offered only for these ROMs (plus any ROM the client sent a "
+            "save for) instead of the user's whole save library. This is a "
+            "read-only scope: omitting a ROM never deletes or unlinks its "
+            f"saves. At most {MAX_ROM_IDS_PER_QUERY} IDs per request."
+        ),
+    )
+
+    @field_validator("rom_ids")
+    @classmethod
+    def validate_rom_ids(cls, rom_ids: list[int] | None) -> list[int] | None:
+        return None if rom_ids is None else normalize_rom_id_scope(rom_ids)
 
 
 class SyncPlaySessionEntry(BaseModel):
@@ -112,6 +131,11 @@ def negotiate_sync(
 
     The client sends its current save state, and the server returns a list of
     operations (upload, download, conflict, no_op) to bring both sides in sync.
+
+    A client that only holds part of the library can send `rom_ids` to scope the
+    negotiation to the ROMs installed on the device, which keeps the response
+    from listing downloads for ROMs it cannot play. The scope is read-only: a
+    ROM left out is simply outside this negotiation, never a deletion signal.
 
     Saves are paired on (rom_id, slot). Clients that want a save to stay in sync
     should send a stable, non-null slot name (e.g. "autosave"). Null-slot saves
@@ -160,9 +184,17 @@ def negotiate_sync(
 
     operations: list[SyncOperationSchema] = []
 
+    # Widen an explicit ROM scope with the ROMs the client sent saves for, so a
+    # client save is never misread as an upload just because its ROM was omitted.
+    rom_id_scope: list[int] | None = None
+    if payload.rom_ids is not None:
+        rom_id_scope = list(
+            dict.fromkeys(payload.rom_ids + [s.rom_id for s in payload.saves])
+        )
+
     # Pair on (rom_id, slot), keeping the newest row per slot: slot uploads are datetime-tagged (spec) so tagged filenames never equal the client's untagged name, and a slot accrues many rows over time. Null-slot rows stay archival-only.
     server_saves = db_save_handler.get_saves(
-        user_id=request.user.id, slot_not_null=True
+        user_id=request.user.id, slot_not_null=True, rom_ids=rom_id_scope
     )
     server_save_map: dict[tuple[int, str | None], Save] = {}
     for save in server_saves:

--- a/backend/endpoints/sync.py
+++ b/backend/endpoints/sync.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from fastapi import HTTPException, Request, status
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, model_validator
 
 from config import TASK_TIMEOUT
 from decorators.auth import protected_route
@@ -23,10 +23,6 @@ from handler.database import (
     db_save_handler,
     db_sync_session_handler,
 )
-from handler.database.saves_handler import (
-    MAX_ROM_IDS_PER_QUERY,
-    normalize_rom_id_scope,
-)
 from handler.play_session_handler import ingest_play_sessions
 from handler.redis_handler import high_prio_queue
 from handler.sync.comparison import compare_save_state
@@ -36,6 +32,11 @@ from models.device import SyncMode
 from models.sync_session import SyncSessionStatus
 from utils.datetime import to_utc
 from utils.router import APIRouter
+from utils.validation import (
+    MAX_ROM_IDS_PER_QUERY,
+    ValidationError,
+    normalize_rom_id_scope,
+)
 
 router = APIRouter(
     prefix="/sync",
@@ -93,11 +94,6 @@ class SyncNegotiatePayload(BaseModel):
             f"saves. At most {MAX_ROM_IDS_PER_QUERY} IDs per request."
         ),
     )
-
-    @field_validator("rom_ids")
-    @classmethod
-    def validate_rom_ids(cls, rom_ids: list[int] | None) -> list[int] | None:
-        return None if rom_ids is None else normalize_rom_id_scope(rom_ids)
 
 
 class SyncPlaySessionEntry(BaseModel):
@@ -157,6 +153,17 @@ def negotiate_sync(
             ),
         )
 
+    try:
+        rom_ids = (
+            normalize_rom_id_scope(payload.rom_ids)
+            if payload.rom_ids is not None
+            else None
+        )
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=exc.message
+        ) from exc
+
     device = db_device_handler.get_device(device_id=device_id, user_id=request.user.id)
     if not device:
         raise HTTPException(
@@ -186,11 +193,9 @@ def negotiate_sync(
 
     # Widen an explicit ROM scope with the ROMs the client sent saves for, so a
     # client save is never misread as an upload just because its ROM was omitted.
-    rom_id_scope: list[int] | None = None
-    if payload.rom_ids is not None:
-        rom_id_scope = list(
-            dict.fromkeys(payload.rom_ids + [s.rom_id for s in payload.saves])
-        )
+    rom_id_scope = (
+        rom_ids + [s.rom_id for s in payload.saves] if rom_ids is not None else None
+    )
 
     # Pair on (rom_id, slot), keeping the newest row per slot: slot uploads are datetime-tagged (spec) so tagged filenames never equal the client's untagged name, and a slot accrues many rows over time. Null-slot rows stay archival-only.
     server_saves = db_save_handler.get_saves(
@@ -203,10 +208,10 @@ def negotiate_sync(
         if current is None or to_utc(save.updated_at) > to_utc(current.updated_at):
             server_save_map[key] = save
 
-    # Get all sync records for this device
-    all_save_ids = [s.id for s in server_saves]
+    # Only the newest row per slot is ever looked up, so superseded rows stay out.
+    current_save_ids = [s.id for s in server_save_map.values()]
     device_syncs = db_device_save_sync_handler.get_syncs_for_device_and_saves(
-        device_id=device.id, save_ids=all_save_ids
+        device_id=device.id, save_ids=current_save_ids
     )
     sync_by_save_id = {s.save_id: s for s in device_syncs}
 

--- a/backend/endpoints/sync.py
+++ b/backend/endpoints/sync.py
@@ -32,11 +32,7 @@ from models.device import SyncMode
 from models.sync_session import SyncSessionStatus
 from utils.datetime import to_utc
 from utils.router import APIRouter
-from utils.validation import (
-    MAX_ROM_IDS_PER_QUERY,
-    ValidationError,
-    normalize_rom_id_scope,
-)
+from utils.validation import MAX_ROM_IDS_PER_QUERY, RomIdScope
 
 router = APIRouter(
     prefix="/sync",
@@ -84,7 +80,7 @@ class SyncNegotiatePayload(BaseModel):
     saves: list[ClientSaveState] = Field(
         description="Current save state on the client."
     )
-    rom_ids: list[int] | None = Field(
+    rom_ids: RomIdScope = Field(
         default=None,
         description=(
             "IDs of the ROMs installed on the device. When provided, downloads "
@@ -153,17 +149,6 @@ def negotiate_sync(
             ),
         )
 
-    try:
-        rom_ids = (
-            normalize_rom_id_scope(payload.rom_ids)
-            if payload.rom_ids is not None
-            else None
-        )
-    except ValidationError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail=exc.message
-        ) from exc
-
     device = db_device_handler.get_device(device_id=device_id, user_id=request.user.id)
     if not device:
         raise HTTPException(
@@ -194,7 +179,9 @@ def negotiate_sync(
     # Widen an explicit ROM scope with the ROMs the client sent saves for, so a
     # client save is never misread as an upload just because its ROM was omitted.
     rom_id_scope = (
-        rom_ids + [s.rom_id for s in payload.saves] if rom_ids is not None else None
+        payload.rom_ids + [s.rom_id for s in payload.saves]
+        if payload.rom_ids is not None
+        else None
     )
 
     # Pair on (rom_id, slot), keeping the newest row per slot: slot uploads are datetime-tagged (spec) so tagged filenames never equal the client's untagged name, and a slot accrues many rows over time. Null-slot rows stay archival-only.

--- a/backend/handler/database/saves_handler.py
+++ b/backend/handler/database/saves_handler.py
@@ -1,5 +1,5 @@
-from collections.abc import Sequence
-from typing import Literal
+from collections.abc import Collection, Iterable, Sequence
+from typing import Final, Literal
 
 from sqlalchemy import and_, asc, delete, desc, func, or_, select, update
 from sqlalchemy.orm import QueryableAttribute, Session, load_only
@@ -9,6 +9,36 @@ from models.assets import Save
 from models.rom import Rom
 
 from .base_handler import DBBaseHandler
+
+# Upper bound on the `rom_ids` scope accepted by save queries, to keep the IN
+# clause within driver parameter limits. Documented so sync clients can batch.
+MAX_ROM_IDS_PER_QUERY: Final = 500
+
+
+def normalize_rom_id_scope(rom_ids: Iterable[int]) -> list[int]:
+    """Validate and deduplicate a `rom_ids` query scope, preserving order.
+
+    Args:
+        rom_ids: ROM IDs the caller wants to scope a save query to.
+
+    Returns:
+        The deduplicated IDs.
+
+    Raises:
+        ValueError: If any ID is not positive, or the scope exceeds
+            `MAX_ROM_IDS_PER_QUERY`.
+    """
+    unique = list(dict.fromkeys(rom_ids))
+
+    if any(rom_id <= 0 for rom_id in unique):
+        raise ValueError("ROM IDs must be positive integers")
+
+    if len(unique) > MAX_ROM_IDS_PER_QUERY:
+        raise ValueError(
+            f"Too many ROM IDs: at most {MAX_ROM_IDS_PER_QUERY} per request"
+        )
+
+    return unique
 
 
 class DBSavesHandler(DBBaseHandler):
@@ -85,6 +115,7 @@ class DBSavesHandler(DBBaseHandler):
         self,
         user_id: int,
         rom_id: int | None = None,
+        rom_ids: Collection[int] | None = None,
         platform_id: int | None = None,
         slot: str | None = None,
         slot_not_null: bool = False,
@@ -97,6 +128,10 @@ class DBSavesHandler(DBBaseHandler):
 
         if rom_id:
             query = query.filter_by(rom_id=rom_id)
+
+        # An empty collection is an explicit empty scope, not an absent filter.
+        if rom_ids is not None:
+            query = query.filter(Save.rom_id.in_(rom_ids))
 
         if platform_id:
             query = query.join(Rom, Save.rom_id == Rom.id).filter(

--- a/backend/handler/database/saves_handler.py
+++ b/backend/handler/database/saves_handler.py
@@ -1,5 +1,5 @@
-from collections.abc import Collection, Iterable, Sequence
-from typing import Final, Literal
+from collections.abc import Collection, Sequence
+from typing import Literal
 
 from sqlalchemy import and_, asc, delete, desc, func, or_, select, update
 from sqlalchemy.orm import QueryableAttribute, Session, load_only
@@ -9,36 +9,6 @@ from models.assets import Save
 from models.rom import Rom
 
 from .base_handler import DBBaseHandler
-
-# Upper bound on the `rom_ids` scope accepted by save queries, to keep the IN
-# clause within driver parameter limits. Documented so sync clients can batch.
-MAX_ROM_IDS_PER_QUERY: Final = 500
-
-
-def normalize_rom_id_scope(rom_ids: Iterable[int]) -> list[int]:
-    """Validate and deduplicate a `rom_ids` query scope, preserving order.
-
-    Args:
-        rom_ids: ROM IDs the caller wants to scope a save query to.
-
-    Returns:
-        The deduplicated IDs.
-
-    Raises:
-        ValueError: If any ID is not positive, or the scope exceeds
-            `MAX_ROM_IDS_PER_QUERY`.
-    """
-    unique = list(dict.fromkeys(rom_ids))
-
-    if any(rom_id <= 0 for rom_id in unique):
-        raise ValueError("ROM IDs must be positive integers")
-
-    if len(unique) > MAX_ROM_IDS_PER_QUERY:
-        raise ValueError(
-            f"Too many ROM IDs: at most {MAX_ROM_IDS_PER_QUERY} per request"
-        )
-
-    return unique
 
 
 class DBSavesHandler(DBBaseHandler):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -144,6 +144,26 @@ def rom(admin_user: User, platform: Platform):
 
 
 @pytest.fixture
+def second_rom(admin_user: User, platform: Platform):
+    """A second ROM on the same platform, for tests that scope by ROM."""
+    rom = Rom(
+        platform_id=platform.id,
+        name="test_rom_2",
+        slug="test_rom_slug_2",
+        fs_name="test_rom_2.zip",
+        fs_name_no_tags="test_rom_2",
+        fs_name_no_ext="test_rom_2",
+        fs_extension="zip",
+        fs_path=f"{platform.slug}/roms",
+    )
+    rom = db_rom_handler.add_rom(rom)
+
+    db_rom_handler.add_rom_user(rom_id=rom.id, user_id=admin_user.id)
+
+    return rom
+
+
+@pytest.fixture
 def rom_file(rom: Rom):
     """A single content file attached to the `rom` fixture."""
     rom_file = RomFile(
@@ -204,6 +224,24 @@ def save(rom: Rom, platform: Platform, admin_user: User):
         file_name="test_save.sav",
         file_name_no_tags="test_save",
         file_name_no_ext="test_save",
+        file_extension="sav",
+        emulator="test_emulator",
+        slot="autosave",
+        file_path=f"{platform.slug}/saves/test_emulator",
+        file_size_bytes=1.0,
+    )
+    return db_save_handler.add_save(save)
+
+
+@pytest.fixture
+def second_save(second_rom: Rom, platform: Platform, admin_user: User):
+    """Slot-bound save on `second_rom`, to check ROM-scoped queries exclude it."""
+    save = Save(
+        rom_id=second_rom.id,
+        user_id=admin_user.id,
+        file_name="test_save_2.sav",
+        file_name_no_tags="test_save_2",
+        file_name_no_ext="test_save_2",
         file_extension="sav",
         emulator="test_emulator",
         slot="autosave",

--- a/backend/tests/endpoints/test_collection.py
+++ b/backend/tests/endpoints/test_collection.py
@@ -7,10 +7,9 @@ from fastapi import status
 
 from config import OAUTH_ACCESS_TOKEN_EXPIRE_SECONDS
 from handler.auth import oauth_handler
-from handler.database import db_collection_handler, db_rom_handler
+from handler.database import db_collection_handler
 from handler.filesystem.resources_handler import FSResourcesHandler
 from models.collection import Collection, SmartCollection
-from models.platform import Platform
 from models.rom import Rom
 from models.user import User
 
@@ -52,21 +51,6 @@ def favorite_collection(admin_user: User) -> Collection:
             user_id=admin_user.id,
         )
     )
-
-
-@pytest.fixture
-def second_rom(admin_user: User, platform: Platform) -> Rom:
-    rom = Rom(
-        platform_id=platform.id,
-        name="test_rom_2",
-        slug="test_rom_slug_2",
-        fs_name="test_rom_2.zip",
-        fs_name_no_tags="test_rom_2",
-        fs_name_no_ext="test_rom_2",
-        fs_extension="zip",
-        fs_path=f"{platform.slug}/roms",
-    )
-    return db_rom_handler.add_rom(rom)
 
 
 @pytest.fixture

--- a/backend/tests/endpoints/test_saves.py
+++ b/backend/tests/endpoints/test_saves.py
@@ -11,9 +11,11 @@ from handler.auth.constants import Scope
 from handler.database import (
     db_device_handler,
     db_device_save_sync_handler,
+    db_rom_handler,
     db_save_handler,
 )
 from handler.database.base_handler import sync_session
+from handler.database.saves_handler import MAX_ROM_IDS_PER_QUERY
 from models.assets import Save
 from models.device import Device
 from models.permission import HiddenEntity, PermEntity
@@ -1442,6 +1444,153 @@ class TestSlotFiltering:
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
         assert len(data) == 0
+
+
+class TestRomIdsScope:
+    @pytest.fixture
+    def second_rom_save(self, admin_user: User, platform: Platform) -> tuple[Rom, Save]:
+        """A save on a ROM other than the `rom` fixture's."""
+        rom = db_rom_handler.add_rom(
+            Rom(
+                platform_id=platform.id,
+                name="second_rom",
+                slug="second_rom_slug",
+                fs_name="second_rom.zip",
+                fs_name_no_tags="second_rom",
+                fs_name_no_ext="second_rom",
+                fs_extension="zip",
+                fs_path=f"{platform.slug}/roms",
+            )
+        )
+        db_rom_handler.add_rom_user(rom_id=rom.id, user_id=admin_user.id)
+
+        save = db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name="second.sav",
+                file_name_no_tags="second",
+                file_name_no_ext="second",
+                file_extension="sav",
+                emulator="test_emulator",
+                slot="autosave",
+                file_path=f"{platform.slug}/saves/test_emulator",
+                file_size_bytes=100,
+            )
+        )
+        return rom, save
+
+    def test_scopes_results_to_listed_roms(
+        self,
+        client,
+        access_token: str,
+        rom: Rom,
+        save: Save,
+        second_rom_save: tuple[Rom, Save],
+    ):
+        response = client.get(
+            f"/api/saves?rom_ids={rom.id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [item["id"] for item in response.json()] == [save.id]
+
+    def test_accepts_multiple_ids(
+        self,
+        client,
+        access_token: str,
+        rom: Rom,
+        save: Save,
+        second_rom_save: tuple[Rom, Save],
+    ):
+        second_rom, second_save = second_rom_save
+
+        response = client.get(
+            f"/api/saves?rom_ids={rom.id},{second_rom.id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert {item["id"] for item in response.json()} == {save.id, second_save.id}
+
+    def test_tolerates_whitespace_and_duplicates(
+        self, client, access_token: str, rom: Rom, save: Save
+    ):
+        response = client.get(
+            f"/api/saves?rom_ids= {rom.id} , {rom.id} ",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [item["id"] for item in response.json()] == [save.id]
+
+    def test_empty_value_returns_no_saves(self, client, access_token: str, save: Save):
+        response = client.get(
+            "/api/saves?rom_ids=",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
+    def test_omitted_returns_all_saves(
+        self,
+        client,
+        access_token: str,
+        save: Save,
+        second_rom_save: tuple[Rom, Save],
+    ):
+        response = client.get(
+            "/api/saves",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert {item["id"] for item in response.json()} == {
+            save.id,
+            second_rom_save[1].id,
+        }
+
+    def test_combines_with_slot_filter(
+        self, client, access_token: str, rom: Rom, save: Save, archival_save: Save
+    ):
+        response = client.get(
+            f"/api/saves?rom_ids={rom.id}&slot=autosave",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [item["id"] for item in response.json()] == [save.id]
+
+    def test_rejects_non_integer_ids(self, client, access_token: str):
+        response = client.get(
+            "/api/saves?rom_ids=1,abc",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "comma-separated integers" in response.json()["detail"]
+
+    def test_rejects_non_positive_ids(self, client, access_token: str):
+        response = client.get(
+            "/api/saves?rom_ids=1,0",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "positive" in response.json()["detail"]
+
+    def test_rejects_scope_over_the_limit(self, client, access_token: str):
+        rom_ids = ",".join(str(i) for i in range(1, MAX_ROM_IDS_PER_QUERY + 2))
+
+        response = client.get(
+            f"/api/saves?rom_ids={rom_ids}",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert str(MAX_ROM_IDS_PER_QUERY) in response.json()["detail"]
 
 
 class TestDatetimeTagging:

--- a/backend/tests/endpoints/test_saves.py
+++ b/backend/tests/endpoints/test_saves.py
@@ -1457,7 +1457,7 @@ class TestRomIdsScope:
         assert response.status_code == status.HTTP_200_OK
         assert [item["id"] for item in response.json()] == [save.id]
 
-    def test_accepts_multiple_ids(
+    def test_accepts_repeated_ids(
         self,
         client,
         access_token: str,
@@ -1467,32 +1467,23 @@ class TestRomIdsScope:
         second_save: Save,
     ):
         response = client.get(
-            f"/api/saves?rom_ids={rom.id},{second_rom.id}",
+            f"/api/saves?rom_ids={rom.id}&rom_ids={second_rom.id}",
             headers={"Authorization": f"Bearer {access_token}"},
         )
 
         assert response.status_code == status.HTTP_200_OK
         assert {item["id"] for item in response.json()} == {save.id, second_save.id}
 
-    def test_tolerates_whitespace_and_duplicates(
+    def test_tolerates_duplicates(
         self, client, access_token: str, rom: Rom, save: Save
     ):
         response = client.get(
-            f"/api/saves?rom_ids= {rom.id} , {rom.id} ",
+            f"/api/saves?rom_ids={rom.id}&rom_ids={rom.id}",
             headers={"Authorization": f"Bearer {access_token}"},
         )
 
         assert response.status_code == status.HTTP_200_OK
         assert [item["id"] for item in response.json()] == [save.id]
-
-    def test_empty_value_returns_no_saves(self, client, access_token: str, save: Save):
-        response = client.get(
-            "/api/saves?rom_ids=",
-            headers={"Authorization": f"Bearer {access_token}"},
-        )
-
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json() == []
 
     def test_omitted_returns_all_saves(
         self, client, access_token: str, save: Save, second_save: Save
@@ -1518,32 +1509,29 @@ class TestRomIdsScope:
 
     def test_rejects_non_integer_ids(self, client, access_token: str):
         response = client.get(
-            "/api/saves?rom_ids=1,abc",
+            "/api/saves?rom_ids=1&rom_ids=abc",
             headers={"Authorization": f"Bearer {access_token}"},
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "comma-separated integers" in response.json()["detail"]
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     def test_rejects_non_positive_ids(self, client, access_token: str):
         response = client.get(
-            "/api/saves?rom_ids=1,0",
+            "/api/saves?rom_ids=1&rom_ids=0",
             headers={"Authorization": f"Bearer {access_token}"},
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "positive" in response.json()["detail"]
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     def test_rejects_scope_over_the_limit(self, client, access_token: str):
-        rom_ids = ",".join(str(i) for i in range(1, MAX_ROM_IDS_PER_QUERY + 2))
+        rom_ids = "&".join(f"rom_ids={i}" for i in range(1, MAX_ROM_IDS_PER_QUERY + 2))
 
         response = client.get(
-            f"/api/saves?rom_ids={rom_ids}",
+            f"/api/saves?{rom_ids}",
             headers={"Authorization": f"Bearer {access_token}"},
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert str(MAX_ROM_IDS_PER_QUERY) in response.json()["detail"]
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 class TestDatetimeTagging:

--- a/backend/tests/endpoints/test_saves.py
+++ b/backend/tests/endpoints/test_saves.py
@@ -11,11 +11,9 @@ from handler.auth.constants import Scope
 from handler.database import (
     db_device_handler,
     db_device_save_sync_handler,
-    db_rom_handler,
     db_save_handler,
 )
 from handler.database.base_handler import sync_session
-from handler.database.saves_handler import MAX_ROM_IDS_PER_QUERY
 from models.assets import Save
 from models.device import Device
 from models.permission import HiddenEntity, PermEntity
@@ -23,6 +21,7 @@ from models.platform import Platform
 from models.rom import Rom
 from models.user import User
 from utils import uploads
+from utils.validation import MAX_ROM_IDS_PER_QUERY
 
 
 def _hide(entity: PermEntity, entity_id: int, user_id: int) -> None:
@@ -1447,46 +1446,8 @@ class TestSlotFiltering:
 
 
 class TestRomIdsScope:
-    @pytest.fixture
-    def second_rom_save(self, admin_user: User, platform: Platform) -> tuple[Rom, Save]:
-        """A save on a ROM other than the `rom` fixture's."""
-        rom = db_rom_handler.add_rom(
-            Rom(
-                platform_id=platform.id,
-                name="second_rom",
-                slug="second_rom_slug",
-                fs_name="second_rom.zip",
-                fs_name_no_tags="second_rom",
-                fs_name_no_ext="second_rom",
-                fs_extension="zip",
-                fs_path=f"{platform.slug}/roms",
-            )
-        )
-        db_rom_handler.add_rom_user(rom_id=rom.id, user_id=admin_user.id)
-
-        save = db_save_handler.add_save(
-            Save(
-                rom_id=rom.id,
-                user_id=admin_user.id,
-                file_name="second.sav",
-                file_name_no_tags="second",
-                file_name_no_ext="second",
-                file_extension="sav",
-                emulator="test_emulator",
-                slot="autosave",
-                file_path=f"{platform.slug}/saves/test_emulator",
-                file_size_bytes=100,
-            )
-        )
-        return rom, save
-
     def test_scopes_results_to_listed_roms(
-        self,
-        client,
-        access_token: str,
-        rom: Rom,
-        save: Save,
-        second_rom_save: tuple[Rom, Save],
+        self, client, access_token: str, rom: Rom, save: Save, second_save: Save
     ):
         response = client.get(
             f"/api/saves?rom_ids={rom.id}",
@@ -1501,11 +1462,10 @@ class TestRomIdsScope:
         client,
         access_token: str,
         rom: Rom,
+        second_rom: Rom,
         save: Save,
-        second_rom_save: tuple[Rom, Save],
+        second_save: Save,
     ):
-        second_rom, second_save = second_rom_save
-
         response = client.get(
             f"/api/saves?rom_ids={rom.id},{second_rom.id}",
             headers={"Authorization": f"Bearer {access_token}"},
@@ -1535,11 +1495,7 @@ class TestRomIdsScope:
         assert response.json() == []
 
     def test_omitted_returns_all_saves(
-        self,
-        client,
-        access_token: str,
-        save: Save,
-        second_rom_save: tuple[Rom, Save],
+        self, client, access_token: str, save: Save, second_save: Save
     ):
         response = client.get(
             "/api/saves",
@@ -1547,10 +1503,7 @@ class TestRomIdsScope:
         )
 
         assert response.status_code == status.HTTP_200_OK
-        assert {item["id"] for item in response.json()} == {
-            save.id,
-            second_rom_save[1].id,
-        }
+        assert {item["id"] for item in response.json()} == {save.id, second_save.id}
 
     def test_combines_with_slot_filter(
         self, client, access_token: str, rom: Rom, save: Save, archival_save: Save

--- a/backend/tests/endpoints/test_sync.py
+++ b/backend/tests/endpoints/test_sync.py
@@ -5,23 +5,20 @@ from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from unittest import mock
 
-import pytest
 from fastapi import status
 
 from handler.database import (
     db_device_handler,
     db_device_save_sync_handler,
     db_play_session_handler,
-    db_rom_handler,
     db_save_handler,
     db_sync_session_handler,
 )
-from handler.database.saves_handler import MAX_ROM_IDS_PER_QUERY
 from models.assets import Save
 from models.device import Device, SyncMode
-from models.platform import Platform
 from models.rom import Rom
 from models.user import User
+from utils.validation import MAX_ROM_IDS_PER_QUERY
 
 
 class TestSyncNegotiate:
@@ -148,38 +145,6 @@ class TestSyncNegotiate:
 class TestNegotiateRomIdsScope:
     """`rom_ids` scopes negotiation to the ROMs installed on the device."""
 
-    @pytest.fixture
-    def uninstalled_rom_save(self, admin_user: User, platform: Platform) -> Save:
-        """A server save for a ROM the device does not have installed."""
-        rom = db_rom_handler.add_rom(
-            Rom(
-                platform_id=platform.id,
-                name="uninstalled_rom",
-                slug="uninstalled_rom_slug",
-                fs_name="uninstalled_rom.zip",
-                fs_name_no_tags="uninstalled_rom",
-                fs_name_no_ext="uninstalled_rom",
-                fs_extension="zip",
-                fs_path=f"{platform.slug}/roms",
-            )
-        )
-        db_rom_handler.add_rom_user(rom_id=rom.id, user_id=admin_user.id)
-
-        return db_save_handler.add_save(
-            Save(
-                rom_id=rom.id,
-                user_id=admin_user.id,
-                file_name="uninstalled.sav",
-                file_name_no_tags="uninstalled",
-                file_name_no_ext="uninstalled",
-                file_extension="sav",
-                emulator="test_emulator",
-                slot="autosave",
-                file_path=f"{platform.slug}/saves/test_emulator",
-                file_size_bytes=100,
-            )
-        )
-
     def test_scope_omits_downloads_for_uninstalled_roms(
         self,
         client,
@@ -187,7 +152,7 @@ class TestNegotiateRomIdsScope:
         admin_user: User,
         rom: Rom,
         save: Save,
-        uninstalled_rom_save: Save,
+        second_save: Save,
     ):
         device = db_device_handler.add_device(
             Device(id="neg-scope-dev", user_id=admin_user.id, sync_enabled=True)
@@ -202,7 +167,7 @@ class TestNegotiateRomIdsScope:
         assert response.status_code == status.HTTP_200_OK
         save_ids = [op["save_id"] for op in response.json()["operations"]]
         assert save.id in save_ids
-        assert uninstalled_rom_save.id not in save_ids
+        assert second_save.id not in save_ids
 
     def test_without_scope_all_saves_are_offered(
         self,
@@ -210,7 +175,7 @@ class TestNegotiateRomIdsScope:
         access_token: str,
         admin_user: User,
         save: Save,
-        uninstalled_rom_save: Save,
+        second_save: Save,
     ):
         device = db_device_handler.add_device(
             Device(id="neg-noscope-dev", user_id=admin_user.id, sync_enabled=True)
@@ -224,7 +189,7 @@ class TestNegotiateRomIdsScope:
 
         assert response.status_code == status.HTTP_200_OK
         save_ids = [op["save_id"] for op in response.json()["operations"]]
-        assert {save.id, uninstalled_rom_save.id} <= set(save_ids)
+        assert {save.id, second_save.id} <= set(save_ids)
 
     def test_client_save_outside_scope_is_still_paired(
         self, client, access_token: str, admin_user: User, rom: Rom, save: Save
@@ -305,7 +270,8 @@ class TestNegotiateRomIdsScope:
             headers={"Authorization": f"Bearer {access_token}"},
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "positive" in response.json()["detail"]
 
     def test_rejects_scope_over_the_limit(
         self, client, access_token: str, admin_user: User
@@ -324,7 +290,8 @@ class TestNegotiateRomIdsScope:
             headers={"Authorization": f"Bearer {access_token}"},
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert str(MAX_ROM_IDS_PER_QUERY) in response.json()["detail"]
 
 
 class TestSyncSessions:

--- a/backend/tests/endpoints/test_sync.py
+++ b/backend/tests/endpoints/test_sync.py
@@ -270,8 +270,7 @@ class TestNegotiateRomIdsScope:
             headers={"Authorization": f"Bearer {access_token}"},
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "positive" in response.json()["detail"]
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     def test_rejects_scope_over_the_limit(
         self, client, access_token: str, admin_user: User
@@ -290,8 +289,7 @@ class TestNegotiateRomIdsScope:
             headers={"Authorization": f"Bearer {access_token}"},
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert str(MAX_ROM_IDS_PER_QUERY) in response.json()["detail"]
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 class TestSyncSessions:

--- a/backend/tests/endpoints/test_sync.py
+++ b/backend/tests/endpoints/test_sync.py
@@ -5,17 +5,21 @@ from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from unittest import mock
 
+import pytest
 from fastapi import status
 
 from handler.database import (
     db_device_handler,
     db_device_save_sync_handler,
     db_play_session_handler,
+    db_rom_handler,
     db_save_handler,
     db_sync_session_handler,
 )
+from handler.database.saves_handler import MAX_ROM_IDS_PER_QUERY
 from models.assets import Save
 from models.device import Device, SyncMode
+from models.platform import Platform
 from models.rom import Rom
 from models.user import User
 
@@ -139,6 +143,188 @@ class TestSyncNegotiate:
         data = response.json()
         assert "session_id" in data
         assert data["session_id"] > 0
+
+
+class TestNegotiateRomIdsScope:
+    """`rom_ids` scopes negotiation to the ROMs installed on the device."""
+
+    @pytest.fixture
+    def uninstalled_rom_save(self, admin_user: User, platform: Platform) -> Save:
+        """A server save for a ROM the device does not have installed."""
+        rom = db_rom_handler.add_rom(
+            Rom(
+                platform_id=platform.id,
+                name="uninstalled_rom",
+                slug="uninstalled_rom_slug",
+                fs_name="uninstalled_rom.zip",
+                fs_name_no_tags="uninstalled_rom",
+                fs_name_no_ext="uninstalled_rom",
+                fs_extension="zip",
+                fs_path=f"{platform.slug}/roms",
+            )
+        )
+        db_rom_handler.add_rom_user(rom_id=rom.id, user_id=admin_user.id)
+
+        return db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=admin_user.id,
+                file_name="uninstalled.sav",
+                file_name_no_tags="uninstalled",
+                file_name_no_ext="uninstalled",
+                file_extension="sav",
+                emulator="test_emulator",
+                slot="autosave",
+                file_path=f"{platform.slug}/saves/test_emulator",
+                file_size_bytes=100,
+            )
+        )
+
+    def test_scope_omits_downloads_for_uninstalled_roms(
+        self,
+        client,
+        access_token: str,
+        admin_user: User,
+        rom: Rom,
+        save: Save,
+        uninstalled_rom_save: Save,
+    ):
+        device = db_device_handler.add_device(
+            Device(id="neg-scope-dev", user_id=admin_user.id, sync_enabled=True)
+        )
+
+        response = client.post(
+            "/api/sync/negotiate",
+            json={"device_id": device.id, "saves": [], "rom_ids": [rom.id]},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        save_ids = [op["save_id"] for op in response.json()["operations"]]
+        assert save.id in save_ids
+        assert uninstalled_rom_save.id not in save_ids
+
+    def test_without_scope_all_saves_are_offered(
+        self,
+        client,
+        access_token: str,
+        admin_user: User,
+        save: Save,
+        uninstalled_rom_save: Save,
+    ):
+        device = db_device_handler.add_device(
+            Device(id="neg-noscope-dev", user_id=admin_user.id, sync_enabled=True)
+        )
+
+        response = client.post(
+            "/api/sync/negotiate",
+            json={"device_id": device.id, "saves": []},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        save_ids = [op["save_id"] for op in response.json()["operations"]]
+        assert {save.id, uninstalled_rom_save.id} <= set(save_ids)
+
+    def test_client_save_outside_scope_is_still_paired(
+        self, client, access_token: str, admin_user: User, rom: Rom, save: Save
+    ):
+        """A ROM missing from `rom_ids` but present in `saves` must not be
+        misread as an upload just because the scope omitted it."""
+        device = db_device_handler.add_device(
+            Device(id="neg-scope-pair-dev", user_id=admin_user.id, sync_enabled=True)
+        )
+
+        response = client.post(
+            "/api/sync/negotiate",
+            json={
+                "device_id": device.id,
+                "rom_ids": [rom.id + 10_000],
+                "saves": [
+                    {
+                        "rom_id": rom.id,
+                        "file_name": save.file_name,
+                        "slot": save.slot,
+                        "updated_at": "2026-01-10T00:00:00Z",
+                        "file_size_bytes": 1024,
+                    }
+                ],
+            },
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["total_upload"] == 0
+        assert [op["save_id"] for op in data["operations"]] == [save.id]
+
+    def test_empty_scope_offers_no_downloads(
+        self, client, access_token: str, admin_user: User, save: Save
+    ):
+        device = db_device_handler.add_device(
+            Device(id="neg-empty-scope-dev", user_id=admin_user.id, sync_enabled=True)
+        )
+
+        response = client.post(
+            "/api/sync/negotiate",
+            json={"device_id": device.id, "saves": [], "rom_ids": []},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["operations"] == []
+
+    def test_scope_does_not_delete_saves_outside_it(
+        self, client, access_token: str, admin_user: User, save: Save
+    ):
+        """The scope is read-only: an omitted ROM keeps its saves."""
+        device = db_device_handler.add_device(
+            Device(
+                id="neg-scope-readonly-dev", user_id=admin_user.id, sync_enabled=True
+            )
+        )
+
+        client.post(
+            "/api/sync/negotiate",
+            json={"device_id": device.id, "saves": [], "rom_ids": []},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert db_save_handler.get_save(user_id=admin_user.id, id=save.id) is not None
+
+    def test_rejects_non_positive_ids(
+        self, client, access_token: str, admin_user: User
+    ):
+        device = db_device_handler.add_device(
+            Device(id="neg-badid-dev", user_id=admin_user.id, sync_enabled=True)
+        )
+
+        response = client.post(
+            "/api/sync/negotiate",
+            json={"device_id": device.id, "saves": [], "rom_ids": [0]},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_rejects_scope_over_the_limit(
+        self, client, access_token: str, admin_user: User
+    ):
+        device = db_device_handler.add_device(
+            Device(id="neg-toomany-dev", user_id=admin_user.id, sync_enabled=True)
+        )
+
+        response = client.post(
+            "/api/sync/negotiate",
+            json={
+                "device_id": device.id,
+                "saves": [],
+                "rom_ids": list(range(1, MAX_ROM_IDS_PER_QUERY + 2)),
+            },
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 class TestSyncSessions:

--- a/backend/tests/handler/database/test_saves_handler.py
+++ b/backend/tests/handler/database/test_saves_handler.py
@@ -7,15 +7,16 @@ it properly filters by platform_id through the Rom relationship.
 
 import pytest
 
-from handler.database import db_rom_handler, db_save_handler
-from handler.database.saves_handler import (
-    MAX_ROM_IDS_PER_QUERY,
-    normalize_rom_id_scope,
-)
+from handler.database import db_save_handler
 from models.assets import Save
 from models.platform import Platform
 from models.rom import Rom
 from models.user import User
+from utils.validation import (
+    MAX_ROM_IDS_PER_QUERY,
+    ValidationError,
+    normalize_rom_id_scope,
+)
 
 
 class TestDBSavesHandlerPlatformFiltering:
@@ -912,60 +913,26 @@ class TestDBSavesHandlerGetLatestSavesForRoms:
 class TestGetSavesRomIdsScope:
     """Test suite for the `rom_ids` scope on DBSavesHandler.get_saves."""
 
-    def _add_save(self, user_id: int, rom: Rom, file_name: str) -> Save:
-        return db_save_handler.add_save(
-            Save(
-                rom_id=rom.id,
-                user_id=user_id,
-                file_name=file_name,
-                file_name_no_tags=file_name.removesuffix(".sav"),
-                file_name_no_ext=file_name.removesuffix(".sav"),
-                file_extension="sav",
-                emulator="test_emulator",
-                slot="autosave",
-                file_path=f"{rom.platform_slug}/saves/test_emulator",
-                file_size_bytes=100,
-            )
-        )
-
-    def _add_rom(self, admin_user: User, platform: Platform, slug: str) -> Rom:
-        rom = db_rom_handler.add_rom(
-            Rom(
-                platform_id=platform.id,
-                name=slug,
-                slug=slug,
-                fs_name=f"{slug}.zip",
-                fs_name_no_tags=slug,
-                fs_name_no_ext=slug,
-                fs_extension="zip",
-                fs_path=f"{platform.slug}/roms",
-            )
-        )
-        db_rom_handler.add_rom_user(rom_id=rom.id, user_id=admin_user.id)
-        return rom
-
     def test_scopes_to_listed_roms(
-        self, admin_user: User, platform: Platform, rom: Rom, save: Save
+        self, admin_user: User, rom: Rom, save: Save, second_save: Save
     ):
-        other_rom = self._add_rom(admin_user, platform, "other_rom")
-        other_save = self._add_save(admin_user.id, other_rom, "other.sav")
-
         saves = db_save_handler.get_saves(user_id=admin_user.id, rom_ids=[rom.id])
 
         assert [s.id for s in saves] == [save.id]
-        assert other_save.id not in [s.id for s in saves]
 
     def test_scopes_to_multiple_roms(
-        self, admin_user: User, platform: Platform, rom: Rom, save: Save
+        self,
+        admin_user: User,
+        rom: Rom,
+        second_rom: Rom,
+        save: Save,
+        second_save: Save,
     ):
-        other_rom = self._add_rom(admin_user, platform, "other_rom")
-        other_save = self._add_save(admin_user.id, other_rom, "other.sav")
-
         saves = db_save_handler.get_saves(
-            user_id=admin_user.id, rom_ids=[rom.id, other_rom.id]
+            user_id=admin_user.id, rom_ids=[rom.id, second_rom.id]
         )
 
-        assert {s.id for s in saves} == {save.id, other_save.id}
+        assert {s.id for s in saves} == {save.id, second_save.id}
 
     def test_empty_scope_returns_nothing(self, admin_user: User, save: Save):
         assert db_save_handler.get_saves(user_id=admin_user.id, rom_ids=[]) == []
@@ -990,10 +957,10 @@ class TestNormalizeRomIdScope:
         assert normalize_rom_id_scope([3, 1, 3, 2, 1]) == [3, 1, 2]
 
     def test_rejects_non_positive_ids(self):
-        with pytest.raises(ValueError, match="positive"):
+        with pytest.raises(ValidationError, match="positive"):
             normalize_rom_id_scope([1, 0])
 
-        with pytest.raises(ValueError, match="positive"):
+        with pytest.raises(ValidationError, match="positive"):
             normalize_rom_id_scope([-1])
 
     def test_accepts_scope_at_the_limit(self):
@@ -1002,5 +969,5 @@ class TestNormalizeRomIdScope:
         assert normalize_rom_id_scope(rom_ids) == rom_ids
 
     def test_rejects_scope_over_the_limit(self):
-        with pytest.raises(ValueError, match="Too many ROM IDs"):
+        with pytest.raises(ValidationError, match="Too many ROM IDs"):
             normalize_rom_id_scope(range(1, MAX_ROM_IDS_PER_QUERY + 2))

--- a/backend/tests/handler/database/test_saves_handler.py
+++ b/backend/tests/handler/database/test_saves_handler.py
@@ -5,18 +5,11 @@ This module tests the platform filtering fixes for DBSavesHandler to ensure
 it properly filters by platform_id through the Rom relationship.
 """
 
-import pytest
-
 from handler.database import db_save_handler
 from models.assets import Save
 from models.platform import Platform
 from models.rom import Rom
 from models.user import User
-from utils.validation import (
-    MAX_ROM_IDS_PER_QUERY,
-    ValidationError,
-    normalize_rom_id_scope,
-)
 
 
 class TestDBSavesHandlerPlatformFiltering:
@@ -950,24 +943,3 @@ class TestGetSavesRomIdsScope:
         )
 
         assert [s.id for s in saves] == [save.id]
-
-
-class TestNormalizeRomIdScope:
-    def test_deduplicates_preserving_order(self):
-        assert normalize_rom_id_scope([3, 1, 3, 2, 1]) == [3, 1, 2]
-
-    def test_rejects_non_positive_ids(self):
-        with pytest.raises(ValidationError, match="positive"):
-            normalize_rom_id_scope([1, 0])
-
-        with pytest.raises(ValidationError, match="positive"):
-            normalize_rom_id_scope([-1])
-
-    def test_accepts_scope_at_the_limit(self):
-        rom_ids = list(range(1, MAX_ROM_IDS_PER_QUERY + 1))
-
-        assert normalize_rom_id_scope(rom_ids) == rom_ids
-
-    def test_rejects_scope_over_the_limit(self):
-        with pytest.raises(ValidationError, match="Too many ROM IDs"):
-            normalize_rom_id_scope(range(1, MAX_ROM_IDS_PER_QUERY + 2))

--- a/backend/tests/handler/database/test_saves_handler.py
+++ b/backend/tests/handler/database/test_saves_handler.py
@@ -5,7 +5,13 @@ This module tests the platform filtering fixes for DBSavesHandler to ensure
 it properly filters by platform_id through the Rom relationship.
 """
 
-from handler.database import db_save_handler
+import pytest
+
+from handler.database import db_rom_handler, db_save_handler
+from handler.database.saves_handler import (
+    MAX_ROM_IDS_PER_QUERY,
+    normalize_rom_id_scope,
+)
 from models.assets import Save
 from models.platform import Platform
 from models.rom import Rom
@@ -901,3 +907,100 @@ class TestDBSavesHandlerGetLatestSavesForRoms:
         )
 
         assert latest == {}
+
+
+class TestGetSavesRomIdsScope:
+    """Test suite for the `rom_ids` scope on DBSavesHandler.get_saves."""
+
+    def _add_save(self, user_id: int, rom: Rom, file_name: str) -> Save:
+        return db_save_handler.add_save(
+            Save(
+                rom_id=rom.id,
+                user_id=user_id,
+                file_name=file_name,
+                file_name_no_tags=file_name.removesuffix(".sav"),
+                file_name_no_ext=file_name.removesuffix(".sav"),
+                file_extension="sav",
+                emulator="test_emulator",
+                slot="autosave",
+                file_path=f"{rom.platform_slug}/saves/test_emulator",
+                file_size_bytes=100,
+            )
+        )
+
+    def _add_rom(self, admin_user: User, platform: Platform, slug: str) -> Rom:
+        rom = db_rom_handler.add_rom(
+            Rom(
+                platform_id=platform.id,
+                name=slug,
+                slug=slug,
+                fs_name=f"{slug}.zip",
+                fs_name_no_tags=slug,
+                fs_name_no_ext=slug,
+                fs_extension="zip",
+                fs_path=f"{platform.slug}/roms",
+            )
+        )
+        db_rom_handler.add_rom_user(rom_id=rom.id, user_id=admin_user.id)
+        return rom
+
+    def test_scopes_to_listed_roms(
+        self, admin_user: User, platform: Platform, rom: Rom, save: Save
+    ):
+        other_rom = self._add_rom(admin_user, platform, "other_rom")
+        other_save = self._add_save(admin_user.id, other_rom, "other.sav")
+
+        saves = db_save_handler.get_saves(user_id=admin_user.id, rom_ids=[rom.id])
+
+        assert [s.id for s in saves] == [save.id]
+        assert other_save.id not in [s.id for s in saves]
+
+    def test_scopes_to_multiple_roms(
+        self, admin_user: User, platform: Platform, rom: Rom, save: Save
+    ):
+        other_rom = self._add_rom(admin_user, platform, "other_rom")
+        other_save = self._add_save(admin_user.id, other_rom, "other.sav")
+
+        saves = db_save_handler.get_saves(
+            user_id=admin_user.id, rom_ids=[rom.id, other_rom.id]
+        )
+
+        assert {s.id for s in saves} == {save.id, other_save.id}
+
+    def test_empty_scope_returns_nothing(self, admin_user: User, save: Save):
+        assert db_save_handler.get_saves(user_id=admin_user.id, rom_ids=[]) == []
+
+    def test_omitted_scope_returns_everything(self, admin_user: User, save: Save):
+        saves = db_save_handler.get_saves(user_id=admin_user.id, rom_ids=None)
+
+        assert save.id in [s.id for s in saves]
+
+    def test_combines_with_slot_filter(
+        self, admin_user: User, rom: Rom, save: Save, archival_save: Save
+    ):
+        saves = db_save_handler.get_saves(
+            user_id=admin_user.id, rom_ids=[rom.id], slot_not_null=True
+        )
+
+        assert [s.id for s in saves] == [save.id]
+
+
+class TestNormalizeRomIdScope:
+    def test_deduplicates_preserving_order(self):
+        assert normalize_rom_id_scope([3, 1, 3, 2, 1]) == [3, 1, 2]
+
+    def test_rejects_non_positive_ids(self):
+        with pytest.raises(ValueError, match="positive"):
+            normalize_rom_id_scope([1, 0])
+
+        with pytest.raises(ValueError, match="positive"):
+            normalize_rom_id_scope([-1])
+
+    def test_accepts_scope_at_the_limit(self):
+        rom_ids = list(range(1, MAX_ROM_IDS_PER_QUERY + 1))
+
+        assert normalize_rom_id_scope(rom_ids) == rom_ids
+
+    def test_rejects_scope_over_the_limit(self):
+        with pytest.raises(ValueError, match="Too many ROM IDs"):
+            normalize_rom_id_scope(range(1, MAX_ROM_IDS_PER_QUERY + 2))

--- a/backend/utils/validation.py
+++ b/backend/utils/validation.py
@@ -1,6 +1,7 @@
 import re
-from collections.abc import Iterable
-from typing import Final
+from typing import Annotated, Final
+
+from pydantic import AfterValidator, Field
 
 from logger.logger import log
 from models.user import TEXT_FIELD_LENGTH
@@ -24,6 +25,19 @@ EMAIL_PATTERN = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
 MAX_ROM_IDS_PER_QUERY: Final = 500
 
 
+def _dedupe_rom_ids(rom_ids: list[int] | None) -> list[int] | None:
+    return None if rom_ids is None else list(dict.fromkeys(rom_ids))
+
+
+# Shared by every route that scopes a query to a set of ROMs, so the cap and
+# the per-ID rule are declared once and both routes reject a bad scope alike.
+RomIdScope = Annotated[
+    list[Annotated[int, Field(gt=0)]] | None,
+    Field(max_length=MAX_ROM_IDS_PER_QUERY),
+    AfterValidator(_dedupe_rom_ids),
+]
+
+
 def parse_comma_separated_ids(value: str, field_name: str = "ID") -> list[int]:
     """Parse a comma-separated list of integer IDs from a query parameter.
 
@@ -37,26 +51,6 @@ def parse_comma_separated_ids(value: str, field_name: str = "ID") -> list[int]:
             f"Invalid {field_name} format. Must be comma-separated integers.",
             field_name,
         ) from exc
-
-
-def normalize_rom_id_scope(rom_ids: Iterable[int]) -> list[int]:
-    """Deduplicate a `rom_ids` request scope, preserving order.
-
-    Raises:
-        ValidationError: If an ID is not positive, or the scope is over the cap.
-    """
-    unique = list(dict.fromkeys(rom_ids))
-
-    if any(rom_id <= 0 for rom_id in unique):
-        raise ValidationError("ROM IDs must be positive integers", "rom_ids")
-
-    if len(unique) > MAX_ROM_IDS_PER_QUERY:
-        raise ValidationError(
-            f"Too many ROM IDs: at most {MAX_ROM_IDS_PER_QUERY} per request",
-            "rom_ids",
-        )
-
-    return unique
 
 
 def validate_ascii_only(value: str, field_name: str = "field") -> None:

--- a/backend/utils/validation.py
+++ b/backend/utils/validation.py
@@ -1,4 +1,6 @@
 import re
+from collections.abc import Iterable
+from typing import Final
 
 from logger.logger import log
 from models.user import TEXT_FIELD_LENGTH
@@ -16,6 +18,45 @@ class ValidationError(Exception):
 # Pre-compiled regex patterns for better performance
 USERNAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 EMAIL_PATTERN = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
+
+# Upper bound on a `rom_ids` request scope, so one request maps to a bounded
+# query and response. Documented so clients can batch a large library.
+MAX_ROM_IDS_PER_QUERY: Final = 500
+
+
+def parse_comma_separated_ids(value: str, field_name: str = "ID") -> list[int]:
+    """Parse a comma-separated list of integer IDs from a query parameter.
+
+    Raises:
+        ValidationError: If any entry is not an integer.
+    """
+    try:
+        return [int(part) for part in value.split(",") if part.strip()]
+    except ValueError as exc:
+        raise ValidationError(
+            f"Invalid {field_name} format. Must be comma-separated integers.",
+            field_name,
+        ) from exc
+
+
+def normalize_rom_id_scope(rom_ids: Iterable[int]) -> list[int]:
+    """Deduplicate a `rom_ids` request scope, preserving order.
+
+    Raises:
+        ValidationError: If an ID is not positive, or the scope is over the cap.
+    """
+    unique = list(dict.fromkeys(rom_ids))
+
+    if any(rom_id <= 0 for rom_id in unique):
+        raise ValidationError("ROM IDs must be positive integers", "rom_ids")
+
+    if len(unique) > MAX_ROM_IDS_PER_QUERY:
+        raise ValidationError(
+            f"Too many ROM IDs: at most {MAX_ROM_IDS_PER_QUERY} per request",
+            "rom_ids",
+        )
+
+    return unique
 
 
 def validate_ascii_only(value: str, field_name: str = "field") -> None:

--- a/frontend/src/__generated__/models/SyncNegotiatePayload.ts
+++ b/frontend/src/__generated__/models/SyncNegotiatePayload.ts
@@ -12,5 +12,9 @@ export type SyncNegotiatePayload = {
      * Current save state on the client.
      */
     saves: Array<ClientSaveState>;
+    /**
+     * IDs of the ROMs installed on the device. When provided, downloads are offered only for these ROMs (plus any ROM the client sent a save for) instead of the user's whole save library. This is a read-only scope: omitting a ROM never deletes or unlinks its saves. At most 500 IDs per request.
+     */
+    rom_ids?: (Array<number> | null);
 };
 


### PR DESCRIPTION
**Description**

Closes #4299 (partially — the two changes the issue asks for first).

A sync client that holds only part of the library had no bounded way to ask RomM for the saves relevant to the ROMs actually on the device:

- `GET /api/saves` filters one ROM at a time (`rom_id`), so discovery cost scaled with the number of installed ROMs.
- `POST /api/sync/negotiate` always evaluated the authenticated user's **entire** slotted save set, so a handheld holding 30 games against a 3000-game library received download operations for all 3000 ROMs' saves.

This adds a `rom_ids` scope to both.

| Route | Shape |
| --- | --- |
| `GET /api/saves` | `?rom_ids=1&rom_ids=2&rom_ids=3` — repeated, as on the other JSON routes that take ID lists (`platform_ids` in `roms`, `music`, `export`) |
| `POST /api/sync/negotiate` | `"rom_ids": [1, 2, 3]` in the request body |

Notes on the semantics:

- **Read-only scope.** An omitted ROM is simply outside the request. It is never interpreted as a signal to delete, archive, or unlink a save. There is a test asserting this.
- **Negotiation widens the scope** with the ROMs the client sent saves for, so a client save is never misclassified as an `upload` just because its ROM was left out of `rom_ids`.
- **Omitting the parameter keeps today's unscoped behaviour,** so existing clients are unaffected. `POST /sync/negotiate` can send `[]` for an explicit empty scope; the query param cannot express one, since an omitted parameter is the only empty form there.
- **The limits are declared once** as a shared `RomIdScope` annotation and enforced identically on both routes, so they show up in the OpenAPI schema (`maxItems: 500`, `exclusiveMinimum: 0`) and a client can read them rather than discover them from an error. A bad scope is a 422 on both routes.

While in `negotiate_sync`, the device-sync lookup is narrowed to the newest save row per slot. It was building an `IN` list from every historical row and discarding the superseded ones, which is the same over-fetch this PR is about.

Not included, deliberately: the issue also proposes a separate paginated `POST /api/saves/search` and surfacing null-slot archival saves in restore discovery. Once the query is scoped to installed ROMs the result is bounded by device capacity, so pagination doesn't seem to earn its complexity yet; and the null-slot exclusion in negotiation is a deliberate design decision (`slot_not_null=True`), so changing it is a separate conversation rather than part of a scoping change.

Frontend types were regenerated from the updated OpenAPI schema (`SyncNegotiatePayload.ts`); `npm run typecheck` is clean.

**AI assistance disclosure**

This PR was written with AI assistance (Claude Code). The design decisions, scoping semantics, and the choice to keep this narrower than the original proposal were reviewed and directed by me; the implementation and tests were AI-authored and human-reviewed.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A — backend only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
