### PR TITLE
fix(v2): read the webp flag the heartbeat actually sends

### DIFF
--- a/frontend/src/v2/components/Gallery/GameListRow.vue
+++ b/frontend/src/v2/components/Gallery/GameListRow.vue
@@ -31,6 +31,7 @@ import SiblingBadge from "@/v2/components/GameCard/SiblingBadge.vue";
 import { useBackgroundArt } from "@/v2/composables/useBackgroundArt";
 import { useGallerySelectionInput } from "@/v2/composables/useGallerySelectionInput";
 import { useViewTransition } from "@/v2/composables/useViewTransition";
+import { toWebpUrl } from "@/v2/composables/useWebpSupport";
 import storeGalleryRoms, { type SimpleRom } from "@/v2/stores/galleryRoms";
 import storeGallerySelection from "@/v2/stores/gallerySelection";
 import { activeProviders } from "@/v2/utils/metadataProviders";
@@ -92,8 +93,6 @@ const platformsStore = storePlatforms();
 const { morphTransition } = useViewTransition();
 const setBgArt = useBackgroundArt();
 const { locale } = useI18n();
-
-const EXTENSION_REGEX = /\.(png|jpg|jpeg)$/i;
 
 const columns = computed(() => getListColumns(props.showPlatformColumn));
 const listSkeletonColumns = columns;
@@ -228,11 +227,7 @@ function onRowHighlight() {
   const item = rom.value;
   if (!item) return;
   const path = item.path_cover_large ?? item.path_cover_small ?? null;
-  const coverUrl = path
-    ? props.webp
-      ? path.replace(EXTENSION_REGEX, ".webp")
-      : path
-    : null;
+  const coverUrl = path ? toWebpUrl(path, !!props.webp) : null;
   if (coverUrl) setBgArt(coverUrl);
   else if (item.url_cover) setBgArt(item.url_cover);
 }

--- a/frontend/src/v2/composables/useBoxFaces/index.ts
+++ b/frontend/src/v2/composables/useBoxFaces/index.ts
@@ -23,7 +23,7 @@ import {
 } from "vue";
 import type { SimpleRom } from "@/stores/roms";
 import { FRONTEND_RESOURCES_PATH } from "@/utils";
-import { useWebpSupport } from "@/v2/composables/useWebpSupport";
+import { toWebpUrl, useWebpSupport } from "@/v2/composables/useWebpSupport";
 
 /** The face-relevant slice of a rom — satisfied by both `SimpleRom` and
  *  `DetailedRom`. */
@@ -40,8 +40,6 @@ export interface BoxFaces {
   complete: boolean;
 }
 
-const RASTER_EXT = /\.(png|jpe?g)$/i;
-
 function resourceUrl(path: string | null | undefined): string | null {
   return path ? `${FRONTEND_RESOURCES_PATH}/${path}` : null;
 }
@@ -52,10 +50,7 @@ export function computeBoxFaces(
   supportsWebp: boolean,
 ): BoxFaces {
   const localCover = rom.path_cover_large ?? rom.path_cover_small ?? null;
-  const cover =
-    localCover && supportsWebp
-      ? localCover.replace(RASTER_EXT, ".webp")
-      : localCover;
+  const cover = localCover ? toWebpUrl(localCover, supportsWebp) : localCover;
 
   const front = resourceUrl(rom.ss_metadata?.box2d_path) ?? cover;
   const back = resourceUrl(rom.ss_metadata?.box2d_back_path);

--- a/frontend/src/v2/composables/useCoverArt/index.ts
+++ b/frontend/src/v2/composables/useCoverArt/index.ts
@@ -40,7 +40,7 @@ import {
   isCDBasedSystem,
   isArcadeSystem,
 } from "@/utils";
-import { useWebpSupport } from "@/v2/composables/useWebpSupport";
+import { toWebpUrl, useWebpSupport } from "@/v2/composables/useWebpSupport";
 
 export type BoxartStyle =
   | "cover_path"
@@ -84,8 +84,6 @@ export const COVER_RATIOS: Record<BoxartStyle, number> = {
   miximage_path: 1,
   miximage_v2_path: 1,
 };
-
-const RASTER_EXT = /\.(png|jpe?g)$/i;
 
 export function isBoxartStyle(value: unknown): value is BoxartStyle {
   return (
@@ -203,8 +201,7 @@ export function computeCoverArt(
     coverUrl = `${opts.resourcesPath}/${altPath}`;
   } else {
     const local = rom.path_cover_large ?? rom.path_cover_small ?? null;
-    coverUrl =
-      local && opts.supportsWebp ? local.replace(RASTER_EXT, ".webp") : local;
+    coverUrl = local ? toWebpUrl(local, opts.supportsWebp) : local;
   }
 
   const fallbackUrl = override != null ? null : (rom.url_cover ?? null);

--- a/frontend/src/v2/composables/useCoverArt/useCoverArt.test.ts
+++ b/frontend/src/v2/composables/useCoverArt/useCoverArt.test.ts
@@ -145,7 +145,7 @@ describe("computeCoverArt — cover_path", () => {
     expect(d.coverUrl).toBe("covers/large.webp");
   });
   it("rewrites a cover carrying the backend's cache-busting query", () => {
-    // The shape every rom actually arrives in — `?ts=<updated_at>`.
+    // The shape every rom actually arrives in: `?ts=<updated_at>`.
     const d = computeCoverArt(
       rom({ path_cover_large: "covers/large.png?ts=2026-09-09T00:00:00" }),
       "cover_path",

--- a/frontend/src/v2/composables/useCoverArt/useCoverArt.test.ts
+++ b/frontend/src/v2/composables/useCoverArt/useCoverArt.test.ts
@@ -144,6 +144,18 @@ describe("computeCoverArt — cover_path", () => {
     );
     expect(d.coverUrl).toBe("covers/large.webp");
   });
+  it("rewrites a cover carrying the backend's cache-busting query", () => {
+    // The shape every rom actually arrives in — `?ts=<updated_at>`.
+    const d = computeCoverArt(
+      rom({ path_cover_large: "covers/large.png?ts=2026-09-09T00:00:00" }),
+      "cover_path",
+      {
+        resourcesPath: RES,
+        supportsWebp: true,
+      },
+    );
+    expect(d.coverUrl).toBe("covers/large.webp?ts=2026-09-09T00:00:00");
+  });
   it("exposes url_cover as the fallback and flags no artwork when empty", () => {
     expect(
       computeCoverArt(rom({ url_cover: "https://x/c.png" }), "cover_path", {

--- a/frontend/src/v2/composables/useWebpSupport/index.ts
+++ b/frontend/src/v2/composables/useWebpSupport/index.ts
@@ -7,11 +7,22 @@
 //
 //   const { supportsWebp, toWebp } = useWebpSupport();
 //   <img :src="toWebp(rom.path_cover_large)" />
+//
+// Code without a component instance (a pure resolver, a store) reaches for
+// `toWebpUrl` and passes the flag in.
 import { storeToRefs } from "pinia";
 import { computed, type ComputedRef } from "vue";
 import storeHeartbeat from "@/stores/heartbeat";
 
-const RASTER_EXT = /\.(png|jpe?g)$/i;
+// The extension ends the *path*, not the URL: a cover arrives from the backend
+// as `.../cover/big.png?ts=<updated_at>`, so anchoring on the end of the string
+// would never match one.
+const RASTER_EXT = /\.(png|jpe?g)(?=$|[?#])/i;
+
+/** Point a cover URL at its converted sibling, when the server serves them. */
+export function toWebpUrl(url: string, supportsWebp: boolean): string {
+  return supportsWebp ? url.replace(RASTER_EXT, ".webp") : url;
+}
 
 export function useWebpSupport(): {
   supportsWebp: ComputedRef<boolean>;
@@ -26,7 +37,7 @@ export function useWebpSupport(): {
 
   function toWebp(url: string | null | undefined): string {
     if (!url) return "";
-    return supportsWebp.value ? url.replace(RASTER_EXT, ".webp") : url;
+    return toWebpUrl(url, supportsWebp.value);
   }
 
   return { supportsWebp, toWebp };

--- a/frontend/src/v2/composables/useWebpSupport/index.ts
+++ b/frontend/src/v2/composables/useWebpSupport/index.ts
@@ -1,9 +1,6 @@
 // useWebpSupport — single-source resolution of whether the backend serves
-// .webp covers for this server. The flag is exposed as
-// `FRONTEND.IMAGES_WEBP` on the heartbeat response, but `FrontendDict` in
-// the generated OpenAPI types currently omits it (backend debt — when the
-// schema is updated and regenerated, the cast below disappears and the
-// composable becomes a thin wrapper).
+// .webp covers for this server. The WebP conversion task is what writes the
+// `.webp` sibling next to every cover, so its heartbeat flag is the signal.
 //
 // Use this everywhere a feature needs to decide whether to rewrite cover
 // URLs `.png|.jpg|.jpeg` → `.webp`.
@@ -13,10 +10,6 @@
 import { storeToRefs } from "pinia";
 import { computed, type ComputedRef } from "vue";
 import storeHeartbeat from "@/stores/heartbeat";
-
-interface FrontendWithWebp {
-  FRONTEND?: { IMAGES_WEBP?: boolean };
-}
 
 const RASTER_EXT = /\.(png|jpe?g)$/i;
 
@@ -28,9 +21,7 @@ export function useWebpSupport(): {
   const { value } = storeToRefs(heartbeatStore);
 
   const supportsWebp = computed<boolean>(() =>
-    Boolean(
-      (value.value as unknown as FrontendWithWebp)?.FRONTEND?.IMAGES_WEBP,
-    ),
+    Boolean(value.value.TASKS?.ENABLE_SCHEDULED_CONVERT_IMAGES_TO_WEBP),
   );
 
   function toWebp(url: string | null | undefined): string {

--- a/frontend/src/v2/composables/useWebpSupport/useWebpSupport.test.ts
+++ b/frontend/src/v2/composables/useWebpSupport/useWebpSupport.test.ts
@@ -1,0 +1,47 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it } from "vitest";
+import storeHeartbeat from "@/stores/heartbeat";
+import { useWebpSupport } from ".";
+
+function setWebpTask(enabled: boolean) {
+  const heartbeat = storeHeartbeat();
+  heartbeat.value = {
+    ...heartbeat.value,
+    TASKS: {
+      ...heartbeat.value.TASKS,
+      ENABLE_SCHEDULED_CONVERT_IMAGES_TO_WEBP: enabled,
+    },
+  };
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe("useWebpSupport", () => {
+  it("is off until the heartbeat says the conversion task runs", () => {
+    const { supportsWebp, toWebp } = useWebpSupport();
+
+    expect(supportsWebp.value).toBe(false);
+    expect(toWebp("roms/1/2/cover/big.png")).toBe("roms/1/2/cover/big.png");
+  });
+
+  it("rewrites raster covers once the conversion task is enabled", () => {
+    const { supportsWebp, toWebp } = useWebpSupport();
+    setWebpTask(true);
+
+    expect(supportsWebp.value).toBe(true);
+    expect(toWebp("roms/1/2/cover/big.png")).toBe("roms/1/2/cover/big.webp");
+    expect(toWebp("roms/1/2/cover/small.JPEG")).toBe(
+      "roms/1/2/cover/small.webp",
+    );
+  });
+
+  it("leaves a cover that is already webp alone", () => {
+    const { toWebp } = useWebpSupport();
+    setWebpTask(true);
+
+    expect(toWebp("roms/1/2/cover/big.webp")).toBe("roms/1/2/cover/big.webp");
+    expect(toWebp(null)).toBe("");
+  });
+});

--- a/frontend/src/v2/composables/useWebpSupport/useWebpSupport.test.ts
+++ b/frontend/src/v2/composables/useWebpSupport/useWebpSupport.test.ts
@@ -1,7 +1,7 @@
 import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it } from "vitest";
 import storeHeartbeat from "@/stores/heartbeat";
-import { useWebpSupport } from ".";
+import { toWebpUrl, useWebpSupport } from ".";
 
 function setWebpTask(enabled: boolean) {
   const heartbeat = storeHeartbeat();
@@ -43,5 +43,31 @@ describe("useWebpSupport", () => {
 
     expect(toWebp("roms/1/2/cover/big.webp")).toBe("roms/1/2/cover/big.webp");
     expect(toWebp(null)).toBe("");
+  });
+});
+
+describe("toWebpUrl", () => {
+  // What the backend actually sends: `path_cover_large` and friends carry a
+  // `?ts=<updated_at>` cache-buster, so an end-anchored match never fires.
+  const COVER = "/assets/romm/resources/roms/1/2/cover/big.png?ts=2026-09-09";
+
+  it("rewrites the extension behind a cache-busting query", () => {
+    expect(toWebpUrl(COVER, true)).toBe(
+      "/assets/romm/resources/roms/1/2/cover/big.webp?ts=2026-09-09",
+    );
+  });
+
+  it("leaves the query itself alone", () => {
+    expect(toWebpUrl("cover/big.jpg?v=a.png", true)).toBe(
+      "cover/big.webp?v=a.png",
+    );
+  });
+
+  it("rewrites a bare path too", () => {
+    expect(toWebpUrl("cover/big.jpeg", true)).toBe("cover/big.webp");
+  });
+
+  it("passes the URL through when the server serves no webp", () => {
+    expect(toWebpUrl(COVER, false)).toBe(COVER);
   });
 });


### PR DESCRIPTION
**AI assistance disclosure**

This PR (code, tests and description) was written by Claude Code under my direction, and I reviewed it before opening.

**Description**

The v2 UI served the original PNG for every cover, even on instances where the WebP conversion task had already written the `.webp` sibling, while v1 on the same instance served the WebP.

`useWebpSupport` resolved the flag from `FRONTEND.IMAGES_WEBP` on the heartbeat. The backend has never emitted that key — `HeartbeatResponse.FRONTEND` carries `DISABLE_USERPASS_LOGIN`, `DISABLE_LOGS_VIEWER` and `YOUTUBE_BASE_URL` — so the cast fell through to `undefined` and `supportsWebp` was permanently `false`. Every consumer (`useCoverArt`, `useBoxFaces`, `toWebp` on Home, Activity, Collections, Scan, the game details tabs) therefore never rewrote the extension.

v1 reads `TASKS.ENABLE_SCHEDULED_CONVERT_IMAGES_TO_WEBP` (`Game/Card/Base.vue`, `Game/RAvatar.vue`, `Collection/Card.vue`, `Collection/RAvatar.vue`), which is the flag for the task that writes those files and is already in the generated `TasksDict`. v2 now reads the same one, which also drops the local `FrontendWithWebp` cast the composable's comment flagged as debt.

Fixes #4194

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

`npm run typecheck` clean; the 32 composable/GameCover suites pass alongside the three new `useWebpSupport` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
