### PR TITLE
fix(v2): keep the player from booting a rom's media instead of the game

### DIFF
--- a/frontend/src/v2/utils/playerDisc.test.ts
+++ b/frontend/src/v2/utils/playerDisc.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import type { RomFileCategory } from "@/__generated__";
 import {
   ALL_DISCS,
   bootDiscId,
@@ -9,10 +10,16 @@ import {
   resolveStoredDisc,
 } from "./playerDisc";
 
-// Only `id` and `file_name` are read off each file; minimal stubs stand in for
-// RomFileSchema.
+// Only `id`, `file_name` and `category` are read off each file; minimal stubs
+// stand in for RomFileSchema.
+const file = (
+  id: number,
+  file_name: string,
+  category: RomFileCategory | null = null,
+) => ({ id, file_name, category });
+
 const files = (...ids: number[]) =>
-  ids.map((id) => ({ id, file_name: `Game (Disc ${id}).chd` }));
+  ids.map((id) => file(id, `Game (Disc ${id}).chd`));
 
 describe("resolveStoredDisc", () => {
   it("keeps a stored id that still belongs to the rom", () => {
@@ -75,17 +82,12 @@ describe("resolveStoredDisc", () => {
 
 describe("defaultDisc", () => {
   it("boots every file together when the set ships its own playlist", () => {
-    expect(
-      defaultDisc([...files(1, 2), { id: 99, file_name: "Game.m3u" }]),
-    ).toBe(ALL_DISCS);
+    expect(defaultDisc([...files(1, 2), file(99, "Game.m3u")])).toBe(ALL_DISCS);
   });
 
   it("matches the playlist extension case-insensitively", () => {
     expect(
-      defaultDisc([
-        { id: 1, file_name: "Game (Disc 1).chd" },
-        { id: 2, file_name: "Game.M3U" },
-      ]),
+      defaultDisc([file(1, "Game (Disc 1).chd"), file(2, "Game.M3U")]),
     ).toBe(ALL_DISCS);
   });
 
@@ -94,7 +96,7 @@ describe("defaultDisc", () => {
   });
 
   it("boots the only file of a single-file rom carrying a playlist", () => {
-    expect(defaultDisc([{ id: 1, file_name: "Game.m3u" }])).toBe(1);
+    expect(defaultDisc([file(1, "Game.m3u")])).toBe(1);
   });
 
   it("returns null for a rom with no files", () => {
@@ -104,50 +106,46 @@ describe("defaultDisc", () => {
   it("skips media that sorts before the game file", () => {
     expect(
       defaultDisc([
-        { id: 1, file_name: "artwork.png", category: "screenshot" },
-        { id: 2, file_name: "Game.chd", category: "game" },
+        file(1, "artwork.png", "screenshot"),
+        file(2, "Game.chd", "game"),
       ]),
     ).toBe(2);
   });
 
   it("still boots a file scanned before categories existed", () => {
-    expect(
-      defaultDisc([{ id: 1, file_name: "Game.chd", category: null }]),
-    ).toBe(1);
+    expect(defaultDisc([file(1, "Game.chd", null)])).toBe(1);
   });
 
   it("boots media rather than nothing when that is all the rom has", () => {
-    expect(
-      defaultDisc([{ id: 1, file_name: "manual.pdf", category: "manual" }]),
-    ).toBe(1);
+    expect(defaultDisc([file(1, "manual.pdf", "manual")])).toBe(1);
   });
 });
 
 describe("bootableFiles", () => {
   it("drops every category a core cannot boot", () => {
-    const game = { id: 1, file_name: "Game.chd", category: "game" as const };
+    const game = file(1, "Game.chd", "game");
 
     expect(
       bootableFiles([
-        { id: 2, file_name: "manual.pdf", category: "manual" },
-        { id: 3, file_name: "guide.txt", category: "walkthrough" },
-        { id: 4, file_name: "shot.png", category: "screenshot" },
-        { id: 5, file_name: "track.mp3", category: "soundtrack" },
-        { id: 6, file_name: "fix.ips", category: "patch" },
-        { id: 7, file_name: "codes.cht", category: "cheat" },
+        file(2, "manual.pdf", "manual"),
+        file(3, "guide.txt", "walkthrough"),
+        file(4, "shot.png", "screenshot"),
+        file(5, "track.mp3", "soundtrack"),
+        file(6, "fix.ips", "patch"),
+        file(7, "codes.cht", "cheat"),
         game,
       ]),
     ).toEqual([game]);
   });
 
   it("keeps the parts of a multi-file release", () => {
-    const files = [
-      { id: 1, file_name: "Game.nsp", category: "game" as const },
-      { id: 2, file_name: "Game.nsz", category: "update" as const },
-      { id: 3, file_name: "Game DLC.nsp", category: "dlc" as const },
+    const release = [
+      file(1, "Game.nsp", "game"),
+      file(2, "Game.nsz", "update"),
+      file(3, "Game DLC.nsp", "dlc"),
     ];
 
-    expect(bootableFiles(files)).toEqual(files);
+    expect(bootableFiles(release)).toEqual(release);
   });
 });
 
@@ -212,11 +210,9 @@ describe("rememberDisc / resolveRememberedDisc", () => {
   });
 
   it("drops a remembered media file once the caller filters media out", () => {
-    // The player hands in `bootableFiles(rom.files)`, so a manual the user
-    // picked before the filter existed reads as stale rather than booting.
     const bootable = bootableFiles([
-      { id: 1, file_name: "manual.pdf", category: "manual" },
-      { id: 2, file_name: "Game.chd", category: "game" },
+      file(1, "manual.pdf", "manual"),
+      file(2, "Game.chd", "game"),
     ]);
     rememberDisc(ROM_ID, 1);
 

--- a/frontend/src/v2/utils/playerDisc.test.ts
+++ b/frontend/src/v2/utils/playerDisc.test.ts
@@ -210,4 +210,17 @@ describe("rememberDisc / resolveRememberedDisc", () => {
     rememberDisc(ROM_ID, 2);
     expect(resolveRememberedDisc(99, files(1, 2))).toBe(1);
   });
+
+  it("drops a remembered media file once the caller filters media out", () => {
+    // The player hands in `bootableFiles(rom.files)`, so a manual the user
+    // picked before the filter existed reads as stale rather than booting.
+    const bootable = bootableFiles([
+      { id: 1, file_name: "manual.pdf", category: "manual" },
+      { id: 2, file_name: "Game.chd", category: "game" },
+    ]);
+    rememberDisc(ROM_ID, 1);
+
+    expect(resolveRememberedDisc(ROM_ID, bootable)).toBe(2);
+    expect(localStorage.getItem(`player:${ROM_ID}:disc-selection`)).toBeNull();
+  });
 });

--- a/frontend/src/v2/utils/playerDisc.test.ts
+++ b/frontend/src/v2/utils/playerDisc.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   ALL_DISCS,
   bootDiscId,
+  bootableFiles,
   defaultDisc,
   rememberDisc,
   resolveRememberedDisc,
@@ -98,6 +99,55 @@ describe("defaultDisc", () => {
 
   it("returns null for a rom with no files", () => {
     expect(defaultDisc([])).toBeNull();
+  });
+
+  it("skips media that sorts before the game file", () => {
+    expect(
+      defaultDisc([
+        { id: 1, file_name: "artwork.png", category: "screenshot" },
+        { id: 2, file_name: "Game.chd", category: "game" },
+      ]),
+    ).toBe(2);
+  });
+
+  it("still boots a file scanned before categories existed", () => {
+    expect(
+      defaultDisc([{ id: 1, file_name: "Game.chd", category: null }]),
+    ).toBe(1);
+  });
+
+  it("boots media rather than nothing when that is all the rom has", () => {
+    expect(
+      defaultDisc([{ id: 1, file_name: "manual.pdf", category: "manual" }]),
+    ).toBe(1);
+  });
+});
+
+describe("bootableFiles", () => {
+  it("drops every category a core cannot boot", () => {
+    const game = { id: 1, file_name: "Game.chd", category: "game" as const };
+
+    expect(
+      bootableFiles([
+        { id: 2, file_name: "manual.pdf", category: "manual" },
+        { id: 3, file_name: "guide.txt", category: "walkthrough" },
+        { id: 4, file_name: "shot.png", category: "screenshot" },
+        { id: 5, file_name: "track.mp3", category: "soundtrack" },
+        { id: 6, file_name: "fix.ips", category: "patch" },
+        { id: 7, file_name: "codes.cht", category: "cheat" },
+        game,
+      ]),
+    ).toEqual([game]);
+  });
+
+  it("keeps the parts of a multi-file release", () => {
+    const files = [
+      { id: 1, file_name: "Game.nsp", category: "game" as const },
+      { id: 2, file_name: "Game.nsz", category: "update" as const },
+      { id: 3, file_name: "Game DLC.nsp", category: "dlc" as const },
+    ];
+
+    expect(bootableFiles(files)).toEqual(files);
   });
 });
 

--- a/frontend/src/v2/utils/playerDisc.ts
+++ b/frontend/src/v2/utils/playerDisc.ts
@@ -10,6 +10,8 @@
 // Asking the download endpoint for no file in particular instead returns every
 // file zipped with a generated .m3u, which EmulatorJS boots with its in-game
 // disc switcher (issue #3985). That choice is stored as `ALL_DISCS`.
+import type { RomFileCategory } from "@/__generated__";
+
 export const ALL_DISCS = "all";
 
 // A file id to boot on its own, ALL_DISCS to boot every file together, or null
@@ -19,6 +21,34 @@ export type DiscSelection = number | typeof ALL_DISCS | null;
 interface DiscFile {
   id: number;
   file_name: string;
+  category?: RomFileCategory | null;
+}
+
+// Categories that are never a thing a core can boot. Media uploaded into a
+// folder rom's subdirectory becomes one of the rom's files, and a manual that
+// sorts before the game would otherwise be what Play defaults to (issue #4074).
+// A file scanned before categories existed carries none, so absence means
+// bootable.
+const NON_BOOTABLE_CATEGORIES: readonly RomFileCategory[] = [
+  "manual",
+  "walkthrough",
+  "screenshot",
+  "soundtrack",
+  "patch",
+  "cheat",
+];
+
+export function isBootableFile(file: DiscFile): boolean {
+  return !file.category || !NON_BOOTABLE_CATEGORIES.includes(file.category);
+}
+
+// The rom's files a core could boot. Falls back to all of them rather than
+// leaving the player with nothing to offer.
+export function bootableFiles<T extends DiscFile>(
+  files: readonly T[],
+): readonly T[] {
+  const bootable = files.filter(isBootableFile);
+  return bootable.length > 0 ? bootable : files;
 }
 
 export interface ResolvedDisc {
@@ -51,7 +81,7 @@ export function resolveStoredDisc(
 // anything else boots one file to avoid pulling hundreds of unused MB.
 export function defaultDisc(files: readonly DiscFile[]): DiscSelection {
   if (files.length > 1 && files.some(isM3uFile)) return ALL_DISCS;
-  return files[0]?.id ?? null;
+  return bootableFiles(files)[0]?.id ?? null;
 }
 
 // The file id to download, or null to download the rom whole.

--- a/frontend/src/v2/utils/playerDisc.ts
+++ b/frontend/src/v2/utils/playerDisc.ts
@@ -24,11 +24,8 @@ interface DiscFile {
   category?: RomFileCategory | null;
 }
 
-// Categories that are never a thing a core can boot. Media uploaded into a
-// folder rom's subdirectory becomes one of the rom's files, and a manual that
-// sorts before the game would otherwise be what Play defaults to (issue #4074).
-// A file scanned before categories existed carries none, so absence means
-// bootable.
+// Media uploaded into a folder rom's subdirectory becomes one of the rom's
+// files, so Play would otherwise default to a manual (issue #4074).
 const NON_BOOTABLE_CATEGORIES: readonly RomFileCategory[] = [
   "manual",
   "walkthrough",
@@ -38,12 +35,13 @@ const NON_BOOTABLE_CATEGORIES: readonly RomFileCategory[] = [
   "cheat",
 ];
 
-export function isBootableFile(file: DiscFile): boolean {
+function isBootableFile(file: DiscFile): boolean {
+  // A file scanned before categories existed carries none, so absence boots.
   return !file.category || !NON_BOOTABLE_CATEGORIES.includes(file.category);
 }
 
-// The rom's files a core could boot. Falls back to all of them rather than
-// leaving the player with nothing to offer.
+// Falls back to every file when media is all the rom has, so the player is
+// never left with nothing to boot.
 export function bootableFiles<T extends DiscFile>(
   files: readonly T[],
 ): readonly T[] {

--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -348,7 +348,10 @@ onMounted(async () => {
   }
   isSavesTabSelected.value = !hasCompatibleState;
 
-  selectedDisc.value = resolveRememberedDisc(rom.value.id, rom.value.files);
+  selectedDisc.value = resolveRememberedDisc(
+    rom.value.id,
+    bootableRomFiles.value,
+  );
 
   selectedCore.value = resolveRememberedCore(
     rom.value.id,

--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -66,6 +66,7 @@ import {
 import {
   ALL_DISCS,
   bootDiscId,
+  bootableFiles,
   rememberDisc,
   resolveRememberedDisc,
   type DiscSelection,
@@ -138,9 +139,11 @@ const compatibleStates = computed(
     ) ?? [],
 );
 
+const bootableRomFiles = computed(() => bootableFiles(rom.value?.files ?? []));
+
 const discItems = computed<{ title: string; value: DiscSelection }[]>(() => [
   { title: t("play.all-discs"), value: ALL_DISCS },
-  ...(rom.value?.files ?? []).map((f) => ({
+  ...bootableRomFiles.value.map((f) => ({
     title: f.file_name,
     value: f.id,
   })),
@@ -590,7 +593,7 @@ const selectedAsset = computed<SaveSchema | StateSchema | null>(() =>
         </div>
         <div class="r-v2-ejs__setup-body">
           <RSelect
-            v-if="(rom?.files?.length ?? 0) > 1"
+            v-if="bootableRomFiles.length > 1"
             v-model="selectedDisc"
             variant="outlined"
             density="comfortable"

--- a/frontend/src/v2/views/Player/Stream.vue
+++ b/frontend/src/v2/views/Player/Stream.vue
@@ -80,6 +80,7 @@ import { useSocketEvent } from "@/v2/composables/useSocketEvent";
 import { useUnloadGuard } from "@/v2/composables/useUnloadGuard";
 import type { SliderBtnGroupItem } from "@/v2/lib/primitives/RSliderBtnGroup/types";
 import storeGalleryRoms from "@/v2/stores/galleryRoms";
+import { bootableFiles } from "@/v2/utils/playerDisc";
 
 type PlayerState = "idle" | "loading" | "playing" | "error" | "exited";
 type ErrorType =
@@ -248,11 +249,13 @@ const hasM3uFile = computed(() =>
   (rom.value?.files ?? []).some((f) => fileExtension(f.file_name) === "m3u"),
 );
 
+const bootableRomFiles = computed(() => bootableFiles(rom.value?.files ?? []));
+
 // Mirrors the download endpoint's playlist filtering: when .cue files are
 // present only those are valid swap targets (raw .bin tracks are not), and
 // the .m3u itself is never something to swap to.
 const discOptions = computed(() => {
-  const files = (rom.value?.files ?? []).filter(
+  const files = bootableRomFiles.value.filter(
     (f) => fileExtension(f.file_name) !== "m3u",
   );
   const cueFiles = files.filter((f) => fileExtension(f.file_name) === "cue");
@@ -275,7 +278,7 @@ const canSwapDisc = computed(
 const showManualDiscHint = computed(
   () =>
     capabilities.value.hasManualDiscSwap &&
-    (rom.value?.files?.length ?? 0) > 1 &&
+    bootableRomFiles.value.length > 1 &&
     !isJoining,
 );
 


### PR DESCRIPTION
**AI assistance disclosure**

This PR (code, tests and description) was written by Claude Code under my direction, and I reviewed it before opening.

**Description**

Media uploaded into a folder rom's subdirectory is registered as one of the rom's `RomFile`s, with its category set (`manual`, `screenshot`, `soundtrack`, `walkthrough`). The EmulatorJS player's file selector listed every one of them, and `defaultDisc` picked `files[0]`, so a manual or a piece of artwork sorting before the game file was what Play booted with.

`bootableFiles` now drops the categories a core can never boot — `manual`, `walkthrough`, `screenshot`, `soundtrack`, `patch`, `cheat` — before the default is chosen and before the selector is built. A file scanned before categories existed carries `null` and stays bootable, and a rom whose files are *all* media falls back to the full list rather than leaving the player with nothing. The selector itself now appears when there is more than one *bootable* file, not more than one file.

The streaming player had the same defect in two places, so it reads the helper too: `discOptions` (with no `.cue` files present it fell back to every rom file, offering a manual as a swap target) and `showManualDiscHint` (media counted toward the multi-disc check, so a single-disc game with a manual got the hint). `hasM3uFile` deliberately keeps reading the unfiltered list, since it mirrors the backend's `Rom.has_m3u_file()` and an `.m3u` is never a media category.

This is the v2 players only, per the frozen-v1 rule.

Fixes #4074

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Six new cases in `playerDisc.test.ts` (media skipped, uncategorized still bootable, media-only fallback, every non-bootable category dropped, multi-part releases kept intact, a remembered media file dropped as stale). The streaming change adds no new logic of its own — it substitutes the same unit-tested helper.

Verified against the dev library, which has real fixtures for this: rom 677 returns its manual *before* the game file, so it booted a PDF before this change. With the fix the disc selector disappears (one bootable file), a 4-disc set with a manual lists only *All discs* + the four discs, and a remembered manual id is dropped as stale on mount. Checked in `v2-dark` and `v2-light`, with mouse and keyboard (focus ring on `data-input="key"`), and at 390px. The streaming control bar could not be exercised in the browser: it only renders in a live session, and no streaming container is running locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
