### PR TITLE
fix(ra): return achievements in RetroAchievements' display order

### DIFF
--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -99,12 +99,8 @@ def compute_full_path_hash(fs_path: str | None, fs_name: str | None) -> str:
     ).hexdigest()
 
 
-def _ra_display_order(achievement: dict) -> tuple[int, int]:
-    """Sort key matching RetroAchievements' "Display Order", ties by id.
-
-    An achievement scanned before `display_order` was captured sinks to the
-    end rather than jumping to the front of the list.
-    """
+def _ra_achievement_sort_key(achievement: dict) -> tuple[int, int]:
+    """Orders achievements by RetroAchievements' "Display Order", ties by id."""
     order = achievement.get("display_order")
     ra_id = achievement.get("ra_id")
     return (
@@ -1080,19 +1076,19 @@ class Rom(BaseModel):
             # This ensures that badge paths remain relative for filesystem operations
             # while the frontend receives absolute paths
             metadata_copy = copy.deepcopy(self.ra_metadata)
-            for achievement in metadata_copy.get("achievements", []):
+            # The provider returns achievements keyed by id, so the stored order
+            # is arbitrary.
+            achievements = sorted(
+                metadata_copy.get("achievements", []), key=_ra_achievement_sort_key
+            )
+            for achievement in achievements:
                 achievement["badge_path_lock"] = (
                     f"{FRONTEND_RESOURCES_PATH}/{achievement['badge_path_lock']}"
                 )
                 achievement["badge_path"] = (
                     f"{FRONTEND_RESOURCES_PATH}/{achievement['badge_path']}"
                 )
-            # The provider returns achievements keyed by id, so the stored order
-            # is arbitrary. RetroAchievements' own "Display Order" is what a
-            # player follows while playing.
-            metadata_copy["achievements"] = sorted(
-                metadata_copy.get("achievements", []), key=_ra_display_order
-            )
+            metadata_copy["achievements"] = achievements
             return metadata_copy
         return self.ra_metadata
 

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -4,6 +4,7 @@ import copy
 import enum
 import hashlib
 import re
+import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
@@ -96,6 +97,20 @@ def compute_full_path_hash(fs_path: str | None, fs_name: str | None) -> str:
     return hashlib.sha256(
         f"{fs_path or ''}/{fs_name or ''}".encode(), usedforsecurity=False
     ).hexdigest()
+
+
+def _ra_display_order(achievement: dict) -> tuple[int, int]:
+    """Sort key matching RetroAchievements' "Display Order", ties by id.
+
+    An achievement scanned before `display_order` was captured sinks to the
+    end rather than jumping to the front of the list.
+    """
+    order = achievement.get("display_order")
+    ra_id = achievement.get("ra_id")
+    return (
+        order if isinstance(order, int) else sys.maxsize,
+        ra_id if isinstance(ra_id, int) else sys.maxsize,
+    )
 
 
 if TYPE_CHECKING:
@@ -1072,6 +1087,12 @@ class Rom(BaseModel):
                 achievement["badge_path"] = (
                     f"{FRONTEND_RESOURCES_PATH}/{achievement['badge_path']}"
                 )
+            # The provider returns achievements keyed by id, so the stored order
+            # is arbitrary. RetroAchievements' own "Display Order" is what a
+            # player follows while playing.
+            metadata_copy["achievements"] = sorted(
+                metadata_copy.get("achievements", []), key=_ra_display_order
+            )
             return metadata_copy
         return self.ra_metadata
 

--- a/backend/tests/models/test_rom.py
+++ b/backend/tests/models/test_rom.py
@@ -258,3 +258,62 @@ class TestFullPathHash:
         nested = Rom(fs_name="Game.zip", fs_path="nes/roms/Hacks")
 
         assert root.full_path_hash != nested.full_path_hash
+
+
+def _achievement(ra_id: int, display_order: int | None) -> dict:
+    return {
+        "ra_id": ra_id,
+        "display_order": display_order,
+        "badge_path": f"{ra_id}.png",
+        "badge_path_lock": f"{ra_id}_lock.png",
+    }
+
+
+class TestMergedRAMetadata:
+    def test_achievements_come_back_in_retroachievements_display_order(self):
+        rom = Rom(
+            fs_name="Game.zip",
+            fs_path="nes/roms",
+            ra_metadata={
+                "achievements": [
+                    _achievement(30, 3),
+                    _achievement(10, 1),
+                    _achievement(20, 2),
+                ]
+            },
+        )
+
+        merged = rom.merged_ra_metadata
+        assert merged is not None
+        assert [a["ra_id"] for a in merged["achievements"]] == [10, 20, 30]
+
+    def test_ties_and_missing_orders_stay_deterministic(self):
+        """Metadata scanned before `display_order` was captured has none, and
+        RetroAchievements itself hands out duplicate orders."""
+        rom = Rom(
+            fs_name="Game.zip",
+            fs_path="nes/roms",
+            ra_metadata={
+                "achievements": [
+                    _achievement(9, None),
+                    _achievement(8, 1),
+                    _achievement(7, 1),
+                ]
+            },
+        )
+
+        merged = rom.merged_ra_metadata
+        assert merged is not None
+        assert [a["ra_id"] for a in merged["achievements"]] == [7, 8, 9]
+
+    def test_the_stored_metadata_keeps_its_own_order_and_relative_paths(self):
+        """Badge paths on disk are relative, and the sort must not leak back
+        into the column the filesystem handlers read."""
+        stored = {"achievements": [_achievement(2, 2), _achievement(1, 1)]}
+        rom = Rom(fs_name="Game.zip", fs_path="nes/roms", ra_metadata=stored)
+
+        merged = rom.merged_ra_metadata
+
+        assert merged is not None
+        assert [a["ra_id"] for a in stored["achievements"]] == [2, 1]
+        assert stored["achievements"][0]["badge_path"] == "2.png"

--- a/backend/tests/models/test_rom.py
+++ b/backend/tests/models/test_rom.py
@@ -260,7 +260,7 @@ class TestFullPathHash:
         assert root.full_path_hash != nested.full_path_hash
 
 
-def _achievement(ra_id: int, display_order: int | None) -> dict:
+def _achievement(ra_id: int | None, display_order: int | None) -> dict:
     return {
         "ra_id": ra_id,
         "display_order": display_order,
@@ -288,13 +288,12 @@ class TestMergedRAMetadata:
         assert [a["ra_id"] for a in merged["achievements"]] == [10, 20, 30]
 
     def test_ties_and_missing_orders_stay_deterministic(self):
-        """Metadata scanned before `display_order` was captured has none, and
-        RetroAchievements itself hands out duplicate orders."""
         rom = Rom(
             fs_name="Game.zip",
             fs_path="nes/roms",
             ra_metadata={
                 "achievements": [
+                    _achievement(None, None),
                     _achievement(9, None),
                     _achievement(8, 1),
                     _achievement(7, 1),
@@ -304,11 +303,10 @@ class TestMergedRAMetadata:
 
         merged = rom.merged_ra_metadata
         assert merged is not None
-        assert [a["ra_id"] for a in merged["achievements"]] == [7, 8, 9]
+        assert [a["ra_id"] for a in merged["achievements"]] == [7, 8, 9, None]
 
     def test_the_stored_metadata_keeps_its_own_order_and_relative_paths(self):
-        """Badge paths on disk are relative, and the sort must not leak back
-        into the column the filesystem handlers read."""
+        """Badge paths on disk stay relative for the filesystem handlers."""
         stored = {"achievements": [_achievement(2, 2), _achievement(1, 1)]}
         rom = Rom(fs_name="Game.zip", fs_path="nes/roms", ra_metadata=stored)
 


### PR DESCRIPTION
**AI assistance disclosure**

This PR (code, tests and description) was written by Claude Code under my direction, and I reviewed it before opening.

**Description**

The achievements tab listed a game's RetroAchievements in an order that matched none of the sorts on the RA website, which makes it awkward to follow along while playing.

`GetGameExtended` returns `Achievements` as an object keyed by achievement id, and `_extract_metadata_from_rom_details` builds the stored list straight off `.values()`. The order is therefore whatever that dict iterated in — neither display order nor id order — and it is persisted into `ra_metadata` and rendered as-is.

`merged_ra_metadata` now sorts by `display_order` (already captured per achievement, ties broken by `ra_id`), which is RetroAchievements' own "Display Order". Sorting on read rather than on scan means existing libraries get the right order immediately, with no rescan.

Achievements stored before `display_order` was captured have none; those sort to the end rather than to the front. The sort runs on the deep copy `merged_ra_metadata` already makes for absolute badge paths, so the stored column is untouched.

The issue also floats a sort-order dropdown matching the RA website's options. That's a larger UI change; this just fixes the default.

Fixes #4312

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Three model tests: display order, deterministic ties/missing orders, and that the stored metadata keeps its own order and relative badge paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
