### PR TITLE
Quiet RQ's per-tick scheduler heartbeat log line

### DIFF
--- a/backend/handler/rq_worker.py
+++ b/backend/handler/rq_worker.py
@@ -1,14 +1,12 @@
 import logging
-from typing import Any
+from typing import Any, Final
 
 import rq.scheduler
 from rq import Worker
 
-# Lines RQ emits on every maintenance sweep or scheduler tick. The work itself
-# still runs (crash recovery for orphaned jobs, TTL reaping, stale worker
-# pruning, scheduler lock renewal); only the records are dropped so they do not
-# flood the logs, which at DEBUG means two heartbeat lines per second.
-_PERIODIC_NOISE = (
+# Fragments of the lines RQ logs on every tick. The maintenance sweep and the
+# scheduler heartbeat still run; only their log records are dropped.
+_PERIODIC_NOISE: Final[tuple[str, ...]] = (
     "cleaning registries for queue",
     "scheduler sending heartbeat to",
 )
@@ -33,6 +31,6 @@ class RomMWorker(Worker):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         _silence_periodic_noise(self.log)
-        # --with-scheduler forks a scheduler off this process, so the filter it
-        # inherits here is the only chance to configure that logger.
+        # --with-scheduler forks the scheduler off this process, so a filter
+        # added here is the only one that logger inherits.
         _silence_periodic_noise(logging.getLogger(rq.scheduler.__name__))

--- a/backend/handler/rq_worker.py
+++ b/backend/handler/rq_worker.py
@@ -1,25 +1,38 @@
 import logging
 from typing import Any
 
+import rq.scheduler
 from rq import Worker
 
+# Lines RQ emits on every maintenance sweep or scheduler tick. The work itself
+# still runs (crash recovery for orphaned jobs, TTL reaping, stale worker
+# pruning, scheduler lock renewal); only the records are dropped so they do not
+# flood the logs, which at DEBUG means two heartbeat lines per second.
+_PERIODIC_NOISE = (
+    "cleaning registries for queue",
+    "scheduler sending heartbeat to",
+)
 
-class _DropRegistryCleanupFilter(logging.Filter):
-    """Drops RQ's periodic "cleaning registries for queue" INFO line.
 
-    The maintenance sweep still runs (crash recovery for orphaned jobs, TTL
-    reaping, stale worker pruning); only its log record is suppressed so it
-    does not flood logs on every maintenance interval.
-    """
+class _DropPeriodicNoiseFilter(logging.Filter):
+    """Drops RQ's per-tick maintenance and scheduler-heartbeat log lines."""
 
     def filter(self, record: logging.LogRecord) -> bool:
-        return "cleaning registries for queue" not in record.getMessage().lower()
+        message = record.getMessage().lower()
+        return not any(fragment in message for fragment in _PERIODIC_NOISE)
+
+
+def _silence_periodic_noise(logger: logging.Logger) -> None:
+    if not any(isinstance(f, _DropPeriodicNoiseFilter) for f in logger.filters):
+        logger.addFilter(_DropPeriodicNoiseFilter())
 
 
 class RomMWorker(Worker):
-    """RQ worker that silences the noisy registry-cleanup log line."""
+    """RQ worker that silences RQ's noisy periodic log lines."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        if not any(isinstance(f, _DropRegistryCleanupFilter) for f in self.log.filters):
-            self.log.addFilter(_DropRegistryCleanupFilter())
+        _silence_periodic_noise(self.log)
+        # --with-scheduler forks a scheduler off this process, so the filter it
+        # inherits here is the only chance to configure that logger.
+        _silence_periodic_noise(logging.getLogger(rq.scheduler.__name__))

--- a/backend/tests/handler/test_rq_worker.py
+++ b/backend/tests/handler/test_rq_worker.py
@@ -1,0 +1,42 @@
+import logging
+
+import pytest
+import rq.scheduler
+
+from handler.rq_worker import _DropPeriodicNoiseFilter, _silence_periodic_noise
+
+
+def record(message: str, *args: object) -> logging.LogRecord:
+    return logging.LogRecord("rq", logging.DEBUG, "f", 1, message, args, None)
+
+
+@pytest.mark.parametrize(
+    "message,args",
+    [
+        ("Scheduler sending heartbeat to %s", ("low, default, high",)),
+        ("Cleaning registries for queue: %s", ("default",)),
+    ],
+)
+def test_drops_periodic_noise(message: str, args: tuple[object, ...]) -> None:
+    assert not _DropPeriodicNoiseFilter().filter(record(message, *args))
+
+
+@pytest.mark.parametrize(
+    "message,args",
+    [
+        ("Acquired scheduler lock for %s", ("default",)),
+        ("Scheduler for %s started with PID %s", ("default", 1)),
+        ("Scheduler lock for %s had expired; re-acquired", ("default",)),
+    ],
+)
+def test_keeps_everything_else(message: str, args: tuple[object, ...]) -> None:
+    assert _DropPeriodicNoiseFilter().filter(record(message, *args))
+
+
+def test_silencing_a_logger_is_idempotent() -> None:
+    log = logging.getLogger(f"{rq.scheduler.__name__}.test")
+
+    _silence_periodic_noise(log)
+    _silence_periodic_noise(log)
+
+    assert len(log.filters) == 1

--- a/backend/tests/handler/test_rq_worker.py
+++ b/backend/tests/handler/test_rq_worker.py
@@ -1,13 +1,29 @@
 import logging
+from collections.abc import Iterator
 
 import pytest
 import rq.scheduler
+from fakeredis import FakeRedis
 
-from handler.rq_worker import _DropPeriodicNoiseFilter, _silence_periodic_noise
+from handler.rq_worker import RomMWorker, _DropPeriodicNoiseFilter
+
+scheduler_log = logging.getLogger(rq.scheduler.__name__)
+
+
+@pytest.fixture(autouse=True)
+def restore_scheduler_log_filters() -> Iterator[None]:
+    """The scheduler logger is global, so a worker built here would leak into other tests."""
+    original = list(scheduler_log.filters)
+    yield
+    scheduler_log.filters = original
 
 
 def record(message: str, *args: object) -> logging.LogRecord:
     return logging.LogRecord("rq", logging.DEBUG, "f", 1, message, args, None)
+
+
+def installed_filters(logger: logging.Logger) -> list[_DropPeriodicNoiseFilter]:
+    return [f for f in logger.filters if isinstance(f, _DropPeriodicNoiseFilter)]
 
 
 @pytest.mark.parametrize(
@@ -33,10 +49,16 @@ def test_keeps_everything_else(message: str, args: tuple[object, ...]) -> None:
     assert _DropPeriodicNoiseFilter().filter(record(message, *args))
 
 
-def test_silencing_a_logger_is_idempotent() -> None:
-    log = logging.getLogger(f"{rq.scheduler.__name__}.test")
+def test_worker_silences_its_own_and_the_scheduler_logger() -> None:
+    worker = RomMWorker(["default"], connection=FakeRedis(version=7))
 
-    _silence_periodic_noise(log)
-    _silence_periodic_noise(log)
+    assert installed_filters(worker.log)
+    assert installed_filters(scheduler_log)
 
-    assert len(log.filters) == 1
+
+def test_a_second_worker_does_not_stack_another_filter() -> None:
+    connection = FakeRedis(version=7)
+    RomMWorker(["default"], connection=connection)
+    RomMWorker(["scans"], connection=connection)
+
+    assert len(installed_filters(scheduler_log)) == 1


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Every RQ worker we start with `--with-scheduler` forks a scheduler process, and that scheduler logs `Scheduler sending heartbeat to <queues>` on each of its 1-second ticks. With `LOGLEVEL=DEBUG` that means two lines per second (one from the `high default low` worker, one from the `scans` worker), which drowns out everything else in the log:

```text
20:42:08 Scheduler sending heartbeat to scans
20:42:08 Scheduler sending heartbeat to low, default, high
20:42:09 Scheduler sending heartbeat to scans
20:42:09 Scheduler sending heartbeat to low, default, high
```

`RomMWorker` already carried a filter to drop RQ's equally noisy "cleaning registries for queue" sweep line, so this generalizes that mechanism instead of adding a second one:

- `_DropRegistryCleanupFilter` becomes `_DropPeriodicNoiseFilter`, matching a `_PERIODIC_NOISE` tuple that now also covers the heartbeat line.
- The filter is installed on the `rq.scheduler` logger in `RomMWorker.__init__`, which runs before the worker forks the scheduler, so the child process inherits it.

Only the log records are dropped, never the work: the maintenance sweep and the scheduler's heartbeat/lock renewal still run, and the scheduler's other lines (lock acquired, "started with PID", expired-lock warnings) still show up.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Verified against a live Redis that a real `rq.scheduler` heartbeat record is filtered out while the other scheduler lines pass through, plus `backend/tests/handler/test_rq_worker.py` (6 tests) covering the dropped and kept lines and the idempotent install.

#### AI assistance

This PR was written with AI assistance (Claude Code): the diff, the tests and this description were AI-authored and reviewed by me before pushing.
