### PR TITLE
fix(v2): keep a click in selection mode from navigating away

### DIFF
--- a/frontend/src/v2/components/GameCard/GameCard.test.ts
+++ b/frontend/src/v2/components/GameCard/GameCard.test.ts
@@ -10,18 +10,8 @@ vi.mock("vue-i18n", () => ({
   useI18n: () => ({ t: (key: string) => key }),
 }));
 
-function makeRom(id: number): SimpleRom {
-  return {
-    id,
-    name: `Game ${id}`,
-    fs_name_no_ext: `Game ${id}`,
-    platform_slug: "snes",
-    path_cover_large: null,
-    path_cover_small: null,
-    url_cover: null,
-    regions: [],
-    languages: [],
-  } as unknown as SimpleRom;
+function rom(id: number): SimpleRom {
+  return { id, name: `Game ${id}`, platform_slug: "snes" } as SimpleRom;
 }
 
 function makeRouter(): Router {
@@ -34,11 +24,11 @@ function makeRouter(): Router {
   });
 }
 
-async function mountCard(rom: SimpleRom, router: Router) {
+async function mountCard(romId: number, router: Router) {
   await router.push("/");
   await router.isReady();
   return mount(GameCard, {
-    props: { rom, selectable: true, position: 0 },
+    props: { rom: rom(romId), selectable: true, position: 0 },
     global: { plugins: [router] },
   });
 }
@@ -50,7 +40,7 @@ beforeEach(() => {
 describe("GameCard selection", () => {
   it("navigates on a plain click when nothing is selected", async () => {
     const router = makeRouter();
-    const wrapper = await mountCard(makeRom(1), router);
+    const wrapper = await mountCard(1, router);
 
     await wrapper.find(".r-gc").trigger("click");
     await flushPromises();
@@ -61,10 +51,10 @@ describe("GameCard selection", () => {
 
   it("toggles instead of navigating once the gallery is in selection mode", async () => {
     const selection = storeGallerySelection();
-    selection.toggle(makeRom(2), 1);
+    selection.toggle(rom(2), 1);
 
     const router = makeRouter();
-    const wrapper = await mountCard(makeRom(1), router);
+    const wrapper = await mountCard(1, router);
 
     await wrapper.find(".r-gc").trigger("click");
     await flushPromises();
@@ -75,9 +65,33 @@ describe("GameCard selection", () => {
 
   it("enters selection mode on a modifier click without navigating", async () => {
     const router = makeRouter();
-    const wrapper = await mountCard(makeRom(1), router);
+    const wrapper = await mountCard(1, router);
 
     await wrapper.find(".r-gc").trigger("click", { ctrlKey: true });
+    await flushPromises();
+
+    expect(router.currentRoute.value.fullPath).toBe("/");
+    expect(storeGallerySelection().ids).toEqual([1]);
+  });
+
+  it("toggles the card once when the click lands on its checkbox", async () => {
+    const selection = storeGallerySelection();
+    selection.toggle(rom(2), 1);
+
+    const router = makeRouter();
+    const wrapper = await mountCard(1, router);
+
+    await wrapper.find(".r-gc__check").trigger("click");
+    await flushPromises();
+
+    expect(selection.ids).toEqual([2, 1]);
+  });
+
+  it("consumes a modifier click on the checkbox", async () => {
+    const router = makeRouter();
+    const wrapper = await mountCard(1, router);
+
+    await wrapper.find(".r-gc__check").trigger("click", { ctrlKey: true });
     await flushPromises();
 
     expect(router.currentRoute.value.fullPath).toBe("/");

--- a/frontend/src/v2/components/GameCard/GameCard.test.ts
+++ b/frontend/src/v2/components/GameCard/GameCard.test.ts
@@ -1,0 +1,86 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMemoryHistory, createRouter, type Router } from "vue-router";
+import type { SimpleRom } from "@/stores/roms";
+import storeGallerySelection from "@/v2/stores/gallerySelection";
+import GameCard from "./GameCard.vue";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+function makeRom(id: number): SimpleRom {
+  return {
+    id,
+    name: `Game ${id}`,
+    fs_name_no_ext: `Game ${id}`,
+    platform_slug: "snes",
+    path_cover_large: null,
+    path_cover_small: null,
+    url_cover: null,
+    regions: [],
+    languages: [],
+  } as unknown as SimpleRom;
+}
+
+function makeRouter(): Router {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: "/", component: { template: "<div />" } },
+      { path: "/rom/:id", component: { template: "<div />" } },
+    ],
+  });
+}
+
+async function mountCard(rom: SimpleRom, router: Router) {
+  await router.push("/");
+  await router.isReady();
+  return mount(GameCard, {
+    props: { rom, selectable: true, position: 0 },
+    global: { plugins: [router] },
+  });
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe("GameCard selection", () => {
+  it("navigates on a plain click when nothing is selected", async () => {
+    const router = makeRouter();
+    const wrapper = await mountCard(makeRom(1), router);
+
+    await wrapper.find(".r-gc").trigger("click");
+    await flushPromises();
+
+    expect(router.currentRoute.value.fullPath).toBe("/rom/1");
+    expect(storeGallerySelection().ids).toEqual([]);
+  });
+
+  it("toggles instead of navigating once the gallery is in selection mode", async () => {
+    const selection = storeGallerySelection();
+    selection.toggle(makeRom(2), 1);
+
+    const router = makeRouter();
+    const wrapper = await mountCard(makeRom(1), router);
+
+    await wrapper.find(".r-gc").trigger("click");
+    await flushPromises();
+
+    expect(router.currentRoute.value.fullPath).toBe("/");
+    expect(selection.ids).toEqual([2, 1]);
+  });
+
+  it("enters selection mode on a modifier click without navigating", async () => {
+    const router = makeRouter();
+    const wrapper = await mountCard(makeRom(1), router);
+
+    await wrapper.find(".r-gc").trigger("click", { ctrlKey: true });
+    await flushPromises();
+
+    expect(router.currentRoute.value.fullPath).toBe("/");
+    expect(storeGallerySelection().ids).toEqual([1]);
+  });
+});

--- a/frontend/src/v2/components/GameCard/GameCard.vue
+++ b/frontend/src/v2/components/GameCard/GameCard.vue
@@ -307,18 +307,18 @@ function onCheckboxClick(e: MouseEvent) {
   selectionStore.toggle(props.rom, props.position);
 }
 
-/** Capture-phase suppressor — when the gallery is in selectable mode
- *  AND the user is holding a modifier key, any click on the card
- *  (overlay buttons included: download / favorite / play / more /
- *  platform icon) is reinterpreted as a selection gesture. Without
- *  this, shift-clicking the favourite star would toggle the favourite
- *  AND extend the selection range — confusing. */
+/** Capture-phase suppressor — while the gallery is in selection mode, or
+ *  the user is holding a modifier key, any click on the card (overlay
+ *  buttons included: download / favorite / play / more / platform icon)
+ *  is reinterpreted as a selection gesture. Without this, shift-clicking
+ *  the favourite star would toggle the favourite AND extend the selection
+ *  range — confusing.
+ *
+ *  It has to be the capture phase: the root is a `router-link`, whose own
+ *  click handler runs before this component's, and vue-router only bails
+ *  on an event that was already prevented. */
 function onCardClickCapture(e: MouseEvent) {
-  if (!props.selectable) return;
-  if (!(e.shiftKey || e.ctrlKey || e.metaKey)) return;
-  e.preventDefault();
-  e.stopPropagation();
-  if (props.position == null) return;
+  if (!props.selectable || props.position == null) return;
   selectionInput.handleActivate(props.rom, props.position, e);
 }
 
@@ -334,18 +334,8 @@ function onCardClick(e: MouseEvent) {
     return;
   }
 
-  // Gallery selection takes precedence over navigation when the card
-  // opts in. Returns `true` if the click was consumed (mode active,
-  // modifier pressed, long-press just fired); we short-circuit and
-  // skip the morph + router push.
-  if (
-    props.selectable &&
-    props.position != null &&
-    selectionInput.handleActivate(props.rom, props.position, e)
-  ) {
-    return;
-  }
-
+  // A click the selection consumed never reaches here — `onCardClickCapture`
+  // stops it in the capture phase.
   if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
     return;
   }

--- a/frontend/src/v2/components/GameCard/GameCard.vue
+++ b/frontend/src/v2/components/GameCard/GameCard.vue
@@ -307,12 +307,12 @@ function onCheckboxClick(e: MouseEvent) {
   selectionStore.toggle(props.rom, props.position);
 }
 
-/** Capture-phase suppressor — while the gallery is in selection mode, or
+/** Capture-phase suppressor. While the gallery is in selection mode, or
  *  the user is holding a modifier key, any click on the card (overlay
  *  buttons included: download / favorite / play / more / platform icon)
  *  is reinterpreted as a selection gesture. Without this, shift-clicking
  *  the favourite star would toggle the favourite AND extend the selection
- *  range — confusing.
+ *  range, which is confusing.
  *
  *  It has to be the capture phase: the root is a `router-link`, whose own
  *  click handler runs before this component's, and vue-router only bails
@@ -334,7 +334,7 @@ function onCardClick(e: MouseEvent) {
     return;
   }
 
-  // A click the selection consumed never reaches here — `onCardClickCapture`
+  // A click the selection consumed never reaches here: `onCardClickCapture`
   // stops it in the capture phase.
   if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
     return;

--- a/frontend/src/v2/components/GameCard/GameCard.vue
+++ b/frontend/src/v2/components/GameCard/GameCard.vue
@@ -300,23 +300,11 @@ function onCheckboxClick(e: MouseEvent) {
   e.preventDefault();
   e.stopPropagation();
   if (props.position == null) return;
-  if (e.shiftKey) {
-    selectionInput.handleActivate(props.rom, props.position, e);
-    return;
-  }
   selectionStore.toggle(props.rom, props.position);
 }
 
-/** Capture-phase suppressor. While the gallery is in selection mode, or
- *  the user is holding a modifier key, any click on the card (overlay
- *  buttons included: download / favorite / play / more / platform icon)
- *  is reinterpreted as a selection gesture. Without this, shift-clicking
- *  the favourite star would toggle the favourite AND extend the selection
- *  range, which is confusing.
- *
- *  It has to be the capture phase: the root is a `router-link`, whose own
- *  click handler runs before this component's, and vue-router only bails
- *  on an event that was already prevented. */
+/** Capture phase so nothing else sees a click the selection consumed: the
+ *  root is a `router-link`, and vue-router only bails on a prevented event. */
 function onCardClickCapture(e: MouseEvent) {
   if (!props.selectable || props.position == null) return;
   selectionInput.handleActivate(props.rom, props.position, e);
@@ -334,8 +322,7 @@ function onCardClick(e: MouseEvent) {
     return;
   }
 
-  // A click the selection consumed never reaches here: `onCardClickCapture`
-  // stops it in the capture phase.
+  // Selection-consumed clicks are stopped by `onCardClickCapture`.
   if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
     return;
   }


### PR DESCRIPTION
**AI assistance disclosure**

This PR (code, tests and description) was written by Claude Code under my direction, and I reviewed it before opening.

**Description**

Clicking anywhere on a card while multi-selecting was already meant to toggle it — `useGallerySelectionInput.handleActivate` consumes a plain click whenever `gallerySelection.enabled` — but in the grid it toggled the card *and* navigated to the game page, which then cleared the selection.

The card's root renders as a `router-link`. Vue merges a parent's `@click` after the component's own handler, so `RouterLink`'s click runs first, and vue-router's `guardEvent` only bails when the event is *already* `defaultPrevented`. `handleActivate`'s `preventDefault()` therefore lands too late. Modifier-clicks were unaffected because `onCardClickCapture` intercepts them in the capture phase; plain selection-mode clicks had no such path.

The capture handler now delegates to `handleActivate` unconditionally (it already decides for itself whether to consume: selection mode, modifier, or a just-fired long press), so the same gesture is stopped before `RouterLink` ever sees it. The now-unreachable duplicate in the bubble handler is gone.

`GameListRow` is a plain `<a href>` with a single click handler, so list mode was never affected.

Fixes #4366

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Three cases against a real `createMemoryHistory` router: plain click navigates when nothing is selected, plain click toggles without navigating once something is, and modifier click enters selection mode without navigating. The middle one fails on `master` (the route ends up at `/rom/1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
