### PR TITLE
fix(tasks): match a running task by its registry key

### DIFF
--- a/backend/endpoints/responses/__init__.py
+++ b/backend/endpoints/responses/__init__.py
@@ -91,7 +91,7 @@ TaskMeta = Union[
 
 
 class TaskExecutionResponse(TypedDict):
-    # None on a scan a client started itself, which answers to no registry entry.
+    # None on scans started outside the catalog, by a client or the watcher.
     task_key: str | None
     task_name: str
     task_id: str

--- a/backend/endpoints/responses/__init__.py
+++ b/backend/endpoints/responses/__init__.py
@@ -91,6 +91,8 @@ TaskMeta = Union[
 
 
 class TaskExecutionResponse(TypedDict):
+    # None on a scan a client started itself, which answers to no registry entry.
+    task_key: str | None
     task_name: str
     task_id: str
     status: JobStatus

--- a/backend/endpoints/sync.py
+++ b/backend/endpoints/sync.py
@@ -495,6 +495,7 @@ def trigger_push_pull(
         force=True,
         job_timeout=TASK_TIMEOUT,
         meta={
+            "task_key": "sync_push_pull",
             "task_name": "Push-Pull Sync",
             "task_type": "sync",
         },

--- a/backend/endpoints/tasks.py
+++ b/backend/endpoints/tasks.py
@@ -74,6 +74,7 @@ def _build_task_status_response(
     job_meta = job.get_meta()
     task_type = job_meta.get("task_type")
     task_name = job_meta.get("task_name") or get_job_func_name(job)
+    task_key = job_meta.get("task_key")
 
     # Convert datetime objects to ISO format strings
     created_at = job.created_at.isoformat() if job.created_at else None
@@ -82,6 +83,7 @@ def _build_task_status_response(
     enqueued_at = job.enqueued_at.isoformat() if job.enqueued_at else None
 
     common_data = {
+        "task_key": task_key,
         "task_name": task_name,
         "task_id": job.id,
         "status": job.get_status(),
@@ -286,6 +288,7 @@ async def run_single_task(
     job = enqueue_task(task_name, task_kwargs=task_kwargs or {})
 
     return {
+        "task_key": task_name,
         "task_name": task_instance.title,
         "task_id": job.id,
         "status": job.get_status() or JobStatus.QUEUED,

--- a/backend/endpoints/tasks.py
+++ b/backend/endpoints/tasks.py
@@ -74,7 +74,7 @@ def _build_task_status_response(
     job_meta = job.get_meta()
     task_type = job_meta.get("task_type")
     task_name = job_meta.get("task_name") or get_job_func_name(job)
-    task_key = job_meta.get("task_key")
+    task_key = job_meta.get("task_key") or job.kwargs.get("name")
 
     # Convert datetime objects to ISO format strings
     created_at = job.created_at.isoformat() if job.created_at else None

--- a/backend/tasks/cron_config.py
+++ b/backend/tasks/cron_config.py
@@ -32,6 +32,6 @@ for name, task in SCHEDULED_TASKS.items():
         # A spent dispatch carries the scan's own name, and RQ drops a job whose
         # result_ttl is 0, so one rescan is not listed as two runs.
         result_ttl=0 if is_scan else TASK_RESULT_TTL,
-        meta=task.job_meta,
+        meta=task.job_meta(name),
     )
     log.info(f"Scheduled '{name}' at '{task.cron_string}'")

--- a/backend/tasks/registry.py
+++ b/backend/tasks/registry.py
@@ -88,7 +88,7 @@ def enqueue_task(
         kwargs={"name": name, "task_kwargs": task_kwargs or {}},
         job_timeout=task.timeout,
         result_ttl=TASK_RESULT_TTL,
-        meta=task.job_meta,
+        meta=task.job_meta(name),
         **job_options,
     )
 

--- a/backend/tasks/tasks.py
+++ b/backend/tasks/tasks.py
@@ -95,10 +95,17 @@ class Task(ABC):
         """Whether an admin can trigger this task on demand."""
         return self.manual_run and self.enabled
 
-    @property
-    def job_meta(self) -> dict[str, Any]:
-        """What a job of this task carries so the API can describe it."""
-        return {"task_name": self.title, "task_type": self.task_type.value}
+    def job_meta(self, key: str) -> dict[str, Any]:
+        """What a job of this task carries so the API can describe it.
+
+        Args:
+            key: The name the task is registered under, which outlives its title.
+        """
+        return {
+            "task_key": key,
+            "task_name": self.title,
+            "task_type": self.task_type.value,
+        }
 
     @abstractmethod
     async def run(self, *args: Any, **kwargs: Any) -> Any: ...

--- a/backend/tests/endpoints/test_tasks.py
+++ b/backend/tests/endpoints/test_tasks.py
@@ -8,6 +8,18 @@ from handler.redis_handler import redis_client
 from tasks.tasks import Task, TaskType
 
 
+def _job_with_meta(meta: dict) -> Mock:
+    """A finished job carrying `meta`, for asserting on what the response reports."""
+    job = Mock()
+    job.id = "test-job-id-123"
+    job.func_name = "test_task"
+    job.get_meta.return_value = {"task_type": TaskType.CLEANUP, **meta}
+    job.get_status.return_value = "finished"
+    for attr in ("created_at", "enqueued_at", "started_at", "ended_at"):
+        setattr(job, attr, None)
+    return job
+
+
 @pytest.fixture
 def mock_task():
     """Create a mock task for testing"""
@@ -247,6 +259,7 @@ class TestRunSingleTask:
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
 
+        assert data["task_key"] == "test_task"
         assert data["task_name"] == "Test Task"
         assert data["task_id"] == "1"
         assert data["status"] == "queued"
@@ -409,6 +422,39 @@ class TestGetTaskById:
         mock_job_fetch.assert_called_once_with(
             "test-job-id-123", connection=redis_client
         )
+
+    @patch("endpoints.tasks.Job.fetch")
+    def test_the_registry_key_survives_the_round_trip(
+        self, mock_job_fetch, client, access_token
+    ):
+        """A job's key reaches the client, which matches runs to the catalog by it."""
+        mock_job_fetch.return_value = _job_with_meta(
+            {
+                "task_key": "cleanup_zip_cache",
+                "task_name": "Scheduled ZIP cache cleanup",
+            }
+        )
+
+        response = client.get(
+            "/api/tasks/test-job-id-123",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.json()["task_key"] == "cleanup_zip_cache"
+
+    @patch("endpoints.tasks.Job.fetch")
+    def test_a_job_outside_the_catalog_reports_no_key(
+        self, mock_job_fetch, client, access_token
+    ):
+        """A scan a client started itself answers to no registry entry."""
+        mock_job_fetch.return_value = _job_with_meta({"task_name": "Quick Scan"})
+
+        response = client.get(
+            "/api/tasks/test-job-id-123",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.json()["task_key"] is None
 
     @patch("endpoints.tasks.Job.fetch")
     def test_get_task_by_id_not_found(self, mock_job_fetch, client, access_token):

--- a/backend/tests/endpoints/test_tasks.py
+++ b/backend/tests/endpoints/test_tasks.py
@@ -12,7 +12,6 @@ def _job_with_meta(meta: dict) -> Mock:
     """A finished job carrying `meta`, for asserting on what the response reports."""
     job = Mock()
     job.id = "test-job-id-123"
-    job.func_name = "test_task"
     job.get_meta.return_value = {"task_type": TaskType.CLEANUP, **meta}
     job.get_status.return_value = "finished"
     for attr in ("created_at", "enqueued_at", "started_at", "ended_at"):
@@ -423,38 +422,33 @@ class TestGetTaskById:
             "test-job-id-123", connection=redis_client
         )
 
+    @pytest.mark.parametrize(
+        ("meta", "expected_key"),
+        [
+            (
+                {
+                    "task_key": "cleanup_zip_cache",
+                    "task_name": "Scheduled ZIP cache cleanup",
+                },
+                "cleanup_zip_cache",
+            ),
+            ({"task_name": "Quick Scan"}, None),
+        ],
+        ids=["catalog entry", "started outside the catalog"],
+    )
     @patch("endpoints.tasks.Job.fetch")
-    def test_the_registry_key_survives_the_round_trip(
-        self, mock_job_fetch, client, access_token
+    def test_the_response_reports_the_registry_key(
+        self, mock_job_fetch, meta, expected_key, client, access_token
     ):
-        """A job's key reaches the client, which matches runs to the catalog by it."""
-        mock_job_fetch.return_value = _job_with_meta(
-            {
-                "task_key": "cleanup_zip_cache",
-                "task_name": "Scheduled ZIP cache cleanup",
-            }
-        )
+        """The key a run is matched to its catalog entry by, null when it has none."""
+        mock_job_fetch.return_value = _job_with_meta(meta)
 
         response = client.get(
             "/api/tasks/test-job-id-123",
             headers={"Authorization": f"Bearer {access_token}"},
         )
 
-        assert response.json()["task_key"] == "cleanup_zip_cache"
-
-    @patch("endpoints.tasks.Job.fetch")
-    def test_a_job_outside_the_catalog_reports_no_key(
-        self, mock_job_fetch, client, access_token
-    ):
-        """A scan a client started itself answers to no registry entry."""
-        mock_job_fetch.return_value = _job_with_meta({"task_name": "Quick Scan"})
-
-        response = client.get(
-            "/api/tasks/test-job-id-123",
-            headers={"Authorization": f"Bearer {access_token}"},
-        )
-
-        assert response.json()["task_key"] is None
+        assert response.json()["task_key"] == expected_key
 
     @patch("endpoints.tasks.Job.fetch")
     def test_get_task_by_id_not_found(self, mock_job_fetch, client, access_token):

--- a/backend/tests/endpoints/test_tasks.py
+++ b/backend/tests/endpoints/test_tasks.py
@@ -13,6 +13,7 @@ def _job_with_meta(meta: dict[str, Any]) -> Mock:
     """A finished job carrying `meta`, for asserting on what the response reports."""
     job = Mock()
     job.id = "test-job-id-123"
+    job.kwargs = {}
     job.get_meta.return_value = {"task_type": TaskType.CLEANUP, **meta}
     job.get_status.return_value = "finished"
     for attr in ("created_at", "enqueued_at", "started_at", "ended_at"):
@@ -397,6 +398,7 @@ class TestGetTaskById:
             "task_type": TaskType.CLEANUP,
         }
         mock_job.func_name = "test_task"
+        mock_job.kwargs = {}
         mock_job.get_status.return_value = "finished"
         mock_job.id = "test-job-id-123"
         mock_job.result = {"status": "completed"}
@@ -452,6 +454,22 @@ class TestGetTaskById:
         assert response.json()["task_key"] == expected_key
 
     @patch("endpoints.tasks.Job.fetch")
+    def test_a_job_predating_the_field_falls_back_to_its_payload(
+        self, mock_job_fetch, client, access_token
+    ):
+        """An in-flight job survives the upgrade matchable, without its meta."""
+        job = _job_with_meta({"task_name": "Scheduled ZIP cache cleanup"})
+        job.kwargs = {"name": "cleanup_zip_cache", "task_kwargs": {}}
+        mock_job_fetch.return_value = job
+
+        response = client.get(
+            "/api/tasks/test-job-id-123",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.json()["task_key"] == "cleanup_zip_cache"
+
+    @patch("endpoints.tasks.Job.fetch")
     def test_get_task_by_id_not_found(self, mock_job_fetch, client, access_token):
         """Test retrieval of a non-existent task by job ID"""
         mock_job_fetch.side_effect = Exception("Job not found")
@@ -484,6 +502,7 @@ class TestGetTaskById:
             "task_type": TaskType.CLEANUP,
         }
         mock_job.func_name = "test_task"
+        mock_job.kwargs = {}
         mock_job.get_status.return_value = "failed"
         mock_job.id = "failed-job-id"
         mock_job.result = {"error": "Task failed"}

--- a/backend/tests/endpoints/test_tasks.py
+++ b/backend/tests/endpoints/test_tasks.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -8,7 +9,7 @@ from handler.redis_handler import redis_client
 from tasks.tasks import Task, TaskType
 
 
-def _job_with_meta(meta: dict) -> Mock:
+def _job_with_meta(meta: dict[str, Any]) -> Mock:
     """A finished job carrying `meta`, for asserting on what the response reports."""
     job = Mock()
     job.id = "test-job-id-123"

--- a/backend/tests/tasks/test_cron_config.py
+++ b/backend/tests/tasks/test_cron_config.py
@@ -30,7 +30,11 @@ def _task(mocker, *, enabled=True, cron_string="0 4 * * *", task_type=TaskType.C
         title="Test Task",
         description="test task",
         task_type=task_type,
-        job_meta={"task_name": "Test Task", "task_type": task_type.value},
+        job_meta=lambda key: {
+            "task_key": key,
+            "task_name": "Test Task",
+            "task_type": task_type.value,
+        },
     )
 
 
@@ -84,6 +88,11 @@ class TestCronConfig:
 
         names = [call.kwargs["name"] for call in register.call_args_list]
         assert names == ["first", "second"]
+
+    def test_the_registered_meta_carries_the_key(self, mocker, registered):
+        register = registered({"test_task": _task(mocker)})
+
+        assert register.call_args.kwargs["meta"]["task_key"] == "test_task"
 
     def test_skips_a_disabled_task(self, mocker, registered):
         assert registered({"off": _task(mocker, enabled=False)}).call_count == 0

--- a/backend/tests/tasks/test_cron_config.py
+++ b/backend/tests/tasks/test_cron_config.py
@@ -6,7 +6,7 @@ from config import TASK_RESULT_TTL, TASK_TIMEOUT
 from handler.redis_handler import QueuePrio
 from tasks import cron_config
 from tasks.registry import SCHEDULED_TASKS, enqueue_scheduled_scan
-from tasks.tasks import TaskType, run_task_by_name
+from tasks.tasks import Task, TaskType, run_task_by_name
 
 
 @pytest.fixture
@@ -23,19 +23,19 @@ def registered(mocker):
 
 
 def _task(mocker, *, enabled=True, cron_string="0 4 * * *", task_type=TaskType.CLEANUP):
-    return mocker.MagicMock(
-        enabled=enabled,
-        cron_string=cron_string,
-        timeout=100,
-        title="Test Task",
-        description="test task",
-        task_type=task_type,
-        job_meta=lambda key: {
-            "task_key": key,
-            "task_name": "Test Task",
-            "task_type": task_type.value,
-        },
-    )
+    task = mocker.create_autospec(Task, instance=True)
+    task.enabled = enabled
+    task.cron_string = cron_string
+    task.timeout = 100
+    task.title = "Test Task"
+    task.description = "test task"
+    task.task_type = task_type
+    task.job_meta.side_effect = lambda key: {
+        "task_key": key,
+        "task_name": "Test Task",
+        "task_type": task_type.value,
+    }
+    return task
 
 
 def _scan_task(mocker, **kwargs):

--- a/backend/tests/tasks/test_registry.py
+++ b/backend/tests/tasks/test_registry.py
@@ -48,12 +48,7 @@ class TestEnqueueTask:
         assert kwargs["job_timeout"] == task.timeout
         assert kwargs["result_ttl"] == TASK_RESULT_TTL
         assert kwargs["meta"] == task.job_meta("cleanup_zip_cache")
-
-    def test_the_payload_carries_the_registry_key(self, queue):
-        enqueue_task("cleanup_zip_cache", queue=queue)
-
-        meta = queue.enqueue.call_args.kwargs["meta"]
-        assert meta["task_key"] == "cleanup_zip_cache"
+        assert kwargs["meta"]["task_key"] == "cleanup_zip_cache"
 
     def test_caller_arguments_are_nested_under_the_name(self, queue):
         enqueue_task("cleanup_missing_roms", queue=queue, task_kwargs={"dry_run": True})

--- a/backend/tests/tasks/test_registry.py
+++ b/backend/tests/tasks/test_registry.py
@@ -47,7 +47,13 @@ class TestEnqueueTask:
         assert kwargs["kwargs"] == {"name": "cleanup_zip_cache", "task_kwargs": {}}
         assert kwargs["job_timeout"] == task.timeout
         assert kwargs["result_ttl"] == TASK_RESULT_TTL
-        assert kwargs["meta"] == task.job_meta
+        assert kwargs["meta"] == task.job_meta("cleanup_zip_cache")
+
+    def test_the_payload_carries_the_registry_key(self, queue):
+        enqueue_task("cleanup_zip_cache", queue=queue)
+
+        meta = queue.enqueue.call_args.kwargs["meta"]
+        assert meta["task_key"] == "cleanup_zip_cache"
 
     def test_caller_arguments_are_nested_under_the_name(self, queue):
         enqueue_task("cleanup_missing_roms", queue=queue, task_kwargs={"dry_run": True})

--- a/frontend/src/__generated__/models/CleanupTaskStatusResponse.ts
+++ b/frontend/src/__generated__/models/CleanupTaskStatusResponse.ts
@@ -5,6 +5,7 @@
 import type { CleanupTaskMeta } from './CleanupTaskMeta';
 import type { JobStatus } from './JobStatus';
 export type CleanupTaskStatusResponse = {
+    task_key: (string | null);
     task_name: string;
     task_id: string;
     status: JobStatus;

--- a/frontend/src/__generated__/models/ConversionTaskStatusResponse.ts
+++ b/frontend/src/__generated__/models/ConversionTaskStatusResponse.ts
@@ -5,6 +5,7 @@
 import type { ConversionTaskMeta } from './ConversionTaskMeta';
 import type { JobStatus } from './JobStatus';
 export type ConversionTaskStatusResponse = {
+    task_key: (string | null);
     task_name: string;
     task_id: string;
     status: JobStatus;

--- a/frontend/src/__generated__/models/ExclusionType.ts
+++ b/frontend/src/__generated__/models/ExclusionType.ts
@@ -3,6 +3,6 @@
 /* tslint:disable */
 /* eslint-disable */
 /**
- * The `Config` lists an exclusion write may target.
+ * The `Config` fields an exclusion write may target.
  */
 export type ExclusionType = 'EXCLUDED_PLATFORMS' | 'EXCLUDED_SINGLE_EXT' | 'EXCLUDED_SINGLE_FILES' | 'EXCLUDED_MULTI_FILES' | 'EXCLUDED_MULTI_PARTS_EXT' | 'EXCLUDED_MULTI_PARTS_FILES';

--- a/frontend/src/__generated__/models/GenericTaskStatusResponse.ts
+++ b/frontend/src/__generated__/models/GenericTaskStatusResponse.ts
@@ -5,6 +5,7 @@
 import type { GenericTaskMeta } from './GenericTaskMeta';
 import type { JobStatus } from './JobStatus';
 export type GenericTaskStatusResponse = {
+    task_key: (string | null);
     task_name: string;
     task_id: string;
     status: JobStatus;

--- a/frontend/src/__generated__/models/ScanTaskStatusResponse.ts
+++ b/frontend/src/__generated__/models/ScanTaskStatusResponse.ts
@@ -5,6 +5,7 @@
 import type { JobStatus } from './JobStatus';
 import type { ScanTaskMeta } from './ScanTaskMeta';
 export type ScanTaskStatusResponse = {
+    task_key: (string | null);
     task_name: string;
     task_id: string;
     status: JobStatus;

--- a/frontend/src/__generated__/models/SyncTaskStatusResponse.ts
+++ b/frontend/src/__generated__/models/SyncTaskStatusResponse.ts
@@ -5,6 +5,7 @@
 import type { JobStatus } from './JobStatus';
 import type { SyncTaskMeta } from './SyncTaskMeta';
 export type SyncTaskStatusResponse = {
+    task_key: (string | null);
     task_name: string;
     task_id: string;
     status: JobStatus;

--- a/frontend/src/__generated__/models/TaskExecutionResponse.ts
+++ b/frontend/src/__generated__/models/TaskExecutionResponse.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 import type { JobStatus } from './JobStatus';
 export type TaskExecutionResponse = {
+    task_key: (string | null);
     task_name: string;
     task_id: string;
     status: JobStatus;

--- a/frontend/src/__generated__/models/UpdateTaskStatusResponse.ts
+++ b/frontend/src/__generated__/models/UpdateTaskStatusResponse.ts
@@ -5,6 +5,7 @@
 import type { JobStatus } from './JobStatus';
 import type { UpdateTaskMeta } from './UpdateTaskMeta';
 export type UpdateTaskStatusResponse = {
+    task_key: (string | null);
     task_name: string;
     task_id: string;
     status: JobStatus;

--- a/frontend/src/__generated__/models/WatcherTaskStatusResponse.ts
+++ b/frontend/src/__generated__/models/WatcherTaskStatusResponse.ts
@@ -5,6 +5,7 @@
 import type { JobStatus } from './JobStatus';
 import type { WatcherTaskMeta } from './WatcherTaskMeta';
 export type WatcherTaskStatusResponse = {
+    task_key: (string | null);
     task_name: string;
     task_id: string;
     status: JobStatus;

--- a/frontend/src/v2/components/Settings/TasksSection.test.ts
+++ b/frontend/src/v2/components/Settings/TasksSection.test.ts
@@ -1,0 +1,115 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TasksSection from "./TasksSection.vue";
+
+const { getTasks, getTaskStatus, runTask } = vi.hoisted(() => ({
+  getTasks: vi.fn(),
+  getTaskStatus: vi.fn(),
+  runTask: vi.fn(),
+}));
+
+vi.mock("@/services/api/task", () => ({
+  default: { getTasks, getTaskStatus, runTask },
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key, locale: { value: "en_US" } }),
+}));
+
+vi.mock("@/v2/composables/useSnackbar", () => ({
+  useSnackbar: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+
+const CLEANUP_TASK = {
+  name: "cleanup_zip_cache",
+  type: "cleanup",
+  title: "Scheduled ZIP cache cleanup",
+  description: "Removes stale cached ZIP files",
+  enabled: true,
+  manual_run: true,
+  cron_string: "",
+};
+
+function status(overrides: Record<string, unknown>) {
+  return {
+    task_key: null,
+    task_name: "Scheduled ZIP cache cleanup",
+    task_id: "job-1",
+    task_type: "cleanup",
+    status: "started",
+    created_at: null,
+    enqueued_at: null,
+    started_at: null,
+    ended_at: null,
+    meta: {},
+    ...overrides,
+  };
+}
+
+async function mountSection() {
+  const wrapper = mount(TasksSection, {
+    global: {
+      stubs: {
+        SettingsSection: { template: "<div><slot /></div>" },
+        RBtn: true,
+        RIcon: true,
+        RSpinner: true,
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+function runButton(wrapper: Awaited<ReturnType<typeof mountSection>>) {
+  return wrapper.get("button.r-v2-tasks__run-btn");
+}
+
+describe("TasksSection", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    getTasks.mockReset();
+    getTasks.mockResolvedValue({
+      data: { watcher: [], scheduled: [], manual: [CLEANUP_TASK] },
+    });
+    getTaskStatus.mockReset();
+    getTaskStatus.mockResolvedValue({ data: [] });
+    runTask.mockReset();
+    runTask.mockResolvedValue({ data: { task_id: "job-1" } });
+  });
+
+  it("disables the run button while that task's job is in flight", async () => {
+    getTaskStatus.mockResolvedValue({
+      data: [status({ task_key: "cleanup_zip_cache" })],
+    });
+
+    const wrapper = await mountSection();
+
+    expect(runButton(wrapper).attributes("disabled")).toBeDefined();
+    wrapper.unmount();
+  });
+
+  it("leaves the button live when only the display title matches", async () => {
+    getTaskStatus.mockResolvedValue({
+      data: [status({ task_key: "some_other_task" })],
+    });
+
+    const wrapper = await mountSection();
+
+    expect(runButton(wrapper).attributes("disabled")).toBeUndefined();
+    wrapper.unmount();
+  });
+
+  it("leaves the button live for a job that carries no key", async () => {
+    // A scan a client started itself answers to no registry entry.
+    getTaskStatus.mockResolvedValue({
+      data: [status({ task_name: "Quick Scan" })],
+    });
+
+    const wrapper = await mountSection();
+
+    expect(runButton(wrapper).attributes("disabled")).toBeUndefined();
+    wrapper.unmount();
+  });
+});

--- a/frontend/src/v2/components/Settings/TasksSection.test.ts
+++ b/frontend/src/v2/components/Settings/TasksSection.test.ts
@@ -79,6 +79,8 @@ describe("TasksSection", () => {
     });
     getTaskStatus.mockReset();
     getTaskStatus.mockResolvedValue({ data: [] });
+    runTask.mockReset();
+    runTask.mockResolvedValue({ data: { task_id: "job-1" } });
   });
 
   it("disables the run button while that task's job is in flight", async () => {
@@ -102,6 +104,36 @@ describe("TasksSection", () => {
     const wrapper = await mountSection();
 
     expect(runButton(wrapper).attributes("disabled")).toBeUndefined();
+    wrapper.unmount();
+  });
+
+  it("holds the button from the click, before any poll has seen the job", async () => {
+    let finishRun = () => {};
+    runTask.mockReturnValue(
+      new Promise((resolve) => {
+        finishRun = () => resolve({ data: { task_id: "job-1" } });
+      }),
+    );
+
+    const wrapper = await mountSection();
+    await runButton(wrapper).trigger("click");
+
+    expect(runButton(wrapper).attributes("disabled")).toBeDefined();
+    expect(runTask).toHaveBeenCalledTimes(1);
+
+    finishRun();
+    await flushPromises();
+    wrapper.unmount();
+  });
+
+  it("asks for the status again rather than waiting out the poll", async () => {
+    const wrapper = await mountSection();
+    getTaskStatus.mockClear();
+
+    await runButton(wrapper).trigger("click");
+    await flushPromises();
+
+    expect(getTaskStatus).toHaveBeenCalledTimes(1);
     wrapper.unmount();
   });
 

--- a/frontend/src/v2/components/Settings/TasksSection.test.ts
+++ b/frontend/src/v2/components/Settings/TasksSection.test.ts
@@ -1,6 +1,8 @@
 import { flushPromises, mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CleanupTaskStatusResponse } from "@/__generated__/models/CleanupTaskStatusResponse";
+import type { TaskInfo } from "@/__generated__/models/TaskInfo";
 import TasksSection from "./TasksSection.vue";
 
 const { getTasks, getTaskStatus, runTask } = vi.hoisted(() => ({
@@ -21,7 +23,7 @@ vi.mock("@/v2/composables/useSnackbar", () => ({
   useSnackbar: () => ({ success: vi.fn(), error: vi.fn() }),
 }));
 
-const CLEANUP_TASK = {
+const CLEANUP_TASK: TaskInfo = {
   name: "cleanup_zip_cache",
   type: "cleanup",
   title: "Scheduled ZIP cache cleanup",
@@ -31,7 +33,9 @@ const CLEANUP_TASK = {
   cron_string: "",
 };
 
-function status(overrides: Record<string, unknown>) {
+function status(
+  overrides: Partial<CleanupTaskStatusResponse> = {},
+): CleanupTaskStatusResponse {
   return {
     task_key: null,
     task_name: "Scheduled ZIP cache cleanup",
@@ -42,7 +46,7 @@ function status(overrides: Record<string, unknown>) {
     enqueued_at: null,
     started_at: null,
     ended_at: null,
-    meta: {},
+    meta: { cleanup_stats: null },
     ...overrides,
   };
 }
@@ -75,8 +79,6 @@ describe("TasksSection", () => {
     });
     getTaskStatus.mockReset();
     getTaskStatus.mockResolvedValue({ data: [] });
-    runTask.mockReset();
-    runTask.mockResolvedValue({ data: { task_id: "job-1" } });
   });
 
   it("disables the run button while that task's job is in flight", async () => {

--- a/frontend/src/v2/components/Settings/TasksSection.test.ts
+++ b/frontend/src/v2/components/Settings/TasksSection.test.ts
@@ -92,7 +92,9 @@ describe("TasksSection", () => {
 
   it("leaves the button live when only the display title matches", async () => {
     getTaskStatus.mockResolvedValue({
-      data: [status({ task_key: "some_other_task" })],
+      data: [
+        status({ task_key: "some_other_task", task_name: "cleanup_zip_cache" }),
+      ],
     });
 
     const wrapper = await mountSection();

--- a/frontend/src/v2/components/Settings/TasksSection.vue
+++ b/frontend/src/v2/components/Settings/TasksSection.vue
@@ -54,7 +54,7 @@ const completedStatuses = computed(() =>
 
 function isTaskRunning(name: string) {
   return taskStatuses.value.some(
-    (s) => s.task_name === name && ["queued", "started"].includes(s.status),
+    (s) => s.task_key === name && ["queued", "started"].includes(s.status),
   );
 }
 

--- a/frontend/src/v2/components/Settings/TasksSection.vue
+++ b/frontend/src/v2/components/Settings/TasksSection.vue
@@ -10,7 +10,7 @@
 // run button that posts to /tasks/{name}/run.
 import { RBtn, RIcon, RSpinner } from "@v2/lib";
 import { storeToRefs } from "pinia";
-import { computed, onMounted, onUnmounted } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import taskApi from "@/services/api/task";
 import storeTasks from "@/stores/tasks";
@@ -54,18 +54,27 @@ const completedStatuses = computed(() =>
   ),
 );
 
+// A click is only visible in `taskStatuses` once a poll has been round the
+// loop, so the names in flight from this tab hold their own buttons until then.
+const startingTasks = ref(new Set<string>());
+
 function isTaskRunning(name: string) {
-  return taskStatuses.value.some(
-    (s) => s.task_key === name && IN_FLIGHT_STATUSES.includes(s.status),
+  return (
+    startingTasks.value.has(name) ||
+    taskStatuses.value.some(
+      (s) => s.task_key === name && IN_FLIGHT_STATUSES.includes(s.status),
+    )
   );
 }
 
 async function runTask(name: string, title: string) {
+  startingTasks.value.add(name);
   try {
     await taskApi.runTask(name);
     snackbar.success(t("settings.task-started", { title }), {
       icon: "mdi-check-bold",
     });
+    await fetchTaskStatus();
   } catch (err) {
     const e = err as {
       response?: { data?: { detail?: string }; statusText?: string };
@@ -78,6 +87,8 @@ async function runTask(name: string, title: string) {
         t("settings.task-failed"),
       { icon: "mdi-close-circle" },
     );
+  } finally {
+    startingTasks.value.delete(name);
   }
 }
 

--- a/frontend/src/v2/components/Settings/TasksSection.vue
+++ b/frontend/src/v2/components/Settings/TasksSection.vue
@@ -46,15 +46,17 @@ const manualTasksUI = computed(() =>
   manualTasks.value.map((task) => ({ ...task, icon: "mdi-broom" })),
 );
 
+const IN_FLIGHT_STATUSES = ["queued", "started"];
+
 const completedStatuses = computed(() =>
   taskStatuses.value.filter(
-    (task) => !["queued", "started"].includes(task.status),
+    (task) => !IN_FLIGHT_STATUSES.includes(task.status),
   ),
 );
 
 function isTaskRunning(name: string) {
   return taskStatuses.value.some(
-    (s) => s.task_key === name && ["queued", "started"].includes(s.status),
+    (s) => s.task_key === name && IN_FLIGHT_STATUSES.includes(s.status),
   );
 }
 


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The run button on a v2 task row is never disabled while that task is in flight, so an admin can queue the same task twice by clicking twice.

`isTaskRunning` compares `task.name` — the key a task is registered under, `cleanup_zip_cache` — against the status response's `task_name`, which carries `Task.title`, `Scheduled ZIP cache cleanup` (`tasks/tasks.py:96`). Those never match, so the predicate is always false. Confirmed against a live Redis: a job enqueued through `enqueue_task("cleanup_zip_cache")` comes back with `task_name` = `"Scheduled ZIP cache cleanup"`, nothing the UI can match on.

**The fix**

A display title is a label two entries could share, so the registry key is what a run should be matched to its catalog entry by. Both enqueue paths already know it — `enqueue_task(name)` (`tasks/registry.py:63`) and the cron registration (`tasks/cron_config.py`) are each called with the name — so `Task.job_meta` becomes a method taking the key, and the job carries `task_key` alongside the title. `TaskExecutionResponse` reports it (inherited by every status response), and the row matches on it.

The device sync endpoint (`endpoints/sync.py:491`) builds its job meta by hand rather than through `Task.job_meta`, so it carried no key even though `sync_push_pull` is a catalog entry (`tasks/registry.py:47`). It carries one now. That leaves the null meaning exactly one thing: a scan started outside the catalog, by a client (`endpoints/sockets/scan.py:97`) or the watcher (`watcher.py:230`). A null never equals a task name, so those rows' buttons stay live, as they are today.

**Two further windows, closed after review**

A review round raised two P1s against the first head. Both were valid and are fixed in 7390bd3c; both threads are resolved and answered inline.

- **The click window.** Matching on the key repaired the steady state but left the race: the button only went disabled once a poll observed the job, so a second click inside those five seconds enqueued the task again — the very defect this PR claims to fix. `startingTasks` now holds the names started from this tab and `isTaskRunning` ORs it with the status match, so the button disables on the click; the run then awaits `fetchTaskStatus()` so the queued job is observed at once, and the local entry clears in a `finally` (a failed run releases the button). **This is a UI guard, not a guarantee** — the backend has no enqueue-side deduplication, so two tabs or a scripted caller can still double-enqueue. `unique=True` with a derived `job_id` on `enqueue_task` would be the real fix, and is out of scope here.
- **Retained jobs.** A job queued before this change carries no `task_key` and outlives a restart, so an in-flight catalog task would have come back unmatchable after an upgrade. Falling back to the title would have revived exactly the identity this PR removes, so `job.kwargs["name"]` answers instead: every catalog job is dispatched by name through `run_task_by_name`, making the payload authoritative and already present on old jobs. Jobs outside the catalog stay null — `scan_platforms` carries `platform_ids`/`scan_type` and `run_push_pull_sync` carries `device_id`/`session_id`, so neither picks up a `name` by accident.

**Scope note**

This narrows "is it running" to runs started through the task registry — a socket-initiated scan no longer counts toward the `scan_library` row. That matches what the button does (run this catalog entry), and it is not a regression: the predicate was false for every case before.

The regenerated types also pick up an `ExclusionType` docstring that had drifted from `config/config_manager.py:308`. That is the output of the mandated regen step, not a hand edit.

**Testing**

- `TasksSection.test.ts` (new, 5 cases): the button disables when a status carries the matching key; stays live when a job's *title* collides with this task's key; stays live for a job with no key; is held from the click before any poll; and a run asks for the status once rather than waiting the poll out.
- **Every one of these was checked by mutation.** Reverting the one-line identity fix turns two red; reverting either half of the click-window fix turns the other two red. None of them passes against the code it is meant to guard against.
- Backend: `task_key` asserted on the enqueue payload, the cron registration meta, the run response, both response cases (parametrized), and a job carrying only the old meta plus its payload. 449 passed across every suite the diff reaches.
- Verified end-to-end against a live Redis that the key survives the round trip into `_build_task_status_response`, since the endpoint tests use mocks.
- The cron stub is autospecced against `Task`, so the call it fakes is signature-checked. Verified by mutation: adding a parameter to `job_meta` now fails the cron test, where the previous hand-written lambda stub stayed green.
- `npm run typecheck`, `npm run test` (1197 passed), `npm run build` clean. Types regenerated from the backend's own OpenAPI schema.

**Review passes**

Ran the four `pr-ready` passes over this range. Security: clean — no new hosts, no exec or obfuscation, no dependency, CI, or infra changes, no auth decorator or scope touched. Code review, simplify and polish produced the follow-up commits on this branch: a test that passed under the buggy comparison and so guarded nothing, the `sync.py` gap above, and test consolidation (parametrized response cases, autospecced cron stub, typed fixtures, a shared in-flight status list).

Two findings were deliberately **not** taken, both naming/shape rather than behavior:
- Renaming the response field to `name` to match `TaskInfo.name`. It would break the `task_*` prefix that the rest of the TypedDict uses, and churn a public API field for vocabulary.
- Making `task_key` non-nullable by giving ad-hoc scans a synthetic key. A scan with no catalog entry genuinely has no key; inventing one to avoid a null trades an honest absence for a value that matches nothing anyway.

`trunk` itself could not run in this environment (its plugin bundle download is blocked by an egress policy), so its linters ran directly: ruff and ESLint clean, black clean, mypy compared against a master baseline with no new errors — the eight `typeddict-item` hits in `endpoints/tasks.py` are pre-existing and still on their `trunk-ignore` lines. Prettier's import ordering was not applied: without the repo's `importOrder` config it reorders imports contrary to what is committed and passing CI; only its wrapping fixes were taken. **CI's Trunk check is the authority here, and it passes on the current head.**

**Verified: the in-browser pass**

Done, in Chromium against a local stack: backend on `:5000`, Vite dev server on `:3000`, MariaDB 11.3.2, Valkey, an admin user with `settings.uiVersion` set to `v2`.

**The "settings suite is unreachable" claim in the first version of this description was wrong**, and is retracted. There is no `/settings/*` URL space in this app. The settings group in `plugins/router.ts:325` is a layout-only parent with `path: ""` nested under `/`, so the routes are flat: `/administration`, `/user-interface`, `/server-stats`, and so on. The URLs tried earlier matched no route at all. They read as a migration gap because the v2 catch-all resolves to the "not migrated yet" fallback rather than a 404 (`v2For(ROUTES.NOT_FOUND)` at `plugins/router.ts:523`, with no `"404"` key in `v2RouteComponents`). That is a real defect, filed separately as #4435, and it is not this PR's. `/administration` renders the v2 Administration view normally, Tasks tab included.

**Result on this head.** Settings > Administration > Tasks, "Cleanup missing ROMs" (registry key `cleanup_missing_roms`, display title `Cleanup missing ROMs`, the same key/title split the fix is about):

| checkpoint | button disabled? |
| --- | --- |
| before the click | no |
| t+0.4s | **yes** |
| t+3s | **yes** |
| t+7s, past the 5s poll | **yes** |

`GET /api/tasks/status` returns `"task_key": "cleanup_missing_roms"` alongside `"task_name": "Cleanup missing ROMs"`. No RQ worker was running, so the job stays `queued`, which `IN_FLIGHT_STATUSES` counts as in flight. The t+7s reading is the load-bearing one: `startingTasks` has long since been cleared in the `finally`, so what holds the button there is the `task_key` match, not the click guard.

**Control, same steps on `master` (3491bc8f):** disabled is `false` at every one of those checkpoints, and the status payload carries no `task_key` at all. The defect reproduces on master and is cleared on this head.

**Noted, not changed**

`frontend/src/components/Settings/Administration/TaskOption.vue:35` has the same identity mismatch in v1, and its disabled condition is also inverted (it keys off completed runs). The two defects cancel into "never disabled". v1 is frozen per `CLAUDE.md`, so it is left alone.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The bug was found while reviewing the RQ 2.12 bump; the fix, its tests, and the review passes above were run locally, and every test was proven to fail without the code it guards. The in-browser pass above was run in a later session, in Chromium against a local stack. A human should review it.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

The change is a `disabled` state rather than a visual one, so the verification table above is the evidence: the same button, same steps, disabled on this head and never disabled on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXV6RTfrRjgH88P9CrtYPQ