### PR TITLE
feat(player): confirm before leaving a running game

### DIFF
--- a/frontend/src/v2/composables/useUnloadGuard/index.test.ts
+++ b/frontend/src/v2/composables/useUnloadGuard/index.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { effectScope, ref, type EffectScope } from "vue";
+import { useUnloadGuard } from "./index";
+
+let scope: EffectScope | null = null;
+
+function arm(armed: Parameters<typeof useUnloadGuard>[0]) {
+  scope = effectScope();
+  scope.run(() => useUnloadGuard(armed));
+}
+
+function dispatchUnload(): BeforeUnloadEvent {
+  const event = new Event("beforeunload", {
+    cancelable: true,
+  }) as BeforeUnloadEvent;
+  window.dispatchEvent(event);
+  return event;
+}
+
+afterEach(() => {
+  scope?.stop();
+  scope = null;
+});
+
+describe("useUnloadGuard", () => {
+  it("blocks the unload while armed", () => {
+    arm(true);
+
+    expect(dispatchUnload().defaultPrevented).toBe(true);
+  });
+
+  it("lets the unload through while disarmed", () => {
+    arm(false);
+
+    expect(dispatchUnload().defaultPrevented).toBe(false);
+  });
+
+  it("re-reads the source on every unload", () => {
+    const running = ref(false);
+    arm(running);
+
+    expect(dispatchUnload().defaultPrevented).toBe(false);
+
+    running.value = true;
+
+    expect(dispatchUnload().defaultPrevented).toBe(true);
+  });
+
+  it("stops guarding once the scope is disposed", () => {
+    arm(true);
+    scope?.stop();
+
+    expect(dispatchUnload().defaultPrevented).toBe(false);
+  });
+});

--- a/frontend/src/v2/composables/useUnloadGuard/index.ts
+++ b/frontend/src/v2/composables/useUnloadGuard/index.ts
@@ -4,6 +4,8 @@ import { useEventListener } from "@vueuse/core";
 import { toValue, type MaybeRefOrGetter } from "vue";
 
 export function useUnloadGuard(armed: MaybeRefOrGetter<boolean>): void {
+  if (typeof window === "undefined") return;
+
   useEventListener(window, "beforeunload", (event: BeforeUnloadEvent) => {
     if (!toValue(armed)) return;
     // preventDefault covers the current spec, returnValue the older browsers.

--- a/frontend/src/v2/composables/useUnloadGuard/index.ts
+++ b/frontend/src/v2/composables/useUnloadGuard/index.ts
@@ -1,0 +1,13 @@
+// useUnloadGuard arms the browser's "leave site?" prompt while a game is
+// live, so a reload or tab close can't drop unsaved progress (#4298).
+import { useEventListener } from "@vueuse/core";
+import { toValue, type MaybeRefOrGetter } from "vue";
+
+export function useUnloadGuard(armed: MaybeRefOrGetter<boolean>): void {
+  useEventListener(window, "beforeunload", (event: BeforeUnloadEvent) => {
+    if (!toValue(armed)) return;
+    // preventDefault covers the current spec, returnValue the older browsers.
+    event.preventDefault();
+    event.returnValue = "";
+  });
+}

--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -279,6 +279,11 @@ async function onPlay() {
     removeIOSFullscreenShim.value?.();
     removeIOSFullscreenShim.value = null;
     console.error("[Play] Emulator load failure:", err);
+    // No emulator booted, so drop back to the config screen instead of
+    // leaving the unload guard and the input mute armed.
+    gameRunning.value = false;
+    playing.value = false;
+    fullScreen.value = false;
   }
 }
 

--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -56,6 +56,7 @@ import { useInputModality } from "@/v2/composables/useInputModality";
 import { usePlaySession } from "@/v2/composables/usePlaySession";
 import { usePlayerHero } from "@/v2/composables/usePlayerHero";
 import { usePlayerNav } from "@/v2/composables/usePlayerNav";
+import { useUnloadGuard } from "@/v2/composables/useUnloadGuard";
 import type { SliderBtnGroupItem } from "@/v2/lib/primitives/RSliderBtnGroup/types";
 import {
   resolveBezelHost,
@@ -116,6 +117,8 @@ const selectedFirmware = ref<FirmwareSchema | null>(null);
 const supportedCores = ref<string[]>([]);
 const gameRunning = ref(false);
 const removeIOSFullscreenShim = ref<(() => void) | null>(null);
+
+useUnloadGuard(gameRunning);
 
 // ── Live activity ("now playing") ──────────────────────────────────
 const ACTIVITY_HEARTBEAT_MS = 30_000;

--- a/frontend/src/v2/views/Player/JsDos.vue
+++ b/frontend/src/v2/views/Player/JsDos.vue
@@ -15,6 +15,7 @@ import { useFullscreenPref } from "@/v2/composables/useFullscreenPref";
 import { usePlaySession } from "@/v2/composables/usePlaySession";
 import { usePlayerHero } from "@/v2/composables/usePlayerHero";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
+import { useUnloadGuard } from "@/v2/composables/useUnloadGuard";
 import { isJsResource, loadScript } from "./scriptLoader";
 
 const JSDOS_LOCAL_BASE = "/assets/jsdos";
@@ -151,15 +152,9 @@ function onlyQuit() {
   void leavePlayer(`/rom/${romId}`);
 }
 
-function onBeforeUnload(event: BeforeUnloadEvent) {
-  if (!dos || quitting.value) return;
-  event.preventDefault();
-  event.returnValue = "";
-}
+useUnloadGuard(() => !!dos && !quitting.value);
 
 onMounted(async () => {
-  window.addEventListener("beforeunload", onBeforeUnload);
-
   // The runtime reads nothing from the ROM payload, so let both loads overlap
   // instead of holding the 300 KB bundle behind the API roundtrip.
   void loadRuntime().catch((e) => console.error(e));
@@ -173,10 +168,7 @@ onBeforeRouteLeave((to) => {
   return false;
 });
 
-onBeforeUnmount(() => {
-  window.removeEventListener("beforeunload", onBeforeUnload);
-  teardown();
-});
+onBeforeUnmount(teardown);
 </script>
 
 <template>

--- a/frontend/src/v2/views/Player/Ruffle.test.ts
+++ b/frontend/src/v2/views/Player/Ruffle.test.ts
@@ -1,0 +1,172 @@
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { nextTick } from "vue";
+import type { RuffleSourceAPI } from "@/types/ruffle";
+import Ruffle from "./Ruffle.vue";
+
+const mocks = vi.hoisted(() => ({
+  getRom: vi.fn(),
+  playSessionStart: vi.fn(),
+  flushPlaySession: vi.fn(),
+  push: vi.fn(),
+  setPlaying: vi.fn(),
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({ params: { rom: "1" } }),
+  useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock("@/plugins/router", () => ({
+  ROUTES: { ROM: "rom", PLATFORM: "platform" },
+}));
+
+vi.mock("@/services/api/rom", () => ({
+  default: { getRom: mocks.getRom },
+}));
+
+vi.mock("@/stores/playing", () => ({
+  default: () => ({ setPlaying: mocks.setPlaying }),
+}));
+
+vi.mock("@/stores/roms", () => ({
+  default: () => ({ currentRom: null }),
+}));
+
+vi.mock("@/utils", () => ({
+  getDownloadPath: () => "/api/roms/1/content/game.swf",
+}));
+
+vi.mock("@/v2/components/shared/GameCover.vue", () => ({
+  default: { template: "<div />" },
+}));
+
+vi.mock("@/v2/composables/useBackgroundArt", () => ({
+  useBackgroundArt: () => vi.fn(),
+}));
+
+vi.mock("@/v2/composables/useFullscreenPref", async () => {
+  const { ref } = await import("vue");
+  return { useFullscreenPref: () => ({ fullscreenOnPlay: ref(false) }) };
+});
+
+vi.mock("@/v2/composables/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+vi.mock("@/v2/composables/usePlaySession", () => ({
+  usePlaySession: () => ({
+    start: mocks.playSessionStart,
+    flush: mocks.flushPlaySession,
+  }),
+}));
+
+vi.mock("@/v2/stores/galleryRoms", () => ({
+  default: () => ({ getRomById: () => null }),
+}));
+
+const rom = {
+  id: 1,
+  name: "Flash Game",
+  fs_name_no_ext: "Flash Game",
+  platform_id: 2,
+  platform_slug: "flash",
+  rom_user: { status: null },
+};
+
+// Swallow the Ruffle runtime <script> injections; the test drives
+// window.RufflePlayer directly.
+beforeAll(() => {
+  const appendChild = document.body.appendChild.bind(document.body);
+  vi.spyOn(document.body, "appendChild").mockImplementation((node) =>
+    (node as Element).tagName === "SCRIPT" ? node : appendChild(node),
+  );
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getRom.mockResolvedValue({ data: rom });
+  window.RufflePlayer = {
+    newest: () => null,
+  } as unknown as typeof window.RufflePlayer;
+});
+
+function makeRuffleSource(): RuffleSourceAPI {
+  const player = Object.assign(document.createElement("div"), {
+    load: vi.fn(),
+    fullscreenEnabled: false,
+    enterFullscreen: vi.fn(),
+  });
+  return {
+    createPlayer: () => player,
+  } as unknown as RuffleSourceAPI;
+}
+
+async function mountAndPlay(): Promise<VueWrapper> {
+  const wrapper = mount(Ruffle, {
+    attachTo: document.body,
+    global: {
+      stubs: {
+        RBtn: {
+          emits: ["click"],
+          template: "<button @click=\"$emit('click')\"><slot /></button>",
+        },
+        RCard: { template: "<div><slot /></div>" },
+        RIcon: true,
+        RSpinner: true,
+        RSwitch: true,
+      },
+    },
+  });
+  await flushPromises();
+  await wrapper.get(".r-v2-player__play").trigger("click");
+  await nextTick();
+  return wrapper;
+}
+
+function dispatchUnload(): Event {
+  const event = new Event("beforeunload", { cancelable: true });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe("Ruffle launch", () => {
+  it("guards the unload once a player is running", async () => {
+    window.RufflePlayer = {
+      newest: () => makeRuffleSource(),
+    } as unknown as typeof window.RufflePlayer;
+
+    const wrapper = await mountAndPlay();
+
+    expect(mocks.playSessionStart).toHaveBeenCalledOnce();
+    expect(dispatchUnload().defaultPrevented).toBe(true);
+    wrapper.unmount();
+  });
+
+  // A failed launch used to leave the running state set, so the browser asked
+  // for a leave confirmation with no game behind it.
+  it("clears the running state when no Ruffle source is available", async () => {
+    const wrapper = await mountAndPlay();
+
+    expect(mocks.playSessionStart).not.toHaveBeenCalled();
+    expect(mocks.setPlaying).toHaveBeenLastCalledWith(false);
+    expect(dispatchUnload().defaultPrevented).toBe(false);
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/v2/views/Player/Ruffle.vue
+++ b/frontend/src/v2/views/Player/Ruffle.vue
@@ -51,6 +51,12 @@ window.RufflePlayer = window.RufflePlayer || {};
 
 const { romId, heroRom, title, platformLabel } = usePlayerHero(rom);
 
+// Nothing is running, so drop the guard and the input mute the launch armed.
+function abortPlay() {
+  gameRunning.value = false;
+  playingStore.setPlaying(false);
+}
+
 function onPlay() {
   gameRunning.value = true;
   // Flash games are keyboard-driven; flag the session so global hotkeys
@@ -58,14 +64,24 @@ function onPlay() {
   playingStore.setPlaying(true);
 
   nextTick(() => {
-    if (!rom.value) return;
+    if (!rom.value) {
+      abortPlay();
+      return;
+    }
 
     const ruffle = window.RufflePlayer.newest();
-    if (!ruffle) return;
+    if (!ruffle) {
+      abortPlay();
+      return;
+    }
 
     const player = ruffle.createPlayer();
     const container = document.getElementById("r-v2-ruffle-stage");
-    container?.appendChild(player);
+    if (!container) {
+      abortPlay();
+      return;
+    }
+    container.appendChild(player);
     player.load({
       allowFullScreen: true,
       autoplay: "on",

--- a/frontend/src/v2/views/Player/Ruffle.vue
+++ b/frontend/src/v2/views/Player/Ruffle.vue
@@ -15,6 +15,7 @@ import PlayerShell from "@/v2/components/Player/PlayerShell.vue";
 import { useFullscreenPref } from "@/v2/composables/useFullscreenPref";
 import { usePlaySession } from "@/v2/composables/usePlaySession";
 import { usePlayerHero } from "@/v2/composables/usePlayerHero";
+import { useUnloadGuard } from "@/v2/composables/useUnloadGuard";
 import { colorCanvas } from "@/v2/tokens";
 
 const RUFFLE_VERSION = "0.2.0-nightly.2025.8.14";
@@ -28,6 +29,8 @@ const playSession = usePlaySession();
 const rom = shallowRef<DetailedRom | null>(null);
 const gameRunning = ref(false);
 const backgroundColor = ref<string>(DEFAULT_BACKGROUND_COLOR);
+
+useUnloadGuard(gameRunning);
 
 declare global {
   interface Window {

--- a/frontend/src/v2/views/Player/Stream.vue
+++ b/frontend/src/v2/views/Player/Stream.vue
@@ -30,6 +30,7 @@ import { useBackgroundArt } from "@/v2/composables/useBackgroundArt";
 import { usePageTitle } from "@/v2/composables/usePageTitle";
 import { usePlaySession } from "@/v2/composables/usePlaySession";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
+import { useUnloadGuard } from "@/v2/composables/useUnloadGuard";
 import storeGalleryRoms from "@/v2/stores/galleryRoms";
 
 type PlayerState = "idle" | "loading" | "playing" | "error" | "exited";
@@ -156,6 +157,10 @@ const sessionActive = computed(
   () => playerState.value === "playing" || playerState.value === "loading",
 );
 watch(sessionActive, (active) => playingStore.setPlaying(active));
+
+// A reload tears the stream down without the save-and-exit handshake, so a
+// claimed session is worth a confirmation prompt too.
+useUnloadGuard(sessionActive);
 
 // Sync volume slider (0-1) and mute button to the broker in real time.
 // Debounced via watch — only fires after the value settles for 150ms.


### PR DESCRIPTION
**Description**

Closes #4298

Refreshing, closing the tab, or navigating away while a game was running dropped it with no confirmation. Only the js-dos player guarded against that (with a hand-rolled `beforeunload` listener); EmulatorJS, Ruffle, and the streaming player had nothing. Streaming was the worst case: a reload abandoned a claimed container session without the save-and-exit handshake.

This extracts the guard into a `useUnloadGuard` composable and arms it in all four v2 players:

- `useUnloadGuard(armed)` takes a ref or getter, read at event time, and unregisters with the effect scope (`useEventListener`).
- **EmulatorJS** / **Ruffle**: armed on `gameRunning`.
- **Stream**: armed on the existing `sessionActive` computed (`playing || loading`), so a claimed session is covered too.
- **JsDos**: swapped its hand-rolled listener for the composable, keeping the `!!dos && !quitting` semantics so the explicit Quit path stays prompt-free.

v2 only: v1 is frozen, and v2 is the default `uiVersion`.

**Not included:** an in-app confirmation for the browser Back button. While a game runs, `playing` is true, which mutes gamepad-to-UI translation, so a `ConfirmDialog` would be unreachable by pad, and for EmulatorJS, Back is currently the only exit path from a running game. `beforeunload` is native browser chrome and unaffected by that. Happy to open a separate issue if back-nav should be covered as well.

**AI assistance disclosure**

This PR was written with Claude Code (Opus 5). The investigation, implementation, tests, and this description were AI-generated and reviewed by me before submitting.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Verified locally: `npm run typecheck` clean, `npm run test` 871/871 passing, `trunk fmt && trunk check` clean. The new composable has unit tests covering armed/disarmed, re-reading a reactive source between events, and cleanup on scope dispose. Not manually browser-checked: the prompt is native browser chrome with no RomM UI surface.

#### Screenshots (if applicable)

N/A - the prompt is the browser's own "Leave site?" dialog.
