### PR TITLE
docs(agents): never run the full backend test suite locally

### DIFF
--- a/.claude/skills/backend-development/SKILL.md
+++ b/.claude/skills/backend-development/SKILL.md
@@ -93,7 +93,7 @@ npm run generate     # writes src/__generated__/ via openapi-typescript-codegen
 ```bash
 cd backend
 uv run python3 main.py            # run (migrations auto-apply on startup)
-uv run pytest [path/file]         # tests (subset by path); uv run pytest -vv for all
+uv run pytest <path/file>         # tests - affected files only, NEVER the whole suite
 ```
 
 - Tests: pytest + pytest-asyncio, isolated per `pytest-xdist` worker (per-worker DBs); `fakeredis`; `pytest-recording` VCR cassettes mock external APIs; Hypothesis for property tests. Mirror the `backend/<area>/` layout under `backend/tests/`. First-time test DB setup: `docker exec -i romm-db-dev mariadb -uroot -p<pw> < backend/romm_test/setup.sql`.

--- a/.claude/skills/review-polish/SKILL.md
+++ b/.claude/skills/review-polish/SKILL.md
@@ -210,7 +210,7 @@ With `uiVersion = "v2"`:
 
 Run from `backend/`:
 
-1. `uv run pytest [path/file]` — zero failures (run the affected subset, or all with `-vv`).
+1. `uv run pytest <path/file>` — zero failures on the tests affected by the diff. Never run the whole suite locally (20+ minutes); see [AGENTS.md](../../../AGENTS.md) for how to pick targets. CI runs it in full.
 2. `trunk fmt && trunk check` — ruff/black/isort/mypy/bandit clean (CI enforces Trunk).
 3. **If you added a migration:** `uv run alembic upgrade head` then `uv run alembic downgrade -1` to prove both directions; it must work on MariaDB **and** PostgreSQL (CI runs both).
 4. **If a response schema or route signature changed:** regenerate frontend types (`npm run generate`) and typecheck the frontend.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,25 @@
 # Repository Instructions
 
 Read and follow [CLAUDE.md](CLAUDE.md) for all repository instructions.
+
+## Never run the full backend test suite locally
+
+A bare `uv run pytest` (or `pytest -vv`) over `backend/` takes 20+ minutes and burns a
+huge number of tokens on output. Don't do it, even to "double check" at the end.
+
+Instead, select the tests affected by the change and run only those:
+
+```bash
+cd backend
+uv run pytest tests/path/to/test_file.py                # one file
+uv run pytest tests/path/to/test_file.py::test_name     # one test
+uv run pytest tests/handler/ tests/endpoints/           # affected areas
+uv run pytest -k "scan or queue"                        # by name pattern
+```
+
+Pick the targets from the diff: the test file mirroring each changed module
+(`backend/<area>/x.py` → `backend/tests/<area>/test_x.py`), plus the tests of the
+callers of anything whose signature or behavior you changed (`grep` for the symbol).
+
+CI runs the whole suite on the PR (`pytest.yml`, MariaDB + PostgreSQL). That is the
+place for full-suite coverage; local runs stay scoped.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ These live in `.claude/skills/` and carry the detailed rules. Invoke the one tha
 ```bash
 uv sync --all-extras --dev          # install
 uv run main.py              # run (migrations auto-apply)
-uv run pytest [path/file]           # test (subset) - or -vv for all
+uv run pytest <path/file>           # test - affected files only, NEVER the whole suite
 uv run alembic revision --autogenerate -m "msg"   # new migration (then HAND-REVIEW)
 uv run alembic upgrade head         # apply migrations
 ```


### PR DESCRIPTION
**Description**

A bare `uv run pytest` over `backend/` takes 20+ minutes and floods an agent's context with output for modules it never touched. `AGENTS.md` now carries a "Never run the full backend test suite locally" section: select the tests affected by the diff (mirroring test file, plus tests of the callers of anything whose signature or behavior changed), and leave full-suite coverage to `pytest.yml` in CI.

The three places that documented the pytest command all offered "or all with `-vv`" as an equally valid option, which would have undercut the new rule, so they now say affected files only:

- `CLAUDE.md` (backend quick command reference)
- `.claude/skills/backend-development/SKILL.md`
- `.claude/skills/review-polish/SKILL.md` (the backend verification gate, which now links to `AGENTS.md` for how to pick targets)

The `[path/file]` placeholder became `<path/file>` in the same pass: square brackets read as "optional argument", which invited the bare invocation.

Docs only, no runtime or test changes.

**AI assistance disclosure**

Written with Claude Code. The rule and the decision to open this PR are the author's; Claude drafted the `AGENTS.md` section, made the four edits, and wrote this description. Reviewed by the author before pushing.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally <sup>(`trunk fmt` / `trunk check` clean on the four files; documentation-only change with nothing to execute)</sup>
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes <sup>(N/A, docs only)</sup>
