### PR TITLE
refactor(assets): make rom_ids the only ROM scope on saves and states

### DIFF
--- a/backend/endpoints/saves.py
+++ b/backend/endpoints/saves.py
@@ -35,7 +35,7 @@ from utils.datetime import to_utc
 from utils.filesystem import sanitize_filename
 from utils.router import APIRouter
 from utils.uploads import check_asset_upload_size
-from utils.validation import RomIdScope
+from utils.validation import RomIdScope, narrow_rom_id_scope
 
 
 def _build_save_schema(
@@ -219,7 +219,7 @@ async def add_save(
     if device and slot and not overwrite:
         slot_saves = db_save_handler.get_saves(
             user_id=request.user.id,
-            rom_id=rom.id,
+            rom_ids=[rom.id],
             slot=slot,
             order_by="updated_at",
         )
@@ -306,7 +306,7 @@ async def add_save(
             still_referenced = any(
                 other.id != db_save.id and other.full_path == stale_full_path
                 for other in db_save_handler.get_saves(
-                    user_id=request.user.id, rom_id=rom.id
+                    user_id=request.user.id, rom_ids=[rom.id]
                 )
             )
             if not still_referenced:
@@ -334,7 +334,7 @@ async def add_save(
     if slot and autocleanup:
         slot_saves = db_save_handler.get_saves(
             user_id=request.user.id,
-            rom_id=rom.id,
+            rom_ids=[rom.id],
             slot=slot,
             order_by="updated_at",
         )
@@ -423,8 +423,7 @@ def get_saves(
 
     saves = db_save_handler.get_saves(
         user_id=request.user.id,
-        rom_id=rom_id,
-        rom_ids=rom_ids,
+        rom_ids=narrow_rom_id_scope(rom_id, rom_ids),
         platform_id=platform_id,
         slot=slot,
     )

--- a/backend/endpoints/states.py
+++ b/backend/endpoints/states.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Annotated
 
-from fastapi import Body, File, HTTPException, Request, UploadFile, status
+from fastapi import Body, File, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import FileResponse
 
 from decorators.auth import protected_route
@@ -21,6 +21,7 @@ from models.assets import State
 from utils.filesystem import sanitize_filename
 from utils.router import APIRouter
 from utils.uploads import check_asset_upload_size
+from utils.validation import RomIdScope, narrow_rom_id_scope
 
 router = APIRouter(
     prefix="/states",
@@ -180,10 +181,25 @@ async def add_state(
 
 @protected_route(router.get, "", [Scope.ASSETS_READ])
 def get_states(
-    request: Request, rom_id: int | None = None, platform_id: int | None = None
+    request: Request,
+    rom_id: int | None = None,
+    rom_ids: Annotated[
+        RomIdScope,
+        Query(
+            description=(
+                "ROM IDs to scope the results to, for clients syncing a known "
+                "set of ROMs. Multiple values are allowed by repeating the "
+                "parameter. Combined with `rom_id` when both are given."
+            ),
+        ),
+    ] = None,
+    platform_id: int | None = None,
 ) -> list[StateSchema]:
+    """Retrieve states for the current user."""
     states = db_state_handler.get_states(
-        user_id=request.user.id, rom_id=rom_id, platform_id=platform_id
+        user_id=request.user.id,
+        rom_ids=narrow_rom_id_scope(rom_id, rom_ids),
+        platform_id=platform_id,
     )
 
     return [StateSchema.model_validate(state) for state in states]

--- a/backend/handler/database/saves_handler.py
+++ b/backend/handler/database/saves_handler.py
@@ -84,7 +84,6 @@ class DBSavesHandler(DBBaseHandler):
     def get_saves(
         self,
         user_id: int,
-        rom_id: int | None = None,
         rom_ids: Collection[int] | None = None,
         platform_id: int | None = None,
         slot: str | None = None,
@@ -95,9 +94,6 @@ class DBSavesHandler(DBBaseHandler):
         session: Session = None,  # type: ignore
     ) -> Sequence[Save]:
         query = select(Save).filter_by(user_id=user_id)
-
-        if rom_id:
-            query = query.filter_by(rom_id=rom_id)
 
         # An empty collection is an explicit empty scope, not an absent filter.
         if rom_ids is not None:

--- a/backend/handler/database/states_handler.py
+++ b/backend/handler/database/states_handler.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 
 from sqlalchemy import and_, delete, desc, or_, select, update
 from sqlalchemy.orm import QueryableAttribute, Session, load_only
@@ -46,15 +46,16 @@ class DBStatesHandler(DBBaseHandler):
     def get_states(
         self,
         user_id: int,
-        rom_id: int | None = None,
+        rom_ids: Collection[int] | None = None,
         platform_id: int | None = None,
         only_fields: Sequence[QueryableAttribute] | None = None,
         session: Session = None,  # type: ignore
     ) -> Sequence[State]:
         query = select(State).filter_by(user_id=user_id)
 
-        if rom_id:
-            query = query.filter_by(rom_id=rom_id)
+        # An empty collection is an explicit empty scope, not an absent filter.
+        if rom_ids is not None:
+            query = query.filter(State.rom_id.in_(rom_ids))
 
         if platform_id:
             query = query.join(Rom, State.rom_id == Rom.id).filter(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -289,6 +289,23 @@ def state(rom: Rom, platform: Platform, admin_user: User):
 
 
 @pytest.fixture
+def second_state(second_rom: Rom, platform: Platform, admin_user: User):
+    """State on `second_rom`, to check ROM-scoped queries exclude it."""
+    state = State(
+        rom_id=second_rom.id,
+        user_id=admin_user.id,
+        file_name="test_state_2.state",
+        file_name_no_tags="test_state_2",
+        file_name_no_ext="test_state_2",
+        file_extension="state",
+        emulator="test_emulator",
+        file_path=f"{platform.slug}/states/test_emulator",
+        file_size_bytes=2.0,
+    )
+    return db_state_handler.add_state(state)
+
+
+@pytest.fixture
 def screenshot(rom: Rom, platform: Platform, admin_user: User):
     screenshot = Screenshot(
         rom_id=rom.id,

--- a/backend/tests/endpoints/test_saves.py
+++ b/backend/tests/endpoints/test_saves.py
@@ -1507,6 +1507,23 @@ class TestRomIdsScope:
         assert response.status_code == status.HTTP_200_OK
         assert [item["id"] for item in response.json()] == [save.id]
 
+    def test_narrows_to_the_intersection_with_rom_id(
+        self,
+        client,
+        access_token: str,
+        rom: Rom,
+        second_rom: Rom,
+        save: Save,
+        second_save: Save,
+    ):
+        response = client.get(
+            f"/api/saves?rom_id={rom.id}&rom_ids={second_rom.id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
     def test_rejects_non_integer_ids(self, client, access_token: str):
         response = client.get(
             "/api/saves?rom_ids=1&rom_ids=abc",
@@ -1719,7 +1736,7 @@ class TestAutocleanup:
         from handler.database import db_save_handler
 
         initial_saves = db_save_handler.get_saves(
-            user_id=admin_user.id, rom_id=rom.id, slot="autosave"
+            user_id=admin_user.id, rom_ids=[rom.id], slot="autosave"
         )
         assert len(initial_saves) == 15
 
@@ -1800,7 +1817,7 @@ class TestAutocleanup:
 
         assert response.status_code == status.HTTP_200_OK
         remaining = db_save_handler.get_saves(
-            user_id=admin_user.id, rom_id=rom.id, slot="autosave"
+            user_id=admin_user.id, rom_ids=[rom.id], slot="autosave"
         )
         assert len(remaining) == 1
 

--- a/backend/tests/endpoints/test_states.py
+++ b/backend/tests/endpoints/test_states.py
@@ -12,6 +12,7 @@ from models.platform import Platform
 from models.rom import Rom
 from models.user import User
 from utils import uploads
+from utils.validation import MAX_ROM_IDS_PER_QUERY
 
 
 def _auth(token: str) -> dict[str, str]:
@@ -315,3 +316,89 @@ def test_kiosk_mode_anonymous_visitor_cannot_upload_state(client, rom: Rom):
         )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+class TestRomIdsScope:
+    def test_scopes_results_to_listed_roms(
+        self, client, access_token: str, rom: Rom, state: State, second_state: State
+    ):
+        response = client.get(
+            f"/api/states?rom_ids={rom.id}", headers=_auth(access_token)
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [item["id"] for item in response.json()] == [state.id]
+
+    def test_accepts_repeated_ids(
+        self,
+        client,
+        access_token: str,
+        rom: Rom,
+        second_rom: Rom,
+        state: State,
+        second_state: State,
+    ):
+        response = client.get(
+            f"/api/states?rom_ids={rom.id}&rom_ids={second_rom.id}",
+            headers=_auth(access_token),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert {item["id"] for item in response.json()} == {state.id, second_state.id}
+
+    def test_tolerates_duplicates(
+        self, client, access_token: str, rom: Rom, state: State
+    ):
+        response = client.get(
+            f"/api/states?rom_ids={rom.id}&rom_ids={rom.id}",
+            headers=_auth(access_token),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [item["id"] for item in response.json()] == [state.id]
+
+    def test_omitted_returns_all_states(
+        self, client, access_token: str, state: State, second_state: State
+    ):
+        response = client.get("/api/states", headers=_auth(access_token))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert {item["id"] for item in response.json()} == {state.id, second_state.id}
+
+    def test_narrows_to_the_intersection_with_rom_id(
+        self,
+        client,
+        access_token: str,
+        rom: Rom,
+        second_rom: Rom,
+        state: State,
+        second_state: State,
+    ):
+        response = client.get(
+            f"/api/states?rom_id={rom.id}&rom_ids={second_rom.id}",
+            headers=_auth(access_token),
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
+    def test_rejects_non_integer_ids(self, client, access_token: str):
+        response = client.get(
+            "/api/states?rom_ids=1&rom_ids=abc", headers=_auth(access_token)
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_rejects_non_positive_ids(self, client, access_token: str):
+        response = client.get(
+            "/api/states?rom_ids=1&rom_ids=0", headers=_auth(access_token)
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_rejects_scope_over_the_limit(self, client, access_token: str):
+        rom_ids = "&".join(f"rom_ids={i}" for i in range(1, MAX_ROM_IDS_PER_QUERY + 2))
+
+        response = client.get(f"/api/states?{rom_ids}", headers=_auth(access_token))
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT

--- a/backend/tests/handler/database/test_saves_handler.py
+++ b/backend/tests/handler/database/test_saves_handler.py
@@ -40,7 +40,7 @@ class TestDBSavesHandlerPlatformFiltering:
     ):
         """Test that get_saves works with both rom_id and platform_id filters."""
         saves = db_save_handler.get_saves(
-            user_id=admin_user.id, rom_id=rom.id, platform_id=platform.id
+            user_id=admin_user.id, rom_ids=[rom.id], platform_id=platform.id
         )
 
         assert len(saves) == 1
@@ -285,13 +285,13 @@ class TestDBSavesHandlerSlotFiltering:
         db_save_handler.add_save(save3)
 
         slot_a_saves = db_save_handler.get_saves(
-            user_id=admin_user.id, rom_id=rom.id, slot="Slot A"
+            user_id=admin_user.id, rom_ids=[rom.id], slot="Slot A"
         )
         assert len(slot_a_saves) == 2
         assert all(s.slot == "Slot A" for s in slot_a_saves)
 
         slot_b_saves = db_save_handler.get_saves(
-            user_id=admin_user.id, rom_id=rom.id, slot="Slot B"
+            user_id=admin_user.id, rom_ids=[rom.id], slot="Slot B"
         )
         assert len(slot_b_saves) == 1
         assert slot_b_saves[0].slot == "Slot B"
@@ -325,7 +325,7 @@ class TestDBSavesHandlerSlotFiltering:
         db_save_handler.add_save(save_with_slot)
         db_save_handler.add_save(save_without_slot)
 
-        all_saves = db_save_handler.get_saves(user_id=admin_user.id, rom_id=rom.id)
+        all_saves = db_save_handler.get_saves(user_id=admin_user.id, rom_ids=[rom.id])
         assert len(all_saves) >= 2
 
     def test_get_saves_order_by(self, admin_user: User, rom: Rom):
@@ -370,7 +370,7 @@ class TestDBSavesHandlerSlotFiltering:
 
         ordered_saves_desc = db_save_handler.get_saves(
             user_id=admin_user.id,
-            rom_id=rom.id,
+            rom_ids=[rom.id],
             slot="order_test",
             order_by="updated_at",
         )
@@ -381,7 +381,7 @@ class TestDBSavesHandlerSlotFiltering:
 
         ordered_saves_asc = db_save_handler.get_saves(
             user_id=admin_user.id,
-            rom_id=rom.id,
+            rom_ids=[rom.id],
             slot="order_test",
             order_by="updated_at",
             order_dir="asc",
@@ -551,7 +551,7 @@ class TestDBSavesHandlerSlotNotNullFilter:
         db_save_handler.add_save(slot_save)
         db_save_handler.add_save(archival_save)
 
-        saves = db_save_handler.get_saves(user_id=admin_user.id, rom_id=rom.id)
+        saves = db_save_handler.get_saves(user_id=admin_user.id, rom_ids=[rom.id])
 
         names = {s.file_name for s in saves}
         assert "slotted.sav" in names
@@ -586,7 +586,7 @@ class TestDBSavesHandlerSlotNotNullFilter:
         db_save_handler.add_save(archival_save)
 
         saves = db_save_handler.get_saves(
-            user_id=admin_user.id, rom_id=rom.id, slot_not_null=True
+            user_id=admin_user.id, rom_ids=[rom.id], slot_not_null=True
         )
 
         names = {s.file_name for s in saves}
@@ -631,7 +631,7 @@ class TestDBSavesHandlerSlotNotNullFilter:
         )
 
         saves = db_save_handler.get_saves(
-            user_id=admin_user.id, rom_id=rom.id, slot="A", slot_not_null=True
+            user_id=admin_user.id, rom_ids=[rom.id], slot="A", slot_not_null=True
         )
 
         assert len(saves) == 1

--- a/backend/tests/handler/database/test_states_handler.py
+++ b/backend/tests/handler/database/test_states_handler.py
@@ -35,12 +35,12 @@ class TestDBStatesHandlerPlatformFiltering:
         assert states[0].id == state.id
         assert states[0].file_name == "test_state.state"
 
-    def test_get_states_with_rom_id_and_platform_filter(
+    def test_get_states_with_rom_ids_and_platform_filter(
         self, admin_user: User, platform: Platform, rom: Rom, state: State
     ):
-        """Test that get_states works with both rom_id and platform_id filters."""
+        """Test that get_states works with both rom_ids and platform_id filters."""
         states = db_state_handler.get_states(
-            user_id=admin_user.id, rom_id=rom.id, platform_id=platform.id
+            user_id=admin_user.id, rom_ids=[rom.id], platform_id=platform.id
         )
 
         assert len(states) == 1
@@ -168,3 +168,45 @@ class TestDBStatesHandlerPlatformFiltering:
 
         # Verify the state is associated with the correct platform through ROM
         assert retrieved_state.rom.platform_id == platform.id
+
+
+class TestGetStatesRomIdsScope:
+    """Test suite for the `rom_ids` scope on DBStatesHandler.get_states."""
+
+    def test_scopes_to_listed_roms(
+        self, admin_user: User, rom: Rom, state: State, second_state: State
+    ):
+        states = db_state_handler.get_states(user_id=admin_user.id, rom_ids=[rom.id])
+
+        assert [s.id for s in states] == [state.id]
+
+    def test_scopes_to_multiple_roms(
+        self,
+        admin_user: User,
+        rom: Rom,
+        second_rom: Rom,
+        state: State,
+        second_state: State,
+    ):
+        states = db_state_handler.get_states(
+            user_id=admin_user.id, rom_ids=[rom.id, second_rom.id]
+        )
+
+        assert {s.id for s in states} == {state.id, second_state.id}
+
+    def test_empty_scope_returns_nothing(self, admin_user: User, state: State):
+        assert db_state_handler.get_states(user_id=admin_user.id, rom_ids=[]) == []
+
+    def test_omitted_scope_returns_everything(self, admin_user: User, state: State):
+        states = db_state_handler.get_states(user_id=admin_user.id, rom_ids=None)
+
+        assert state.id in [s.id for s in states]
+
+    def test_combines_with_platform_filter(
+        self, admin_user: User, platform: Platform, rom: Rom, state: State
+    ):
+        states = db_state_handler.get_states(
+            user_id=admin_user.id, rom_ids=[rom.id], platform_id=platform.id
+        )
+
+        assert [s.id for s in states] == [state.id]

--- a/backend/tests/utils/test_validation.py
+++ b/backend/tests/utils/test_validation.py
@@ -6,6 +6,7 @@ from hypothesis import strategies as st
 
 from utils.validation import (
     ValidationError,
+    narrow_rom_id_scope,
     validate_ascii_only,
     validate_email,
     validate_password,
@@ -185,3 +186,25 @@ class TestValidateEmailProperties:
     )
     def test_well_formed_emails_pass(self, local, domain, tld):
         validate_email(f"{local}@{domain}.{tld}")
+
+
+class TestNarrowRomIdScope:
+    """Test folding a single-ROM filter into a `rom_ids` scope."""
+
+    def test_no_filters_leaves_the_scope_absent(self):
+        assert narrow_rom_id_scope(None, None) is None
+
+    def test_rom_id_alone_becomes_a_single_id_scope(self):
+        assert narrow_rom_id_scope(7, None) == [7]
+
+    def test_rom_ids_alone_passes_through(self):
+        assert narrow_rom_id_scope(None, [1, 2]) == [1, 2]
+
+    def test_both_narrow_to_their_intersection(self):
+        assert narrow_rom_id_scope(2, [1, 2, 3]) == [2]
+
+    def test_disjoint_filters_yield_an_empty_scope(self):
+        assert narrow_rom_id_scope(9, [1, 2]) == []
+
+    def test_empty_scope_stays_empty(self):
+        assert narrow_rom_id_scope(1, []) == []

--- a/backend/utils/validation.py
+++ b/backend/utils/validation.py
@@ -30,12 +30,27 @@ def _dedupe_rom_ids(rom_ids: list[int] | None) -> list[int] | None:
 
 
 # Shared by every route that scopes a query to a set of ROMs, so the cap and
-# the per-ID rule are declared once and both routes reject a bad scope alike.
+# the per-ID rule are declared once and every route rejects a bad scope alike.
 RomIdScope = Annotated[
     list[Annotated[int, Field(gt=0)]] | None,
     Field(max_length=MAX_ROM_IDS_PER_QUERY),
     AfterValidator(_dedupe_rom_ids),
 ]
+
+
+def narrow_rom_id_scope(
+    rom_id: int | None, rom_ids: list[int] | None
+) -> list[int] | None:
+    """Fold a route's single-ROM `rom_id` filter into its `rom_ids` scope.
+
+    Both filters apply together, so the result is their intersection. `None`
+    means no ROM scope at all, while an empty list is an explicit empty one.
+    """
+    if rom_id is None:
+        return rom_ids
+    if rom_ids is None:
+        return [rom_id]
+    return [rom_id] if rom_id in rom_ids else []
 
 
 def parse_comma_separated_ids(value: str, field_name: str = "ID") -> list[int]:


### PR DESCRIPTION
**Description**

Follow-up to #4304, which added a `rom_ids` scope to `GET /api/saves` and `POST /api/sync/negotiate`. This finishes the job on the asset side.

**1. `db_save_handler.get_saves` only accepts `rom_ids`.**

It was left carrying both `rom_id` and `rom_ids`, ANDed together, while its sibling `db_state_handler.get_states` had only the singular one. The same "which ROMs" question had three answers across two handlers that are otherwise mirror images. A single-ROM lookup is just a one-element scope, so `rom_id` is gone from both handlers and the three internal callers in `endpoints/saves.py` (slot conflict check, orphaned-path check, autocleanup) pass `rom_ids=[rom.id]`.

**2. `GET /api/states` gains `rom_ids`, and `get_states` takes it.**

Declared with the same shared `RomIdScope` annotation, with the same description, so a client syncing a known set of ROMs discovers states the way it discovers saves — same cap, same `maxItems`/`exclusiveMinimum` in the schema, same 422 on a bad scope. `get_states` gets the matching `rom_ids: Collection[int] | None`, including the empty-collection-is-an-explicit-empty-scope rule the saves handler already had.

**3. The public `rom_id` param stays on both routes.**

Dropping it would break every existing client, so both routes keep it and fold it into the scope themselves. Rather than write that fold twice, `narrow_rom_id_scope` joins `utils/validation.py` next to `RomIdScope`. It preserves the semantics the `rom_ids` description already documents — both filters apply together, so the effective scope is their intersection — which means `?rom_id=1&rom_ids=2` returns nothing on both routes.

Deliberately **not** included: the remaining `rom_ids` params elsewhere keep their current shapes. `GET /api/roms/download` is comma-separated because that is this repo's download-route convention (built by hand for a URL the browser navigates to, alongside the two `file_ids` params), and the collection routes take unbounded mutation lists that a 500-ID query cap has no business limiting.

**One behaviour shift**, worth calling out: the old handler used a falsy check (`if rom_id:`), so `?rom_id=0` was silently ignored and returned the caller's whole library. It now scopes to nothing, which is what `RomIdScope`'s positive-ID rule already says a zero means.

No frontend regeneration: query parameters produce no generated models, and no response schema changed.

**Testing**

- `TestGetStatesRomIdsScope` in the states handler tests, mirroring the existing saves suite, backed by a new `second_state` conftest fixture (paired with `second_rom`, like `second_save`).
- `TestRomIdsScope` in `tests/endpoints/test_states.py`: scoping, repeated params, duplicates, omission, and the 422s for non-integer, non-positive, and over-cap scopes.
- `TestNarrowRomIdScope` unit tests, plus an intersection test on each of the saves and states routes.
- Full backend suite passes (`3119 passed`); the only failures locally are the 5 known cover tests that depend on my local `.env` WebP setting, untouched by this change. `trunk check` clean.

**AI assistance disclosure**

This PR was written with AI assistance (Claude Code). I directed the scope — in particular the decision to leave the download route and the collection routes alone rather than apply `RomIdScope` everywhere a `rom_ids` param appears; the implementation and tests were AI-authored and human-reviewed.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A — backend only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
