### PR TITLE
fix(ss): let region_mode decide the title, not just the artwork

### DIFF
--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -395,8 +395,8 @@ VALID_SCAN_PRIORITY_SOURCES = frozenset(
 )
 
 # Valid values for scan.priority.region_mode. "prefer_rom_tags" keeps the
-# rom's filename region tags authoritative for media selection;
-# "prefer_config" makes scan.priority.region win over the rom's own tags.
+# rom's filename region tags authoritative; "prefer_config" makes
+# scan.priority.region win over them, for artwork, title and release date alike.
 VALID_SCAN_REGION_MODES = frozenset({"prefer_rom_tags", "prefer_config"})
 
 

--- a/backend/handler/metadata/ss_handler.py
+++ b/backend/handler/metadata/ss_handler.py
@@ -156,9 +156,7 @@ def add_ss_auth_to_url(url: str | None) -> str:
     )
 
 
-def get_preferred_regions(
-    rom: Rom | None = None, *, for_media: bool = False
-) -> list[str]:
+def get_preferred_regions(rom: Rom | None = None) -> list[str]:
     """Get preferred regions, prepending the rom's own region tags when available.
 
     When a rom is tagged with multiple regions (e.g. "(Japan, USA)"), the rom's
@@ -167,11 +165,11 @@ def get_preferred_regions(
     Filename-tagged regions not present in the priority list keep their relative
     order and follow the prioritized ones.
 
-    With SCAN_REGION_MODE set to "prefer_config" and for_media=True, the
-    configured priority is authoritative instead: config regions come first and
-    the rom's own tags become the fallback when the config regions have no
-    media. The mode only applies to media selection; name and release-date
-    selection always keep the rom-tags-first ordering.
+    With SCAN_REGION_MODE set to "prefer_config" the configured priority is
+    authoritative instead: config regions come first and the rom's own tags
+    become the fallback. Everything region-selected reads this ordering, so a
+    game picked up in French comes back with its French artwork, title and
+    release date rather than a mix.
     """
     config = cm.get_config()
     priority = config.SCAN_REGION_PRIORITY
@@ -186,7 +184,7 @@ def get_preferred_regions(
             key=lambda code: priority.index(code) if code in priority else len(priority)
         )
 
-    if for_media and config.SCAN_REGION_MODE == "prefer_config":
+    if config.SCAN_REGION_MODE == "prefer_config":
         ordered = priority + rom_codes
     else:
         ordered = rom_codes + priority
@@ -396,7 +394,7 @@ def extract_media_from_ss_game(rom: Rom, game: SSGame) -> SSMetadataMedia:
         video_normalized_path=None,
     )
 
-    for region in get_preferred_regions(rom, for_media=True):
+    for region in get_preferred_regions(rom):
         for media in game.get("medias", []):
             if media.get("region", "unk") != region or media.get("parent") != "jeu":
                 continue

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -148,7 +148,7 @@ class TestGetPreferredRegions:
         rom.regions = ["Europe"]
         config = _make_config(region_priority=["fr", "eu"], region_mode="prefer_config")
         with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
-            regions = get_preferred_regions(rom, for_media=True)
+            regions = get_preferred_regions(rom)
 
         assert regions.index("fr") < regions.index("eu")
 
@@ -159,21 +159,10 @@ class TestGetPreferredRegions:
         rom.regions = ["Japan"]
         config = _make_config(region_priority=["fr"], region_mode="prefer_config")
         with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
-            regions = get_preferred_regions(rom, for_media=True)
+            regions = get_preferred_regions(rom)
 
         assert regions.index("fr") < regions.index("jp")
         assert regions.index("jp") < regions.index("us")
-
-    def test_prefer_config_mode_only_applies_to_media(self):
-        """region_mode only affects media selection; name/date ordering keeps
-        the rom's own tags first."""
-        rom = MagicMock()
-        rom.regions = ["Europe"]
-        config = _make_config(region_priority=["fr", "eu"], region_mode="prefer_config")
-        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
-            regions = get_preferred_regions(rom)
-
-        assert regions.index("eu") < regions.index("fr")
 
     def test_default_mode_rom_tags_still_win(self):
         """Default prefer_rom_tags mode keeps the current behavior."""
@@ -637,11 +626,11 @@ class TestExtractMetadataFromSsRom:
 
 
 class TestBuildSSGame:
-    def _make_rom(self) -> MagicMock:
+    def _make_rom(self, regions: list[str] | None = None) -> MagicMock:
         rom = MagicMock()
         rom.platform_id = 1
         rom.id = 100
-        rom.regions = None
+        rom.regions = regions
         return rom
 
     def _make_media(self, media_type: str) -> dict:
@@ -708,6 +697,46 @@ class TestBuildSSGame:
 
         # Empty values are stripped from the returned dict.
         assert "summary" not in result
+
+    def test_prefer_config_picks_the_title_from_the_configured_region(self):
+        """The mode used to reach the artwork only, so a European rom came back
+        with French box art under an English title."""
+        config = _make_config(region_priority=["fr", "eu"], region_mode="prefer_config")
+        game = cast(
+            SSGame,
+            {
+                "id": "42",
+                "medias": [],
+                "noms": [
+                    {"region": "eu", "text": "007 - Everything or Nothing"},
+                    {"region": "fr", "text": "007 : Quitte ou Double"},
+                ],
+            },
+        )
+
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            result = build_ss_game(self._make_rom(regions=["Europe"]), game)
+
+        assert result["name"] == "007: Quitte ou Double"
+
+    def test_prefer_rom_tags_keeps_the_title_of_the_rom_s_own_region(self):
+        config = _make_config(region_priority=["fr", "eu"])
+        game = cast(
+            SSGame,
+            {
+                "id": "42",
+                "medias": [],
+                "noms": [
+                    {"region": "eu", "text": "007 - Everything or Nothing"},
+                    {"region": "fr", "text": "007 : Quitte ou Double"},
+                ],
+            },
+        )
+
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            result = build_ss_game(self._make_rom(regions=["Europe"]), game)
+
+        assert result["name"] == "007 - Everything or Nothing"
 
     def test_summary_uses_configured_language(self):
         config = _make_config(language_priority=["de", "en"])

--- a/backend/tests/handler/metadata/test_ss_handler.py
+++ b/backend/tests/handler/metadata/test_ss_handler.py
@@ -583,6 +583,46 @@ class TestExtractMetadataFromSsRom:
 
         assert metadata["first_release_date"] == 593568000
 
+    def test_release_date_follows_the_configured_region_under_prefer_config(self):
+        """The same ordering that picks the artwork and the title picks the
+        date, so a game resolved as French is not dated by its US release."""
+        config = _make_config(region_priority=["fr"], region_mode="prefer_config")
+        rom = self._make_rom(regions=["USA"])
+        game = cast(
+            SSGame,
+            {
+                "dates": [
+                    {"region": "us", "text": "1990-02-12"},
+                    {"region": "fr", "text": "1991-08-29"},
+                ],
+                "medias": [],
+            },
+        )
+
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            metadata = extract_metadata_from_ss_rom(rom, game)
+
+        assert metadata["first_release_date"] == 683424000
+
+    def test_release_date_keeps_the_rom_s_region_under_prefer_rom_tags(self):
+        config = _make_config(region_priority=["fr"])
+        rom = self._make_rom(regions=["USA"])
+        game = cast(
+            SSGame,
+            {
+                "dates": [
+                    {"region": "us", "text": "1990-02-12"},
+                    {"region": "fr", "text": "1991-08-29"},
+                ],
+                "medias": [],
+            },
+        )
+
+        with patch("handler.metadata.ss_handler.cm.get_config", return_value=config):
+            metadata = extract_metadata_from_ss_rom(rom, game)
+
+        assert metadata["first_release_date"] == 634780800
+
     def test_franchises_fall_back_to_french(self):
         """ScreenScraper's taxonomy is often French-only, so those fields still
         fall back even when the user asked for another language."""


### PR DESCRIPTION
**AI assistance disclosure**

This PR (code, tests and description) was written by Claude Code under my direction, and I reviewed it before opening.

**Description**

`scan.priority.region_mode: prefer_config` reordered the region list only when `get_preferred_regions` was called with `for_media=True`, which is just `extract_media_from_ss_game`. Name selection (`build_ss_game`) and release-date selection called it without the flag and kept the rom's own filename tags first. A `(Europe)` rom with `fr` at the top of `scan.priority.region` therefore got the French box art and the English title, which is the mix the issue reports.

That split was deliberate and tested, but it makes the setting mean "media region mode" while being named for regions, and a half-applied preference is worse than either whole. `prefer_config` now orders every region-selected field, so a game resolved as French comes back French throughout.

Behaviour change for anyone already running `prefer_config`: titles and release dates will now follow the configured region on the next metadata scan. `prefer_rom_tags`, the default, is unaffected.

The issue also mentions descriptions. Those are chosen by `scan.priority.language`, not by region, so they already follow the configured language and aren't touched here.

Fixes #4268

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Two `build_ss_game` tests on the issue's own example (`007 - Everything or Nothing` vs `007 : Quitte ou Double`), one per mode; the region-ordering tests lose the `for_media` argument along with the parameter, and the one asserting the media-only split is gone. 663 tests across `tests/handler/metadata` and `tests/config` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
