### PR TITLE
fix(gallery): join roms_metadata before the grouped dedup window

### DIFF
--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -1411,6 +1411,25 @@ class DBRomsHandler(DBBaseHandler):
         if updated_after:
             query = query.filter(Rom.updated_at > updated_after)
 
+        # Only join the metadata table when a filter reads from it. The dedup
+        # subquery below is derived from `query`, so the join has to land before
+        # the filters, or that subquery inherits them without it.
+        needs_metadata_join = any(
+            [
+                genres,
+                franchises,
+                collections,
+                companies,
+                publishers,
+                developers,
+                age_ratings,
+                player_counts,
+            ]
+        )
+
+        if needs_metadata_join:
+            query = query.outerjoin(RomMetadata)
+
         # Apply metadata and rom-level filters efficiently
         # Moved before applying group_by_meta_id to avoid missing titles when
         # filters don't match the primary ROM version in a group but would match a different version instead.
@@ -1561,23 +1580,6 @@ class DBRomsHandler(DBBaseHandler):
                     )
                 )
             )
-
-        # Optimize JOINs - only join tables when needed
-        needs_metadata_join = any(
-            [
-                genres,
-                franchises,
-                collections,
-                companies,
-                publishers,
-                developers,
-                age_ratings,
-                player_counts,
-            ]
-        )
-
-        if needs_metadata_join:
-            query = query.outerjoin(RomMetadata)
 
         # The RomUser table is already joined if user_id is set
         if statuses and user_id:

--- a/backend/tests/handler/database/test_roms_metadata_filter_join.py
+++ b/backend/tests/handler/database/test_roms_metadata_filter_join.py
@@ -1,0 +1,91 @@
+"""Filtering on a `roms_metadata` field while grouping ROMs by title.
+
+The dedup window that grouping materializes is derived from the query the
+metadata filters were already applied to, so the join to `roms_metadata` has to
+be in place before them. Without it the window filters on a table it never
+joined: the database cross-joins `roms` against `roms_metadata` (a view over
+`roms`), the window ranks the whole library instead of the matching ROMs, and
+the version of a game that did match the filter drops out of the gallery.
+"""
+
+import warnings
+
+import pytest
+from sqlalchemy.dialects import mysql
+from sqlalchemy.exc import SAWarning
+from sqlalchemy.sql.compiler import FROM_LINTING
+
+from handler.database import db_rom_handler
+from models.platform import Platform
+from models.rom import Rom
+
+METADATA_FILTERS = [
+    {"genres": ["Shooter"]},
+    {"franchises": ["Metroid"]},
+    {"collections": ["Trilogy"]},
+    {"companies": ["Nintendo"]},
+    {"publishers": ["Nintendo"]},
+    {"developers": ["Retro Studios"]},
+    {"age_ratings": ["E"]},
+    {"player_counts": ["4"]},
+]
+
+
+def _make_rom(platform: Platform, fs_name: str, **fields) -> Rom:
+    rom = db_rom_handler.add_rom(
+        Rom(
+            platform_id=platform.id,
+            name=fs_name,
+            slug=fs_name,
+            fs_name=f"{fs_name}.zip",
+            fs_name_no_tags=fs_name,
+            fs_name_no_ext=fs_name,
+            fs_extension="zip",
+            fs_path=f"{platform.slug}/roms",
+        )
+    )
+    return db_rom_handler.update_rom(rom.id, fields)
+
+
+def _cartesian_warnings(statement) -> list[str]:
+    """Every cartesian-product lint the statement compiles with."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        statement.compile(dialect=mysql.dialect(), linting=FROM_LINTING)
+    return [
+        str(warning.message)
+        for warning in caught
+        if issubclass(warning.category, SAWarning)
+        and "cartesian product" in str(warning.message)
+    ]
+
+
+class TestGroupedMetadataFilterJoin:
+    @pytest.mark.parametrize("filters", METADATA_FILTERS, ids=lambda f: next(iter(f)))
+    def test_grouped_query_joins_what_it_filters_on(self, filters: dict):
+        query, _ = db_rom_handler.get_roms_query()
+        grouped = db_rom_handler.filter_roms(
+            query=query, group_by_meta_id=True, **filters
+        )
+
+        assert not _cartesian_warnings(grouped)
+
+    def test_group_keeps_the_version_that_matches_the_filter(self, platform: Platform):
+        # `fs_name_no_ext` breaks ties in the window, so the version that misses
+        # the filter is the one the window would rank first.
+        _make_rom(
+            platform,
+            "a_version",
+            igdb_id=1234,
+            igdb_metadata={"genres": ["Action"]},
+        )
+        _make_rom(
+            platform,
+            "b_version",
+            igdb_id=1234,
+            igdb_metadata={"genres": ["Shooter"]},
+        )
+
+        roms = db_rom_handler.get_roms_scalar(genres=["Shooter"], group_by_meta_id=True)
+
+        assert [rom.name for rom in roms] == ["b_version"]


### PR DESCRIPTION
**Description**

Fixes #4389.

The metadata-backed gallery filters (`genres`, `franchises`, `collections`, `companies`, `publishers`, `developers`, `age_ratings`, `player_counts`) all filter on `roms_metadata`, but `filter_roms` only joined that table at the very end of the function. The "Group ROMs" block sits in between, and it derives its dedup window from the query:

```python
base_subquery = query.order_by(None).with_only_columns(Rom.id, ...)
```

That derived subquery inherits the metadata `WHERE` clause but not the join added after it, so the database cross-joins `roms` against `roms_metadata` (itself a view over `roms`). SQLAlchemy reports it as a cartesian product.

There are two consequences:

- **Cost.** The dedup window runs over `roms × roms_metadata`, and the gallery issues the grouped query up to four times per page load (page, count, char index, id index).
- **Wrong results.** Ranking over the cross join covers the whole library instead of the matching ROMs, so the window picks a group's primary version without regard to the filter. When that primary version does not match, the outer filter drops it and the sibling that *did* match was already excluded by the window, so the title disappears from the gallery entirely. That is precisely the case the comment above the filter loop says the ordering exists to avoid.

The fix moves the `needs_metadata_join` block above the filter loop, so both the outer query and the dedup subquery carry `LEFT OUTER JOIN roms_metadata ON roms.id = roms_metadata.rom_id`. No behaviour change for the filters themselves; the join gating is unchanged.

One note on the issue text: the isolated `FROM` element is `roms_metadata`, not `platforms`. `_filter_by_playable` is the only place the query reads `Platform` columns and it does join the table, so `platforms` shows up in the *connected* side of the warning. Sweeping the roms list endpoint over ~46 filter/grouping/sort combinations, and running `tests/endpoints`, `tests/handler`, `tests/models` and `tests/utils` with SAWarnings surfaced, this was the only cartesian product in the codebase.

**Testing**

New `backend/tests/handler/database/test_roms_metadata_filter_join.py`:

- one lint assertion per metadata filter, compiling the grouped query with `linting=FROM_LINTING` (the FROM linter is off for a plain `stmt.compile(dialect=...)`, which is why this never showed up in a test before);
- a behavioural test with two versions of one title, `a_version` (Action) and `b_version` (Shooter), filtered on `genres=["Shooter"]` with grouping on. It returns `[]` on `master` and `["b_version"]` with the fix.

All 9 tests fail without the change. `571 passed` across `tests/handler/database`, `tests/handler/test_db_handler.py` and `tests/endpoints/roms`. `trunk fmt && trunk check` clean. No schema or route change, so no OpenAPI regen, and no UI change.

**AI assistance disclosure**

Written with Claude Code (Opus 5). The model did the investigation, wrote the fix and the tests, and ran the verification above; I reviewed the result.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
