### PR TITLE
feat(streaming): ScummVM capabilities and language forwarding to brokers

### DIFF
--- a/backend/endpoints/streaming.py
+++ b/backend/endpoints/streaming.py
@@ -17,6 +17,7 @@ from decorators.auth import protected_route
 from handler.auth.constants import Scope
 from handler.auth.dependencies import assert_rom_visible
 from handler.database import db_rom_handler
+from handler.filesystem.base_handler import LANGUAGES
 from handler.redis_handler import async_cache
 from models.user import Role
 from utils.router import APIRouter
@@ -353,7 +354,40 @@ def _broker_request_safe(
         return None
 
 
-def _call_broker(container: dict[str, Any], rom_path: str, rom_name: str) -> None:
+# ISO-639-1 codes for the languages RomM recognizes. rom.languages stores names
+# ("French") from filename parsing and shortcodes ("fr") from metadata
+# providers; ui_settings.locale stores locale codes ("fr_FR"). Every broker
+# receives the same reduced ISO-639-1 code and maps it to its own dialect.
+_LANGUAGE_NAME_TO_ISO = {
+    name.lower(): code.lower()
+    for code, name in LANGUAGES
+    if code.lower() != "nolang"
+}
+_ISO_CODES = set(_LANGUAGE_NAME_TO_ISO.values())
+
+
+def _language_code(value: Any) -> str | None:
+    """Reduce a RomM language value to an ISO-639-1 code, or None.
+
+    Unknown values are omitted so a broker falls back to its own default
+    instead of failing the launch.
+    """
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower().replace("-", "_")
+    base = normalized.split("_")[0]
+    return _LANGUAGE_NAME_TO_ISO.get(normalized) or (
+        base if base in _ISO_CODES else None
+    )
+
+
+def _call_broker(
+    container: dict[str, Any],
+    rom_path: str,
+    rom_name: str,
+    language: str | None = None,
+    gui_language: str | None = None,
+) -> None:
     """
     POST to the broker's /launch endpoint to tell the emulator container to
     load a ROM.
@@ -361,11 +395,16 @@ def _call_broker(container: dict[str, Any], rom_path: str, rom_name: str) -> Non
     Raises HTTPException if the broker is unreachable or returns an error.
     """
     url = _broker_url(container, "/launch")
+    body = {"rom_path": rom_path, "rom_name": rom_name}
+    if language:
+        body["language"] = language
+    if gui_language:
+        body["gui_language"] = gui_language
     try:
         body = _broker_request(
             container,
             "/launch",
-            body={"rom_path": rom_path, "rom_name": rom_name},
+            body=body,
             timeout=10,
         )
         log.info("broker launched ROM, %s", body)
@@ -537,6 +576,17 @@ async def claim_session(
     rom_path = f"{LIBRARY_BASE_PATH}/{rom.full_path}"
     rom_name = rom.name or rom.fs_name_no_ext
 
+    # The game language comes from the ROM's metadata; the interface locale from
+    # the user's own UI settings. Both are optional, and when no game metadata
+    # exists the broker falls back to the interface locale for the game language.
+    language = None
+    for candidate in rom.languages or []:
+        language = _language_code(candidate)
+        if language:
+            break
+    ui_settings = request.user.ui_settings or {}
+    gui_language = _language_code(ui_settings.get("locale"))
+
     session_key = _container_key(container)
     now = datetime.now(timezone.utc).isoformat()
     session = {
@@ -569,7 +619,9 @@ async def claim_session(
     try:
         # Tell the broker to load the ROM, raises HTTPException on failure.
         # Wrapped in asyncio.to_thread because urllib is synchronous.
-        await asyncio.to_thread(_call_broker, container, rom_path, rom_name)
+        await asyncio.to_thread(
+            _call_broker, container, rom_path, rom_name, language, gui_language
+        )
     except Exception:
         # Launch failed, free the claim so the container isn't wedged.
         await async_cache.delete(_session_redis_key(session_key))

--- a/backend/endpoints/streaming.py
+++ b/backend/endpoints/streaming.py
@@ -135,6 +135,9 @@ _PLATFORM_CAPABILITIES: dict[str, PlatformCapabilities] = {
     # PCSX2 (ps2) and xemu (xbox): slots 1-9 manual, slot 10 autosave.
     "ps2": {"max_slots": 9, "has_autosave": True, "autosave_slot": 10},
     "xbox": {"max_slots": 9, "has_autosave": True, "autosave_slot": 10},
+    # ScummVM: slots 1-9 manual. Its autosave sits in slot 0, which the GUI
+    # marks write protected, so the broker never targets it.
+    "scummvm": {"max_slots": 9, "has_autosave": False, "autosave_slot": 0},
 }
 
 _NO_CAPABILITIES: PlatformCapabilities = {

--- a/backend/tests/endpoints/test_streaming.py
+++ b/backend/tests/endpoints/test_streaming.py
@@ -160,6 +160,19 @@ def test_get_config_ships_platform_capabilities(client, access_token):
     }
 
 
+def test_get_config_ships_scummvm_capabilities(client, access_token):
+    """ScummVM is the first platform exposed without a loadable autosave."""
+    container = {"platform": "scummvm", "host": "http://192.168.1.10:3000"}
+    with _streaming(container):
+        r = client.get("/api/streaming/config", headers=_auth(access_token))
+    assert r.status_code == 200
+    assert r.json()["containers"][0]["capabilities"] == {
+        "max_slots": 9,
+        "has_autosave": False,
+        "autosave_slot": 0,
+    }
+
+
 # ── Claiming ──────────────────────────────────────────────────────────────────
 
 

--- a/backend/tests/endpoints/test_streaming.py
+++ b/backend/tests/endpoints/test_streaming.py
@@ -11,7 +11,7 @@ from main import app
 
 from config import LIBRARY_BASE_PATH, OAUTH_ACCESS_TOKEN_EXPIRE_SECONDS
 from handler.auth import oauth_handler
-from handler.database import db_platform_handler, db_rom_handler
+from handler.database import db_platform_handler, db_rom_handler, db_user_handler
 from handler.database.base_handler import sync_session
 from handler.redis_handler import async_cache
 from models.permission import HiddenEntity, PermEntity
@@ -183,8 +183,44 @@ def test_claim_derives_rom_path_server_side(client, access_token, rom: Rom):
             r = _claim(client, access_token, rom.id)
     assert r.status_code == 200
     assert r.json()["rom_name"] == rom.name
-    _, rom_path, _ = call_broker.call_args[0]
+    _, rom_path, _, _, _ = call_broker.call_args[0]
     assert rom_path == f"{LIBRARY_BASE_PATH}/{rom.full_path}"
+
+
+def test_claim_forwards_language_and_gui_language(
+    client, access_token, admin_user: User, rom: Rom
+):
+    """The broker gets the game language from rom.languages and the interface
+    locale from the user's ui_settings, mapped to ISO-639-1 codes."""
+    db_rom_handler.update_rom(rom.id, {"languages": ["French"]})
+    db_user_handler.update_user(admin_user.id, {"ui_settings": {"locale": "fr_FR"}})
+    with _streaming(_container_for(rom)):
+        with patch("endpoints.streaming._call_broker") as call_broker:
+            r = _claim(client, access_token, rom.id)
+    assert r.status_code == 200
+    _, _, _, language, gui_language = call_broker.call_args[0]
+    assert language == "fr"
+    assert gui_language == "fr"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("French", "fr"),
+        ("FR", "fr"),
+        ("fr_FR", "fr"),
+        ("pt_BR", "pt"),
+        ("No Language", None),
+        ("xx", None),
+        (None, None),
+        (123, None),
+    ],
+)
+def test_language_code(value, expected):
+    """RomM language names, shortcodes and locales all reduce to one ISO code."""
+    from endpoints.streaming import _language_code
+
+    assert _language_code(value) == expected
 
 
 def test_claim_unknown_rom_returns_404(client, access_token):


### PR DESCRIPTION
**Description**

Two additions to the emulator streaming backend:

- **ScummVM platform capabilities.** `scummvm` joins the capabilities table with slots 1-9 manual, `has_autosave: false` and `autosave_slot: 0`. ScummVM autosaves to slot 0 and marks that slot write protected in its own GUI, so the broker substitutes its managed slot when the frontend targets slot 0 on save-and-exit, and the frontend must not offer slot 0 as a loadable autosave. This is the first platform exposed without a loadable autosave, and the frontend already handles it (the load-autosave button is gated on `has_autosave`).

- **Language forwarding on session claim.** The broker `/launch` call now carries `language` (the game's language, from the first mappable entry of `rom.languages`) and `gui_language` (the claiming user's `ui_settings.locale`). `rom.languages` mixes names ("French") from filename parsing with shortcodes ("fr") from metadata providers, and the locale is a code like "fr_FR"; all reduce to one ISO-639-1 code so every broker receives the same shape and maps it to its own dialect. Unknown values are omitted, so a broker falls back to its own default instead of failing the launch. Both fields are optional and existing brokers that ignore them are unaffected.

The consuming broker is published at [jfrag/scummvm-romm-integration](https://github.com/jfrag/scummvm-romm-integration), a linuxserver/scummvm Docker mod kept in parity with the Dolphin/PCSX2/xemu brokers: it uses `language` as ScummVM's `--language` boot flag (picking the right variant of a multilingual game folder) and `gui_language` for ScummVM's own interface.

**AI assistance disclosure**: developed with Claude Code assistance (code and tests), reviewed and verified by me against a live ScummVM streaming container.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes
