### PR TITLE
fix(auth): require platforms.write and enforce platform visibility on the export endpoints

### DIFF
--- a/backend/endpoints/export.py
+++ b/backend/endpoints/export.py
@@ -18,7 +18,7 @@ router = APIRouter(
 )
 
 
-@protected_route(router.post, "/gamelist-xml", [Scope.ROMS_READ])
+@protected_route(router.post, "/gamelist-xml", [Scope.PLATFORMS_WRITE])
 async def export_gamelist_xml(
     request: Request,
     platform_ids: Annotated[
@@ -71,7 +71,7 @@ async def export_gamelist_xml(
         ) from e
 
 
-@protected_route(router.post, "/pegasus", [Scope.ROMS_READ])
+@protected_route(router.post, "/pegasus", [Scope.PLATFORMS_WRITE])
 async def export_pegasus(
     request: Request,
     platform_ids: Annotated[

--- a/backend/endpoints/export.py
+++ b/backend/endpoints/export.py
@@ -4,7 +4,10 @@ from fastapi import HTTPException, Query, Request, status
 from fastapi.responses import Response
 
 from decorators.auth import protected_route
+from exceptions.endpoint_exceptions import PlatformNotFoundInDatabaseException
 from handler.auth.constants import Scope
+from handler.auth.dependencies import assert_platform_visible
+from handler.database import db_platform_handler
 from logger.formatter import BLUE
 from logger.formatter import highlight as hl
 from logger.logger import log
@@ -16,6 +19,19 @@ router = APIRouter(
     prefix="/export",
     tags=["export"],
 )
+
+
+def _assert_platforms_exportable(request: Request, platform_ids: List[int]) -> None:
+    """Reject the whole request before anything is written to disk.
+
+    A platform hidden from the caller 404s exactly like a missing one, so the
+    response never reveals that the platform exists.
+    """
+    for platform_id in platform_ids:
+        platform = db_platform_handler.get_platform(platform_id)
+        if not platform:
+            raise PlatformNotFoundInDatabaseException(platform_id)
+        assert_platform_visible(request, platform)
 
 
 @protected_route(router.post, "/gamelist-xml", [Scope.PLATFORMS_WRITE])
@@ -34,6 +50,8 @@ async def export_gamelist_xml(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="At least one platform ID must be provided",
         )
+
+    _assert_platforms_exportable(request, platform_ids)
 
     try:
         exporter = GamelistExporter(local_export=local_export)
@@ -87,6 +105,8 @@ async def export_pegasus(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="At least one platform ID must be provided",
         )
+
+    _assert_platforms_exportable(request, platform_ids)
 
     try:
         exporter = PegasusExporter(local_export=local_export)

--- a/backend/tests/endpoints/test_export.py
+++ b/backend/tests/endpoints/test_export.py
@@ -1,0 +1,47 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import status
+
+from utils.gamelist_exporter import GamelistExporter
+from utils.pegasus_exporter import PegasusExporter
+
+EXPORTERS = {
+    "/api/export/gamelist-xml": GamelistExporter,
+    "/api/export/pegasus": PegasusExporter,
+}
+
+with_endpoint = pytest.mark.parametrize("path", list(EXPORTERS))
+
+
+@with_endpoint
+def test_export_rejects_viewer(client, viewer_access_token: str, path: str):
+    # Both endpoints write into the library, so reading ROMs is not enough.
+    response = client.post(
+        f"{path}?platform_ids=1",
+        headers={"Authorization": f"Bearer {viewer_access_token}"},
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@with_endpoint
+def test_export_rejects_anonymous(client, path: str):
+    response = client.post(f"{path}?platform_ids=1")
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@with_endpoint
+def test_export_allows_editor(client, editor_access_token: str, path: str):
+    with patch.object(
+        EXPORTERS[path],
+        "export_platform_to_file",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as export_mock:
+        response = client.post(
+            f"{path}?platform_ids=1",
+            headers={"Authorization": f"Bearer {editor_access_token}"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    export_mock.assert_awaited_once()

--- a/backend/tests/endpoints/test_export.py
+++ b/backend/tests/endpoints/test_export.py
@@ -15,23 +15,23 @@ with_endpoint = pytest.mark.parametrize("path", list(EXPORTERS))
 
 
 @with_endpoint
-def test_export_rejects_viewer(client, viewer_access_token: str, path: str):
+def test_export_rejects_viewer(client, viewer_access_token: str, platform, path: str):
     # Both endpoints write into the library, so reading ROMs is not enough.
     response = client.post(
-        f"{path}?platform_ids=1",
+        f"{path}?platform_ids={platform.id}",
         headers={"Authorization": f"Bearer {viewer_access_token}"},
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @with_endpoint
-def test_export_rejects_anonymous(client, path: str):
-    response = client.post(f"{path}?platform_ids=1")
+def test_export_rejects_anonymous(client, platform, path: str):
+    response = client.post(f"{path}?platform_ids={platform.id}")
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 @with_endpoint
-def test_export_allows_editor(client, editor_access_token: str, path: str):
+def test_export_allows_editor(client, editor_access_token: str, platform, path: str):
     with patch.object(
         EXPORTERS[path],
         "export_platform_to_file",
@@ -39,9 +39,42 @@ def test_export_allows_editor(client, editor_access_token: str, path: str):
         return_value=True,
     ) as export_mock:
         response = client.post(
-            f"{path}?platform_ids=1",
+            f"{path}?platform_ids={platform.id}",
             headers={"Authorization": f"Bearer {editor_access_token}"},
         )
 
     assert response.status_code == status.HTTP_200_OK
     export_mock.assert_awaited_once()
+
+
+@with_endpoint
+def test_export_unknown_platform_is_404(client, editor_access_token: str, path: str):
+    # Matches the 404 a hidden platform gets, so the response is not an oracle
+    # for whether the platform exists (see test_permissions_visibility).
+    with patch.object(
+        EXPORTERS[path], "export_platform_to_file", new_callable=AsyncMock
+    ) as export_mock:
+        response = client.post(
+            f"{path}?platform_ids=99999",
+            headers={"Authorization": f"Bearer {editor_access_token}"},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    export_mock.assert_not_awaited()
+
+
+@with_endpoint
+def test_export_rejects_batch_with_one_unknown_platform(
+    client, editor_access_token: str, platform, path: str
+):
+    # The whole request is refused up front, so a partial batch never writes.
+    with patch.object(
+        EXPORTERS[path], "export_platform_to_file", new_callable=AsyncMock
+    ) as export_mock:
+        response = client.post(
+            f"{path}?platform_ids={platform.id}&platform_ids=99999",
+            headers={"Authorization": f"Bearer {editor_access_token}"},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    export_mock.assert_not_awaited()

--- a/backend/tests/endpoints/test_permissions_visibility.py
+++ b/backend/tests/endpoints/test_permissions_visibility.py
@@ -26,6 +26,8 @@ from models.permission import (
     PermissionGroupGrant,
 )
 from models.rom import Rom, RomFile, RomFileCategory
+from utils.gamelist_exporter import GamelistExporter
+from utils.pegasus_exporter import PegasusExporter
 
 
 def _auth(user):
@@ -153,6 +155,29 @@ def test_physical_game_create_on_hidden_platform_is_404_masked(
     )
     assert resp.status_code == status.HTTP_404_NOT_FOUND
     assert db_rom_handler.get_roms_scalar(platform_ids=[platform.id]) == []
+
+
+@pytest.mark.parametrize(
+    ("path", "exporter"),
+    [
+        ("/api/export/gamelist-xml", GamelistExporter),
+        ("/api/export/pegasus", PegasusExporter),
+    ],
+)
+def test_export_of_hidden_platform_is_404_masked(
+    client, editor_user, platform, monkeypatch, path, exporter
+):
+    # Editor holds platforms write, so the coarse gate passes. The hide must
+    # mask the export before it reads or rewrites the platform's metadata file.
+    _hide(PermEntity.PLATFORMS, platform.id, editor_user.id)
+
+    async def _unreachable(*args, **kwargs):
+        raise AssertionError("exported a hidden platform")
+
+    monkeypatch.setattr(exporter, "export_platform_to_file", _unreachable)
+
+    resp = client.post(f"{path}?platform_ids={platform.id}", headers=_auth(editor_user))
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_hidden_rom_props_update_is_404_masked(client, viewer_user, rom):


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Two pre-existing authorization gaps on `POST /api/export/gamelist-xml` and `POST /api/export/pegasus`, found while security-auditing #4368. Both endpoints write into the library — `gamelist.xml` / `metadata.pegasus.txt` in the platform directory, plus media copied into the per-type folders — and since #4368 they also **merge** the file already on disk rather than rebuilding it, so they read user-authored content off the library and write it back.

**1. The routes were gated on `roms.read`.** Any Viewer, or any client token holding only `roms.read`, could trigger a library write. Both move to `Scope.PLATFORMS_WRITE` — the scope that already gates the sibling library-configuration writes in `endpoints/configs.py` (platform bindings, versions, exclusions, and the `PUT /config/scan` that toggles the `scan.gamelist.export` / `scan.pegasus.export` auto-export these endpoints mirror). It lives in `EDIT_SCOPES`, so Editor and Admin keep access and Viewer loses it.

**2. Neither route applied platform visibility.** Caller-supplied `platform_ids` went straight to the exporter, so a caller could export a platform hidden from them. Both now resolve every id and run `assert_platform_visible` before any exporter is constructed, the way `update_platform` / `delete_platform` already do. Checking up front rather than inside the loop means a rejected request writes nothing instead of failing part way through a batch, and a platform that does not exist 404s like a hidden one so the response is not an oracle for whether it exists.

**Breaking change (API only):** callers driving exports with a Viewer account or a `roms.read`-scoped client token now get a 403 and need `platforms.write`; an unknown platform id now returns 404 rather than 500. No UI is affected — `exportGamelistXml` / `exportPegasus` exist in `frontend/src/services/api/export.ts` but no component calls them, and the generated frontend types carry no paths or scopes, so no `npm run generate` is needed. The scan-time export path in `endpoints/sockets/scan.py` is internal and unaffected.

**AI disclosure:** this PR was written by Claude Code (Opus 5), including the tests; both findings came out of a Claude Code security audit of #4368. The author reviewed and directed the changes.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

New `backend/tests/endpoints/test_export.py` covers both endpoints against viewer (403), anonymous (401), editor (200), unknown platform (404), and a mixed batch where one id is unknown (404, nothing written). `test_export_of_hidden_platform_is_404_masked` in `test_permissions_visibility.py` hides a platform from an editor and asserts the exporter is never reached. The gates are pinned, not just exercised: neutering either check fails the corresponding tests.

`uv run pytest tests/endpoints/test_export.py tests/endpoints/test_permissions_visibility.py tests/endpoints/test_permissions_admin.py tests/endpoints/test_platform.py` → 63 passed on MariaDB. `trunk fmt && trunk check` clean on the changed files.

#### Screenshots (if applicable)

n/a — backend only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
