### PR TITLE
fix(export): share the ES-DE media folders with the Pegasus export

### DIFF
--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -66,9 +66,9 @@ DEFAULT_EXCLUDED_PLATFORM_DIRS: Final = [
     ".DocumentRevisions-V100",
     "System Volume Information",
 ]
-# The per-media-type folders ES-DE and Batocera resolve beside the ROMs, at
-# <platform>/<folder>/<rom>.<ext>.
-GAMELIST_MEDIA_DIRS: Final = {
+# The per-media-type folders beside the ROMs, at <platform>/<folder>/<rom>.<ext>.
+# ES-DE and Batocera resolve media here by name; the Pegasus export shares them.
+PLATFORM_MEDIA_DIRS: Final = {
     "image": "images",
     "box2d": "covers",
     "box2d_back": "backcovers",
@@ -88,7 +88,7 @@ GAMELIST_MEDIA_DIRS: Final = {
 # Folders inside a platform that are never a multi-file ROM (a ROM whose parts
 # live in a directory). Scraper media output lands here, so it is skipped too.
 DEFAULT_EXCLUDED_MULTI_FILE_DIRS: Final = sorted(
-    {*DEFAULT_EXCLUDED_PLATFORM_DIRS, *GAMELIST_MEDIA_DIRS.values()}
+    {*DEFAULT_EXCLUDED_PLATFORM_DIRS, *PLATFORM_MEDIA_DIRS.values()}
 )
 
 

--- a/backend/handler/metadata/gamelist_handler.py
+++ b/backend/handler/metadata/gamelist_handler.py
@@ -10,7 +10,7 @@ from xml.etree.ElementTree import Element  # trunk-ignore(bandit/B405)
 import pydash
 from defusedxml import ElementTree as ET
 
-from config.config_manager import GAMELIST_MEDIA_DIRS, MetadataMediaType
+from config.config_manager import PLATFORM_MEDIA_DIRS, MetadataMediaType
 from config.config_manager import config_manager as cm
 from handler.filesystem import fs_platform_handler, fs_resource_handler
 from logger.logger import log
@@ -86,20 +86,20 @@ class GamelistRom(BaseRom):
 
 
 ESDE_MEDIA_MAP: Final = {
-    "image_url": GAMELIST_MEDIA_DIRS["image"],
-    "box2d_url": GAMELIST_MEDIA_DIRS["box2d"],
-    "box2d_back_url": GAMELIST_MEDIA_DIRS["box2d_back"],
-    "box3d_url": GAMELIST_MEDIA_DIRS["box3d"],
-    "fanart_url": GAMELIST_MEDIA_DIRS["fanart"],
-    "manual_url": GAMELIST_MEDIA_DIRS["manual"],
-    "marquee_url": GAMELIST_MEDIA_DIRS["marquee"],
-    "miximage_url": GAMELIST_MEDIA_DIRS["miximage"],
-    "miximage_v2_url": GAMELIST_MEDIA_DIRS["miximage_v2"],
-    "physical_url": GAMELIST_MEDIA_DIRS["physical"],
-    "screenshot_url": GAMELIST_MEDIA_DIRS["screenshot"],
-    "title_screen_url": GAMELIST_MEDIA_DIRS["title_screen"],
-    "thumbnail_url": GAMELIST_MEDIA_DIRS["thumbnail"],
-    "video_url": GAMELIST_MEDIA_DIRS["video"],
+    "image_url": PLATFORM_MEDIA_DIRS["image"],
+    "box2d_url": PLATFORM_MEDIA_DIRS["box2d"],
+    "box2d_back_url": PLATFORM_MEDIA_DIRS["box2d_back"],
+    "box3d_url": PLATFORM_MEDIA_DIRS["box3d"],
+    "fanart_url": PLATFORM_MEDIA_DIRS["fanart"],
+    "manual_url": PLATFORM_MEDIA_DIRS["manual"],
+    "marquee_url": PLATFORM_MEDIA_DIRS["marquee"],
+    "miximage_url": PLATFORM_MEDIA_DIRS["miximage"],
+    "miximage_v2_url": PLATFORM_MEDIA_DIRS["miximage_v2"],
+    "physical_url": PLATFORM_MEDIA_DIRS["physical"],
+    "screenshot_url": PLATFORM_MEDIA_DIRS["screenshot"],
+    "title_screen_url": PLATFORM_MEDIA_DIRS["title_screen"],
+    "thumbnail_url": PLATFORM_MEDIA_DIRS["thumbnail"],
+    "video_url": PLATFORM_MEDIA_DIRS["video"],
 }
 
 XML_TAG_MAP: Final = {

--- a/backend/tests/utils/test_gamelist_exporter.py
+++ b/backend/tests/utils/test_gamelist_exporter.py
@@ -6,7 +6,7 @@ from xml.etree.ElementTree import fromstring
 import pytest
 
 from config import FRONTEND_RESOURCES_PATH
-from config.config_manager import GAMELIST_MEDIA_DIRS
+from config.config_manager import PLATFORM_MEDIA_DIRS
 from handler.database import db_platform_handler, db_rom_handler
 from handler.filesystem import (
     fs_platform_handler,
@@ -648,4 +648,4 @@ def test_export_gamelist_xml_mix_falls_back_to_miximage_v2(platform_with_roms):
 
 def test_gamelist_media_dirs_are_excluded_from_scan():
     """Media folders beside the ROMs are never scanned as multi-file ROMs."""
-    assert fs_rom_handler.exclude_multi_roms(list(GAMELIST_MEDIA_DIRS.values())) == []
+    assert fs_rom_handler.exclude_multi_roms(list(PLATFORM_MEDIA_DIRS.values())) == []

--- a/backend/tests/utils/test_pegasus_exporter.py
+++ b/backend/tests/utils/test_pegasus_exporter.py
@@ -3,12 +3,17 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from config.config_manager import GAMELIST_MEDIA_DIRS
 from handler.database import db_platform_handler, db_rom_handler
-from handler.filesystem import fs_resource_handler
+from handler.filesystem import (
+    fs_platform_handler,
+    fs_resource_handler,
+    fs_rom_handler,
+)
 from models.platform import Platform
 from models.rom import Rom
 from models.user import User
-from utils.pegasus_exporter import PegasusExporter
+from utils.pegasus_exporter import PEGASUS_MEDIA_KEYS, PegasusExporter
 
 
 class ParsedPegasus(TypedDict):
@@ -477,9 +482,9 @@ class TestCopyAndEntry:
             name="Test", fs_name="test.sfc", fs_name_no_tags="test", metadatum=metadatum
         )
         exported_assets = {
-            "box_front": "assets/covers/test.png",
-            "screenshot": "assets/screenshots/test.jpg",
-            "video": "assets/videos/test.mp4",
+            "box_front": "covers/test.png",
+            "screenshot": "screenshots/test.jpg",
+            "video": "videos/test.mp4",
         }
 
         entry = PegasusExporter(local_export=True)._create_game_entry(
@@ -487,3 +492,82 @@ class TestCopyAndEntry:
         )
         for key, path in exported_assets.items():
             assert f"assets.{key}: {path}" in entry
+
+
+class TestExportToFile:
+    def test_media_keys_resolve_to_esde_dirs(self):
+        assert set(PEGASUS_MEDIA_KEYS.values()) <= set(GAMELIST_MEDIA_DIRS)
+
+    async def test_media_shares_esde_dirs(
+        self, admin_user: User, tmp_path, monkeypatch
+    ):
+        """Media lands in the same per-type folders the gamelist export uses, so
+        exporting for both frontends yields one copy and no assets/ tree."""
+        resources_base = tmp_path / "resources"
+        library_base = tmp_path / "library"
+        monkeypatch.setattr(fs_resource_handler, "base_path", resources_base)
+        monkeypatch.setattr(fs_platform_handler, "base_path", library_base)
+
+        platform = db_platform_handler.add_platform(
+            Platform(name="Super Nintendo", slug="snes", fs_slug="snes")
+        )
+        rom = db_rom_handler.add_rom(
+            Rom(
+                platform_id=platform.id,
+                name="Super Mario World",
+                slug="super-mario-world",
+                fs_name="Super Mario World (USA).sfc",
+                fs_name_no_tags="Super Mario World",
+                fs_name_no_ext="Super Mario World (USA)",
+                fs_extension="sfc",
+                fs_path="snes/roms",
+            )
+        )
+        db_rom_handler.add_rom_user(rom_id=rom.id, user_id=admin_user.id)
+        db_rom_handler.update_rom(
+            rom.id,
+            {
+                "path_cover_l": "snes/covers/smw.jpg",
+                "path_screenshots": ["snes/screenshots/smw-1.jpg"],
+                "ss_metadata": {
+                    "logo_path": "snes-ss/logo/smw.png",
+                    "physical_path": "snes-ss/physical/smw.png",
+                    "fanart_path": "snes-ss/fanart/smw.jpg",
+                },
+            },
+        )
+        for rel in (
+            "snes/covers/smw.jpg",
+            "snes/screenshots/smw-1.jpg",
+            "snes-ss/logo/smw.png",
+            "snes-ss/physical/smw.png",
+            "snes-ss/fanart/smw.jpg",
+        ):
+            src = resources_base / rel
+            src.parent.mkdir(parents=True, exist_ok=True)
+            src.write_bytes(b"x")
+
+        exporter = PegasusExporter(local_export=True)
+        assert await exporter.export_platform_to_file(platform.id, request=None)
+
+        platform_dir = library_base / fs_platform_handler.get_platform_fs_structure(
+            platform.fs_slug
+        )
+        expected = {
+            "box_front": "covers/Super Mario World (USA).jpg",
+            "screenshot": "screenshots/Super Mario World (USA).jpg",
+            "logo": "marquees/Super Mario World (USA).png",
+            "cartridge": "physicalmedia/Super Mario World (USA).png",
+            "background": "fanart/Super Mario World (USA).jpg",
+        }
+        for rel in expected.values():
+            assert (platform_dir / rel).is_file(), f"missing media {rel}"
+        assert not (platform_dir / "assets").exists()
+
+        content = (platform_dir / "metadata.pegasus.txt").read_text()
+        for key, rel in expected.items():
+            assert f"assets.{key}: {rel}" in content
+
+        written_dirs = [p.name for p in platform_dir.iterdir() if p.is_dir()]
+        assert written_dirs
+        assert fs_rom_handler.exclude_multi_roms(written_dirs) == []

--- a/backend/tests/utils/test_pegasus_exporter.py
+++ b/backend/tests/utils/test_pegasus_exporter.py
@@ -497,7 +497,7 @@ class TestCopyAndEntry:
 
 class TestExportToFile:
     def test_media_keys_resolve_to_esde_dirs(self):
-        assert set(PEGASUS_MEDIA_KEYS.values()) <= set(PLATFORM_MEDIA_DIRS)
+        assert set(PEGASUS_MEDIA_KEYS.values()).issubset(PLATFORM_MEDIA_DIRS.keys())
 
     @staticmethod
     async def _export(

--- a/backend/tests/utils/test_pegasus_exporter.py
+++ b/backend/tests/utils/test_pegasus_exporter.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from config.config_manager import GAMELIST_MEDIA_DIRS
+from config.config_manager import PLATFORM_MEDIA_DIRS
 from handler.database import db_platform_handler, db_rom_handler
 from handler.filesystem import (
     fs_platform_handler,
@@ -496,7 +496,7 @@ class TestCopyAndEntry:
 
 class TestExportToFile:
     def test_media_keys_resolve_to_esde_dirs(self):
-        assert set(PEGASUS_MEDIA_KEYS.values()) <= set(GAMELIST_MEDIA_DIRS)
+        assert set(PEGASUS_MEDIA_KEYS.values()) <= set(PLATFORM_MEDIA_DIRS)
 
     async def test_media_shares_esde_dirs(
         self, admin_user: User, tmp_path, monkeypatch

--- a/backend/tests/utils/test_pegasus_exporter.py
+++ b/backend/tests/utils/test_pegasus_exporter.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import TypedDict
 from unittest.mock import MagicMock
 
@@ -498,11 +499,17 @@ class TestExportToFile:
     def test_media_keys_resolve_to_esde_dirs(self):
         assert set(PEGASUS_MEDIA_KEYS.values()) <= set(PLATFORM_MEDIA_DIRS)
 
-    async def test_media_shares_esde_dirs(
-        self, admin_user: User, tmp_path, monkeypatch
-    ):
-        """Media lands in the same per-type folders the gamelist export uses, so
-        exporting for both frontends yields one copy and no assets/ tree."""
+    @staticmethod
+    async def _export(
+        admin_user: User,
+        tmp_path: Path,
+        monkeypatch,
+        rom_fields: dict[str, object],
+        sources: dict[str, bytes],
+    ) -> tuple[Path, str]:
+        """Export one SNES ROM with ``rom_fields`` applied and ``sources``
+        present under the resources base. Returns the platform dir and the
+        written metadata.pegasus.txt."""
         resources_base = tmp_path / "resources"
         library_base = tmp_path / "library"
         monkeypatch.setattr(fs_resource_handler, "base_path", resources_base)
@@ -524,8 +531,29 @@ class TestExportToFile:
             )
         )
         db_rom_handler.add_rom_user(rom_id=rom.id, user_id=admin_user.id)
-        db_rom_handler.update_rom(
-            rom.id,
+        db_rom_handler.update_rom(rom.id, rom_fields)
+        for rel, content in sources.items():
+            src = resources_base / rel
+            src.parent.mkdir(parents=True, exist_ok=True)
+            src.write_bytes(content)
+
+        exporter = PegasusExporter(local_export=True)
+        assert await exporter.export_platform_to_file(platform.id, request=None)
+
+        platform_dir = library_base / fs_platform_handler.get_platform_fs_structure(
+            platform.fs_slug
+        )
+        return platform_dir, (platform_dir / "metadata.pegasus.txt").read_text()
+
+    async def test_media_shares_esde_dirs(
+        self, admin_user: User, tmp_path, monkeypatch
+    ):
+        """Media lands in the same per-type folders the gamelist export uses, so
+        exporting for both frontends yields one copy and no assets/ tree."""
+        platform_dir, content = await self._export(
+            admin_user,
+            tmp_path,
+            monkeypatch,
             {
                 "path_cover_l": "snes/covers/smw.jpg",
                 "path_screenshots": ["snes/screenshots/smw-1.jpg"],
@@ -535,24 +563,18 @@ class TestExportToFile:
                     "fanart_path": "snes-ss/fanart/smw.jpg",
                 },
             },
+            {
+                rel: b"x"
+                for rel in (
+                    "snes/covers/smw.jpg",
+                    "snes/screenshots/smw-1.jpg",
+                    "snes-ss/logo/smw.png",
+                    "snes-ss/physical/smw.png",
+                    "snes-ss/fanart/smw.jpg",
+                )
+            },
         )
-        for rel in (
-            "snes/covers/smw.jpg",
-            "snes/screenshots/smw-1.jpg",
-            "snes-ss/logo/smw.png",
-            "snes-ss/physical/smw.png",
-            "snes-ss/fanart/smw.jpg",
-        ):
-            src = resources_base / rel
-            src.parent.mkdir(parents=True, exist_ok=True)
-            src.write_bytes(b"x")
 
-        exporter = PegasusExporter(local_export=True)
-        assert await exporter.export_platform_to_file(platform.id, request=None)
-
-        platform_dir = library_base / fs_platform_handler.get_platform_fs_structure(
-            platform.fs_slug
-        )
         expected = {
             "box_front": "covers/Super Mario World (USA).jpg",
             "screenshot": "screenshots/Super Mario World (USA).jpg",
@@ -564,10 +586,35 @@ class TestExportToFile:
             assert (platform_dir / rel).is_file(), f"missing media {rel}"
         assert not (platform_dir / "assets").exists()
 
-        content = (platform_dir / "metadata.pegasus.txt").read_text()
         for key, rel in expected.items():
             assert f"assets.{key}: {rel}" in content
 
         written_dirs = [p.name for p in platform_dir.iterdir() if p.is_dir()]
         assert written_dirs
         assert fs_rom_handler.exclude_multi_roms(written_dirs) == []
+
+    async def test_logo_and_marquee_both_survive(
+        self, admin_user: User, tmp_path, monkeypatch
+    ):
+        """Both map to marquees/; the second gets its own filename instead of
+        being dropped or pointed at the first."""
+        platform_dir, content = await self._export(
+            admin_user,
+            tmp_path,
+            monkeypatch,
+            {
+                "ss_metadata": {"logo_path": "snes-ss/logo/smw.png"},
+                "gamelist_metadata": {"marquee_path": "snes-gl/marquee/smw.png"},
+            },
+            {
+                "snes-ss/logo/smw.png": b"logo",
+                "snes-gl/marquee/smw.png": b"marquee",
+            },
+        )
+
+        logo = platform_dir / "marquees/Super Mario World (USA).png"
+        marquee = platform_dir / "marquees/Super Mario World (USA)-marquee.png"
+        assert logo.read_bytes() == b"logo"
+        assert marquee.read_bytes() == b"marquee"
+        assert "assets.logo: marquees/Super Mario World (USA).png" in content
+        assert "assets.marquee: marquees/Super Mario World (USA)-marquee.png" in content

--- a/backend/utils/gamelist_exporter.py
+++ b/backend/utils/gamelist_exporter.py
@@ -12,7 +12,7 @@ from fastapi import Request
 from starlette.datastructures import URLPath
 
 from config import FRONTEND_RESOURCES_PATH, YOUTUBE_BASE_URL
-from config.config_manager import GAMELIST_MEDIA_DIRS
+from config.config_manager import PLATFORM_MEDIA_DIRS
 from config.config_manager import config_manager as cm
 from handler.database import db_platform_handler, db_rom_handler
 from handler.filesystem import fs_platform_handler, fs_resource_handler
@@ -130,7 +130,7 @@ class GamelistExporter:
 
         if self.local_export:
             for asset_key, source_path in assets.items():
-                subdir = GAMELIST_MEDIA_DIRS[asset_key]
+                subdir = PLATFORM_MEDIA_DIRS[asset_key]
                 dest_name = f"{rom.fs_name_no_ext}{source_path.suffix}"
                 rel_path = f"./{subdir}/{dest_name}"
 

--- a/backend/utils/pegasus_exporter.py
+++ b/backend/utils/pegasus_exporter.py
@@ -1,8 +1,10 @@
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Final
 
 from fastapi import Request
 
+from config.config_manager import GAMELIST_MEDIA_DIRS
 from handler.database import db_platform_handler, db_rom_handler
 from handler.filesystem import fs_platform_handler, fs_resource_handler
 from logger.logger import log
@@ -114,19 +116,21 @@ SLUG_TO_PEGASUS: dict[UPS, tuple[str, str]] = {
     UPS.STEAM: ("Steam", "steam"),
 }
 
-# Map Pegasus asset keys to subdirectory names inside assets/
-ASSET_DIRS: dict[str, str] = {
-    "box_front": "covers",
-    "box_back": "backcovers",
-    "box_full": "boxes",
-    "screenshot": "screenshots",
-    "titlescreen": "titlescreens",
-    "video": "videos",
-    "marquee": "marquees",
-    "cartridge": "cartridges",
-    "logo": "logos",
-    "background": "backgrounds",
-    "bezel": "bezels",
+# Pegasus resolves media from the paths written in metadata.pegasus.txt, so its
+# files share the ES-DE media folders instead of a parallel assets/ tree. ES-DE
+# keeps logos under marquees.
+PEGASUS_MEDIA_KEYS: Final[dict[str, str]] = {
+    "box_front": "box2d",
+    "box_back": "box2d_back",
+    "box_full": "box3d",
+    "screenshot": "screenshot",
+    "titlescreen": "title_screen",
+    "video": "video",
+    "marquee": "marquee",
+    "logo": "marquee",
+    "cartridge": "physical",
+    "background": "fanart",
+    "bezel": "bezel",
 }
 
 
@@ -356,7 +360,7 @@ class PegasusExporter:
         request: Request | None,
     ) -> bool:
         """Export platform ROMs to metadata.pegasus.txt file in the platform's directory,
-        including media assets copied into a local assets/ folder.
+        copying media into the ES-DE per-type folders when local_export=True.
 
         Args:
             platform_id: Platform ID to export
@@ -396,12 +400,12 @@ class PegasusExporter:
                     assets = self._collect_assets(rom)
 
                     for asset_key, source_path in assets.items():
-                        subdir = ASSET_DIRS.get(asset_key, asset_key)
+                        subdir = GAMELIST_MEDIA_DIRS[PEGASUS_MEDIA_KEYS[asset_key]]
                         dest_name = f"{rom.fs_name_no_ext}{source_path.suffix}"
-                        dest_path = platform_dir / "assets" / subdir / dest_name
+                        dest_path = platform_dir / subdir / dest_name
 
                         if self._copy_asset(source_path, dest_path):
-                            exported_assets[asset_key] = f"assets/{subdir}/{dest_name}"
+                            exported_assets[asset_key] = f"{subdir}/{dest_name}"
 
                 if game_count > 0:
                     lines.append("")

--- a/backend/utils/pegasus_exporter.py
+++ b/backend/utils/pegasus_exporter.py
@@ -4,7 +4,7 @@ from typing import Final
 
 from fastapi import Request
 
-from config.config_manager import GAMELIST_MEDIA_DIRS
+from config.config_manager import PLATFORM_MEDIA_DIRS
 from handler.database import db_platform_handler, db_rom_handler
 from handler.filesystem import fs_platform_handler, fs_resource_handler
 from logger.logger import log
@@ -400,7 +400,7 @@ class PegasusExporter:
                     assets = self._collect_assets(rom)
 
                     for asset_key, source_path in assets.items():
-                        subdir = GAMELIST_MEDIA_DIRS[PEGASUS_MEDIA_KEYS[asset_key]]
+                        subdir = PLATFORM_MEDIA_DIRS[PEGASUS_MEDIA_KEYS[asset_key]]
                         dest_name = f"{rom.fs_name_no_ext}{source_path.suffix}"
                         dest_path = platform_dir / subdir / dest_name
 

--- a/backend/utils/pegasus_exporter.py
+++ b/backend/utils/pegasus_exporter.py
@@ -399,10 +399,19 @@ class PegasusExporter:
                 if self.local_export:
                     assets = self._collect_assets(rom)
 
+                    claimed: dict[Path, Path] = {}
                     for asset_key, source_path in assets.items():
                         subdir = PLATFORM_MEDIA_DIRS[PEGASUS_MEDIA_KEYS[asset_key]]
                         dest_name = f"{rom.fs_name_no_ext}{source_path.suffix}"
                         dest_path = platform_dir / subdir / dest_name
+
+                        # Logo and marquee share one folder; keep both files.
+                        if claimed.get(dest_path, source_path) != source_path:
+                            dest_name = (
+                                f"{rom.fs_name_no_ext}-{asset_key}{source_path.suffix}"
+                            )
+                            dest_path = platform_dir / subdir / dest_name
+                        claimed[dest_path] = source_path
 
                         if self._copy_asset(source_path, dest_path):
                             exported_assets[asset_key] = f"{subdir}/{dest_name}"


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Follow-up to rommapp/romm#4344, prompted by the last comment on rommapp/romm#4226: with both the gamelist and Pegasus exports enabled, a scan wrote every media file twice. The gamelist export placed it in ES-DE's per-type folders beside the ROMs, and the Pegasus export placed a second copy in a parallel `assets/` tree with its own folder names (`boxes`, `cartridges`, `logos`, `backgrounds`).

Pegasus resolves media from the paths written in `metadata.pegasus.txt`, so it does not need a layout of its own. The Pegasus exporter now copies into the same per-type folders the gamelist export uses and references those paths from the metadata file. Exporting for both frontends yields one copy of each file and no `assets/` directory.

Since the folder map now serves the gamelist import, the gamelist export, and the Pegasus export, `GAMELIST_MEDIA_DIRS` is renamed to `PLATFORM_MEDIA_DIRS`.

Mapping notes:

- Pegasus `logo` and `marquee` both land in `marquees/`, matching how ES-DE files logos.
- `cartridge` lands in `physicalmedia/`, `background` in `fanart/`, `box_full` in `3dboxes/`.
- Existing `assets/` trees are left untouched. The scan already excludes `assets` at both the platform and multi-file level, so they are harmless and can be deleted by hand.

**AI assistance disclosure:** this PR, including the tests, was written by Claude Code under the author's direction.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally (`pytest tests/utils/test_pegasus_exporter.py tests/utils/test_gamelist_exporter.py tests/handler/metadata/test_gamelist_handler.py tests/config` on MariaDB: 91 passed; ruff, black, isort, and mypy clean on the changed files)
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)