### PR TITLE
chore: drop the vcrpy exclude-newer override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,9 +144,6 @@ DEP002 = [ # DEP002 rule: Project should not contain unused dependencies
 [tool.uv]
 package = false
 exclude-newer = "7 days"
-# vcrpy >= 8.2.0 is required for aiohttp 3.14 compatibility (the removal of
-# `AsyncStreamReaderMixin`); allow it past the rolling 7-day window.
-exclude-newer-package = { vcrpy = "2026-06-17" }
 
 [tool.ty.environment]
 root = ["./backend"]

--- a/uv.lock
+++ b/uv.lock
@@ -10,9 +10,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
-[options.exclude-newer-package]
-vcrpy = "2026-06-18T00:00:00Z"
-
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.2"
@@ -2797,15 +2794,15 @@ wheels = [
 
 [[package]]
 name = "vcrpy"
-version = "8.2.1"
+version = "8.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/db/08183b845b0040bb877dad2bd7e4e0976fc232bb3476d7ee369c6c4f8b5a/vcrpy-8.2.1.tar.gz", hash = "sha256:d73a6e4eb6dae8148e659764b7a00e68cc51ba29ba9e6a85e1f0790ad96b97df", size = 90511, upload-time = "2026-06-16T13:20:52.906Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/d5/8a1f8eb603e2d35fbb0ecd1e309d0c5c18a0ecfc8c0a8f04088bbc8f833b/vcrpy-8.3.0.tar.gz", hash = "sha256:46d64e77e8d95e5c76c7d9a94ff05d8b38b2ae4e1d4869eb0235024b6fcb5212", size = 96117, upload-time = "2026-07-04T14:27:01.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/7c/0e812ab83f5289404c674f3461ba783250b967d34b5ab034d361236ec042/vcrpy-8.2.1-py3-none-any.whl", hash = "sha256:7ce58c9e2792b246f79d6f4b3e9660676cc6f853be17e1547305b4437ab1ff85", size = 44925, upload-time = "2026-06-16T13:20:51.734Z" },
+    { url = "https://files.pythonhosted.org/packages/34/77/cb4219be91508399cbcb6143bad89462cfb16f6c638458f454a5d46ac95a/vcrpy-8.3.0-py3-none-any.whl", hash = "sha256:bd66e6143746778157f00e2a922527a8d96b2fdc350be8988a45a29c843815b9", size = 46530, upload-time = "2026-07-04T14:27:00.546Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Removes the `exclude-newer-package = { vcrpy = "2026-06-17" }` override under `[tool.uv]`.

The override was added the day after vcrpy 8.2.1 shipped so it could get past the rolling 7-day `exclude-newer` window (8.2.0 carried the aiohttp 3.14 compatibility fix). That window has long since caught up, and the fixed June 17 cutoff had become a de-facto ceiling: vcrpy 8.3.0 (released 2026-07-04) was being silently excluded. The aiohttp fix is present in every release since 8.2.0, so nothing depends on the override anymore.

Changes:

- `pyproject.toml`: drop the override and its comment.
- `uv.lock`: drop the `[options.exclude-newer-package]` entry and bump vcrpy 8.2.1 -> 8.3.0 (`uv lock --upgrade-package vcrpy`). No other package changed.

Verification: all 364 cassette-backed tests (`tests/adapters/services`, `tests/handler/test_fastapi.py`) pass on vcrpy 8.3.0 against aiohttp 3.14.3. The 8.3.0 replay-side changes are a clearer error for unsupported YAML tags and a keep-alive connection reuse fix; none of the existing cassettes contain Python object tags.

AI assistance disclosure: this PR was written with Claude Code (Claude Fable 5.1). The agent investigated the pin's history, made the edit, re-locked, and ran the tests; I reviewed the result.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
