### PR TITLE
perf(tests): stop the suite waiting on connections it never wanted

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,10 @@
+import errno
+import functools
 import os
 import re
+import socket
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import alembic.config
 import pytest
@@ -42,6 +46,37 @@ session = sessionmaker(bind=engine, expire_on_commit=False)
 settings.register_profile("ci", max_examples=200, deadline=None)
 settings.register_profile("dev", max_examples=50, deadline=None)
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "dev"))
+
+# The test suite talks to nothing but the database; a connection anywhere else
+# means a mock was missed. A workstation answers those instantly, a CI runner
+# silently drops the packets and the test burns its whole socket timeout (up to
+# two minutes for a broker transfer), so refuse them outright.
+_ALLOWED_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+_real_connect = socket.socket.connect
+_real_connect_ex = socket.socket.connect_ex
+
+
+def _blocked(address: Any) -> bool:
+    # Non-tuple addresses are unix sockets, which never leave the machine.
+    return isinstance(address, tuple) and address[0] not in _ALLOWED_HOSTS
+
+
+def _guarded_connect(sock: socket.socket, address: Any) -> None:
+    if _blocked(address):
+        raise OSError(
+            errno.ENETUNREACH, f"outbound network blocked in tests: {address}"
+        )
+    _real_connect(sock, address)
+
+
+def _guarded_connect_ex(sock: socket.socket, address: Any) -> int:
+    if _blocked(address):
+        return errno.ENETUNREACH
+    return _real_connect_ex(sock, address)
+
+
+socket.socket.connect = _guarded_connect  # type: ignore[method-assign,assignment]
+socket.socket.connect_ex = _guarded_connect_ex  # type: ignore[method-assign,assignment]
 
 
 def _ensure_database_exists() -> None:
@@ -397,11 +432,18 @@ def memory_card_version(memory_card: MemoryCard, platform: Platform):
     return db_memory_card_handler.add_version(version)
 
 
+@functools.cache
+def _password_hash(password: str) -> str:
+    """Memoized: bcrypt costs a quarter-second and the user fixtures below hash
+    the same three passwords for well over a thousand tests."""
+    return auth_handler.get_password_hash(password)
+
+
 @pytest.fixture
 def admin_user():
     user = User(
         username="test_admin",
-        hashed_password=auth_handler.get_password_hash("test_admin_password"),
+        hashed_password=_password_hash("test_admin_password"),
         role=Role.ADMIN,
     )
     return db_user_handler.add_user(user)
@@ -413,7 +455,7 @@ def editor_user():
     group = db_permission_handler.get_group_by_name("Editor (legacy)")
     user = User(
         username="test_editor",
-        hashed_password=auth_handler.get_password_hash("test_editor_password"),
+        hashed_password=_password_hash("test_editor_password"),
         role=Role.USER,
         permission_group_id=group.id if group else None,
     )
@@ -425,7 +467,7 @@ def viewer_user():
     group = db_permission_handler.get_group_by_name("Viewer (legacy)")
     user = User(
         username="test_viewer",
-        hashed_password=auth_handler.get_password_hash("test_viewer_password"),
+        hashed_password=_password_hash("test_viewer_password"),
         role=Role.USER,
         permission_group_id=group.id if group else None,
     )

--- a/backend/tests/endpoints/roms/test_manual.py
+++ b/backend/tests/endpoints/roms/test_manual.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
+from pytest_mock import MockerFixture
 
 from endpoints.roms import manual as manual_endpoint
 from handler.database import db_rom_handler
@@ -18,7 +19,7 @@ def _auth(token: str) -> dict[str, str]:
 
 
 @pytest.fixture
-def manual_fs_resources(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def manual_fs_resources(tmp_path: Path, mocker: MockerFixture):
     """Mock fs_resource_handler so /manuals (resources path) writes to tmp_path."""
     resources_dir = tmp_path / "resources"
     resources_dir.mkdir()
@@ -27,10 +28,10 @@ def manual_fs_resources(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         target = resources_dir / Path(path).name
         return target
 
-    monkeypatch.setattr(
+    mocker.patch.object(
         manual_endpoint.fs_resource_handler, "validate_path", validate_path
     )
-    monkeypatch.setattr(
+    mocker.patch.object(
         manual_endpoint.fs_resource_handler,
         "make_directory",
         AsyncMock(return_value=None),
@@ -39,7 +40,7 @@ def manual_fs_resources(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture
-def manual_fs_folder(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def manual_fs_folder(tmp_path: Path, mocker: MockerFixture):
     """Mock fs_rom_handler so /manuals/files (folder path) writes to tmp_path."""
     folder_dir = tmp_path / "library"
     folder_dir.mkdir()
@@ -54,13 +55,13 @@ def manual_fs_folder(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         else:
             raise FileNotFoundError(path)
 
-    monkeypatch.setattr(manual_endpoint.fs_rom_handler, "validate_path", validate_path)
-    monkeypatch.setattr(
+    mocker.patch.object(manual_endpoint.fs_rom_handler, "validate_path", validate_path)
+    mocker.patch.object(
         manual_endpoint.fs_rom_handler,
         "make_directory",
         AsyncMock(return_value=None),
     )
-    monkeypatch.setattr(
+    mocker.patch.object(
         manual_endpoint.fs_rom_handler,
         "remove_file",
         AsyncMock(side_effect=remove_file),
@@ -252,7 +253,7 @@ def test_redownload_manual_success(
     client: TestClient,
     access_token: str,
     rom: Rom,
-    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
 ):
     db_rom_handler.update_rom(
         rom.id,
@@ -262,7 +263,7 @@ def test_redownload_manual_success(
         },
     )
     fake_path = f"{rom.fs_resources_path}/manual/{rom.id}.pdf"
-    monkeypatch.setattr(
+    mocker.patch.object(
         manual_endpoint.fs_resource_handler,
         "get_manual",
         AsyncMock(return_value=fake_path),
@@ -286,9 +287,9 @@ def test_delete_manual_no_manual_returns_404(
     client: TestClient,
     access_token: str,
     rom: Rom,
-    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
 ):
-    monkeypatch.setattr(
+    mocker.patch.object(
         manual_endpoint.fs_resource_handler,
         "manual_exists",
         lambda _rom: False,
@@ -306,7 +307,7 @@ def test_delete_manual_success(
     client: TestClient,
     access_token: str,
     rom: Rom,
-    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
 ):
     db_rom_handler.update_rom(
         rom.id,
@@ -316,11 +317,11 @@ def test_delete_manual_success(
             "locked_fields": ["url_manual"],
         },
     )
-    monkeypatch.setattr(
+    mocker.patch.object(
         manual_endpoint.fs_resource_handler, "manual_exists", lambda _rom: True
     )
     remove_mock = AsyncMock(return_value=None)
-    monkeypatch.setattr(
+    mocker.patch.object(
         manual_endpoint.fs_resource_handler, "remove_manual", remove_mock
     )
 

--- a/backend/tests/endpoints/roms/test_rom.py
+++ b/backend/tests/endpoints/roms/test_rom.py
@@ -637,9 +637,16 @@ def test_get_romfile_hidden_rom_returns_404(
 
 @patch.object(FSRomsHandler, "rename_fs_rom")
 @patch.object(IGDBHandler, "get_rom_by_id", return_value=IGDBRom(igdb_id=None))
+@patch.object(
+    FSResourcesHandler,
+    "get_cover",
+    new_callable=AsyncMock,
+    return_value=("path/to/small.png", "path/to/big.png"),
+)
 def test_update_rom(
-    rename_fs_rom_mock: AsyncMock,
+    get_cover_mock: AsyncMock,
     get_rom_by_id_mock: AsyncMock,
+    rename_fs_rom_mock: AsyncMock,
     client: TestClient,
     access_token: str,
     rom: Rom,
@@ -861,12 +868,19 @@ def test_remove_cover_releases_the_lock(
 
 @patch.object(
     FSResourcesHandler,
+    "get_manual",
+    new_callable=AsyncMock,
+    return_value="path/to/manual.pdf",
+)
+@patch.object(
+    FSResourcesHandler,
     "get_cover",
     new_callable=AsyncMock,
     return_value=("path/to/small.png", "path/to/big.png"),
 )
 def test_saving_without_changing_urls_keeps_locks(
     get_cover_mock: AsyncMock,
+    get_manual_mock: AsyncMock,
     client: TestClient,
     access_token: str,
     rom: Rom,
@@ -877,7 +891,7 @@ def test_saving_without_changing_urls_keeps_locks(
         rom.id,
         {
             "url_cover": "",
-            "url_manual": "https://ss.fr/manual?id=1",
+            "url_manual": "https://www.screenscraper.fr/manual?id=1",
             "locked_fields": ["url_cover", "url_manual"],
         },
     )
@@ -885,7 +899,10 @@ def test_saving_without_changing_urls_keeps_locks(
     response = client.put(
         f"/api/roms/{rom.id}",
         headers={"Authorization": f"Bearer {access_token}"},
-        data={"url_cover": "", "url_manual": "https://ss.fr/manual?id=1"},
+        data={
+            "url_cover": "",
+            "url_manual": "https://www.screenscraper.fr/manual?id=1",
+        },
     )
     assert response.status_code == status.HTTP_200_OK
 
@@ -920,7 +937,7 @@ def test_naming_new_source_urls_releases_both_locks(
         rom.id,
         {
             "url_cover": "",
-            "url_manual": "https://ss.fr/manual?id=1",
+            "url_manual": "https://www.screenscraper.fr/manual?id=1",
             "locked_fields": ["url_cover", "url_manual"],
         },
     )
@@ -929,8 +946,8 @@ def test_naming_new_source_urls_releases_both_locks(
         f"/api/roms/{rom.id}",
         headers={"Authorization": f"Bearer {access_token}"},
         data={
-            "url_cover": "https://ss.fr/cover?id=2",
-            "url_manual": "https://ss.fr/manual?id=2",
+            "url_cover": "https://www.screenscraper.fr/cover?id=2",
+            "url_manual": "https://www.screenscraper.fr/manual?id=2",
         },
     )
     assert response.status_code == status.HTTP_200_OK

--- a/backend/tests/endpoints/test_streaming.py
+++ b/backend/tests/endpoints/test_streaming.py
@@ -36,6 +36,7 @@ from handler.database.base_handler import sync_session
 from handler.redis_handler import async_cache
 from handler.streaming import (
     access,
+    broker,
     commands,
     lifecycle,
     memory_cards,
@@ -97,6 +98,12 @@ def clear_streaming_sessions():
     """Streaming sessions live in Redis (fakeredis under pytest), start clean."""
     asyncio.run(async_cache.flushall())
     yield
+
+
+@pytest.fixture(autouse=True)
+def no_pull_backoff(monkeypatch):
+    """The pull tests assert on how many attempts happen, not on the wait."""
+    monkeypatch.setattr(broker, "PULL_RETRY_DELAY", 0)
 
 
 def _access_token(user: User):

--- a/backend/tests/handler/test_db_handler.py
+++ b/backend/tests/handler/test_db_handler.py
@@ -15,6 +15,7 @@ from handler.database import (
     db_state_handler,
     db_user_handler,
 )
+from handler.database.base_handler import sync_session
 from models.assets import Save, Screenshot, State
 from models.platform import Platform
 from models.rom import Rom, compute_name_sort_key
@@ -796,9 +797,10 @@ def test_bulk_mark_present_empty_list(platform: Platform):
 
 def test_bulk_mark_present_chunking(platform: Platform):
     """bulk_mark_present handles >1000 IDs via internal chunking."""
-    roms = []
-    for i in range(1050):
-        rom = db_rom_handler.add_rom(
+    # One transaction rather than a thousand round trips through add_rom: the
+    # chunking is what's under test, not the insert path.
+    with sync_session.begin() as s:
+        roms = [
             Rom(
                 platform_id=platform.id,
                 name=f"rom_{i}",
@@ -810,15 +812,17 @@ def test_bulk_mark_present_chunking(platform: Platform):
                 fs_path=f"{platform.slug}/roms",
                 missing_from_fs=True,
             )
-        )
-        roms.append(rom)
+            for i in range(1050)
+        ]
+        s.add_all(roms)
+        s.flush()
+        all_ids = [r.id for r in roms]
 
-    all_ids = [r.id for r in roms]
     db_rom_handler.bulk_mark_present(platform.id, all_ids)
 
     # Spot-check a few across chunk boundaries
     for idx in [0, 999, 1000, 1049]:
-        updated = db_rom_handler.get_rom(roms[idx].id)
+        updated = db_rom_handler.get_rom(all_ids[idx])
         assert updated is not None
         assert updated.missing_from_fs is False
 

--- a/backend/tests/handler/test_fastapi.py
+++ b/backend/tests/handler/test_fastapi.py
@@ -594,7 +594,7 @@ def _scraped_cover_rom(platform: Platform, **overrides) -> Rom:
         "tags": [],
         "ss_id": 321,
         "name": "Game",
-        "url_cover": "https://ss.fr/media?media=box-2D&id=old",
+        "url_cover": "https://www.screenscraper.fr/media?media=box-2D&id=old",
         "path_cover_s": "roms/1/1/cover/small.png",
         "path_cover_l": "roms/1/1/cover/big.png",
     }
@@ -602,7 +602,7 @@ def _scraped_cover_rom(platform: Platform, **overrides) -> Rom:
     return db_rom_handler.add_rom(Rom(**attrs))
 
 
-NEW_COVER_URL = "https://ss.fr/media?media=box-2D&id=new"
+NEW_COVER_URL = "https://www.screenscraper.fr/media?media=box-2D&id=new"
 
 
 def _ss_returns_new_cover(mock_ss_get_by_id: AsyncMock) -> None:
@@ -693,19 +693,19 @@ async def test_update_scan_replaces_screenshot_urls(
     mock_ss_get_by_id.return_value = SSRom(
         ss_id=321,
         name="Game",
-        url_screenshots=["https://ss.fr/ss?id=new"],
+        url_screenshots=["https://www.screenscraper.fr/ss?id=new"],
     )
 
     platform = _ss_quota_platform()
     rom = _scraped_cover_rom(
         platform,
-        url_screenshots=["https://ss.fr/ss?id=old"],
+        url_screenshots=["https://www.screenscraper.fr/ss?id=old"],
         path_screenshots=["roms/1/1/screenshots/0.png"],
     )
 
     result = await _update_scan(platform, rom)
 
-    assert result.url_screenshots == ["https://ss.fr/ss?id=new"]
+    assert result.url_screenshots == ["https://www.screenscraper.fr/ss?id=new"]
 
 
 @patch.object(meta_playmatch_handler, "is_enabled", return_value=False)
@@ -720,7 +720,7 @@ async def test_update_scan_keeps_name_summary_and_manual(
         ss_id=321,
         name="Provider Name",
         summary="Provider summary",
-        url_manual="https://ss.fr/manual?id=new",
+        url_manual="https://www.screenscraper.fr/manual?id=new",
     )
 
     platform = _ss_quota_platform()
@@ -728,7 +728,7 @@ async def test_update_scan_keeps_name_summary_and_manual(
         platform,
         name="My Title",
         summary="My summary",
-        url_manual="https://ss.fr/manual?id=old",
+        url_manual="https://www.screenscraper.fr/manual?id=old",
         path_manual="roms/1/1/manual/1.pdf",
     )
 
@@ -736,7 +736,7 @@ async def test_update_scan_keeps_name_summary_and_manual(
 
     assert result.name == "My Title"
     assert result.summary == "My summary"
-    assert result.url_manual == "https://ss.fr/manual?id=old"
+    assert result.url_manual == "https://www.screenscraper.fr/manual?id=old"
 
 
 @patch.object(meta_playmatch_handler, "is_enabled", return_value=False)


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**

The pytest job went from ~5 minutes to ~21. It regressed with #4314, and the cause isn't the amount of work: it's that the suite makes **real outbound TCP connections** and waits for them to time out.

Nineteen tests in `test_streaming.py` take **60-66s each on a runner**. They point at a fake broker on `192.168.1.10:8000` without mocking the transport. A workstation answers "network unreachable" immediately; a GitHub runner silently drops the packets, so each test burns the full socket deadline (`TRANSFER_TIMEOUT = 60`, `SWAP_DISC_TIMEOUT = 120`). Confirmed with a socket probe:

```
SOCKET connect ('192.168.1.10', 8000) took 4.005s timeout=5.0
  -> broker stop failed, <urlopen error [Errno 51] Network is unreachable>
SOCKET connect ('192.168.1.10', 8000) took 4.020s timeout=60.0
  -> broker save-file GET failed, <urlopen error [Errno 51] Network is unreachable>
```

`test_saving_without_changing_urls_keeps_locks` (120.8s) is the same shape: `get_manual` isn't mocked, so CI fetches `https://ss.fr/manual?id=1` live.

Reconstructing per-test durations from the `-vv` timestamps in the CI log:

| file | total | n | avg |
| --- | --- | --- | --- |
| `tests/endpoints/test_streaming.py` | 1250.8s | 325 | 3.85s |
| `tests/endpoints/roms/test_rom.py` | 187.1s | 82 | 2.28s |
| everything else | ~560s | 3572 | - |

And the job hangs off a single worker: gw1 ran 638 tests over **1236s** while gw0, gw2 and gw3 all finished in ~4 minutes and idled for seventeen.

**Changes**

- `tests/conftest.py`: refuse socket connections outside loopback. A missed mock now fails instantly with the same `OSError` the calling code already handles, instead of waiting out a CI timeout. It also stops CI making live third-party requests.
- `tests/conftest.py`: memoize the fixture password hashes. bcrypt costs ~0.26s a call and `--setup-plan` counts 1670 of them per run (~430s of CPU) for three constant passwords.
- `tests/endpoints/test_streaming.py`: autouse fixture zeroing `broker.PULL_RETRY_DELAY`. The save-pull tests assert on attempt count, not on the wait, and were sleeping 4 x 3s for real.
- `tests/handler/test_db_handler.py`: insert the 1050 rows of the chunking test in one transaction rather than 1050 `add_rom` round trips (20.6s -> 1.4s).

**Result**

Reproducing the CI invocation locally (`-n 4`, coverage, `HYPOTHESIS_PROFILE=ci`):

| | before | after |
| --- | --- | --- |
| wall clock | 264.6s | **61.8s** |
| slowest test | 120s on CI / 12s locally | 2.6s |

`3977 passed, 3 skipped` on both runs, unchanged. The duration curve is flat now, with no test over 2.6s.

Not changed: `--dist load` in `pytest.yml`. The three-idle-workers imbalance was a symptom of the one slow file rather than a scheduling bug, so it should resolve on its own. If you want insurance against a future slow file gating the job, `--dist worksteal` is a one-word change.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes <sup>(n/a, this is a test-only change)</sup>

<sub>This PR was written with AI assistance (Claude Code): the investigation, the CI-log duration analysis, the changes and the local benchmarking were all done by the agent, reviewed by me.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

