### PR TITLE
fix(v2): read the date picker's value in UTC, not local time

### DIFF
--- a/frontend/src/v2/components/Gallery/GameListRow.vue
+++ b/frontend/src/v2/components/Gallery/GameListRow.vue
@@ -19,6 +19,7 @@ import {
   RSkeletonBlock,
   RTooltip,
 } from "@v2/lib";
+import { formatReleaseDate } from "@v2/utils/time";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
@@ -165,15 +166,11 @@ function formatDate(value: string | null | undefined): string {
 }
 
 function releaseDate(item: SimpleRom): string {
-  const ts = item.metadatum?.first_release_date;
-  if (!ts) return "—";
-  return new Date(Number(ts)).toLocaleDateString(
-    toBrowserLocale(locale.value),
-    {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-    },
+  return (
+    formatReleaseDate(
+      item.metadatum?.first_release_date,
+      toBrowserLocale(locale.value),
+    ) ?? "—"
   );
 }
 

--- a/frontend/src/v2/components/Home/Widgets/RandomPickWidget.vue
+++ b/frontend/src/v2/components/Home/Widgets/RandomPickWidget.vue
@@ -7,6 +7,7 @@
 // server-side, so it costs the same on any library size. The pick is
 // intentionally not cached so each mount re-shuffles.
 import { RBtn, RChip } from "@v2/lib";
+import { releaseYear } from "@v2/utils/time";
 import { computed, nextTick, onMounted, ref } from "vue";
 import type { ComponentPublicInstance } from "vue";
 import { useI18n } from "vue-i18n";
@@ -47,12 +48,9 @@ function rerollEl(): HTMLElement | null {
 
 const title = computed(() => pick.value?.name || pick.value?.fs_name || "");
 
-const releaseYear = computed(() => {
-  const ts = pick.value?.metadatum?.first_release_date;
-  if (!ts) return null;
-  const date = new Date(Number(ts));
-  return Number.isNaN(date.getTime()) ? null : date.getFullYear();
-});
+const pickReleaseYear = computed(() =>
+  releaseYear(pick.value?.metadatum?.first_release_date),
+);
 
 const region = computed(() => pick.value?.regions?.[0] ?? null);
 
@@ -141,8 +139,8 @@ onMounted(() => reroll({ notify: false }));
         </div>
         <!-- Year + region disambiguate the pick when a library holds
              several variations of the same title. -->
-        <div v-if="releaseYear || region" class="r-v2-widget-pick__meta">
-          <span v-if="releaseYear">{{ releaseYear }}</span>
+        <div v-if="pickReleaseYear || region" class="r-v2-widget-pick__meta">
+          <span v-if="pickReleaseYear">{{ pickReleaseYear }}</span>
           <RChip v-if="region" size="x-small" variant="translucent">
             {{ region }}
           </RChip>

--- a/frontend/src/v2/lib/forms/RDateField/RDateField.test.ts
+++ b/frontend/src/v2/lib/forms/RDateField/RDateField.test.ts
@@ -1,0 +1,104 @@
+import { enableAutoUnmount, mount } from "@vue/test-utils";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import RDateField from "./RDateField.vue";
+
+// Runs in a timezone west of UTC on purpose: the picker emits UTC midnight,
+// so any local-time getter left in the calendar reads back as the previous
+// day and every cell in the grid shifts by one. See rommapp/romm#4321.
+process.env.TZ = "America/New_York";
+
+// The calendar teleports to <body>, so a wrapper left mounted by a failing
+// assertion would leak its panel into the next test's queries.
+enableAutoUnmount(afterEach);
+
+async function openPicker() {
+  const wrapper = mount(RDateField, {
+    props: { modelValue: Date.UTC(2024, 2, 15) },
+    attachTo: document.body,
+  });
+  await wrapper.get("input").trigger("click");
+  await wrapper.vm.$nextTick();
+  return wrapper;
+}
+
+function dayCell(day: number) {
+  return document.querySelector<HTMLButtonElement>(
+    `.r-date-cal__day[data-day-key="2024-2-${day}"]`,
+  );
+}
+
+function focusedKey() {
+  return document
+    .querySelector('.r-date-cal__day[tabindex="0"]')
+    ?.getAttribute("data-day-key");
+}
+
+describe("RDateField", () => {
+  beforeAll(() => {
+    // Guard the guard: without a west-of-UTC offset these tests pass either way.
+    expect(new Date().getTimezoneOffset()).toBeGreaterThan(0);
+  });
+
+  it("shows the selected day, not the one before it", () => {
+    const wrapper = mount(RDateField, {
+      props: { modelValue: Date.UTC(2024, 2, 15) },
+    });
+    expect(wrapper.get("input").element.value).toBe("Mar 15, 2024");
+  });
+
+  it("opens on the month of the selected value", async () => {
+    await openPicker();
+    expect(document.querySelector(".r-date-cal__title")?.textContent).toContain(
+      "March",
+    );
+    expect(dayCell(15)?.classList).toContain("r-date-cal__day--selected");
+  });
+
+  it("lines the grid up under the weekday header", async () => {
+    await openPicker();
+    const headers = Array.from(
+      document.querySelectorAll(".r-date-cal__weekday"),
+      (n) => n.textContent?.trim(),
+    );
+    expect(headers[0]).toBe("Mon");
+
+    // firstDayOfWeek defaults to Monday and March 2024 opens on a Friday, so
+    // the grid leads with Mon 26 Feb.
+    const first = document.querySelector(".r-date-cal__day");
+    expect(first?.getAttribute("data-day-key")).toBe("2024-1-26");
+  });
+
+  it("emits the day that was clicked", async () => {
+    const wrapper = await openPicker();
+    const cell = dayCell(22);
+    expect(cell?.textContent?.trim()).toBe("22");
+
+    cell?.click();
+    await wrapper.vm.$nextTick();
+
+    const picked = wrapper.emitted("update:modelValue")?.[0]?.[0] as Date;
+    expect(picked.getTime()).toBe(Date.UTC(2024, 2, 22));
+  });
+
+  it("walks one day per arrow key", async () => {
+    const wrapper = await openPicker();
+    expect(focusedKey()).toBe("2024-2-15");
+
+    const panel = document.querySelector(".r-date-cal") as HTMLElement;
+    for (const key of ["ArrowRight", "ArrowDown"]) {
+      panel.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+      await wrapper.vm.$nextTick();
+    }
+    expect(focusedKey()).toBe("2024-2-23");
+  });
+
+  it("keeps the label and the emitted value on the same day", async () => {
+    const wrapper = await openPicker();
+    dayCell(1)?.click();
+    await wrapper.vm.$nextTick();
+
+    const picked = wrapper.emitted("update:modelValue")?.[0]?.[0] as Date;
+    await wrapper.setProps({ modelValue: picked });
+    expect(wrapper.get("input").element.value).toBe("Mar 1, 2024");
+  });
+});

--- a/frontend/src/v2/lib/forms/RDateField/RDateField.test.ts
+++ b/frontend/src/v2/lib/forms/RDateField/RDateField.test.ts
@@ -46,6 +46,16 @@ describe("RDateField", () => {
     expect(wrapper.get("input").element.value).toBe("Mar 15, 2024");
   });
 
+  it("does not let displayFormat move the label off UTC", () => {
+    const wrapper = mount(RDateField, {
+      props: {
+        modelValue: Date.UTC(2024, 2, 15),
+        displayFormat: { dateStyle: "medium", timeZone: "America/New_York" },
+      },
+    });
+    expect(wrapper.get("input").element.value).toBe("Mar 15, 2024");
+  });
+
   it("opens on the month of the selected value", async () => {
     await openPicker();
     expect(document.querySelector(".r-date-cal__title")?.textContent).toContain(

--- a/frontend/src/v2/lib/forms/RDateField/RDateField.vue
+++ b/frontend/src/v2/lib/forms/RDateField/RDateField.vue
@@ -57,7 +57,8 @@ interface Props {
   /** Disable opening the picker. RTextField also accepts `disabled` —
    *  we forward it to the field so it gets the muted look too. */
   disabled?: boolean;
-  /** Override the display format. Defaults to `dateStyle: medium`. */
+  /** Override the display format. Defaults to `dateStyle: medium`. The
+   *  timezone is fixed to UTC and can't be overridden here. */
   displayFormat?: Intl.DateTimeFormatOptions;
   /** Render an inline X next to the calendar icon when a date is set.
    *  Mirrors RTextField's clearable affordance so the two primitives
@@ -102,9 +103,11 @@ const maxDate = computed(() => toDate(props.max));
 // = navigator default, same call shape Intl prefers for "user locale".
 const displayValue = computed(() => {
   if (!selectedDate.value) return "";
+  // timeZone last: the value is a UTC calendar date, so a caller-supplied
+  // zone would only desync the label from the grid.
   return new Intl.DateTimeFormat(undefined, {
-    timeZone: "UTC",
     ...props.displayFormat,
+    timeZone: "UTC",
   }).format(selectedDate.value);
 });
 

--- a/frontend/src/v2/lib/forms/RDateField/RDateField.vue
+++ b/frontend/src/v2/lib/forms/RDateField/RDateField.vue
@@ -13,7 +13,9 @@
 // Model value accepts whatever the call site already has (Date object,
 // UNIX timestamp in milliseconds, ISO/yyyy-MM-dd string, or null) and
 // emits a `Date | null` anchored at UTC midnight so timezone shifts
-// don't bump the value across day boundaries.
+// don't bump the value across day boundaries. Every read is UTC too --
+// grid, labels and comparisons -- because reading a UTC-midnight
+// instant with local getters lands on the previous day west of UTC.
 import {
   autoUpdate,
   flip,
@@ -100,9 +102,10 @@ const maxDate = computed(() => toDate(props.max));
 // = navigator default, same call shape Intl prefers for "user locale".
 const displayValue = computed(() => {
   if (!selectedDate.value) return "";
-  return new Intl.DateTimeFormat(undefined, props.displayFormat).format(
-    selectedDate.value,
-  );
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone: "UTC",
+    ...props.displayFormat,
+  }).format(selectedDate.value);
 });
 
 // ── Open state + floating-ui ───────────────────────────────────
@@ -142,25 +145,30 @@ function toggle() {
 // `focusedDay` tracks the keyboard cursor — separate from selection so
 // users can navigate without committing.
 function startOfMonth(d: Date): Date {
-  return new Date(d.getFullYear(), d.getMonth(), 1);
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
 }
 function sameDay(a: Date | null, b: Date | null): boolean {
   if (!a || !b) return false;
   return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
+    a.getUTCFullYear() === b.getUTCFullYear() &&
+    a.getUTCMonth() === b.getUTCMonth() &&
+    a.getUTCDate() === b.getUTCDate()
   );
 }
+/** The user's local calendar day, re-anchored at UTC midnight. */
+function todayUtc(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+}
 
-const viewMonth = ref<Date>(startOfMonth(selectedDate.value ?? new Date()));
-const focusedDay = ref<Date>(selectedDate.value ?? new Date());
+const viewMonth = ref<Date>(startOfMonth(selectedDate.value ?? todayUtc()));
+const focusedDay = ref<Date>(selectedDate.value ?? todayUtc());
 
 // Whenever the popup opens, snap the view + cursor back to the current
 // selection (or today) so the user never lands on a stale month.
 watch(isOpen, (next) => {
   if (!next) return;
-  const anchor = selectedDate.value ?? new Date();
+  const anchor = selectedDate.value ?? todayUtc();
   viewMonth.value = startOfMonth(anchor);
   focusedDay.value = new Date(anchor);
   nextTick(focusDayCell);
@@ -177,7 +185,7 @@ interface GridCell {
   key: string;
 }
 
-const today = computed(() => new Date());
+const today = computed(() => todayUtc());
 
 function isDisabledDate(d: Date): boolean {
   if (minDate.value && d < startOfDay(minDate.value)) return true;
@@ -185,30 +193,42 @@ function isDisabledDate(d: Date): boolean {
   return false;
 }
 function startOfDay(d: Date): Date {
-  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0);
+  return new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
 }
 function endOfDay(d: Date): Date {
-  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999);
+  return new Date(
+    Date.UTC(
+      d.getUTCFullYear(),
+      d.getUTCMonth(),
+      d.getUTCDate(),
+      23,
+      59,
+      59,
+      999,
+    ),
+  );
 }
 
 const grid = computed<GridCell[]>(() => {
   const first = startOfMonth(viewMonth.value);
-  const startOffset = (first.getDay() - props.firstDayOfWeek + 7) % 7;
+  const startOffset = (first.getUTCDay() - props.firstDayOfWeek + 7) % 7;
   const gridStart = new Date(first);
-  gridStart.setDate(first.getDate() - startOffset);
+  gridStart.setUTCDate(first.getUTCDate() - startOffset);
 
   const cells: GridCell[] = [];
   for (let i = 0; i < 42; i += 1) {
     const d = new Date(gridStart);
-    d.setDate(gridStart.getDate() + i);
+    d.setUTCDate(gridStart.getUTCDate() + i);
     cells.push({
       date: d,
-      inMonth: d.getMonth() === viewMonth.value.getMonth(),
+      inMonth: d.getUTCMonth() === viewMonth.value.getUTCMonth(),
       isToday: sameDay(d, today.value),
       isSelected: sameDay(d, selectedDate.value),
       isDisabled: isDisabledDate(d),
       isFocused: sameDay(d, focusedDay.value),
-      key: `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`,
+      key: `${d.getUTCFullYear()}-${d.getUTCMonth()}-${d.getUTCDate()}`,
     });
   }
   return cells;
@@ -218,17 +238,21 @@ const grid = computed<GridCell[]>(() => {
 const monthYearFormat = new Intl.DateTimeFormat(undefined, {
   month: "long",
   year: "numeric",
+  timeZone: "UTC",
 });
 const monthLabel = computed(() => monthYearFormat.format(viewMonth.value));
 
-const weekdayFormat = new Intl.DateTimeFormat(undefined, { weekday: "short" });
+const weekdayFormat = new Intl.DateTimeFormat(undefined, {
+  weekday: "short",
+  timeZone: "UTC",
+});
 const weekdays = computed(() => {
   // Anchor on a known Sunday (2024-01-07) and step `firstDayOfWeek` ahead.
-  const anchor = new Date(2024, 0, 7);
+  const anchor = new Date(Date.UTC(2024, 0, 7));
   const out: string[] = [];
   for (let i = 0; i < 7; i += 1) {
     const d = new Date(anchor);
-    d.setDate(anchor.getDate() + ((i + props.firstDayOfWeek) % 7));
+    d.setUTCDate(anchor.getUTCDate() + ((i + props.firstDayOfWeek) % 7));
     out.push(weekdayFormat.format(d));
   }
   return out;
@@ -237,25 +261,29 @@ const weekdays = computed(() => {
 // ── Month / year navigation ────────────────────────────────────
 function shiftMonth(delta: number) {
   viewMonth.value = new Date(
-    viewMonth.value.getFullYear(),
-    viewMonth.value.getMonth() + delta,
-    1,
+    Date.UTC(
+      viewMonth.value.getUTCFullYear(),
+      viewMonth.value.getUTCMonth() + delta,
+      1,
+    ),
   );
 }
 function shiftYear(delta: number) {
   viewMonth.value = new Date(
-    viewMonth.value.getFullYear() + delta,
-    viewMonth.value.getMonth(),
-    1,
+    Date.UTC(
+      viewMonth.value.getUTCFullYear() + delta,
+      viewMonth.value.getUTCMonth(),
+      1,
+    ),
   );
 }
 
 // ── Selection ──────────────────────────────────────────────────
 function selectDay(d: Date) {
   if (isDisabledDate(d)) return;
-  // Emit UTC midnight so the round-trip survives timezones — matches the
+  // Emit UTC midnight so the round-trip survives timezones, matching the
   // shape callers already store (e.g. `released_at` timestamps in DB).
-  const utc = Date.UTC(d.getFullYear(), d.getMonth(), d.getDate());
+  const utc = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
   emit("update:modelValue", new Date(utc));
   close();
 }
@@ -341,13 +369,13 @@ function onPanelKeydown(evt: KeyboardEvent) {
 
 function moveFocus(deltaDays: number) {
   const next = new Date(focusedDay.value);
-  next.setDate(next.getDate() + deltaDays);
+  next.setUTCDate(next.getUTCDate() + deltaDays);
   focusedDay.value = next;
   // If the cursor walked off-month, scroll the view to follow it so the
   // cell stays visible.
   if (
-    next.getFullYear() !== viewMonth.value.getFullYear() ||
-    next.getMonth() !== viewMonth.value.getMonth()
+    next.getUTCFullYear() !== viewMonth.value.getUTCFullYear() ||
+    next.getUTCMonth() !== viewMonth.value.getUTCMonth()
   ) {
     viewMonth.value = startOfMonth(next);
   }
@@ -355,14 +383,14 @@ function moveFocus(deltaDays: number) {
 }
 function moveFocusToWeekEdge(direction: -1 | 1) {
   // -1: Home → start of week. +1: End → end of week.
-  const dow = focusedDay.value.getDay();
+  const dow = focusedDay.value.getUTCDay();
   const fdow = props.firstDayOfWeek;
   const offsetFromStart = (dow - fdow + 7) % 7;
   const next = new Date(focusedDay.value);
   if (direction === -1) {
-    next.setDate(next.getDate() - offsetFromStart);
+    next.setUTCDate(next.getUTCDate() - offsetFromStart);
   } else {
-    next.setDate(next.getDate() + (6 - offsetFromStart));
+    next.setUTCDate(next.getUTCDate() + (6 - offsetFromStart));
   }
   focusedDay.value = next;
   nextTick(focusDayCell);
@@ -370,7 +398,7 @@ function moveFocusToWeekEdge(direction: -1 | 1) {
 
 function focusDayCell() {
   if (!panelRef.value) return;
-  const key = `${focusedDay.value.getFullYear()}-${focusedDay.value.getMonth()}-${focusedDay.value.getDate()}`;
+  const key = `${focusedDay.value.getUTCFullYear()}-${focusedDay.value.getUTCMonth()}-${focusedDay.value.getUTCDate()}`;
   const cell = panelRef.value.querySelector(
     `[data-day-key="${key}"]`,
   ) as HTMLElement | null;
@@ -543,7 +571,7 @@ onBeforeUnmount(() => {
               :disabled="cell.isDisabled"
               @click="selectDay(cell.date)"
             >
-              {{ cell.date.getDate() }}
+              {{ cell.date.getUTCDate() }}
             </button>
           </div>
 

--- a/frontend/src/v2/utils/time.test.ts
+++ b/frontend/src/v2/utils/time.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { formatTrackTime } from "./time";
+import { formatReleaseDate, formatTrackTime, releaseYear } from "./time";
+
+// West of UTC on purpose: release dates are UTC-midnight timestamps, so a
+// local-time reader lands on the previous day. See rommapp/romm#4321.
+process.env.TZ = "America/New_York";
 
 describe("formatTrackTime", () => {
   it("formats seconds as a digital track position", () => {
@@ -17,5 +21,37 @@ describe("formatTrackTime", () => {
 
   it("truncates fractional seconds", () => {
     expect(formatTrackTime(61.9)).toBe("1:01");
+  });
+});
+
+describe("formatReleaseDate", () => {
+  it("renders the stored UTC day, not the local one", () => {
+    expect(formatReleaseDate(Date.UTC(2024, 2, 15), "en-US")).toBe(
+      "Mar 15, 2024",
+    );
+  });
+
+  it("accepts a stringified timestamp", () => {
+    expect(formatReleaseDate(String(Date.UTC(1998, 10, 21)), "en-US")).toBe(
+      "Nov 21, 1998",
+    );
+  });
+
+  it("returns null for missing or unusable values", () => {
+    for (const value of [undefined, null, 0, "", "not-a-date"]) {
+      expect(formatReleaseDate(value, "en-US")).toBeNull();
+    }
+  });
+});
+
+describe("releaseYear", () => {
+  it("reads the year in UTC", () => {
+    expect(releaseYear(Date.UTC(2024, 0, 1))).toBe(2024);
+  });
+
+  it("returns null for missing or unusable values", () => {
+    for (const value of [undefined, null, 0, "nope"]) {
+      expect(releaseYear(value)).toBeNull();
+    }
   });
 });

--- a/frontend/src/v2/utils/time.test.ts
+++ b/frontend/src/v2/utils/time.test.ts
@@ -38,7 +38,7 @@ describe("formatReleaseDate", () => {
   });
 
   it("returns null for missing or unusable values", () => {
-    for (const value of [undefined, null, 0, "", "not-a-date"]) {
+    for (const value of [undefined, null, 0, "0", "", "not-a-date"]) {
       expect(formatReleaseDate(value, "en-US")).toBeNull();
     }
   });
@@ -50,7 +50,7 @@ describe("releaseYear", () => {
   });
 
   it("returns null for missing or unusable values", () => {
-    for (const value of [undefined, null, 0, "nope"]) {
+    for (const value of [undefined, null, 0, "0", "nope"]) {
       expect(releaseYear(value)).toBeNull();
     }
   });

--- a/frontend/src/v2/utils/time.ts
+++ b/frontend/src/v2/utils/time.ts
@@ -8,3 +8,31 @@ export function formatTrackTime(s: number | undefined | null): string {
   const seconds = Math.floor(s % 60);
   return `${minutes}:${String(seconds).padStart(2, "0")}`;
 }
+
+// Release dates are stored as UTC-midnight timestamps, so they are read back
+// in UTC: local formatting shows the previous day west of Greenwich.
+
+/** A `first_release_date` timestamp as a short date, or null if unset. */
+export function formatReleaseDate(
+  timestamp: number | string | null | undefined,
+  locale: string,
+): string | null {
+  if (!timestamp) return null;
+  const date = new Date(Number(timestamp));
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString(locale, {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/** The year of a `first_release_date` timestamp, or null if unset. */
+export function releaseYear(
+  timestamp: number | string | null | undefined,
+): number | null {
+  if (!timestamp) return null;
+  const date = new Date(Number(timestamp));
+  return Number.isNaN(date.getTime()) ? null : date.getUTCFullYear();
+}

--- a/frontend/src/v2/utils/time.ts
+++ b/frontend/src/v2/utils/time.ts
@@ -12,27 +12,33 @@ export function formatTrackTime(s: number | undefined | null): string {
 // Release dates are stored as UTC-midnight timestamps, so they are read back
 // in UTC: local formatting shows the previous day west of Greenwich.
 
+// Coerce before testing for emptiness, so "0" and 0 are both unset. The epoch
+// itself is not a real release date -- the roms_metadata view drops it too.
+function toReleaseDate(
+  timestamp: number | string | null | undefined,
+): Date | null {
+  const ms = Number(timestamp);
+  return ms ? new Date(ms) : null;
+}
+
 /** A `first_release_date` timestamp as a short date, or null if unset. */
 export function formatReleaseDate(
   timestamp: number | string | null | undefined,
   locale: string,
 ): string | null {
-  if (!timestamp) return null;
-  const date = new Date(Number(timestamp));
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleDateString(locale, {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-    timeZone: "UTC",
-  });
+  return (
+    toReleaseDate(timestamp)?.toLocaleDateString(locale, {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+      timeZone: "UTC",
+    }) ?? null
+  );
 }
 
 /** The year of a `first_release_date` timestamp, or null if unset. */
 export function releaseYear(
   timestamp: number | string | null | undefined,
 ): number | null {
-  if (!timestamp) return null;
-  const date = new Date(Number(timestamp));
-  return Number.isNaN(date.getTime()) ? null : date.getUTCFullYear();
+  return toReleaseDate(timestamp)?.getUTCFullYear() ?? null;
 }

--- a/frontend/src/v2/views/GameDetails.vue
+++ b/frontend/src/v2/views/GameDetails.vue
@@ -6,6 +6,7 @@
 // orchestrator — data + tab state live here, every visual piece is a
 // sub-component under components/GameDetails/.
 import { RTabNav, type RTabNavItem } from "@v2/lib";
+import { formatReleaseDate } from "@v2/utils/time";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
@@ -107,18 +108,12 @@ const platformLabel = computed(() => {
   return r.platform_custom_name || r.platform_display_name;
 });
 
-const releaseDate = computed(() => {
-  const ts = currentRom.value?.metadatum?.first_release_date;
-  if (!ts) return null;
-  return new Date(Number(ts)).toLocaleDateString(
+const releaseDate = computed(() =>
+  formatReleaseDate(
+    currentRom.value?.metadatum?.first_release_date,
     toBrowserLocale(locale.value),
-    {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-    },
-  );
-});
+  ),
+);
 
 const genres = computed(() => currentRom.value?.metadatum?.genres ?? []);
 const franchises = computed(


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

Fixes #4321 — picking a day in the "Released at" calendar landed on the day before.

`RDateField` emitted its value at **UTC midnight** but read it back everywhere with **local-time** getters: `Intl` formatting, the `sameDay` comparison, the grid keys and the day labels all went through `getDate()`/`getMonth()`. West of Greenwich that resolves a UTC-midnight instant to the previous local day, so clicking 15 showed 14. In UTC+ timezones the bug is invisible, which is why it went unnoticed.

The read path had the same mismatch. `first_release_date` is stored as a UTC-midnight millisecond timestamp (the `roms_metadata` view multiplies provider seconds by 1000), but the game details page and the gallery list row formatted it in local time — so even a correct pick would still have displayed a day early.

Changes:

- `RDateField.vue` — all calendar arithmetic moves to UTC (`getUTC*` / `setUTC*` / `Date.UTC`), and the three `Intl.DateTimeFormat` instances pass `timeZone: "UTC"`. The "Today" shortcut still resolves the user's *local* calendar day, re-anchored to UTC midnight via a new `todayUtc()` helper.
- `v2/utils/time.ts` — new `formatReleaseDate()` / `releaseYear()` give the UTC rule one home. This also collapses a pre-existing duplicate: `GameDetails.vue` and `GameListRow.vue` had byte-identical formatting blocks.
- Call sites rewired: `GameDetails.vue`, `GameListRow.vue`, `RandomPickWidget.vue`.

v1's edit dialog is untouched — it uses Vuetify's `v-date-input`, which is local-midnight end to end and doesn't have this bug.

**Verification**

Reverting `RDateField.vue` alone makes 4 of the 6 new cases fail, the first with `expected 'Mar 14, 2024' to contain '15'` — the reported symptom exactly.

Both new test files force `TZ=America/New_York`; without a west-of-UTC offset these tests pass either way, so `RDateField.test.ts` asserts the offset in `beforeAll`.

Full frontend suite green (922 tests / 86 files), plus `typecheck`, `build`, `trunk fmt` and `trunk check`.

Also driven manually in Storybook in a browser reporting `America/Chicago` (UTC-5, the failing condition): grid aligns under the weekday header, clicking 22 gives "Nov 22, 2023", arrow keys step exactly one day and one week, Enter commits the focused cell, and "Today" gives the local date. Checked in both `r-v2-dark` and `r-v2-light`.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The diagnosis, the implementation, the tests and the manual browser verification were all produced by the agent and reviewed by me before opening the PR.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

n/a — no visual change; the calendar renders identically, it just resolves the right day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
