### PR TITLE
fix(docker): name the volume the image declares at /romm

### DIFF
--- a/examples/docker-compose.example.yml
+++ b/examples/docker-compose.example.yml
@@ -1,5 +1,6 @@
 volumes:
   mysql_data:
+  romm_data:
   romm_resources:
   romm_redis_data:
 
@@ -22,6 +23,7 @@ services:
       - SCAN_WORKERS=4 # How many ROMs to scan at once
       - WEB_SERVER_CONCURRENCY=4 # Workers for API calls, raise for several concurrent users
     volumes:
+      - romm_data:/romm # Everything the image declares a volume for that isn't mounted below: the zip cache, the LaunchBox store, and save-sync's SSH keys
       - romm_resources:/romm/resources # Resources fetched from IGDB (covers, screenshots, etc.)
       - romm_redis_data:/redis-data # Cached data for background tasks
       - /path/to/library:/romm/library # Your game library. Check https://docs.romm.app/latest/Getting-Started/Folder-Structure/ for more details.

--- a/examples/docker-compose.example.yml
+++ b/examples/docker-compose.example.yml
@@ -23,7 +23,10 @@ services:
       - SCAN_WORKERS=4 # How many ROMs to scan at once
       - WEB_SERVER_CONCURRENCY=4 # Workers for API calls, raise for several concurrent users
     volumes:
-      - romm_data:/romm # Everything the image declares a volume for that isn't mounted below: the zip cache, the LaunchBox store, and save-sync's SSH keys
+      # Everything the image declares a volume for that isn't mounted below: the zip cache, the LaunchBox store, and save-sync's SSH keys.
+      # Adding this to an existing install starts it empty. The caches rebuild themselves, but if you use save sync, copy /romm/sync out of
+      # the old anonymous volume first: docker run --rm -v <old>:/from -v romm_data:/to alpine cp -a /from/sync /to/
+      - romm_data:/romm
       - romm_resources:/romm/resources # Resources fetched from IGDB (covers, screenshots, etc.)
       - romm_redis_data:/redis-data # Cached data for background tasks
       - /path/to/library:/romm/library # Your game library. Check https://docs.romm.app/latest/Getting-Started/Folder-Structure/ for more details.


### PR DESCRIPTION
**AI assistance disclosure**

This PR (code and description) was written by Claude Code under my direction, and I reviewed it before opening.

**Description**

`docker/Dockerfile` declares `VOLUME ["/romm", "/redis-data"]`, deliberately at the parent so the subdirectories stay on one `st_dev` and cross-directory `os.link()` works. The example compose mounts only the subdirectories (`/romm/library`, `/romm/resources`, `/romm/assets`, `/romm/config`), so Docker fulfils the `/romm` declaration with an anonymous volume, which is what the issue reports.

It isn't only cosmetic. What lands in that unnamed volume is everything under `ROMM_BASE_PATH` that isn't separately mounted: `/romm/cache/zips`, `/romm/launchbox`, and `/romm/sync` — and the last one holds save-sync's SSH private key and `known_hosts`. Today that sits behind a random id, so it can't be found, backed up, or moved.

Naming it is the reporter's own verified fix.

Verified the nested mounts actually behave, against `rommapp/romm:5.2.0` with the example's exact volume set:

```
/dev/vdb1 on /romm type btrfs (rw,...)
/dev/vdb1 on /romm/resources type btrfs (rw,...)
mac on /romm/library type virtiofs (rw,relatime)
mac on /romm/assets type virtiofs (rw,relatime)
mac on /romm/config type virtiofs (rw,relatime)
```

`mkdir -p /romm/cache/zips /romm/sync` then writing into it succeeds, and no anonymous volume is created.

Note for existing installs: adopting this starts `/romm` empty, so the zip cache and the LaunchBox store are rebuilt on demand. Anyone already using save sync should copy `/romm/sync` out of the old anonymous volume first. The same snippet is published on docs.romm.app and wants the matching change there.

Fixes #3734

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

No tests — this is the example compose file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
