### PR TITLE
feat(v2): make game header tags clickable

### DIFF
--- a/frontend/src/v2/components/GameDetails/GameHeader.vue
+++ b/frontend/src/v2/components/GameDetails/GameHeader.vue
@@ -3,21 +3,21 @@
 // Four rows, top to bottom:
 //   1. Title (+ previous / next game arrows on the right)
 //   2. Meta (year · platform-icon + platform · verified RTag)
-//   3. Tags (regions + languages + custom tags) — RTag primitive
+//   3. Tags (regions + languages + custom tags) — RTag primitive,
+//      each a `searchLocation` pivot into the filtered search
 //   4. GameActions (Play · Download · Favorite · Share · More)
 //
 // Metadata-provider links live in the Metadata tab, not the header.
 // Genre/franchise belong in the Overview tab info grid.
 import { RIcon, RPlatformIcon, RTag, RTooltip } from "@v2/lib";
 import { useI18n } from "vue-i18n";
-import { ROUTES } from "@/plugins/router";
-import type { FilterType } from "@/stores/galleryFilter";
 import type { DetailedRom } from "@/stores/roms";
 import GameActions from "@/v2/components/GameActions/GameActions.vue";
 import MainSiblingToggle from "@/v2/components/GameDetails/MainSiblingToggle.vue";
 import PrevNextNav from "@/v2/components/GameDetails/PrevNextNav.vue";
 import VersionSwitcher from "@/v2/components/GameDetails/VersionSwitcher.vue";
 import { useGameActions } from "@/v2/composables/useGameActions";
+import { searchLocation } from "@/v2/utils/searchLocation";
 
 defineOptions({ inheritAttrs: false });
 
@@ -35,13 +35,6 @@ const props = defineProps<{
 }>();
 
 const actions = useGameActions(() => props.rom);
-
-// Same pivot-to-search the Overview info grid offers on genres/companies:
-// a link (not a click handler) so middle-click and open-in-new-tab work.
-const searchLocation = (filter: FilterType, item: string) => ({
-  name: ROUTES.SEARCH,
-  query: { [filter]: item },
-});
 </script>
 
 <template>

--- a/frontend/src/v2/components/GameDetails/GameHeader.vue
+++ b/frontend/src/v2/components/GameDetails/GameHeader.vue
@@ -10,6 +10,8 @@
 // Genre/franchise belong in the Overview tab info grid.
 import { RIcon, RPlatformIcon, RTag, RTooltip } from "@v2/lib";
 import { useI18n } from "vue-i18n";
+import { ROUTES } from "@/plugins/router";
+import type { FilterType } from "@/stores/galleryFilter";
 import type { DetailedRom } from "@/stores/roms";
 import GameActions from "@/v2/components/GameActions/GameActions.vue";
 import MainSiblingToggle from "@/v2/components/GameDetails/MainSiblingToggle.vue";
@@ -33,6 +35,13 @@ const props = defineProps<{
 }>();
 
 const actions = useGameActions(() => props.rom);
+
+// Same pivot-to-search the Overview info grid offers on genres/companies:
+// a link (not a click handler) so middle-click and open-in-new-tab work.
+const searchLocation = (filter: FilterType, item: string) => ({
+  name: ROUTES.SEARCH,
+  query: { [filter]: item },
+});
 </script>
 
 <template>
@@ -92,21 +101,30 @@ const actions = useGameActions(() => props.rom);
         v-if="regions.length || languages.length || tags.length"
         class="r-v2-det-header__tags"
       >
-        <RTag
+        <router-link
           v-for="r in regions"
           :key="`r-${r}`"
-          :text="r"
-          tone="info"
-          size="small"
-        />
-        <RTag
+          :to="searchLocation('regions', r)"
+          class="r-v2-det-header__tag-link"
+        >
+          <RTag :text="r" tone="info" size="small" />
+        </router-link>
+        <router-link
           v-for="l in languages"
           :key="`l-${l}`"
-          :text="l"
-          tone="brand"
-          size="small"
-        />
-        <RTag v-for="t in tags" :key="`t-${t}`" :text="t" size="small" />
+          :to="searchLocation('languages', l)"
+          class="r-v2-det-header__tag-link"
+        >
+          <RTag :text="l" tone="brand" size="small" />
+        </router-link>
+        <router-link
+          v-for="tag in tags"
+          :key="`t-${tag}`"
+          :to="searchLocation('tags', tag)"
+          class="r-v2-det-header__tag-link"
+        >
+          <RTag :text="tag" size="small" />
+        </router-link>
       </span>
     </div>
 
@@ -181,6 +199,16 @@ const actions = useGameActions(() => props.rom);
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+.r-v2-det-header__tag-link {
+  display: inline-flex;
+  text-decoration: none;
+  border-radius: var(--r-radius-chip);
+}
+/* Strengthen the border in the tag's own tone so the affordance reads the
+   same for region / language / custom tags. */
+.r-v2-det-header__tag-link:hover :deep(.r-tag) {
+  --r-tag-border: var(--r-tag-fg);
 }
 
 .r-v2-det-header__versions {

--- a/frontend/src/v2/components/GameDetails/InfoGrid.vue
+++ b/frontend/src/v2/components/GameDetails/InfoGrid.vue
@@ -8,14 +8,11 @@
 // Sections with no items are omitted so the grid doesn't show empty
 // columns.
 //
-// A section carrying a `filter` renders its chips as links into the
-// global search scoped to that value (`/search?genres=Adventure`), the
-// pivot-to-search v1 offered from the same rows. Links (not click
-// handlers) so middle-click / open-in-new-tab work and the chips join
-// keyboard + spatial navigation as `a[href]`.
+// A section carrying a `filter` renders its chips as `searchLocation`
+// links, pivoting into the global search scoped to that value.
 import { RIcon } from "@v2/lib";
-import { ROUTES } from "@/plugins/router";
 import type { FilterType } from "@/stores/galleryFilter";
+import { searchLocation } from "@/v2/utils/searchLocation";
 
 defineOptions({ inheritAttrs: false });
 
@@ -33,11 +30,6 @@ export type InfoGridSection = {
 const props = defineProps<{ sections: InfoGridSection[] }>();
 
 const visible = () => props.sections.filter((s) => s.items.length > 0);
-
-const searchLocation = (filter: FilterType, item: string) => ({
-  name: ROUTES.SEARCH,
-  query: { [filter]: item },
-});
 </script>
 
 <template>

--- a/frontend/src/v2/utils/searchLocation.ts
+++ b/frontend/src/v2/utils/searchLocation.ts
@@ -1,0 +1,11 @@
+// Pivot from a metadata value (genre, region, tag, …) into the global
+// search scoped to it (`/search?genres=Adventure`), the pivot v1 offered
+// from the same rows. Render the result as a link, not a click handler,
+// so middle-click / open-in-new-tab work and the chips join keyboard +
+// spatial navigation as `a[href]`.
+import { ROUTES } from "@/plugins/router";
+import type { FilterType } from "@/stores/galleryFilter";
+
+export function searchLocation(filter: FilterType, value: string) {
+  return { name: ROUTES.SEARCH, query: { [filter]: value } };
+}


### PR DESCRIPTION
**Description**

Region, language and custom tags in the v2 game details header are now clickable: each one links into a filtered search (`/search?regions=USA`, `?languages=…`, `?tags=…`), the same pivot the Overview info grid already offers on genres, companies and franchises.

Those query keys are already round-tripped by `useGalleryFilterUrl`, so this is a single-component change: no store, route or backend work.

- Links (`router-link`) rather than click handlers, so middle-click / open-in-new-tab work and the tags join keyboard and spatial navigation as `a[href]`.
- Hover affordance is one rule (`--r-tag-border: var(--r-tag-fg)`), so the border strengthens in each tag's own tone instead of hardcoding a colour per tone.

Closes #4363

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

Verified against a local instance: clicking the `USA` tag lands on `/search?regions=USA` with the filter applied, the tag is reachable by Tab and activates on Enter with a visible focus ring, and hover/idle were checked in both light and dark themes. `npm run typecheck`, the GameDetails vitest files and `trunk check` all pass.

---

**AI assistance disclosure**

This PR was written by Claude Code (code and PR description), reviewed by me before opening.
