### PR TITLE
test(streaming): refuse broker connections instead of waiting out timeouts

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -88,4 +88,4 @@ jobs:
         run: |
           cd backend
           # GitHub-hosted Linux runners have 4 vCPUs; run one worker per core.
-          uv run pytest -n 4 -vv --maxfail=10 --junitxml=pytest-report.xml --cov --cov-report xml:coverage.xml --cov-config=.coveragerc .
+          uv run pytest -n 4 -vv --maxfail=10 --durations=25 --junitxml=pytest-report.xml --cov --cov-report xml:coverage.xml --cov-config=.coveragerc .

--- a/backend/tests/endpoints/test_streaming.py
+++ b/backend/tests/endpoints/test_streaming.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 import time
+import urllib.error
 import zipfile
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -97,6 +98,23 @@ def clear_streaming_sessions():
     """Streaming sessions live in Redis (fakeredis under pytest), start clean."""
     asyncio.run(async_cache.flushall())
     yield
+
+
+@pytest.fixture(autouse=True)
+def unreachable_broker():
+    """Refuse every broker connection at once instead of after the socket timeout.
+
+    The fixture containers point at a host nothing answers, so an unpatched
+    call would otherwise block for its full timeout (60s for a save pull, and
+    the detached teardown tasks hold the client's shutdown for that long).
+    Tests that need a broker reply patch urlopen themselves; inner patches win.
+    """
+    refused = urllib.error.URLError(ConnectionRefusedError("broker unreachable"))
+    with (
+        patch("handler.streaming.broker.urllib.request.urlopen", side_effect=refused),
+        patch("handler.streaming.broker.PULL_RETRY_DELAY", 0),
+    ):
+        yield
 
 
 def _access_token(user: User):

--- a/backend/tests/handler/test_db_handler.py
+++ b/backend/tests/handler/test_db_handler.py
@@ -15,6 +15,7 @@ from handler.database import (
     db_state_handler,
     db_user_handler,
 )
+from handler.database.base_handler import sync_session
 from models.assets import Save, Screenshot, State
 from models.platform import Platform
 from models.rom import Rom, compute_name_sort_key
@@ -796,29 +797,31 @@ def test_bulk_mark_present_empty_list(platform: Platform):
 
 def test_bulk_mark_present_chunking(platform: Platform):
     """bulk_mark_present handles >1000 IDs via internal chunking."""
-    roms = []
-    for i in range(1050):
-        rom = db_rom_handler.add_rom(
-            Rom(
-                platform_id=platform.id,
-                name=f"rom_{i}",
-                slug=f"rom-{i}",
-                fs_name=f"rom_{i}.zip",
-                fs_name_no_tags=f"rom_{i}",
-                fs_name_no_ext=f"rom_{i}",
-                fs_extension="zip",
-                fs_path=f"{platform.slug}/roms",
-                missing_from_fs=True,
-            )
+    roms = [
+        Rom(
+            platform_id=platform.id,
+            name=f"rom_{i}",
+            slug=f"rom-{i}",
+            fs_name=f"rom_{i}.zip",
+            fs_name_no_tags=f"rom_{i}",
+            fs_name_no_ext=f"rom_{i}",
+            fs_extension="zip",
+            fs_path=f"{platform.slug}/roms",
+            missing_from_fs=True,
         )
-        roms.append(rom)
+        for i in range(1050)
+    ]
+    # One transaction for the seed rows; a commit per ROM takes tens of seconds.
+    with sync_session.begin() as s:
+        s.add_all(roms)
+        s.flush()
+        all_ids = [r.id for r in roms]
 
-    all_ids = [r.id for r in roms]
     db_rom_handler.bulk_mark_present(platform.id, all_ids)
 
     # Spot-check a few across chunk boundaries
     for idx in [0, 999, 1000, 1049]:
-        updated = db_rom_handler.get_rom(roms[idx].id)
+        updated = db_rom_handler.get_rom(all_ids[idx])
         assert updated is not None
         assert updated.missing_from_fs is False
 


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The pytest workflow went from about 4 minutes to about 20 after #4314 landed. Parsing the CI job log timestamps showed one module, `backend/tests/endpoints/test_streaming.py`, accounting for roughly 1,250s of worker time, with 18 tests each stalling for 60 to 65 seconds.

Root cause: the module points every fixture container at a broker host nothing answers (`192.168.1.10`). Any broker call a test left unpatched hung for its full socket timeout: 5s for the stop ack inside the test body, and 60s for the detached save pull that the release teardown spawns, which the `TestClient` shutdown then waited on in fixture teardown.

Changes:

- `test_streaming.py`: add an autouse fixture that makes `urllib.request.urlopen` raise a connection-refused `URLError` for the whole module and zeroes `PULL_RETRY_DELAY`. The unreachable-broker path is exercised exactly as before, just immediately. Tests that need a broker reply keep their own inner `urlopen` patches, which take precedence.
- `test_db_handler.py`: seed the 1,050 ROMs of the `bulk_mark_present` chunking test in one transaction instead of a commit per row (40s down to under 1s).
- `pytest.yml`: add `--durations=25` so the slowest tests show up in the CI log and a regression like this is visible.

Measured with `-n 4` against MariaDB: the streaming module runs in about 50s wall (no single test above 1s), and the whole suite in 3m23s, versus the roughly 20 minutes the CI job currently takes.

**AI assistance disclosure:** this PR was written primarily by Claude Code (investigation, code changes, and this description), with the author reviewing.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A
