### PR TITLE
fix: allow INI files in library scans

### DIFF
--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -33,7 +33,6 @@ ROMM_USER_CONFIG_FILE: Final = f"{ROMM_USER_CONFIG_PATH}/config.yml"
 SQLITE_DB_BASE_PATH: Final = f"{ROMM_BASE_PATH}/database"
 DEFAULT_EXCLUDED_EXTENSIONS: Final = [
     "db",
-    "ini",
     "tmp",
     "bak",
     "lock",

--- a/backend/tests/config/test_config_loader.py
+++ b/backend/tests/config/test_config_loader.py
@@ -106,11 +106,13 @@ def test_empty_config_loader():
     assert loader.config.EXCLUDED_SINGLE_EXT == sorted(
         {e.lower() for e in DEFAULT_EXCLUDED_EXTENSIONS}
     )
+    assert "ini" not in loader.config.EXCLUDED_SINGLE_EXT
     assert loader.config.EXCLUDED_SINGLE_FILES == sorted(DEFAULT_EXCLUDED_FILES)
     assert loader.config.EXCLUDED_MULTI_FILES == sorted(DEFAULT_EXCLUDED_DIRS)
     assert loader.config.EXCLUDED_MULTI_PARTS_EXT == sorted(
         {e.lower() for e in DEFAULT_EXCLUDED_EXTENSIONS}
     )
+    assert "ini" not in loader.config.EXCLUDED_MULTI_PARTS_EXT
     assert loader.config.EXCLUDED_MULTI_PARTS_FILES == sorted(DEFAULT_EXCLUDED_FILES)
     assert loader.config.PLATFORMS_BINDING == {}
     assert loader.config.PLATFORMS_VERSIONS == {}


### PR DESCRIPTION
#### Screenshots (if applicable)

Remove `ini` from `DEFAULT_EXCLUDED_EXTENSIONS` in `backend/config/config_manager.py`, leaving all other default exclusions and user-supplied exclusion merging unchanged. This automatically updates both effective extension lists because the config loader derives `EXCLUDED_SINGLE_EXT` and `EXCLUDED_MULTI_PARTS_EXT` from the shared constant. Add explicit regression coverage in `backend/tests/config/test_config_loader.py` proving an empty/default configuration does not exclude `ini` in either scan mode.

RomM 5.0 adds `ini` to `DEFAULT_EXCLUDED_EXTENSIONS`, so the config loader places it in both `EXCLUDED_SINGLE_EXT` and `EXCLUDED_MULTI_PARTS_EXT`. Files with that extension are therefore omitted from Windows game libraries even when users need them as part of a game distribution. The exclusion is a built-in default and cannot be removed through `config.yml` or the settings UI. After discussion with the reporter, a maintainer proposed removing `.ini` from the default list rather than adding a new configuration or UI override mechanism.

Fixes #4319

AI was used for assistance.
