### PR TITLE
fix(docker): bump sigil past the zstd asm link failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,7 +129,7 @@ ENV PATH="/app/.venv/bin:${PATH}"
 # Build and install sigil (optional, for title ID extraction)
 # Placed after `uv sync` because the extension is compiled with the venv's
 # Python so the ABI matches. Keep the pin in sync with docker/Dockerfile.
-ARG SIGIL_VERSION=9665f03c04d0f547ed38dd5e5e31916c1da5f2e9
+ARG SIGIL_VERSION=4b0f138fef12caf0b2ceb85e034cd5a3ba18a653
 # One layer, so the clone and the cmake tree never reach the image.
 # trunk-ignore(hadolint/DL3003)
 RUN git clone --filter=blob:none https://github.com/rommforge/argosy-sigil.git /tmp/argosy-sigil \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -118,7 +118,7 @@ RUN apk add --no-cache \
     musl-dev
 
 # Keep this pin in sync with the dev image's SIGIL_VERSION in ../Dockerfile.
-ARG SIGIL_VERSION=9665f03c04d0f547ed38dd5e5e31916c1da5f2e9
+ARG SIGIL_VERSION=4b0f138fef12caf0b2ceb85e034cd5a3ba18a653
 
 RUN git clone --filter=blob:none https://github.com/rommforge/argosy-sigil.git && \
     cd ./argosy-sigil && \


### PR DESCRIPTION
**Description**

The pinned sigil revision globs zstd's decompress sources as C only, so `huf_decompress_amd64.S` is never assembled while `huf_decompress.c` still calls into it. Building the cffi bindings fails at the shared-object link:

> undefined reference to `HUF_decompress4X2_usingDTable_internal_fast_asm_loop' relocation R_X86_64_PC32 against undefined hidden symbol ... can not be used when making a shared object

This breaks `docker compose build` for anyone using the dev image. Normal CI does not catch it, since the image build only runs on workflow_dispatch or the `build-preview` label.

argosy-sigil fixed this on main by selecting zstd's C fallback with `ZSTD_DISABLE_ASM`. This bumps the pin to pick it up.

Verified on linux/amd64 against 4b0f138: reproduced the failure at the old pin, then confirmed the cmake build, the shared-object link, the cffi binding build under Python 3.14, and importing the module. `sigil.extract` keeps the signature `adapters/services/sigil.py` calls.

**AI assistance disclosure:** diagnosed and prepared with Claude Code (Anthropic), reviewed by me.

**Checklist**

- [x] I've tested the changes locally
- [ ] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes