### PR TITLE
fix(screenscraper): map mega-duck-slash-cougar-boy to ss id 90

### DIFF
--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -1156,6 +1156,7 @@ SCREENSAVER_PLATFORM_LIST: dict[UPS, SlugToSSId] = {
     UPS.MSX2: {"id": 116, "name": "MSX2"},
     UPS.MSX_TURBO: {"id": 118, "name": "MSX Turbo R"},
     UPS.MAC: {"id": 146, "name": "Mac OS"},
+    UPS.MEGA_DUCK_SLASH_COUGAR_BOY: {"id": 90, "name": "Mega Duck"},
     UPS.NGAGE: {"id": 30, "name": "N-Gage"},
     UPS.NES: {"id": 3, "name": "NES"},
     UPS.FAMICOM: {"id": 3, "name": "Famicom"},


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

ScreenScraper has a Mega Duck system (id `90`), but `mega-duck-slash-cougar-boy` was missing from `SCREENSAVER_PLATFORM_LIST`, so scans of that platform skipped ScreenScraper entirely even with valid credentials.

Adds the single missing mapping:

```python
UPS.MEGA_DUCK_SLASH_COUGAR_BOY: {"id": 90, "name": "Mega Duck"},
```

Notes:

- The ID was verified against [`systemeinfos.php?plateforme=90`](https://www.screenscraper.fr/systemeinfos.php?plateforme=90), which reports "Mega Duck" (34 games / 49 ROMs), rather than taken from the issue on faith.
- `90` was previously unused in the list, so the `SS_ID_TO_SLUG` reverse map resolves cleanly with no collision.
- No migration is needed. `0036_screenscraper_platforms_id` was a one-time backfill, but `scan_platform` re-derives `ss_id` from this map on every scan, so existing installs pick it up on their next platform scan. This matches how the equivalent RA (`69`), TGDB (`4948`) and LaunchBox (`127`) mappings for this platform already behave.
- The supported-platforms docs live in `rommapp/docs` and will need a follow-up PR there, as the issue notes.

Fixes #4284

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

`trunk check` is clean on the changed file and `tests/handler/metadata/test_ss_handler.py` passes 99/99. No new unit test was added: this is a data entry in an existing platform-mapping table, and the surrounding entries are not individually tested.

#### Screenshots (if applicable)

N/A, backend-only data change.

---

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The model located the missing mapping, verified the ScreenScraper system ID against screenscraper.fr, made the one-line edit, and ran the linter and the ScreenScraper handler test suite. All of it was reviewed by me before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
