### PR TITLE
fix(retroachievements): don't match ROMs against games with no achievement set

### DIFF
--- a/backend/handler/metadata/ra_handler.py
+++ b/backend/handler/metadata/ra_handler.py
@@ -132,7 +132,7 @@ def extract_metadata_from_rom_details(
 class RAHandler(MetadataHandler):
     def __init__(self) -> None:
         self.ra_service = RetroAchievementsService()
-        self.HASHES_FILE_NAME = "ra_hashes_v2.json"
+        self.HASHES_FILE_NAME = "ra_hashes_v3.json"
 
     @classmethod
     def is_enabled(cls) -> bool:
@@ -189,10 +189,10 @@ class RAHandler(MetadataHandler):
             <= await self._days_since_last_cache_file_update(rom.platform.id)
             or not await self._exists_cache_file(rom.platform.id)
         ):
-            # Fetch all games (including those without achievements) and build index
+            # An RA match should mean a set exists, so skip games without one
             roms = await self.ra_service.get_game_list(
                 system_id=rom.platform.ra_id,
-                only_games_with_achievements=False,
+                only_games_with_achievements=True,
                 include_hashes=True,
             )
 

--- a/backend/tests/handler/metadata/test_ra_handler.py
+++ b/backend/tests/handler/metadata/test_ra_handler.py
@@ -36,6 +36,39 @@ class TestSearchRom:
         """A local .env may set this to 0, which would force a refresh every time."""
         monkeypatch.setattr(ra_handler, "REFRESH_RETROACHIEVEMENTS_CACHE_DAYS", 30)
 
+    @pytest.fixture
+    def resources_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+        """Back the platform resources directory with a real one, so mtime is real too."""
+
+        def resolve(file_path: str) -> Path:
+            return tmp_path / Path(file_path).name
+
+        def write_file(file: bytes, path: str, filename: str) -> None:
+            (tmp_path / filename).write_bytes(file)
+
+        monkeypatch.setattr(
+            ra_handler.fs_resource_handler,
+            "get_platform_resources_path",
+            lambda _platform_id: "roms/1",
+        )
+        monkeypatch.setattr(
+            ra_handler.fs_resource_handler,
+            "file_exists",
+            AsyncMock(side_effect=lambda file_path: resolve(file_path).is_file()),
+        )
+        monkeypatch.setattr(ra_handler.fs_resource_handler, "validate_path", resolve)
+        monkeypatch.setattr(
+            ra_handler.fs_resource_handler,
+            "read_file",
+            AsyncMock(side_effect=lambda file_path: resolve(file_path).read_bytes()),
+        )
+        monkeypatch.setattr(
+            ra_handler.fs_resource_handler,
+            "write_file",
+            AsyncMock(side_effect=write_file),
+        )
+        return tmp_path
+
     def _make_rom(self) -> MagicMock:
         rom = MagicMock()
         rom.platform.id = 1
@@ -43,22 +76,12 @@ class TestSearchRom:
         return rom
 
     async def test_skips_games_without_achievements(
-        self, handler: RAHandler, monkeypatch: pytest.MonkeyPatch
+        self, handler: RAHandler, monkeypatch: pytest.MonkeyPatch, resources_dir: Path
     ):
         get_game_list = AsyncMock(
             return_value=[{"ID": 10210, "Hashes": ["ABCDEF", "123456"]}]
         )
-        write_file = AsyncMock()
         monkeypatch.setattr(handler.ra_service, "get_game_list", get_game_list)
-        monkeypatch.setattr(
-            ra_handler.fs_resource_handler, "file_exists", AsyncMock(return_value=False)
-        )
-        monkeypatch.setattr(
-            ra_handler.fs_resource_handler,
-            "get_platform_resources_path",
-            lambda _platform_id: "roms/1",
-        )
-        monkeypatch.setattr(ra_handler.fs_resource_handler, "write_file", write_file)
 
         ra_id = await handler._search_rom(self._make_rom(), "abcdef")
 
@@ -69,33 +92,37 @@ class TestSearchRom:
         )
         assert ra_id == 10210
 
-        written = json.loads(write_file.await_args_list[0].args[0].decode("utf-8"))
-        assert written == {"abcdef": 10210, "123456": 10210}
+        cached = resources_dir / handler.HASHES_FILE_NAME
+        assert json.loads(cached.read_bytes()) == {"abcdef": 10210, "123456": 10210}
 
     async def test_reads_the_cached_index_without_refetching(
-        self, handler: RAHandler, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+        self, handler: RAHandler, monkeypatch: pytest.MonkeyPatch, resources_dir: Path
     ):
-        cache_file = tmp_path / handler.HASHES_FILE_NAME
+        cache_file = resources_dir / handler.HASHES_FILE_NAME
         cache_file.write_bytes(json.dumps({"abcdef": 10210}).encode("utf-8"))
 
         get_game_list = AsyncMock()
         monkeypatch.setattr(handler.ra_service, "get_game_list", get_game_list)
-        monkeypatch.setattr(
-            ra_handler.fs_resource_handler, "file_exists", AsyncMock(return_value=True)
-        )
-        monkeypatch.setattr(
-            ra_handler.fs_resource_handler, "validate_path", lambda _path: cache_file
-        )
-        monkeypatch.setattr(
-            ra_handler.fs_resource_handler,
-            "read_file",
-            AsyncMock(return_value=cache_file.read_bytes()),
-        )
 
         ra_id = await handler._search_rom(self._make_rom(), "ABCDEF")
 
         assert ra_id == 10210
         get_game_list.assert_not_awaited()
+
+    async def test_ignores_an_unfiltered_index_from_an_older_version(
+        self, handler: RAHandler, monkeypatch: pytest.MonkeyPatch, resources_dir: Path
+    ):
+        """Freshness is an mtime test, so a filter change has to come with a new filename."""
+        legacy_cache = resources_dir / "ra_hashes_v2.json"
+        legacy_cache.write_bytes(json.dumps({"abcdef": 10138}).encode("utf-8"))
+
+        get_game_list = AsyncMock(return_value=[{"ID": 10210, "Hashes": ["ABCDEF"]}])
+        monkeypatch.setattr(handler.ra_service, "get_game_list", get_game_list)
+
+        ra_id = await handler._search_rom(self._make_rom(), "abcdef")
+
+        get_game_list.assert_awaited_once()
+        assert ra_id == 10210
 
     async def test_returns_none_without_a_platform_ra_id(self, handler: RAHandler):
         rom = self._make_rom()

--- a/backend/tests/handler/metadata/test_ra_handler.py
+++ b/backend/tests/handler/metadata/test_ra_handler.py
@@ -1,7 +1,12 @@
-"""Tests for the RetroAchievements metadata handler platform mapping."""
+"""Tests for the RetroAchievements metadata handler."""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from handler.metadata import ra_handler
 from handler.metadata.ra_handler import RA_PLATFORM_LIST, RAHandler
 from utils.platform_slugs import UniversalPlatformSlug as UPS
 
@@ -21,3 +26,79 @@ def test_platform_list_uses_ups_keys():
     """Every entry in RA_PLATFORM_LIST should be a UniversalPlatformSlug."""
     for key in RA_PLATFORM_LIST.keys():
         assert isinstance(key, UPS)
+
+
+class TestSearchRom:
+    """The hash index must only map hashes of games that actually have a set."""
+
+    @pytest.fixture(autouse=True)
+    def _pin_cache_ttl(self, monkeypatch: pytest.MonkeyPatch):
+        """A local .env may set this to 0, which would force a refresh every time."""
+        monkeypatch.setattr(ra_handler, "REFRESH_RETROACHIEVEMENTS_CACHE_DAYS", 30)
+
+    def _make_rom(self) -> MagicMock:
+        rom = MagicMock()
+        rom.platform.id = 1
+        rom.platform.ra_id = 2
+        return rom
+
+    async def test_skips_games_without_achievements(
+        self, handler: RAHandler, monkeypatch: pytest.MonkeyPatch
+    ):
+        get_game_list = AsyncMock(
+            return_value=[{"ID": 10210, "Hashes": ["ABCDEF", "123456"]}]
+        )
+        write_file = AsyncMock()
+        monkeypatch.setattr(handler.ra_service, "get_game_list", get_game_list)
+        monkeypatch.setattr(
+            ra_handler.fs_resource_handler, "file_exists", AsyncMock(return_value=False)
+        )
+        monkeypatch.setattr(
+            ra_handler.fs_resource_handler,
+            "get_platform_resources_path",
+            lambda _platform_id: "roms/1",
+        )
+        monkeypatch.setattr(ra_handler.fs_resource_handler, "write_file", write_file)
+
+        ra_id = await handler._search_rom(self._make_rom(), "abcdef")
+
+        get_game_list.assert_awaited_once_with(
+            system_id=2,
+            only_games_with_achievements=True,
+            include_hashes=True,
+        )
+        assert ra_id == 10210
+
+        written = json.loads(write_file.await_args_list[0].args[0].decode("utf-8"))
+        assert written == {"abcdef": 10210, "123456": 10210}
+
+    async def test_reads_the_cached_index_without_refetching(
+        self, handler: RAHandler, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        cache_file = tmp_path / handler.HASHES_FILE_NAME
+        cache_file.write_bytes(json.dumps({"abcdef": 10210}).encode("utf-8"))
+
+        get_game_list = AsyncMock()
+        monkeypatch.setattr(handler.ra_service, "get_game_list", get_game_list)
+        monkeypatch.setattr(
+            ra_handler.fs_resource_handler, "file_exists", AsyncMock(return_value=True)
+        )
+        monkeypatch.setattr(
+            ra_handler.fs_resource_handler, "validate_path", lambda _path: cache_file
+        )
+        monkeypatch.setattr(
+            ra_handler.fs_resource_handler,
+            "read_file",
+            AsyncMock(return_value=cache_file.read_bytes()),
+        )
+
+        ra_id = await handler._search_rom(self._make_rom(), "ABCDEF")
+
+        assert ra_id == 10210
+        get_game_list.assert_not_awaited()
+
+    async def test_returns_none_without_a_platform_ra_id(self, handler: RAHandler):
+        rom = self._make_rom()
+        rom.platform.ra_id = None
+
+        assert await handler._search_rom(rom, "abcdef") is None


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The RetroAchievements hash index was built with RA's `f=0`, so it also mapped hashes of games
that exist on RetroAchievements but have no achievement set. ROMs matching those hashes came
out of a scan with an `ra_id`, which lights up every RA signal in the UI (achievements tab,
match chip, `has_ra` filter, smart collections) while answering the only question those
signals are asked: no, there is nothing to earn here.

This flips `RAHandler._search_rom` to `only_games_with_achievements=True` (`f=1`) and bumps the
cache filename `ra_hashes_v2.json` -> `ra_hashes_v3.json`. The rename is required rather than
cosmetic: index freshness is an mtime test, so without a new name existing installs would keep
serving the stale index for up to `REFRESH_RETROACHIEVEMENTS_CACHE_DAYS` (30) after upgrading.

Measured live against N64 (system 2) on 2026-09-04:

| | games | hashes |
| --- | --- | --- |
| `f=0` (before) | 875 | 1577 |
| `f=1` (after) | 511 | 861 |

So 45% of previously indexed N64 hashes pointed at set-less games; NES and PlayStation are
above 60%. `f=1` still returns `Hashes` and is a strict subset of `f=0`, so nothing that
currently matches a set-bearing game loses its match. RA 10138 (Aero Fighters Assault) drops
out as expected.

Per the discussion on #4343 this is the straight reversal, so the admin-toggle alternative
floated in the issue body is deliberately out of scope.

Known limits, all pre-existing and out of scope here:

- ROMs that already carry a set-less `ra_id` don't self-correct, because an UPDATE scan routes
  to `get_rom_by_id` rather than re-hashing.
- Stale `ra_hashes_v2.json` files linger on disk (same as the v1 files did after `2c3335e8c`).
- An explicit `(ra-12345)` filename tag still forces that ID regardless of whether it has a set.

AI assistance disclosure: this change was developed with Claude Code. The behavior change, the
live `f=0` vs `f=1` comparison against the RA API, and the test coverage were reviewed and
verified by me before opening this PR.

Fixes #4343

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes