### PR TITLE
Add crossorigin attribute to manifest link so CloudFlare Tunnels doesn't break site.webmanifest

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#9205f2" />
     <meta name="msapplication-TileColor" content="#9205f2" />
     <meta name="theme-color" content="#2a0145" />


### PR DESCRIPTION
So that cloudflare doesn't intercept it and cors blocking it. See: https://github.com/open-webui/open-webui/issues/1538 Also (i think): https://github.com/cloudflare/cloudflare-docs/blob/production/src/content/docs/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/cors.mdx

<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Fix an error that happens in the console, due to CF tunnels intercepting the site.webmanifest</sup>

**Checklist**
<sup>Please check all that apply.</sup>

- [x ] I've tested the changes locally
- [x ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

Failing:
<img width="2545" height="437" alt="image" src="https://github.com/user-attachments/assets/4e324faa-e835-43a3-b738-58bfcec36bf9" />

Working:
<img width="2554" height="216" alt="image" src="https://github.com/user-attachments/assets/9901a56e-c445-45fe-a2d9-33f7dbf0262f" />

I admit, i did ask chatgpt for some help, as i'm not a frontend dev.
I tested browsing through my selfhosted instance, and didn't encounter any issues with my change.