### PR TITLE
fix(player): keep RomM chrome off the emulator on mobile

### DIFF
--- a/frontend/src/stores/playing.ts
+++ b/frontend/src/stores/playing.ts
@@ -4,6 +4,9 @@ export default defineStore("playing", {
   state: () => ({
     playing: false,
     fullScreen: false,
+    // True while a player's running stage covers the viewport; the v2
+    // AppLayout unmounts the nav chrome and zeroes the nav-height tokens.
+    stageActive: false,
   }),
 
   actions: {
@@ -12,6 +15,9 @@ export default defineStore("playing", {
     },
     setFullScreen(fullScreen: boolean) {
       this.fullScreen = fullScreen;
+    },
+    setStageActive(stageActive: boolean) {
+      this.stageActive = stageActive;
     },
   },
 });

--- a/frontend/src/stores/playing.ts
+++ b/frontend/src/stores/playing.ts
@@ -4,8 +4,7 @@ export default defineStore("playing", {
   state: () => ({
     playing: false,
     fullScreen: false,
-    // True while a player's running stage covers the viewport; the v2
-    // AppLayout unmounts the nav chrome and zeroes the nav-height tokens.
+    // True while a running player stage owns the viewport (see useStageActive).
     stageActive: false,
   }),
 

--- a/frontend/src/v2/components/Player/PlayerShell.test.ts
+++ b/frontend/src/v2/components/Player/PlayerShell.test.ts
@@ -3,10 +3,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SimpleRom } from "@/stores/roms";
 import PlayerShell from "./PlayerShell.vue";
 
-const mocks = vi.hoisted(() => ({ push: vi.fn() }));
+const mocks = vi.hoisted(() => ({ push: vi.fn(), setStageActive: vi.fn() }));
 
 vi.mock("vue-i18n", () => ({
   useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/stores/playing", () => ({
+  default: () => ({ setStageActive: mocks.setStageActive }),
 }));
 
 vi.mock("vue-router", () => ({
@@ -59,6 +63,7 @@ function mountShell(
 
 beforeEach(() => {
   mocks.push.mockReset();
+  mocks.setStageActive.mockReset();
 });
 
 describe("PlayerShell", () => {
@@ -132,5 +137,17 @@ describe("PlayerShell", () => {
     expect(
       wrapper.get(".r-v2-player__quit").attributes("disabled"),
     ).toBeDefined();
+  });
+
+  it("mirrors the running stage into the global chrome flag", async () => {
+    const wrapper = mountShell({ running: true });
+    expect(mocks.setStageActive).toHaveBeenLastCalledWith(true);
+
+    await wrapper.setProps({ running: false });
+    expect(mocks.setStageActive).toHaveBeenLastCalledWith(false);
+
+    await wrapper.setProps({ running: true });
+    wrapper.unmount();
+    expect(mocks.setStageActive).toHaveBeenLastCalledWith(false);
   });
 });

--- a/frontend/src/v2/components/Player/PlayerShell.vue
+++ b/frontend/src/v2/components/Player/PlayerShell.vue
@@ -35,8 +35,6 @@ const { backToRom, backToPlatform } = usePlayerNav(
   props.romId,
   () => props.heroRom?.platform_id,
 );
-// The shell owns the running flag, so it also drives the chrome unmount
-// for every player built on it.
 useStageActive(() => props.running);
 </script>
 

--- a/frontend/src/v2/components/Player/PlayerShell.vue
+++ b/frontend/src/v2/components/Player/PlayerShell.vue
@@ -9,6 +9,7 @@ import { useI18n } from "vue-i18n";
 import type { DetailedRom, SimpleRom } from "@/stores/roms";
 import GameCover from "@/v2/components/shared/GameCover.vue";
 import { usePlayerNav } from "@/v2/composables/usePlayerNav";
+import { useStageActive } from "@/v2/composables/useStageActive";
 
 interface Props {
   /** Full rom once loaded, else the cover-only seed during the morph-in. */
@@ -34,6 +35,9 @@ const { backToRom, backToPlatform } = usePlayerNav(
   props.romId,
   () => props.heroRom?.platform_id,
 );
+// The shell owns the running flag, so it also drives the chrome unmount
+// for every player built on it.
+useStageActive(() => props.running);
 </script>
 
 <template>

--- a/frontend/src/v2/composables/useStageActive/index.test.ts
+++ b/frontend/src/v2/composables/useStageActive/index.test.ts
@@ -43,8 +43,7 @@ describe("useStageActive", () => {
     scope.run(() => useStageActive(() => false));
     const store = storePlaying();
 
-    // Stream sets playing during its loading phase while the config
-    // screen is still up; the chrome must not react to that.
+    // Stream sets `playing` while still on its config screen.
     store.setPlaying(true);
     expect(store.stageActive).toBe(false);
     scope.stop();

--- a/frontend/src/v2/composables/useStageActive/index.test.ts
+++ b/frontend/src/v2/composables/useStageActive/index.test.ts
@@ -1,0 +1,86 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it } from "vitest";
+import { effectScope, nextTick, ref } from "vue";
+import storePlaying from "@/stores/playing";
+import { installStageActiveClass, useStageActive } from "./index";
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  document.documentElement.classList.remove("r-v2-stage-active");
+});
+
+describe("useStageActive", () => {
+  it("mirrors the running source into the store flag", async () => {
+    const running = ref(false);
+    const scope = effectScope();
+    scope.run(() => useStageActive(running));
+    const store = storePlaying();
+    expect(store.stageActive).toBe(false);
+
+    running.value = true;
+    await nextTick();
+    expect(store.stageActive).toBe(true);
+
+    running.value = false;
+    await nextTick();
+    expect(store.stageActive).toBe(false);
+    scope.stop();
+  });
+
+  it("clears the flag when its owning scope is disposed", () => {
+    const running = ref(true);
+    const scope = effectScope();
+    scope.run(() => useStageActive(running));
+    const store = storePlaying();
+    expect(store.stageActive).toBe(true);
+
+    scope.stop();
+    expect(store.stageActive).toBe(false);
+  });
+
+  it("stays independent of the playing flag", () => {
+    const scope = effectScope();
+    scope.run(() => useStageActive(() => false));
+    const store = storePlaying();
+
+    // Stream sets playing during its loading phase while the config
+    // screen is still up; the chrome must not react to that.
+    store.setPlaying(true);
+    expect(store.stageActive).toBe(false);
+    scope.stop();
+  });
+});
+
+describe("installStageActiveClass", () => {
+  function htmlHasClass(): boolean {
+    return document.documentElement.classList.contains("r-v2-stage-active");
+  }
+
+  it("mirrors the flag onto <html> in both directions", async () => {
+    const scope = effectScope();
+    scope.run(() => installStageActiveClass());
+    const store = storePlaying();
+    expect(htmlHasClass()).toBe(false);
+
+    store.setStageActive(true);
+    await nextTick();
+    expect(htmlHasClass()).toBe(true);
+
+    store.setStageActive(false);
+    await nextTick();
+    expect(htmlHasClass()).toBe(false);
+    scope.stop();
+  });
+
+  it("removes the class when its owning scope is disposed", async () => {
+    const scope = effectScope();
+    scope.run(() => installStageActiveClass());
+    const store = storePlaying();
+    store.setStageActive(true);
+    await nextTick();
+    expect(htmlHasClass()).toBe(true);
+
+    scope.stop();
+    expect(htmlHasClass()).toBe(false);
+  });
+});

--- a/frontend/src/v2/composables/useStageActive/index.ts
+++ b/frontend/src/v2/composables/useStageActive/index.ts
@@ -1,0 +1,32 @@
+import { onScopeDispose, toValue, watch, type MaybeRefOrGetter } from "vue";
+import storePlaying from "@/stores/playing";
+
+/** Mirrors a player's running state into the global stage flag that
+ *  unmounts the app chrome and zeroes the nav-height tokens. */
+export function useStageActive(running: MaybeRefOrGetter<boolean>): void {
+  const playingStore = storePlaying();
+  // Deliberately not the `playing` flag: that one also covers pre-stage
+  // phases (Stream mutes input while loading behind its config screen).
+  watch(
+    () => toValue(running),
+    (active) => playingStore.setStageActive(active),
+    { immediate: true },
+  );
+  onScopeDispose(() => playingStore.setStageActive(false));
+}
+
+/** Mirrors the flag onto <html> (next to the theme classes) so
+ *  body-teleported overlays resolve the zeroed nav-height tokens too. */
+export function installStageActiveClass(): void {
+  const playingStore = storePlaying();
+  watch(
+    () => playingStore.stageActive,
+    (active) => {
+      document.documentElement.classList.toggle("r-v2-stage-active", active);
+    },
+    { immediate: true },
+  );
+  onScopeDispose(() =>
+    document.documentElement.classList.remove("r-v2-stage-active"),
+  );
+}

--- a/frontend/src/v2/composables/useStageActive/index.ts
+++ b/frontend/src/v2/composables/useStageActive/index.ts
@@ -5,8 +5,8 @@ import storePlaying from "@/stores/playing";
  *  unmounts the app chrome and zeroes the nav-height tokens. */
 export function useStageActive(running: MaybeRefOrGetter<boolean>): void {
   const playingStore = storePlaying();
-  // Deliberately not the `playing` flag: that one also covers pre-stage
-  // phases (Stream mutes input while loading behind its config screen).
+  // Deliberately not the `playing` flag: that one also spans pre-stage
+  // phases (Stream sets it while loading behind its config screen).
   watch(
     () => toValue(running),
     (active) => playingStore.setStageActive(active),

--- a/frontend/src/v2/layouts/AppLayout.vue
+++ b/frontend/src/v2/layouts/AppLayout.vue
@@ -20,6 +20,7 @@ import {
 import { useRouter } from "vue-router";
 import storeCollections from "@/stores/collections";
 import storePlatforms from "@/stores/platforms";
+import storePlaying from "@/stores/playing";
 import { useStreamingStore } from "@/stores/streaming";
 import AppNav from "@/v2/components/AppShell/AppNav.vue";
 import BackgroundArt from "@/v2/components/AppShell/BackgroundArt.vue";
@@ -39,6 +40,7 @@ import { installOverlayRouteDismiss } from "@/v2/composables/useOverlayRouteDism
 import { prefetchPlatformIcons } from "@/v2/composables/usePlatformIconCache";
 import { useReducedMotion } from "@/v2/composables/useReducedMotion";
 import { installScanLifecycle } from "@/v2/composables/useScanLifecycle";
+import { installStageActiveClass } from "@/v2/composables/useStageActive";
 import { installBackMorph } from "@/v2/composables/useViewTransition";
 
 installPermissionsHydration();
@@ -51,6 +53,7 @@ installScanLifecycle();
 // can branch on viewport via `html[data-bp~="xs"] .foo { … }` instead of
 // hardcoding `@media (max-width: …)` values across every SFC.
 installBreakpointAttribute();
+installStageActiveClass();
 
 // Reduced-motion mode: mirror the flag onto <html> so global CSS can drop
 // its heaviest work via `html.r-v2-reduced-motion .foo { … }` (background-art
@@ -70,6 +73,10 @@ watch(
 const collectionsStore = storeCollections();
 const platformsStore = storePlatforms();
 const streamingStore = useStreamingStore();
+
+// While a player stage covers the viewport the emulator owns the screen,
+// so the fixed nav chrome unmounts (and its links drop from the tab order).
+const playingStore = storePlaying();
 
 // Developer debug overlay — opt-in via Settings → Developer (per-device).
 // Lazily loaded so its chunk (and the vueuse perf hooks it pulls in) is only
@@ -194,11 +201,11 @@ onBeforeUnmount(() => {
     />
 
     <div class="r-v2-shell__app">
-      <AppNav />
+      <AppNav v-if="!playingStore.stageActive" />
       <main id="r-v2-main" class="r-v2-shell__main" tabindex="-1">
         <router-view name="v2" />
       </main>
-      <BottomNav />
+      <BottomNav v-if="!playingStore.stageActive" />
     </div>
 
     <GlobalDialogs />

--- a/frontend/src/v2/layouts/AppLayout.vue
+++ b/frontend/src/v2/layouts/AppLayout.vue
@@ -74,8 +74,6 @@ const collectionsStore = storeCollections();
 const platformsStore = storePlatforms();
 const streamingStore = useStreamingStore();
 
-// While a player stage covers the viewport the emulator owns the screen,
-// so the fixed nav chrome unmounts (and its links drop from the tab order).
 const playingStore = storePlaying();
 
 // Developer debug overlay — opt-in via Settings → Developer (per-device).

--- a/frontend/src/v2/styles/global.css
+++ b/frontend/src/v2/styles/global.css
@@ -33,6 +33,13 @@ html[data-bp~="xs"].r-v2 {
   --r-row-pad: 14px;
 }
 
+/* A running player stage owns the viewport: AppLayout unmounts the nav
+   chrome and this collapses the nav-height tokens for every consumer. */
+html.r-v2.r-v2-stage-active {
+  --r-nav-h: 0px;
+  --r-bottom-nav-h: 0px;
+}
+
 /* Focus rings are modality-gated — invisible for mouse/touch so we don't
    dog-pile the hover states, visible and prominent for keyboard/pad so
    the user always knows where they are.

--- a/frontend/src/v2/styles/global.css
+++ b/frontend/src/v2/styles/global.css
@@ -33,8 +33,8 @@ html[data-bp~="xs"].r-v2 {
   --r-row-pad: 14px;
 }
 
-/* A running player stage owns the viewport: AppLayout unmounts the nav
-   chrome and this collapses the nav-height tokens for every consumer. */
+/* The nav chrome unmounts while a player stage owns the viewport, so its
+   height tokens collapse for everything that offsets by them. */
 html.r-v2.r-v2-stage-active {
   --r-nav-h: 0px;
   --r-bottom-nav-h: 0px;

--- a/frontend/src/v2/utils/playerTouchGuard.test.ts
+++ b/frontend/src/v2/utils/playerTouchGuard.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { suppressVirtualGamepadZoneTouch } from "./playerTouchGuard";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+// Mirrors the production wiring: the handler listens on the stage root and
+// touches bubble up from the EmulatorJS virtual-gamepad DOM inside it.
+function mountStage(): { zone: HTMLElement; button: HTMLElement } {
+  const stage = document.createElement("div");
+  const zone = document.createElement("div");
+  zone.classList.add("ejs_virtualGamepad_right");
+  const button = document.createElement("div");
+  button.classList.add("ejs_virtualGamepad_button");
+  zone.appendChild(button);
+  stage.appendChild(zone);
+  document.body.appendChild(stage);
+  stage.addEventListener("touchstart", suppressVirtualGamepadZoneTouch);
+  return { zone, button };
+}
+
+function dispatchTouch(target: Element, type: string): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe("suppressVirtualGamepadZoneTouch", () => {
+  it("cancels touches that land on an empty gamepad zone", () => {
+    const { zone } = mountStage();
+    expect(dispatchTouch(zone, "touchstart").defaultPrevented).toBe(true);
+  });
+
+  it("leaves touches on gamepad buttons alone", () => {
+    const { button } = mountStage();
+    expect(dispatchTouch(button, "touchstart").defaultPrevented).toBe(false);
+  });
+});

--- a/frontend/src/v2/utils/playerTouchGuard.ts
+++ b/frontend/src/v2/utils/playerTouchGuard.ts
@@ -8,8 +8,7 @@ const VIRTUAL_GAMEPAD_ZONE_SELECTOR = [
   ".ejs_virtualGamepad_right",
 ].join(", ");
 
-/** Cancels a touch on an empty virtual-gamepad zone so the browser never
- *  synthesizes the mouse events that would open the EmulatorJS menu. */
+/** Cancels a touch that lands on an empty virtual-gamepad zone. */
 export function suppressVirtualGamepadZoneTouch(event: Event): void {
   const target = event.target;
   if (

--- a/frontend/src/v2/utils/playerTouchGuard.ts
+++ b/frontend/src/v2/utils/playerTouchGuard.ts
@@ -1,0 +1,21 @@
+// EmulatorJS never preventDefault()s touches on the virtual gamepad's empty
+// zones; the synthesized mouse events then open its menu (EmulatorJS#1221).
+const VIRTUAL_GAMEPAD_ZONE_SELECTOR = [
+  ".ejs_virtualGamepad_parent",
+  ".ejs_virtualGamepad_top",
+  ".ejs_virtualGamepad_bottom",
+  ".ejs_virtualGamepad_left",
+  ".ejs_virtualGamepad_right",
+].join(", ");
+
+/** Cancels a touch on an empty virtual-gamepad zone so the browser never
+ *  synthesizes the mouse events that would open the EmulatorJS menu. */
+export function suppressVirtualGamepadZoneTouch(event: Event): void {
+  const target = event.target;
+  if (
+    target instanceof Element &&
+    target.matches(VIRTUAL_GAMEPAD_ZONE_SELECTOR)
+  ) {
+    event.preventDefault();
+  }
+}

--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -123,8 +123,7 @@ const removeIOSFullscreenShim = ref<(() => void) | null>(null);
 useUnloadGuard(gameRunning);
 useStageActive(gameRunning);
 
-// Stage-scoped so the non-passive listener never taxes touches elsewhere;
-// cancelling touchstart alone suppresses the synthesized mouse sequence.
+// Stage-scoped so the non-passive listener never taxes touches elsewhere.
 const stageRef = ref<HTMLElement | null>(null);
 useEventListener(stageRef, "touchstart", suppressVirtualGamepadZoneTouch, {
   passive: false,
@@ -894,8 +893,8 @@ const selectedAsset = computed<SaveSchema | StateSchema | null>(() =>
   z-index: 1;
 }
 
-/* EmulatorJS (pinned 4.2.3) parks its touch menu button 5px into the
-   corner; clear rounded corners and pad the icon up to the touch target. */
+/* EmulatorJS parks its touch menu button 5px into the corner, which lands
+   under the rounded screen corners on phones. */
 .r-v2-ejs__stage :deep(.ejs_virtualGamepad_open) {
   top: 10px;
   right: 14px;

--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -56,6 +56,7 @@ import { usePlaySession } from "@/v2/composables/usePlaySession";
 import { usePlayerHero } from "@/v2/composables/usePlayerHero";
 import { usePlayerNav } from "@/v2/composables/usePlayerNav";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
+import { useStageActive } from "@/v2/composables/useStageActive";
 import { useUnloadGuard } from "@/v2/composables/useUnloadGuard";
 import type { SliderBtnGroupItem } from "@/v2/lib/primitives/RSliderBtnGroup/types";
 import {
@@ -71,6 +72,7 @@ import {
   type DiscSelection,
 } from "@/v2/utils/playerDisc";
 import { resolveInitialFirmware } from "@/v2/utils/playerFirmware";
+import { suppressVirtualGamepadZoneTouch } from "@/v2/utils/playerTouchGuard";
 import { isJsResource, loadScript } from "@/v2/utils/scriptLoader";
 import { installIOSFullscreenShim } from "@/views/Player/EmulatorJS/utils";
 import { rememberCore, resolveRememberedCore } from "./coreStorage";
@@ -119,6 +121,14 @@ const gameRunning = ref(false);
 const removeIOSFullscreenShim = ref<(() => void) | null>(null);
 
 useUnloadGuard(gameRunning);
+useStageActive(gameRunning);
+
+// Stage-scoped so the non-passive listener never taxes touches elsewhere;
+// cancelling touchstart alone suppresses the synthesized mouse sequence.
+const stageRef = ref<HTMLElement | null>(null);
+useEventListener(stageRef, "touchstart", suppressVirtualGamepadZoneTouch, {
+  passive: false,
+});
 
 const presence = useActivityPresence(() => rom.value?.id);
 
@@ -239,8 +249,6 @@ async function onPlay() {
       console.warn("[Play] Local loader failed, trying CDN", e);
       await attemptLoad(EJS_NETPLAY_ENABLED ? LOCAL_PATH : CDN_PATH);
     }
-    playing.value = true;
-    fullScreen.value = fullscreenOnPlay.value;
   } catch (err) {
     removeIOSFullscreenShim.value?.();
     removeIOSFullscreenShim.value = null;
@@ -656,7 +664,7 @@ const selectedAsset = computed<SaveSchema | StateSchema | null>(() =>
     </div>
 
     <!-- Running state -->
-    <div v-else-if="rom" class="r-v2-ejs__stage">
+    <div v-else-if="rom" ref="stageRef" class="r-v2-ejs__stage">
       <Player
         :rom="rom"
         :state="selectedState"
@@ -884,6 +892,16 @@ const selectedAsset = computed<SaveSchema | StateSchema | null>(() =>
   inset: var(--r-nav-h) 0 0 0;
   background: var(--r-color-canvas-bg);
   z-index: 1;
+}
+
+/* EmulatorJS (pinned 4.2.3) parks its touch menu button 5px into the
+   corner; clear rounded corners and pad the icon up to the touch target. */
+.r-v2-ejs__stage :deep(.ejs_virtualGamepad_open) {
+  top: 10px;
+  right: 14px;
+  width: var(--r-touch-target);
+  height: var(--r-touch-target);
+  padding: 10px;
 }
 
 /* Scraped bezel framing the running game. Full-height, centred, aspect

--- a/frontend/src/v2/views/Player/JsDos.test.ts
+++ b/frontend/src/v2/views/Player/JsDos.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   galleryRom: null as Record<string, unknown> | null,
   routeLeaveGuard: null as ((to: { fullPath: string }) => unknown) | null,
   setPlaying: vi.fn(),
+  setStageActive: vi.fn(),
   snackbarError: vi.fn(),
   userId: 7,
 }));
@@ -51,7 +52,10 @@ vi.mock("@/stores/auth", () => ({
 }));
 
 vi.mock("@/stores/playing", () => ({
-  default: () => ({ setPlaying: mocks.setPlaying }),
+  default: () => ({
+    setPlaying: mocks.setPlaying,
+    setStageActive: mocks.setStageActive,
+  }),
 }));
 
 vi.mock("@/stores/roms", () => ({

--- a/frontend/src/v2/views/Player/Ruffle.test.ts
+++ b/frontend/src/v2/views/Player/Ruffle.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   flushPlaySession: vi.fn(),
   push: vi.fn(),
   setPlaying: vi.fn(),
+  setStageActive: vi.fn(),
 }));
 
 vi.mock("vue-i18n", () => ({
@@ -38,7 +39,10 @@ vi.mock("@/services/api/rom", () => ({
 }));
 
 vi.mock("@/stores/playing", () => ({
-  default: () => ({ setPlaying: mocks.setPlaying }),
+  default: () => ({
+    setPlaying: mocks.setPlaying,
+    setStageActive: mocks.setStageActive,
+  }),
 }));
 
 vi.mock("@/stores/roms", () => ({

--- a/frontend/src/v2/views/Player/Stream.vue
+++ b/frontend/src/v2/views/Player/Stream.vue
@@ -122,8 +122,6 @@ const selectedDisc = ref<number | null>(null);
 const isSwappingDisc = ref(false);
 
 const gameRunning = computed(() => playerState.value === "playing");
-// Chrome-wise only the mounted stage counts; `playing` also spans the
-// loading phase, where the config screen still needs the nav.
 useStageActive(gameRunning);
 
 // Set by the Join action on the game page. A join attaches to a session

--- a/frontend/src/v2/views/Player/Stream.vue
+++ b/frontend/src/v2/views/Player/Stream.vue
@@ -77,6 +77,7 @@ import { usePageTitle } from "@/v2/composables/usePageTitle";
 import { usePlaySession } from "@/v2/composables/usePlaySession";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
 import { useSocketEvent } from "@/v2/composables/useSocketEvent";
+import { useStageActive } from "@/v2/composables/useStageActive";
 import { useUnloadGuard } from "@/v2/composables/useUnloadGuard";
 import type { SliderBtnGroupItem } from "@/v2/lib/primitives/RSliderBtnGroup/types";
 import storeGalleryRoms from "@/v2/stores/galleryRoms";
@@ -121,6 +122,9 @@ const selectedDisc = ref<number | null>(null);
 const isSwappingDisc = ref(false);
 
 const gameRunning = computed(() => playerState.value === "playing");
+// Chrome-wise only the mounted stage counts; `playing` also spans the
+// loading phase, where the config screen still needs the nav.
+useStageActive(gameRunning);
 
 // Set by the Join action on the game page. A join attaches to a session
 // someone else is hosting instead of claiming a container, so none of the


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Since 5.0.0, playing a game on a mobile browser left the v2 chrome (logo, user menu, tab bar) painted over the EmulatorJS UI. Four mechanisms, all addressed:

1. **Chrome over the emulator**: the running stage is `position: fixed; z-index: 1`, a stacking context that traps EmulatorJS's internal `z-index: 999/9999` layers below `AppNav`/`BottomNav` (`z-index: 100`). Players now mirror their running stage into a new `stageActive` store flag via `useStageActive()` (`PlayerShell` drives it for Ruffle/JsDos/Pico8; EmulatorJS and Stream wire their own). `AppLayout` unmounts both navs while it is set (dropping their links from the tab order) and mirrors the flag onto `<html>`, where `global.css` zeroes `--r-nav-h`/`--r-bottom-nav-h`, so stages, RDialog/RMenu sheets, toasts, the MiniPlayer, and Pico8's bottom padding all reclaim the space through the tokens they already consume.
2. **"Invisible button" between A and B**: EmulatorJS 4.2.3 never `preventDefault()`s touches on the virtual gamepad's empty zone boxes, so the synthesized mouse events ghost-open its menu (EmulatorJS/EmulatorJS#1221, being reported upstream separately). A stage-scoped, non-passive `touchstart` guard cancels touches whose target is an empty zone; real buttons/dpad/joystick are untouched.
3. **iOS fullscreen "does nothing"**: the shim's `z-index: 99999` was trapped in the same stacking context, and its nav-hiding selectors only matched v1 Vuetify classes. With the chrome unmounted the shim now works in and out of fullscreen.
4. **Menu button flush to the corner / over the R button**: a scoped `:deep` override moves `.ejs_virtualGamepad_open` off the corner and pads its 24px icon up to the 44px touch target.

`stageActive` is deliberately separate from `playing`: Stream sets `playing` during its whole loading phase (input-mute semantics) while its config screen still needs the nav, and the admin Desktop view mounts `StreamStage` with the chrome intentionally kept.

Deliberate decision (repo owner): the Soundtrack MiniPlayer stays visible during play so the audio controls remain reachable; it already floated over the stage before this change.

Known limitations / follow-up candidates: with `EJS_NETPLAY_ENABLED` the nightly CDN build's class names can drift past the guard and CSS override silently; misses that land on the game canvas near the bottom edge can still ghost-open the menu (full fix belongs upstream); `viewport-fit=cover` is not set app-wide, so safe-area insets stay inert; consolidating the hand-written `setPlaying` lifecycles into the same composable seam would remove ~11 manual call sites.

Fixes #4081

**AI disclosure:** this PR was developed with AI assistance (Claude Code) end to end: diagnosis, implementation, tests, and multi-agent review passes (security audit, code review, simplification), with human direction and final review by the repo owner.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

Verified: vue-tsc, full Vitest suite (1158 passing; the 3 RDateField failures are a system-locale artifact and fail identically on master), production build, Trunk. Device pass pending on real phones with this checklist:

1. Portrait, fullscreen off: chrome disappears when the game starts, returns on Quit / Save & Quit / back-nav.
2. Portrait: every EmulatorJS menu row (Quit, Save & Quit, fullscreen) tappable.
3. Repeated taps between/around A and B: menu must NOT open; A/B/L/R, dpad, Select/Start still respond.
4. Landscape: menu button clear of the rounded corner and of the R button.
5. iOS Safari/Brave with "Start Fullscreen": full-bleed game, no chrome, hamburger reachable; exit restores chrome.
6. Streaming: nav stays during the loading phase, disappears once the stream starts; admin Desktop view keeps the nav.
7. Desktop regression: nav hides during play and returns on exit; save/load dialogs render above the game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ND1wfNV3vKwu8Mfinn4WkA