### PR TITLE
fix(hashing): read zips zipfile can't decode through 7zz

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install mariadb connectors
         run: |
           sudo apt-get update
-          sudo apt-get install -y libmariadb3 libmariadb-dev
+          sudo apt-get install -y libmariadb3 libmariadb-dev 7zip
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/backend/tests/utils/test_archives.py
+++ b/backend/tests/utils/test_archives.py
@@ -575,7 +575,8 @@ class TestZipUndecodableCompression:
     """Zips using a method zipfile can't decode must be read through 7zz, not
     hashed as a container (GitHub issue #4159)."""
 
-    ZIP_PPMD = 98
+    # An id the zip spec never assigned, so no Python release can learn to decode it.
+    UNASSIGNED_METHOD = 0xFFFF
 
     def _write_zip(
         self, path: Path, members: dict[str, bytes], stamped: frozenset[str]
@@ -590,9 +591,9 @@ class TestZipUndecodableCompression:
             encoded = name.encode()
             # The name follows a 30-byte local header and a 46-byte central one.
             local = raw.index(encoded, raw.index(b"PK\x03\x04")) - 30
-            struct.pack_into("<H", raw, local + 8, self.ZIP_PPMD)
+            struct.pack_into("<H", raw, local + 8, self.UNASSIGNED_METHOD)
             central = raw.index(encoded, raw.index(b"PK\x01\x02")) - 46
-            struct.pack_into("<H", raw, central + 10, self.ZIP_PPMD)
+            struct.pack_into("<H", raw, central + 10, self.UNASSIGNED_METHOD)
         path.write_bytes(bytes(raw))
 
     def test_stamped_zip_is_rejected_by_zipfile(self, tmp_path):

--- a/backend/tests/utils/test_archives.py
+++ b/backend/tests/utils/test_archives.py
@@ -1,4 +1,5 @@
 import io
+import struct
 import tarfile
 import time
 import zipfile
@@ -565,3 +566,116 @@ class TestZipAndTarReadFailures:
 
         with pytest.raises(archives.ArchiveReadError):
             list(archives._iter_chunks(_FailingReader(), Path("/fake.tar.gz"), "a.bin"))
+
+
+class TestZipUndecodableCompression:
+    """Zips using a method zipfile can't decode must be read through 7zz, not
+    hashed as a container (GitHub issue #4159)."""
+
+    ZIP_PPMD = 98
+
+    def _write_zip(
+        self, path: Path, members: dict[str, bytes], stamped: frozenset[str]
+    ) -> None:
+        ensure_zipfile_writable()
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_STORED) as z:
+            for name, data in members.items():
+                z.writestr(name, data)
+
+        raw = bytearray(path.read_bytes())
+        for name in stamped:
+            encoded = name.encode()
+            # The name follows a 30-byte local header and a 46-byte central one.
+            local = raw.index(encoded, raw.index(b"PK\x03\x04")) - 30
+            struct.pack_into("<H", raw, local + 8, self.ZIP_PPMD)
+            central = raw.index(encoded, raw.index(b"PK\x01\x02")) - 46
+            struct.pack_into("<H", raw, central + 10, self.ZIP_PPMD)
+        path.write_bytes(bytes(raw))
+
+    def test_stamped_zip_is_rejected_by_zipfile(self, tmp_path):
+        path = tmp_path / "game.zip"
+        self._write_zip(path, {"game.bin": b"G" * 64}, frozenset({"game.bin"}))
+
+        with zipfile.ZipFile(path) as z, pytest.raises(NotImplementedError):
+            z.open("game.bin").close()
+
+    def test_undecodable_member_reads_whole_archive_through_7zz(self, tmp_path):
+        path = tmp_path / "game.zip"
+        self._write_zip(path, {"game.bin": b"G" * 64}, frozenset({"game.bin"}))
+        listing = MagicMock(stdout=_fake_7z_listing_sized([("game.bin", 64)]))
+        popen = _mock_popen_streaming([[b"G" * 32, b"G" * 32]], [0])
+
+        with (
+            patch.object(archives.subprocess, "run", return_value=listing),
+            patch.object(archives.subprocess, "Popen", popen),
+        ):
+            result = [
+                (name, size, b"".join(chunks))
+                for name, size, chunks in archives.read_zip_archive_files(path, [], [])
+            ]
+
+        assert result == [("game.bin", 64, b"G" * 64)]
+        extract_args = popen.call_args[0][0]
+        assert extract_args[:3] == [archives.SEVEN_ZIP_PATH, "e", str(path)]
+        assert "game.bin" in extract_args
+
+    def test_mixed_methods_do_not_split_the_read(self, tmp_path):
+        """Splitting the read between zipfile and 7zz would double-count the composite hash."""
+        path = tmp_path / "game.zip"
+        self._write_zip(
+            path,
+            {"game.bin": b"B" * 64, "game.cue": b"C" * 16},
+            frozenset({"game.bin"}),
+        )
+        listing = MagicMock(
+            stdout=_fake_7z_listing_sized([("game.bin", 64), ("game.cue", 16)])
+        )
+        popen = _mock_popen_streaming([[b"B" * 64], [b"C" * 16]], [0, 0])
+
+        with (
+            patch.object(archives.subprocess, "run", return_value=listing),
+            patch.object(archives.subprocess, "Popen", popen),
+        ):
+            result = [
+                (name, size, b"".join(chunks))
+                for name, size, chunks in archives.read_zip_archive_files(path, [], [])
+            ]
+
+        assert result == [("game.bin", 64, b"B" * 64), ("game.cue", 16, b"C" * 16)]
+        assert popen.call_count == 2
+
+    def test_excluded_undecodable_member_does_not_trigger_7zz(self, tmp_path):
+        path = tmp_path / "game.zip"
+        self._write_zip(
+            path,
+            {"game.bin": b"B" * 64, "readme.txt": b"R" * 8},
+            frozenset({"readme.txt"}),
+        )
+
+        with (
+            patch.object(archives.subprocess, "run", side_effect=AssertionError),
+            patch.object(archives.subprocess, "Popen", side_effect=AssertionError),
+        ):
+            result = [
+                (name, size, b"".join(chunks))
+                for name, size, chunks in archives.read_zip_archive_files(
+                    path, [], ["txt"]
+                )
+            ]
+
+        assert result == [("game.bin", 64, b"B" * 64)]
+
+    def test_decodable_zip_never_spawns_7zz(self, tmp_path):
+        path = tmp_path / "game.zip"
+        self._write_zip(path, {"game.bin": b"B" * 64}, frozenset())
+
+        with (
+            patch.object(archives.subprocess, "run", side_effect=AssertionError),
+            patch.object(archives.subprocess, "Popen", side_effect=AssertionError),
+        ):
+            result = [
+                (name, size, b"".join(chunks))
+                for name, size, chunks in archives.read_zip_archive_files(path, [], [])
+            ]
+
+        assert result == [("game.bin", 64, b"B" * 64)]

--- a/backend/tests/utils/test_archives.py
+++ b/backend/tests/utils/test_archives.py
@@ -1,5 +1,8 @@
+import hashlib
 import io
+import shutil
 import struct
+import subprocess
 import tarfile
 import time
 import zipfile
@@ -679,3 +682,43 @@ class TestZipUndecodableCompression:
             ]
 
         assert result == [("game.bin", 64, b"B" * 64)]
+
+
+_SEVEN_ZIP = shutil.which("7zz") or archives.SEVEN_ZIP_PATH
+
+
+@pytest.mark.skipif(not shutil.which(_SEVEN_ZIP), reason="7zz not installed")
+def test_real_ppmd_zip_hashes_through_7zz(tmp_path):
+    """End-to-end on a zip 7zz itself wrote: a PPMd .bin next to a stored .cue."""
+    source = tmp_path / "src"
+    source.mkdir()
+    # Random bytes don't compress, so 7zz would silently store them instead.
+    track = (b"sector data track audio pregap index " * 4000)[:150000]
+    cue = b'FILE "Game (USA) (Track 01).cue" BINARY\n  TRACK 01 MODE2/2352\n'
+    (source / "Game (USA) (Track 01).bin").write_bytes(track)
+    (source / "Game (USA).cue").write_bytes(cue)
+    zip_path = tmp_path / "Game (USA).zip"
+    for member, method in (
+        ("Game (USA) (Track 01).bin", "PPMd"),
+        ("Game (USA).cue", "Copy"),
+    ):
+        subprocess.run(
+            [_SEVEN_ZIP, "a", "-tzip", f"-mm={method}", str(zip_path), member],
+            cwd=source,
+            check=True,
+            capture_output=True,
+        )
+
+    with zipfile.ZipFile(zip_path) as z, pytest.raises(NotImplementedError):
+        z.open("Game (USA) (Track 01).bin").close()
+
+    with patch.object(archives, "SEVEN_ZIP_PATH", _SEVEN_ZIP):
+        result = [
+            (name, size, hashlib.sha1(b"".join(chunks)).hexdigest())
+            for name, size, chunks in archives.read_zip_archive_files(zip_path, [], [])
+        ]
+
+    assert result == [
+        ("Game (USA) (Track 01).bin", len(track), hashlib.sha1(track).hexdigest()),
+        ("Game (USA).cue", len(cue), hashlib.sha1(cue).hexdigest()),
+    ]

--- a/backend/utils/archives.py
+++ b/backend/utils/archives.py
@@ -242,6 +242,30 @@ def _iter_chunks(reader: IO[bytes], file_path: Path, name: str) -> Iterator[byte
         raise ArchiveReadError(f"Error reading {name} from {file_path}: {e}") from e
 
 
+def _eligible_zip_entries(
+    z: zipfile.ZipFile, excluded_names: list[str], excluded_exts: list[str]
+) -> list[zipfile.ZipInfo]:
+    return [
+        entry
+        for entry in sorted(z.infolist(), key=lambda e: e.filename)
+        if not entry.is_dir()
+        and not _is_member_excluded(entry.filename, excluded_names, excluded_exts)
+    ]
+
+
+def _undecodable_zip_method(
+    z: zipfile.ZipFile, entries: list[zipfile.ZipInfo]
+) -> int | None:
+    """Opening an entry reads only its local header, so probing every member
+    is cheap and tracks whatever this Python and the inflate64 patch decode."""
+    for entry in entries:
+        try:
+            z.open(entry, "r").close()
+        except NotImplementedError:
+            return entry.compress_type
+    return None
+
+
 def read_zip_archive_files(
     file_path: Path,
     excluded_names: list[str],
@@ -253,29 +277,30 @@ def read_zip_archive_files(
     member's bytes lazily; chunks must be fully consumed before advancing
     to the next entry, since the underlying file is closed at that point.
 
+    An archive with a method zipfile can't decode goes through 7zz as a whole,
+    so a stored .cue next to a PPMd .bin is never streamed twice.
+
     Raises `ArchiveReadError` if the archive can't be read in full, so callers
     never mistake a partial read for a complete one.
     """
     try:
         with zipfile.ZipFile(file_path, "r") as z:
-            entries = sorted(z.infolist(), key=lambda e: e.filename)
-            for entry in entries:
-                if entry.is_dir():
-                    continue
-                name = entry.filename
-                base_name = Path(name).name
-                lower = base_name.lower()
-                if any(lower.endswith("." + ext) for ext in excluded_exts):
-                    continue
-                if any(
-                    base_name == exc or fnmatch.fnmatch(base_name, exc)
-                    for exc in excluded_names
-                ):
-                    continue
-                with z.open(entry, "r") as f:
-                    yield name, entry.file_size, _iter_chunks(f, file_path, name)
-    except (zipfile.BadZipFile, RuntimeError, NotImplementedError, OSError) as e:
+            entries = _eligible_zip_entries(z, excluded_names, excluded_exts)
+            undecodable_method = _undecodable_zip_method(z, entries)
+            if undecodable_method is None:
+                for entry in entries:
+                    name = entry.filename
+                    with z.open(entry, "r") as f:
+                        yield name, entry.file_size, _iter_chunks(f, file_path, name)
+                return
+    except (zipfile.BadZipFile, RuntimeError, OSError) as e:
         raise ArchiveReadError(f"Error reading zip {file_path}: {e}") from e
+
+    log.debug(
+        f"Zip {file_path} uses compression method {undecodable_method}, which "
+        "zipfile can't decode; reading it through 7zz"
+    )
+    yield from read_7z_archive_files(file_path, excluded_names, excluded_exts)
 
 
 def read_tar_archive_files(


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Fixes #4159
Related to #4167 (the `2002 FIFA World Cup` and `ATV Racers` archives in that thread)

Python's `zipfile` only decodes Stored, Deflate, bzip2, LZMA and, through the `zipfile-inflate64` patch, Deflate64. A zip written with PPMd, zstd, xz, AES or the legacy Implode family (WinZip's zipx output and Bandizip commonly produce these) raised `NotImplementedError`. The scanner treated that as an unreadable archive and hashed the container's raw bytes, which is the log line the reporter saw:

```
Incomplete read of archive ...zip: Error reading zip ...: That compression method is not supported. Hashing the archive itself instead, which won't match a hash database.
```

Container hashes match nothing in No-Intro or Redump, so those ROMs could never be verified against Hasheous, and `archive_members` stayed `null`.

The zip reader now opens each eligible entry once before streaming anything. If `zipfile` has no decoder for any of them, the whole archive is read through the existing 7zz-backed reader (`read_7z_archive_files`), which already lists and extracts arbitrary containers via `7zz`. The bundled 7-Zip 25.01 handles every method the zip spec allows, including zstd.

Two design points:

- The fallback covers the **whole archive**, not just the undecodable member. A PSX zip often holds a stored `.cue` next to a PPMd `.bin`; streaming part of it through `zipfile` and the rest through 7zz would double-count members in the composite hash.
- Only members that would actually be hashed influence the decision, so an excluded readme compressed with an exotic method doesn't push an otherwise plain zip through a subprocess.

The pre-check asks `zipfile` what it can open rather than hardcoding a method list, so it adapts on its own if the Python version or the inflate64 patch changes what is decodable. The inline exclusion filter in the zip reader was replaced with the existing `_is_member_excluded` helper while touching this code.

Verified end to end against a real archive built with `7zz a -tzip -mm=PPMd`: `zipfile` refuses it with the exact error above, and the reader now yields per-member SHA-1s identical to `shasum` on the extracted files.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A

---

**AI assistance disclosure:** this PR was investigated and written primarily by Claude Code, including the code, tests and this description. I reviewed the diff and ran the verification myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
