### PR TITLE
fix(firmware): 404 the content endpoints when the file is gone

### DIFF
--- a/backend/endpoints/firmware.py
+++ b/backend/endpoints/firmware.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Annotated
 
 from fastapi import Body, File, HTTPException, Query, Request, UploadFile, status
@@ -196,6 +197,36 @@ def get_firmware(request: Request, id: int) -> FirmwareSchema:
     return FirmwareSchema.model_validate(firmware)
 
 
+def _resolve_firmware_content(request: Request, id: int) -> tuple[Firmware, Path]:
+    """Resolve a firmware row and the readable file backing it.
+
+    Args:
+        request (Request): Fastapi Request object
+        id (int): Firmware internal id
+
+    Returns:
+        tuple[Firmware, Path]: The firmware row and its absolute path on disk
+    """
+
+    firmware = db_firmware_handler.get_firmware(id)
+    if not firmware:
+        error = f"Firmware with ID {id} not found"
+        log.error(error)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=error)
+
+    assert_firmware_visible(request, firmware)
+
+    firmware_path = fs_firmware_handler.validate_path(firmware.full_path)
+    # A row can outlive its file: the scan marks it missing, or it was moved
+    # away without one. Either way FileResponse would raise a 500.
+    if firmware.missing_from_fs or not firmware_path.is_file():
+        error = f"Firmware file '{firmware.file_name}' is missing from filesystem"
+        log.error(error)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=error)
+
+    return firmware, firmware_path
+
+
 @protected_route(
     router.head,
     "/{id}/content/{file_name}",
@@ -213,15 +244,7 @@ def head_firmware_content(request: Request, id: int, file_name: str):
         FileResponse: Returns the response with headers
     """
 
-    firmware = db_firmware_handler.get_firmware(id)
-    if not firmware:
-        error = f"Firmware with ID {id} not found"
-        log.error(error)
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=error)
-
-    assert_firmware_visible(request, firmware)
-
-    firmware_path = fs_firmware_handler.validate_path(firmware.full_path)
+    firmware, firmware_path = _resolve_firmware_content(request, id)
 
     return FileResponse(
         path=firmware_path,
@@ -253,15 +276,7 @@ def get_firmware_content(
         FileResponse: Returns the firmware file
     """
 
-    firmware = db_firmware_handler.get_firmware(id)
-    if not firmware:
-        error = f"Firmware with ID {id} not found"
-        log.error(error)
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=error)
-
-    assert_firmware_visible(request, firmware)
-
-    firmware_path = fs_firmware_handler.validate_path(firmware.full_path)
+    firmware, firmware_path = _resolve_firmware_content(request, id)
 
     return FileResponse(path=firmware_path, filename=firmware.file_name)
 

--- a/backend/tests/endpoints/test_firmware.py
+++ b/backend/tests/endpoints/test_firmware.py
@@ -1,5 +1,7 @@
 """Tests for `GET /api/firmware`."""
 
+from unittest import mock
+
 from fastapi import status
 
 
@@ -70,3 +72,62 @@ def test_get_firmware_missing_filter_stacks_with_platform_id(
     )
     assert response.status_code == status.HTTP_200_OK
     assert [f["file_name"] for f in response.json()] == ["gone.bin"]
+
+
+@mock.patch("endpoints.firmware.fs_firmware_handler.validate_path")
+def test_get_firmware_content_serves_the_file(
+    mock_validate_path, client, access_token, firmware, tmp_path
+):
+    bios = tmp_path / "present.bin"
+    bios.write_bytes(b"BIOS")
+    mock_validate_path.return_value = bios
+
+    response = client.get(
+        f"/api/firmware/{firmware.id}/content/present.bin",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.content == b"BIOS"
+
+
+@mock.patch("endpoints.firmware.fs_firmware_handler.validate_path")
+def test_get_firmware_content_404s_when_the_file_is_gone(
+    mock_validate_path, client, access_token, firmware, tmp_path
+):
+    """A row outliving its file used to reach FileResponse, which raises."""
+    mock_validate_path.return_value = tmp_path / "not-there.bin"
+
+    response = client.get(
+        f"/api/firmware/{firmware.id}/content/present.bin",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert "missing from filesystem" in response.json()["detail"]
+
+
+@mock.patch("endpoints.firmware.fs_firmware_handler.validate_path")
+def test_get_firmware_content_404s_when_flagged_missing(
+    mock_validate_path, client, access_token, missing_firmware, tmp_path
+):
+    bios = tmp_path / "gone.bin"
+    bios.write_bytes(b"BIOS")
+    mock_validate_path.return_value = bios
+
+    response = client.get(
+        f"/api/firmware/{missing_firmware.id}/content/gone.bin",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@mock.patch("endpoints.firmware.fs_firmware_handler.validate_path")
+def test_head_firmware_content_404s_when_the_file_is_gone(
+    mock_validate_path, client, access_token, firmware, tmp_path
+):
+    mock_validate_path.return_value = tmp_path / "not-there.bin"
+
+    response = client.head(
+        f"/api/firmware/{firmware.id}/content/present.bin",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
**AI assistance disclosure**

This PR (code, tests and description) was written by Claude Code under my direction, and I reviewed it before opening.

**Description**

`GET`/`HEAD /api/firmware/{id}/content/{file_name}` answered **500** for a firmware row whose file is no longer on disk. `validate_path()` checks traversal, not existence, so the path went straight to `FileResponse`, and Starlette's own `RuntimeError: File at path ... does not exist.` escaped unhandled. A row whose *id* is unknown already got the intended 404; a row whose *file* is gone did not.

Both content endpoints now resolve the firmware through one helper that 404s when the row is flagged `missing_from_fs` or the path is not a readable file, matching what `/api/roms/files/{id}/patch` already does for ROM files.

Fixes #4380

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Four endpoint tests, three of which fail on `master` (500 instead of 404) and pass here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
