### PR TITLE
fix(v2): don't reload the page on reconnect while a game is running

### DIFF
--- a/frontend/src/v2/composables/useServerConnection/index.test.ts
+++ b/frontend/src/v2/composables/useServerConnection/index.test.ts
@@ -1,5 +1,78 @@
-import { describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { nextTick, reactive } from "vue";
 import { shouldRefreshOnReconnect } from "./index";
+
+// Each install() leaves an app-lifetime watcher behind, so every test gets
+// fresh store objects rather than sharing one the old watchers still see.
+function makeHeartbeatStore() {
+  return reactive({
+    connected: true,
+    setConnected(value: boolean) {
+      this.connected = value;
+    },
+    fetchHeartbeat: vi.fn().mockResolvedValue({}),
+  });
+}
+
+let heartbeatStore = makeHeartbeatStore();
+let playingStore = reactive({ playing: false });
+
+vi.mock("@/stores/heartbeat", () => ({ default: () => heartbeatStore }));
+vi.mock("@/stores/playing", () => ({ default: () => playingStore }));
+
+const reload = vi.fn();
+let originalLocation: Location;
+
+// `installed` is module state, so each test needs a fresh module to install
+// its own watchers.
+async function install() {
+  vi.resetModules();
+  const { useServerConnection } = await import("./index");
+  return useServerConnection();
+}
+
+/** Drive a full offline → online round trip through the store. */
+async function goOfflineThenOnline() {
+  heartbeatStore.connected = false;
+  await nextTick();
+  heartbeatStore.connected = true;
+  await nextTick();
+}
+
+beforeAll(() => {
+  originalLocation = window.location;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...originalLocation, reload },
+  });
+});
+
+afterAll(() => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: originalLocation,
+  });
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  reload.mockClear();
+  heartbeatStore = makeHeartbeatStore();
+  playingStore = reactive({ playing: false });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("shouldRefreshOnReconnect", () => {
   it("refreshes only on a real reconnect (offline → online)", () => {
@@ -20,5 +93,46 @@ describe("shouldRefreshOnReconnect", () => {
 
   it("does not refresh while staying offline", () => {
     expect(shouldRefreshOnReconnect(false, false)).toBe(false);
+  });
+});
+
+describe("useServerConnection recovery", () => {
+  it("refreshes on reconnect when no game is running", async () => {
+    await install();
+    await goOfflineThenOnline();
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("holds the refresh back while a game is running", async () => {
+    await install();
+    playingStore.playing = true;
+    await nextTick();
+    await goOfflineThenOnline();
+    vi.advanceTimersByTime(60_000);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("refreshes once the player is left", async () => {
+    await install();
+    playingStore.playing = true;
+    await nextTick();
+    await goOfflineThenOnline();
+
+    playingStore.playing = false;
+    await nextTick();
+    // The teardown grace period keeps the page alive for a beat.
+    expect(reload).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1_000);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("does not refresh on a later play session when nothing was pending", async () => {
+    await install();
+    playingStore.playing = true;
+    await nextTick();
+    playingStore.playing = false;
+    await nextTick();
+    vi.advanceTimersByTime(60_000);
+    expect(reload).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/v2/composables/useServerConnection/index.test.ts
+++ b/frontend/src/v2/composables/useServerConnection/index.test.ts
@@ -48,6 +48,19 @@ async function goOfflineThenOnline() {
   await nextTick();
 }
 
+/** A blip survived mid-game, leaving a refresh held back. */
+async function playThroughABlip() {
+  playingStore.playing = true;
+  await nextTick();
+  await goOfflineThenOnline();
+  expect(reload).not.toHaveBeenCalled();
+}
+
+/** The api layer's "no requests left in flight" announcement. */
+function quiesce() {
+  document.dispatchEvent(new CustomEvent("network-quiesced"));
+}
+
 beforeAll(() => {
   originalLocation = window.location;
   Object.defineProperty(window, "location", {
@@ -112,17 +125,47 @@ describe("useServerConnection recovery", () => {
     expect(reload).not.toHaveBeenCalled();
   });
 
-  it("refreshes once the player is left", async () => {
+  it("refreshes once the player is left and the network goes quiet", async () => {
     await install();
-    playingStore.playing = true;
-    await nextTick();
-    await goOfflineThenOnline();
+    await playThroughABlip();
 
     playingStore.playing = false;
     await nextTick();
-    // The teardown grace period keeps the page alive for a beat.
+    // The player's teardown requests are still settling.
     expect(reload).not.toHaveBeenCalled();
-    vi.advanceTimersByTime(1_000);
+
+    quiesce();
+    expect(reload).toHaveBeenCalledOnce();
+    // The cap must not fire a second reload behind it.
+    vi.advanceTimersByTime(60_000);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes on the cap when the network never goes quiet", async () => {
+    await install();
+    await playThroughABlip();
+
+    playingStore.playing = false;
+    await nextTick();
+    vi.advanceTimersByTime(10_000);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("drops a held-back refresh when the backend goes offline again", async () => {
+    await install();
+    await playThroughABlip();
+
+    playingStore.playing = false;
+    await nextTick();
+    heartbeatStore.connected = false;
+    await nextTick();
+    quiesce();
+    vi.advanceTimersByTime(60_000);
+    expect(reload).not.toHaveBeenCalled();
+
+    // The next recovery refreshes instead, now that nothing is running.
+    heartbeatStore.connected = true;
+    await nextTick();
     expect(reload).toHaveBeenCalledOnce();
   });
 

--- a/frontend/src/v2/composables/useServerConnection/index.ts
+++ b/frontend/src/v2/composables/useServerConnection/index.ts
@@ -30,9 +30,9 @@ const POLL_ONLINE_MS = 5 * 60_000;
 // Once offline, poll quickly so recovery is picked up promptly.
 const POLL_OFFLINE_MS = 5_000;
 const HEARTBEAT_TIMEOUT_MS = 5_000;
-// Leaving a player fires its teardown requests (play-session flush, presence
-// stop); give them a moment to reach the backend before the page goes away.
-const DEFERRED_REFRESH_DELAY_MS = 1_000;
+// Cap on the wait for `network-quiesced` before a held-back refresh gives up
+// on a quiet moment and reloads anyway.
+const QUIESCE_WAIT_MS = 10_000;
 
 let installed = false;
 
@@ -80,13 +80,30 @@ function install() {
       },
     );
 
-    // A refresh held back during play lands as soon as the player is left.
+    // A refresh held back during play lands once the player is left. Leaving
+    // fires teardown requests (stream save + release, play-session flush,
+    // presence stop) that a reload would abort, so wait for the network to go
+    // quiet — the api layer already announces that — rather than guessing at a
+    // delay. `network-quiesced` needs a settling request to fire at all, hence
+    // the cap for an app that has gone silent.
     watch(
       () => playing.playing,
       (isPlaying) => {
         if (isPlaying || !refreshPending) return;
         refreshPending = false;
-        setTimeout(() => window.location.reload(), DEFERRED_REFRESH_DELAY_MS);
+
+        let refreshed = false;
+        const refresh = () => {
+          if (refreshed) return;
+          refreshed = true;
+          document.removeEventListener("network-quiesced", refresh);
+          clearTimeout(capTimer);
+          // Back offline during the wait: leave the refresh to the next
+          // reconnect rather than rebooting against a dead backend.
+          if (heartbeat.connected) window.location.reload();
+        };
+        const capTimer = setTimeout(refresh, QUIESCE_WAIT_MS);
+        document.addEventListener("network-quiesced", refresh);
       },
     );
   });

--- a/frontend/src/v2/composables/useServerConnection/index.ts
+++ b/frontend/src/v2/composables/useServerConnection/index.ts
@@ -11,7 +11,9 @@
 //   * Recovery — on a false→true transition we do a full page refresh. A fresh
 //     boot re-runs initializeData() + the router guard from scratch, so the
 //     user lands on the correct destination (setup / login / home) with clean
-//     state instead of a half-recovered SPA.
+//     state instead of a half-recovered SPA. While a game is running the
+//     refresh waits: tearing down the page would kill the emulator and lose
+//     any progress it has not synced yet.
 //
 // `install()` runs once for the app's lifetime (idempotent). The banner calls
 // `useServerConnection()` in its <script setup>, which both returns the
@@ -19,6 +21,7 @@
 import { debounce } from "lodash";
 import { computed, effectScope, watch } from "vue";
 import storeHeartbeat from "@/stores/heartbeat";
+import storePlaying from "@/stores/playing";
 
 // While online, probe only occasionally — a network blip shouldn't rush to
 // flag the backend as down. Passive interceptor events still flip us offline
@@ -27,6 +30,9 @@ const POLL_ONLINE_MS = 5 * 60_000;
 // Once offline, poll quickly so recovery is picked up promptly.
 const POLL_OFFLINE_MS = 5_000;
 const HEARTBEAT_TIMEOUT_MS = 5_000;
+// Leaving a player fires its teardown requests (play-session flush, presence
+// stop); give them a moment to reach the backend before the page goes away.
+const DEFERRED_REFRESH_DELAY_MS = 1_000;
 
 let installed = false;
 
@@ -40,6 +46,7 @@ export function shouldRefreshOnReconnect(
 
 function install() {
   const heartbeat = storeHeartbeat();
+  const playing = storePlaying();
 
   // Passive detection — the interceptor classifies each response:
   //   * backend-online  → a request succeeded; the backend is up.
@@ -62,11 +69,24 @@ function install() {
   // scope so the watcher lives for the app's lifetime rather than the banner's
   // (the banner unmounts on a live v1↔v2 UI switch, yet `install()` only ever
   // runs once, so a scope-bound watcher would silently die on the way back).
+  let refreshPending = false;
   effectScope(true).run(() => {
     watch(
       () => heartbeat.connected,
       (now, was) => {
-        if (shouldRefreshOnReconnect(now, was)) window.location.reload();
+        if (!shouldRefreshOnReconnect(now, was)) return;
+        if (playing.playing) refreshPending = true;
+        else window.location.reload();
+      },
+    );
+
+    // A refresh held back during play lands as soon as the player is left.
+    watch(
+      () => playing.playing,
+      (isPlaying) => {
+        if (isPlaying || !refreshPending) return;
+        refreshPending = false;
+        setTimeout(() => window.location.reload(), DEFERRED_REFRESH_DELAY_MS);
       },
     );
   });


### PR DESCRIPTION
**Description**

A transient backend/network blip while an EmulatorJS game is running would reload the whole page the moment the connection came back, terminating the emulator session and losing any progress that had not been synced yet.

`useServerConnection` installs an app-lifetime watcher that does a full page refresh on every `offline -> online` transition, deliberately, so a recovered session re-boots through `initializeData()` and the router guard with clean state. It had no notion of what the page was doing at the time. The `playing` store already tracks an active session (EmulatorJS, JS-DOS, Ruffle and Stream all set it), it just wasn't consulted.

The recovery watcher now checks it:

- not playing -> refresh immediately, as before;
- playing -> mark the refresh pending and leave the page alone;
- pending refresh + player left -> refresh once the network goes quiet, so the player's teardown requests (stream save + release, play-session flush, presence stop, all fired un-awaited from `onBeforeUnmount`) reach the backend before the page goes away. That trigger is the api layer's existing `network-quiesced` event, capped at 10s for an app that goes silent without emitting one, and skipped altogether if the backend dropped again while waiting (the next reconnect refreshes instead).

This is the "defer until after the user exits the player" option from the issue, which keeps the recovery intent rather than dropping it.

**Verification**

Unit tests cover reconnect-while-idle, reconnect-while-playing, the deferred refresh landing on a quiet network, the cap, a second disconnect during the wait, and that a play session with nothing pending never triggers a refresh.

Also checked in a real browser (production build served with `vite preview` against a running backend, driven with Playwright) using the reproduction from the issue, dispatching `backend-offline` then `backend-online` on `document`:

- home page: the page still reloads on reconnect (mechanism intact);
- running EmulatorJS session: the offline banner appears and clears, the page does not reload and the session survives;
- after leaving the player: the held-back refresh lands.

`npm run typecheck`, `npx vitest run src/v2/composables` (243 passing) and `trunk fmt && trunk check` are clean.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A, no visual change.

---

**AI assistance disclosure**: this change was written with AI assistance (Claude Code). The investigation, the fix, the tests and the browser verification were carried out by the agent and reviewed by me.

Fixes #4356

🤖 Generated with [Claude Code](https://claude.com/claude-code)
