### PR TITLE
security: strip control characters from names reaching the mod_zip manifest

### DIFF
--- a/backend/tests/utils/test_filesystem.py
+++ b/backend/tests/utils/test_filesystem.py
@@ -15,7 +15,7 @@ from utils.filesystem import (
     sanitize_filename,
 )
 
-INVALID_AFTER_SANITIZE = set('\\/:|*?"<>+\0')
+INVALID_AFTER_SANITIZE = set('\\/:|*?"<>+') | {chr(c) for c in (*range(0x20), 0x7F)}
 
 
 class TestLinkOrCopyFile:
@@ -238,6 +238,28 @@ class TestSanitizeFilename:
 
     @pytest.mark.parametrize("name", ["", ".", "..", "../", "some/dir/"])
     def test_rejects_names_without_a_basename(self, name: str):
+        with pytest.raises(ValueError):
+            sanitize_filename(name)
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("save\n.sav", "save.sav"),
+            ("save\r\n.sav", "save.sav"),
+            ("save\t.sav", "save.sav"),
+            ("save\x7f.sav", "save.sav"),
+            ("save\0.sav", "save.sav"),
+            # A mod_zip manifest line forged through a rom folder rename: the
+            # payload needs a URI, whose slash takes the line feed with it.
+            ("game\n- 3 /decode?value=cG5n pwned", "decodevalue=cG5n pwned"),
+            ("game\n- 3 decode pwned", "game- 3 decode pwned"),
+        ],
+    )
+    def test_drops_control_characters(self, name: str, expected: str):
+        assert sanitize_filename(name) == expected
+
+    @pytest.mark.parametrize("name", ["\n", "\0", "\r\n\t"])
+    def test_rejects_names_made_only_of_control_characters(self, name: str):
         with pytest.raises(ValueError):
             sanitize_filename(name)
 

--- a/backend/tests/utils/test_nginx.py
+++ b/backend/tests/utils/test_nginx.py
@@ -1,0 +1,100 @@
+"""Tests for the nginx response helpers."""
+
+import pytest
+
+from utils.nginx import ZipContentLine, ZipResponse
+
+
+class TestZipContentLine:
+    """The manifest is line-oriented, so a line must render as exactly one record."""
+
+    def test_renders_the_mod_zip_field_order(self):
+        line = ZipContentLine(
+            crc32="deadbeef",
+            size_bytes=42,
+            encoded_location="/library/roms/gc/game/disc.iso",
+            filename="roms/gc/game/disc.iso",
+        )
+
+        assert (
+            str(line)
+            == "deadbeef 42 /library/roms/gc/game/disc.iso roms/gc/game/disc.iso"
+        )
+
+    def test_renders_a_missing_crc32_as_a_hyphen(self):
+        line = ZipContentLine(
+            crc32=None,
+            size_bytes=42,
+            encoded_location="/library/rom.iso",
+            filename="rom.iso",
+        )
+
+        assert str(line).startswith("- 42 ")
+
+    @pytest.mark.parametrize("control", ["\n", "\r", "\t", "\0", "\x7f"])
+    def test_replaces_control_characters_in_the_filename(self, control: str):
+        line = ZipContentLine(
+            crc32=None,
+            size_bytes=3,
+            encoded_location="/library/rom.iso",
+            filename=f"a{control}b",
+        )
+
+        assert line.filename == "a_b"
+        assert str(line).count("\n") == 0
+
+    def test_a_forged_filename_stays_one_record(self):
+        """A folder named on disk to look like a second manifest entry."""
+        line = ZipContentLine(
+            crc32=None,
+            size_bytes=8,
+            encoded_location="/library/roms/gc/game/disc.iso",
+            filename="roms/gc/a\n- 3 /decode?value=cG5n pwned/disc.iso",
+        )
+
+        assert "\n" not in str(line)
+
+    @pytest.mark.parametrize(
+        "location",
+        ["/library/a b.iso", "/library/a\nb.iso", "/decode?value=cG5n\x7f"],
+    )
+    def test_rejects_an_unencoded_location(self, location: str):
+        with pytest.raises(ValueError, match="URL-encoded"):
+            ZipContentLine(
+                crc32=None,
+                size_bytes=1,
+                encoded_location=location,
+                filename="rom.iso",
+            )
+
+    def test_accepts_the_m3u_decode_location(self):
+        line = ZipContentLine(
+            crc32="deadbeef",
+            size_bytes=4,
+            encoded_location="/decode?value=YS9iCg==",
+            filename="game.m3u",
+        )
+
+        assert line.encoded_location == "/decode?value=YS9iCg=="
+
+
+class TestZipResponse:
+    def test_body_holds_one_line_per_entry(self):
+        lines = [
+            ZipContentLine(
+                crc32=None,
+                size_bytes=3,
+                encoded_location=f"/library/rom{i}.iso",
+                filename=f"a\nrom{i}.iso",
+            )
+            for i in range(3)
+        ]
+
+        response = ZipResponse(content_lines=lines, filename="roms.zip")
+
+        assert len(response.body.decode().splitlines()) == 3
+        assert response.headers["x-archive-files"] == "zip"
+
+    def test_rejects_a_caller_supplied_body(self):
+        with pytest.raises(ValueError, match="must not be provided"):
+            ZipResponse(content_lines=[], filename="roms.zip", content="whatever")

--- a/backend/utils/filesystem.py
+++ b/backend/utils/filesystem.py
@@ -112,6 +112,11 @@ def link_or_copy_file(source: Path, dest: Path) -> None:
 INVALID_CHARS_HYPHENS = re.compile(r"[\\/:|]")
 INVALID_CHARS_EMPTY = re.compile(r'[*?"<>+]')
 
+# C0 controls plus DEL. Illegal on most filesystems, and a line feed in a name
+# that reaches a line-oriented protocol (the nginx mod_zip manifest) would split
+# the record it sits in.
+CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
 
 def sanitize_filename(filename: str) -> str:
     """
@@ -136,8 +141,8 @@ def sanitize_filename(filename: str) -> str:
     # Remove other invalid characters
     sanitized_filename = INVALID_CHARS_EMPTY.sub("", sanitized_filename)
 
-    # Ensure null bytes are not included (ZFS allows any characters except null bytes)
-    sanitized_filename = sanitized_filename.replace("\0", "")
+    # Drop control characters, null bytes included (ZFS allows every other character)
+    sanitized_filename = CONTROL_CHARS.sub("", sanitized_filename)
 
     # Remove leading/trailing whitespace
     sanitized_filename = sanitized_filename.strip()

--- a/backend/utils/nginx.py
+++ b/backend/utils/nginx.py
@@ -7,6 +7,8 @@ from urllib.parse import quote
 from anyio import Path
 from fastapi.responses import Response
 
+from utils.filesystem import CONTROL_CHARS
+
 
 @dataclasses.dataclass(frozen=True)
 class ZipContentLine:
@@ -20,6 +22,18 @@ class ZipContentLine:
     size_bytes: int
     encoded_location: str
     filename: str
+
+    def __post_init__(self) -> None:
+        """Keep the rendered line parseable as exactly one mod_zip record.
+
+        The manifest is line-oriented, so a line feed in a name taken off disk
+        would otherwise let that name forge an extra archive entry.
+        """
+        location = self.encoded_location
+        if " " in location or CONTROL_CHARS.search(location):
+            raise ValueError(f"mod_zip location must be URL-encoded, got {location!r}")
+
+        object.__setattr__(self, "filename", CONTROL_CHARS.sub("_", self.filename))
 
     def __str__(self) -> str:
         crc32 = self.crc32 or "-"


### PR DESCRIPTION
**Description**

Hardening from a security report about the nginx `mod_zip` manifest we emit for multi-file downloads. The reported exploit chain does not work on current `master` (`sanitize_filename` starts with `os.path.basename`, and a manifest record needs a URI whose slash takes the injected line feed with it), but the two underlying gaps it points at are real:

1. **`sanitize_filename` only removed null bytes**, so a rename could put any other control character into `fs_name` and from there into `rom_files.file_path`. A line feed with no following slash survived, which is enough to split a manifest record and make `mod_zip` abort the download. It now drops the whole C0 range plus DEL.

2. **`ZipContentLine` interpolated the entry name verbatim.** That name is a path (`full_path`), so it cannot go through `sanitize_filename`, and scanner-derived names never did. A directory named on disk to look like a second record would compose a well-formed injected line pointing at an internal nginx location (`/library/`, `/cache/`, `/decode`). The dataclass now scrubs control characters from the name and rejects a location that was not URL-encoded, so a rendered line is always exactly one record no matter what the caller passes.

Enforcement lives in `__post_init__` rather than as a second pass over the joined body, so all three call sites are covered and the guarantee cannot be bypassed by a future one.

Severity is low: reaching the manifest through path 2 needs write access to the library filesystem, at which point planting a malicious ROM directly is easier. Path 1 needs `roms.write` and only breaks downloads. Reported as CWE-74 arbitrary entry injection; it isn't that on any released version.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Tests: new `backend/tests/utils/test_nginx.py` (field order, control-character scrubbing, the forged-record regression, location rejection, one line per entry) and control-character cases added to `TestSanitizeFilename`. `tests/utils`, `tests/endpoints/roms`, `tests/handler/filesystem`, `tests/endpoints/test_saves.py`, `tests/endpoints/test_states.py` and `tests/utils/test_zip_cache.py` pass; `trunk fmt && trunk check` clean.

AI assistance: written with Claude Code (Claude Opus 5). The model validated the report against the source, wrote both fixes and all tests, and ran the suites; a human reviewed the diff and the severity assessment before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
