### PR TITLE
fix(manual): only ask where a manual goes when the answer is open

### DIFF
--- a/frontend/src/v2/components/Dialogs/ManualUploadTargetDialog.test.ts
+++ b/frontend/src/v2/components/Dialogs/ManualUploadTargetDialog.test.ts
@@ -6,9 +6,11 @@ import type { DetailedRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import ManualUploadTargetDialog from "./ManualUploadTargetDialog.vue";
 
+type UploadArgs = { romId: number; filesToUpload: File[] };
+
 const { uploadManuals, uploadManualFiles, getRom } = vi.hoisted(() => ({
-  uploadManuals: vi.fn(() => Promise.resolve([])),
-  uploadManualFiles: vi.fn(() => Promise.resolve([])),
+  uploadManuals: vi.fn((_args: UploadArgs) => Promise.resolve([])),
+  uploadManualFiles: vi.fn((_args: UploadArgs) => Promise.resolve([])),
   getRom: vi.fn(() => Promise.resolve({ data: {} })),
 }));
 
@@ -43,8 +45,26 @@ function rom(overrides: Partial<DetailedRom> = {}): DetailedRom {
   } as DetailedRom;
 }
 
-function manualFile() {
-  return { id: 1, file_name: "guide.pdf", category: "manual" };
+function manualFile(): NonNullable<DetailedRom["files"]>[number] {
+  return {
+    id: 1,
+    rom_id: 7,
+    file_name: "guide.pdf",
+    file_path: "switch/roms/Game",
+    file_size_bytes: 1024,
+    full_path: "switch/roms/Game/manual/guide.pdf",
+    is_top_level: false,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_modified: "2026-01-01T00:00:00Z",
+    crc_hash: null,
+    md5_hash: null,
+    sha1_hash: null,
+    ra_hash: null,
+    chd_sha1_hash: null,
+    archive_members: null,
+    category: "manual",
+  };
 }
 
 function mountDialog(emitter: Emitter<Events>): VueWrapper {
@@ -90,11 +110,40 @@ describe("ManualUploadTargetDialog", () => {
   });
 
   it("appends to the ROM folder without asking once it holds a manual", async () => {
-    const wrapper = await upload(rom({ files: [manualFile()] } as never));
+    const wrapper = await upload(rom({ files: [manualFile()] }));
 
     expect(uploadManualFiles).toHaveBeenCalledOnce();
     expect(uploadManuals).not.toHaveBeenCalled();
     expect(wrapper.find("[data-test-dialog]").exists()).toBe(false);
+  });
+
+  it("uploads both manuals when a second is dropped mid-upload", async () => {
+    let release: (() => void) | undefined;
+    uploadManuals.mockImplementationOnce(
+      () => new Promise<never[]>((resolve) => (release = () => resolve([]))),
+    );
+
+    const emitter = mitt<Events>();
+    mountDialog(emitter);
+    const payload = (name: string) => ({
+      rom: rom({ has_simple_single_file: true }),
+      files: [new File(["x"], name)],
+    });
+
+    emitter.emit("showManualUploadTargetDialog", payload("first.pdf"));
+    await flushPromises();
+    emitter.emit("showManualUploadTargetDialog", payload("second.pdf"));
+    await flushPromises();
+
+    expect(uploadManuals).toHaveBeenCalledOnce();
+
+    release?.();
+    await flushPromises();
+
+    expect(uploadManuals).toHaveBeenCalledTimes(2);
+    const secondCall = uploadManuals.mock.calls[1];
+    if (!secondCall) throw new Error("the queued upload never ran");
+    expect(secondCall[0].filesToUpload[0]?.name).toBe("second.pdf");
   });
 
   it("asks when a folder ROM has no manual yet", async () => {

--- a/frontend/src/v2/components/Dialogs/ManualUploadTargetDialog.test.ts
+++ b/frontend/src/v2/components/Dialogs/ManualUploadTargetDialog.test.ts
@@ -1,0 +1,107 @@
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import mitt, { type Emitter } from "mitt";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DetailedRom } from "@/stores/roms";
+import type { Events } from "@/types/emitter";
+import ManualUploadTargetDialog from "./ManualUploadTargetDialog.vue";
+
+const { uploadManuals, uploadManualFiles, getRom } = vi.hoisted(() => ({
+  uploadManuals: vi.fn(() => Promise.resolve([])),
+  uploadManualFiles: vi.fn(() => Promise.resolve([])),
+  getRom: vi.fn(() => Promise.resolve({ data: {} })),
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/services/api/rom", () => ({
+  default: { uploadManuals, uploadManualFiles, getRom },
+}));
+
+vi.mock("@/v2/composables/useSnackbar", () => ({
+  useSnackbar: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+vi.mock("@/v2/composables/useRomSync", () => ({
+  useRomSync: () => ({ syncCachedRom: vi.fn() }),
+}));
+
+function rom(overrides: Partial<DetailedRom> = {}): DetailedRom {
+  return {
+    id: 7,
+    name: "Game",
+    has_simple_single_file: false,
+    files: [],
+    ...overrides,
+  } as DetailedRom;
+}
+
+function manualFile() {
+  return { id: 1, file_name: "guide.pdf", category: "manual" };
+}
+
+function mountDialog(emitter: Emitter<Events>): VueWrapper {
+  return mount(ManualUploadTargetDialog, {
+    global: {
+      provide: { emitter },
+      stubs: {
+        RDialog: {
+          props: { modelValue: { type: Boolean, default: false } },
+          template:
+            "<div v-if='modelValue' data-test-dialog><slot name='content' /></div>",
+        },
+        RBtn: true,
+        RIcon: true,
+      },
+    },
+  });
+}
+
+async function upload(target: DetailedRom): Promise<VueWrapper> {
+  const emitter = mitt<Events>();
+  const wrapper = mountDialog(emitter);
+  emitter.emit("showManualUploadTargetDialog", {
+    rom: target,
+    files: [new File(["x"], "manual.pdf")],
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe("ManualUploadTargetDialog", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it("sends a single-file ROM's manual to resources without asking", async () => {
+    const wrapper = await upload(rom({ has_simple_single_file: true }));
+
+    expect(uploadManuals).toHaveBeenCalledOnce();
+    expect(uploadManualFiles).not.toHaveBeenCalled();
+    expect(wrapper.find("[data-test-dialog]").exists()).toBe(false);
+  });
+
+  it("appends to the ROM folder without asking once it holds a manual", async () => {
+    const wrapper = await upload(rom({ files: [manualFile()] } as never));
+
+    expect(uploadManualFiles).toHaveBeenCalledOnce();
+    expect(uploadManuals).not.toHaveBeenCalled();
+    expect(wrapper.find("[data-test-dialog]").exists()).toBe(false);
+  });
+
+  it("asks when a folder ROM has no manual yet", async () => {
+    const wrapper = await upload(rom());
+
+    expect(uploadManuals).not.toHaveBeenCalled();
+    expect(uploadManualFiles).not.toHaveBeenCalled();
+    expect(wrapper.find("[data-test-dialog]").exists()).toBe(true);
+  });
+});

--- a/frontend/src/v2/components/Dialogs/ManualUploadTargetDialog.vue
+++ b/frontend/src/v2/components/Dialogs/ManualUploadTargetDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-// ManualUploadTargetDialog — asks the user whether an uploaded manual
-// should live in the shared resources directory (sticks to the ROM in the
-// database) or the ROM's folder on disk (visible to external tools).
+// ManualUploadTargetDialog: asks whether an uploaded manual should live in the
+// shared resources directory (sticks to the ROM in the database) or the ROM's
+// folder on disk (visible to external tools).
 import { RBtn, RDialog, RIcon } from "@v2/lib";
 import type { Emitter } from "mitt";
 import { inject, onBeforeUnmount, ref } from "vue";
@@ -22,34 +22,45 @@ const romsStore = storeRoms();
 const { syncCachedRom } = useRomSync();
 const uploadStore = storeUpload();
 
+const TARGETS = {
+  resources: {
+    upload: romApi.uploadManuals,
+    successKey: "rom.manuals-upload-success",
+    skippedKey: "rom.manuals-upload-skipped",
+  },
+  folder: {
+    upload: romApi.uploadManualFiles,
+    successKey: "rom.manual-files-upload-success",
+    skippedKey: "rom.manual-files-upload-skipped",
+  },
+} as const;
+
+type UploadTarget = keyof typeof TARGETS;
+
 const show = ref(false);
 const rom = ref<DetailedRom | null>(null);
 const files = ref<File[]>([]);
-const uploading = ref(false);
 
-// Asking only pays off when the destination is genuinely open. A single-file
-// ROM has no folder to put a manual in, and a ROM already holding folder
-// manuals has answered the question once already.
+// Only ask when the destination is still open.
 const handleShow = (payload: Events["showManualUploadTargetDialog"]) => {
-  rom.value = payload.rom;
-  files.value = payload.files;
   if (payload.rom.has_simple_single_file) {
-    void chooseTarget("resources");
+    enqueue("resources", payload.rom, payload.files);
     return;
   }
   if (payload.rom.files?.some((file) => file.category === "manual")) {
-    void chooseTarget("folder");
+    enqueue("folder", payload.rom, payload.files);
     return;
   }
+  rom.value = payload.rom;
+  files.value = payload.files;
   show.value = true;
 };
 emitter?.on("showManualUploadTargetDialog", handleShow);
 onBeforeUnmount(() => emitter?.off("showManualUploadTargetDialog", handleShow));
 
-async function refreshRom() {
-  if (!rom.value) return;
+async function refreshRom(target: DetailedRom) {
   try {
-    const { data } = await romApi.getRom({ romId: rom.value.id });
+    const { data } = await romApi.getRom({ romId: target.id });
     romsStore.currentRom = data;
     syncCachedRom(data);
   } catch (error) {
@@ -61,6 +72,7 @@ async function handleUploadResult(
   responses: PromiseSettledResult<unknown>[],
   successKey: string,
   skippedKey: string,
+  target: DetailedRom,
 ) {
   const successful = responses.filter((r) => r.status === "fulfilled").length;
   const failed = responses.length - successful;
@@ -72,7 +84,7 @@ async function handleUploadResult(
       icon: "mdi-check-bold",
       timeout: 3000,
     });
-    await refreshRom();
+    await refreshRom(target);
   } else {
     snackbar.warning(t(skippedKey), {
       icon: "mdi-close-circle",
@@ -81,42 +93,39 @@ async function handleUploadResult(
   }
 }
 
-async function chooseTarget(target: "resources" | "folder") {
-  if (!rom.value || uploading.value) return;
-  const currentRom = rom.value;
-  const pending = files.value;
-  if (pending.length === 0) {
-    closeDialog();
-    return;
-  }
+async function uploadTo(
+  target: UploadTarget,
+  targetRom: DetailedRom,
+  targetFiles: File[],
+) {
+  const { upload, successKey, skippedKey } = TARGETS[target];
+  const responses = await upload({
+    romId: targetRom.id,
+    filesToUpload: targetFiles,
+  });
+  await handleUploadResult(responses, successKey, skippedKey, targetRom);
+}
 
-  uploading.value = true;
-  try {
-    if (target === "resources") {
-      const responses = await romApi.uploadManuals({
-        romId: currentRom.id,
-        filesToUpload: pending,
-      });
-      await handleUploadResult(
-        responses,
-        "rom.manuals-upload-success",
-        "rom.manuals-upload-skipped",
-      );
-    } else {
-      const responses = await romApi.uploadManualFiles({
-        romId: currentRom.id,
-        filesToUpload: pending,
-      });
-      await handleUploadResult(
-        responses,
-        "rom.manual-files-upload-success",
-        "rom.manual-files-upload-skipped",
-      );
-    }
-    closeDialog();
-  } finally {
-    uploading.value = false;
-  }
+// Serialized so a drop mid-upload waits rather than replacing the one running.
+let queue: Promise<void> = Promise.resolve();
+
+function enqueue(
+  target: UploadTarget,
+  targetRom: DetailedRom,
+  targetFiles: File[],
+) {
+  if (targetFiles.length === 0) return;
+  queue = queue
+    .catch(() => undefined)
+    .then(() => uploadTo(target, targetRom, targetFiles));
+}
+
+function chooseTarget(target: UploadTarget) {
+  const currentRom = rom.value;
+  if (!currentRom) return;
+  const pending = files.value;
+  closeDialog();
+  enqueue(target, currentRom, pending);
 }
 
 function closeDialog() {
@@ -141,7 +150,6 @@ function closeDialog() {
         <button
           type="button"
           class="r-v2-upload-target__option"
-          :disabled="uploading"
           @click="chooseTarget('resources')"
         >
           <div class="r-v2-upload-target__icon">
@@ -164,7 +172,6 @@ function closeDialog() {
         <button
           type="button"
           class="r-v2-upload-target__option"
-          :disabled="uploading"
           @click="chooseTarget('folder')"
         >
           <div class="r-v2-upload-target__icon">
@@ -187,7 +194,7 @@ function closeDialog() {
       </div>
     </template>
     <template #footer>
-      <RBtn variant="text" :disabled="uploading" @click="closeDialog">
+      <RBtn variant="text" @click="closeDialog">
         {{ t("common.cancel") }}
       </RBtn>
     </template>

--- a/frontend/src/v2/components/Dialogs/ManualUploadTargetDialog.vue
+++ b/frontend/src/v2/components/Dialogs/ManualUploadTargetDialog.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 // ManualUploadTargetDialog — asks the user whether an uploaded manual
 // should live in the shared resources directory (sticks to the ROM in the
-// database) or the ROM's folder on disk (visible to external tools). If
-// the ROM is a simple single-file ROM we skip the dialog and default to
-// resources, same as v1.
+// database) or the ROM's folder on disk (visible to external tools).
 import { RBtn, RDialog, RIcon } from "@v2/lib";
 import type { Emitter } from "mitt";
 import { inject, onBeforeUnmount, ref } from "vue";
@@ -29,11 +27,18 @@ const rom = ref<DetailedRom | null>(null);
 const files = ref<File[]>([]);
 const uploading = ref(false);
 
+// Asking only pays off when the destination is genuinely open. A single-file
+// ROM has no folder to put a manual in, and a ROM already holding folder
+// manuals has answered the question once already.
 const handleShow = (payload: Events["showManualUploadTargetDialog"]) => {
   rom.value = payload.rom;
   files.value = payload.files;
   if (payload.rom.has_simple_single_file) {
     void chooseTarget("resources");
+    return;
+  }
+  if (payload.rom.files?.some((file) => file.category === "manual")) {
+    void chooseTarget("folder");
     return;
   }
   show.value = true;

--- a/frontend/src/v2/components/GameDetails/ManualSubtab.vue
+++ b/frontend/src/v2/components/GameDetails/ManualSubtab.vue
@@ -16,7 +16,6 @@ import storeRoms, { type DetailedRom } from "@/stores/roms";
 import type { Events } from "@/types/emitter";
 import { FRONTEND_RESOURCES_PATH } from "@/utils";
 import { useCan } from "@/v2/composables/useCan";
-import { useConfirm } from "@/v2/composables/useConfirm";
 import { useRomSync } from "@/v2/composables/useRomSync";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
 import { errorMessage } from "@/v2/utils/errorMessage";
@@ -34,7 +33,6 @@ const TextViewer = defineAsyncComponent(
 const props = defineProps<{ rom: DetailedRom }>();
 const emitter = inject<Emitter<Events>>("emitter");
 const snackbar = useSnackbar();
-const confirm = useConfirm();
 const romsStore = storeRoms();
 const { syncCachedRom } = useRomSync();
 const { t } = useI18n();
@@ -119,19 +117,6 @@ const manualItems = computed(() =>
   manualEntries.value.map((e) => ({ title: e.label, value: e.id })),
 );
 
-// ---------- Single-file -> folder conversion ----------
-// Manuals live inside the ROM folder, so uploading one to a single-file ROM
-// promotes it to a folder ROM in place (the backend does this automatically on
-// upload). Warn first since it is not reversible.
-async function confirmFolderConversionIfNeeded(): Promise<boolean> {
-  if (!props.rom.has_simple_single_file) return true;
-  return confirm({
-    title: t("rom.convert-to-folder-title"),
-    body: t("rom.convert-to-folder-body"),
-    tone: "warning",
-  });
-}
-
 // ---------- Upload / refresh plumbing ----------
 // The filled viewer is wrapped in an overlay RDropzone (drag files onto the
 // manual to add another); the header's Upload button opens its picker.
@@ -148,12 +133,10 @@ async function refreshRom() {
   }
 }
 
-// Manual upload routes through the target-selection dialog (mounted in
-// AppLayout): the user picks which platform/folder the manual belongs to, so
-// we hand off rather than uploading inline.
+// The target dialog picks the destination, and takes a single-file ROM straight
+// to resources without asking, so nothing here can convert one.
 async function handleManualFiles(files: File[]) {
   if (files.length === 0) return;
-  if (!(await confirmFolderConversionIfNeeded())) return;
   emitter?.emit("showManualUploadTargetDialog", { rom: props.rom, files });
 }
 

--- a/frontend/src/v2/components/GameDetails/ManualSubtab.vue
+++ b/frontend/src/v2/components/GameDetails/ManualSubtab.vue
@@ -133,9 +133,7 @@ async function refreshRom() {
   }
 }
 
-// The target dialog picks the destination, and takes a single-file ROM straight
-// to resources without asking, so nothing here can convert one.
-async function handleManualFiles(files: File[]) {
+function handleManualFiles(files: File[]) {
   if (files.length === 0) return;
   emitter?.emit("showManualUploadTargetDialog", { rom: props.rom, files });
 }


### PR DESCRIPTION
**Description**

Uploading a manual to a single-file ROM showed a warning that the ROM would be irreversibly converted to a folder ROM. The conversion never happened: `ManualUploadTargetDialog` already sends a simple single-file ROM straight to the resources path without opening, so the warning preceded nothing and the folder target was never reachable for the ROMs it could have converted.

The warning is gone, and the destination is now decided by whether there is a decision to make:

- **Single-file ROM** goes to the resources path, the same slot a scraped manual uses. Unchanged.
- **Folder ROM that already holds a manual in its folder** appends there. The question was answered the first time.
- **Folder ROM with no manual yet** asks, as before.

No path converts a ROM, so nothing in this flow rewrites a library's layout.

One narrowing worth flagging: once a ROM has a folder manual, an upload can no longer replace its scraped manual, since the choice stops being offered. The redownload action still refreshes the scraped copy.

---

> AI Disclosure
> Planning and implementation supported by Claude Code.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes