### PR TITLE
ci: align and manage the Docker service image pins

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mariadb:
-        image: mariadb:11.3.2
+        image: mariadb:12.3.3
         ports:
           - 3306:3306
         env:
           MYSQL_ROOT_PASSWORD: passwd
-        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3 --health-start-period=30s
       valkey:
-        image: valkey/valkey:7.2
+        image: valkey/valkey:9.0.6
         ports:
           - 6379:6379
         options: --health-cmd="redis-cli ping" --health-interval=5s --health-timeout=2s --health-retries=3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mariadb:
-        image: mariadb:11.3.2
+        image: mariadb:12.3.3
         ports:
           - 3306
         env:
@@ -37,9 +37,9 @@ jobs:
           MYSQL_PASSWORD: passwd
           MYSQL_DATABASE: romm_e2e
           MYSQL_ROOT_PASSWORD: passwd
-        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3 --health-start-period=30s
       valkey:
-        image: valkey/valkey:7.2
+        image: valkey/valkey:9.0.6
         ports:
           - 6379
         options: >-

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     services:
       postgres:
-        image: postgres:15
+        image: postgres:16
         env:
           POSTGRES_USER: user
           POSTGRES_PASSWORD: password
@@ -66,7 +66,7 @@ jobs:
     # A server configured for utf8mb3 makes the roms table, the view literals
     # and the JSON_TABLE columns utf8mb3, which breaks collation-sensitive
     # migration SQL that a default utf8mb4 server accepts (issue #4350).
-    name: migrate-mariadb (${{ matrix.collation }})
+    name: migrate-mariadb (${{ matrix.mariadb }}, ${{ matrix.collation }})
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -75,10 +75,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - charset: utf8mb4
+          # renovate: datasource=docker depName=mariadb
+          - mariadb: "12.3.3"
+            charset: utf8mb4
             collation: utf8mb4_general_ci
-          - charset: utf8mb3
+          # renovate: datasource=docker depName=mariadb
+          - mariadb: "12.3.3"
+            charset: utf8mb3
             collation: utf8mb3_unicode_ci
+          # Oldest supported LTS, and the only leg still on the pre-uca1400
+          # default. Unmarked so updates cannot raise it off that floor.
+          - mariadb: "10.11.19"
+            charset: utf8mb4
+            collation: utf8mb4_general_ci
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -101,6 +110,7 @@ jobs:
         env:
           CHARSET: ${{ matrix.charset }}
           COLLATION: ${{ matrix.collation }}
+          MARIADB_IMAGE_TAG: ${{ matrix.mariadb }}
         run: |
           docker run -d --name mariadb -p 3306:3306 \
             -e MARIADB_USER=user \
@@ -111,7 +121,7 @@ jobs:
             --health-interval 5s \
             --health-timeout 2s \
             --health-retries 10 \
-            mariadb:11.3.2 \
+            "mariadb:$MARIADB_IMAGE_TAG" \
             --character-set-server="$CHARSET" \
             --collation-server="$COLLATION"
           for _ in $(seq 1 30); do

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,7 +32,7 @@ jobs:
         db: [mariadb, postgresql]
     services:
       mariadb:
-        image: mariadb:11.3.2
+        image: mariadb:12.3.3
         ports:
           - 3306
         env:
@@ -40,7 +40,7 @@ jobs:
           MYSQL_PASSWORD: passwd
           MYSQL_DATABASE: romm_test
           MYSQL_ROOT_PASSWORD: passwd
-        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3 --health-start-period=30s
       postgresql:
         image: postgres:16
         ports:
@@ -51,7 +51,7 @@ jobs:
           POSTGRES_DB: romm_test
         options: --health-cmd="pg_isready" --health-interval=5s --health-timeout=2s --health-retries=3
       valkey:
-        image: valkey/valkey:7.2
+        image: valkey/valkey:9.0.6
         ports:
           - 6379
         options: >-

--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -3,7 +3,7 @@
 #        uv run pytest
 services:
   mariadb:
-    image: mariadb:10.11
+    image: mariadb:12.3.3
     ports:
       - "3306:3306"
     environment:
@@ -27,7 +27,7 @@ services:
       retries: 10
 
   valkey:
-    image: valkey/valkey:7.2
+    image: valkey/valkey:9.0.6
     ports:
       - "6379:6379"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     tty: true
 
   romm-db-dev:
-    image: mariadb:11.3.2
+    image: mariadb:12.3.3
     container_name: romm-db-dev
     restart: unless-stopped
     env_file: .env
@@ -52,7 +52,7 @@ services:
       - "3306:3306"
 
   romm-valkey-dev:
-    image: valkey/valkey:8
+    image: valkey/valkey:9.0.6
     container_name: romm-valkey-dev
     restart: unless-stopped
     env_file: .env

--- a/docs/BACKEND_ARCHITECTURE.md
+++ b/docs/BACKEND_ARCHITECTURE.md
@@ -412,11 +412,18 @@ HTTP Request
 
 ### Supported Databases
 
-| Database      | Driver                | Status    |
-| ------------- | --------------------- | --------- |
-| MariaDB 10.5+ | `mariadb+pymysql`     | Default   |
-| MySQL 8.0+    | `mysql+pymysql`       | Supported |
-| PostgreSQL    | `postgresql+psycopg2` | Supported |
+| Database       | Driver                | Status    |
+| -------------- | --------------------- | --------- |
+| MariaDB 10.11+ | `mariadb+pymysql`     | Default   |
+| MySQL 8.0+     | `mysql+pymysql`       | Supported |
+| PostgreSQL     | `postgresql+psycopg2` | Supported |
+
+MariaDB 10.5 and 10.6 reached upstream end of life in June 2025 and July 2026, so
+10.11 is the oldest LTS still receiving fixes.
+
+CI runs the test suite against MariaDB 12.3 and PostgreSQL 16, and the migration
+suite additionally against MariaDB 10.11, which predates the 11.6 `uca1400`
+collation default. MySQL has no CI coverage.
 
 ### Engine & Session Setup
 

--- a/renovate.json
+++ b/renovate.json
@@ -11,10 +11,11 @@
       "groupName": "mariadb"
     },
     {
-      "description": "The shipped image installs valkey from Alpine rather than a tag, so check docker/Dockerfile's ALPINE_VERSION on a major bump to keep tests on what users run.",
+      "description": "The shipped image installs valkey from Alpine's package repo, currently the 9.0 line. Hold the test pins there so they keep matching what users run, and raise this bound deliberately when ALPINE_VERSION in docker/Dockerfile moves.",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["valkey/valkey"],
-      "groupName": "valkey"
+      "groupName": "valkey",
+      "allowedVersions": "<9.1"
     },
     {
       "matchDatasources": ["docker"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":semanticCommitTypeAll(chore)"],
+  "enabledManagers": ["github-actions", "docker-compose", "custom.regex"],
+  "ignorePaths": ["examples/**"],
+  "packageRules": [
+    {
+      "description": "One PR per service, since each tag is repeated across several workflows and compose files.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["mariadb"],
+      "groupName": "mariadb"
+    },
+    {
+      "description": "The shipped image installs valkey from Alpine rather than a tag, so check docker/Dockerfile's ALPINE_VERSION on a major bump to keep tests on what users run.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["valkey/valkey"],
+      "groupName": "valkey"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["postgres"],
+      "groupName": "postgres"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["action"],
+      "groupName": "github actions"
+    }
+  ],
+  "customManagers": [
+    {
+      "description": "Image tags built at runtime in workflow steps, marked with a renovate comment. Legs deliberately left unmarked stay pinned.",
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/[^/]+\\.ya?ml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+?)\\s+-?\\s*[A-Za-z0-9_-]+?: [\"'](?<currentValue>[^\"'\\s]+)[\"']"
+      ],
+      "versioningTemplate": "docker"
+    }
+  ]
+}


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Closes #4381.

The MariaDB, PostgreSQL and Valkey images used by CI, the dev stack and the test stack were never covered by any update tooling, so they drifted apart from each other and from the shipped image. This aligns them and adds Renovate so they stay aligned.

**Version alignment**

| Service | Before | After |
| --- | --- | --- |
| mariadb (`pytest`, `e2e`, `copilot-setup-steps`, `migrations`) | 11.3.2 (EOL since early 2025) | 12.3.3 |
| mariadb (`docker-compose.yml` dev) | 11.3.2 | 12.3.3 |
| mariadb (`backend/docker-compose.test.yml`) | 10.11 | 12.3.3 |
| postgres (`migrations`) | 15 | 16 |
| valkey (all four CI/test pins) | 7.2 | 9.0.6 |
| valkey (`docker-compose.yml` dev) | 8 | 9.0.6 |

12.3.3 is what both `latest` and `lts` resolve to today, so CI now matches what `examples/docker-compose.example.yml` users already run. Valkey 9.0.x is what the production image installs from Alpine 3.23, so the test pins now track the shipped version rather than sitting two majors behind it.

`backend/docker-compose.test.yml` claims in its header to mirror `pytest.yml`; it was on a different MariaDB major, so it now actually does.

This bump is what makes the `utf8mb4` migrations leg meaningful for the first time. `character_set_collations` (the 11.6+ `uca1400` default) is a separate variable from `--collation-server`, so on 12.3 the leg gets `general_ci` table columns against `uca1400` view literals — exactly the mismatch migrations 0082, 0089 and 0096 were written to work around, and which CI has never executed while pinned to 11.3.

**Renovate**

New `renovate.json`, scoped to the `github-actions` and `docker-compose` managers so the npm and Python manifests are untouched. Dependabot cannot cover these pins: it offers no Docker security updates, and its Docker version updates parse Dockerfiles, not `services:` images in workflow files ([dependabot-core#5541](https://github.com/dependabot/dependabot-core/issues/5541)).

- Grouped one PR per service, since each tag repeats across several files and there is no clean way to share one literal (Actions does not expose `env` inside `services.image`).
- A `customManagers` regex keyed on `# renovate:` marker comments covers the tag the migrations matrix builds at runtime.
- `examples/` is excluded. It points users at `latest`; pinning it backwards would be a MariaDB major downgrade, which has no in-place path.
- A new 10.11.19 floor leg in the migrations matrix keeps the pre-`uca1400` default covered, deliberately carrying no marker comment so Renovate cannot raise it off the floor it exists to test.
- The valkey group is bounded to `<9.1`. A dry run showed the config would otherwise offer 9.1.2 and walk the test pins straight off the 9.0.x the production image installs, recreating the drift this PR removes. Patches inside the line still flow; the bound is raised deliberately when `ALPINE_VERSION` moves.

⚠️ **A config file alone does nothing.** This needs the Mend-hosted Renovate App installed on the repo (free for public repos, no workflow and no secrets) or a self-hosted `renovatebot/github-action` with a token that can open PRs. That is a repo-admin step and is not part of this PR.

For reference, a dry run against this branch says the first wave after install is: one grouped PR for 70 SHA-pinned actions across 13 workflows, one for postgres 16 → 18, and a jump on `ghcr.io/goauthentik/server` (2024.10.4 → 2026.8.2) in `docker-compose.oidc.yml`. mariadb and valkey resolve to no update at all. The authentik one is on an OIDC dev stack that nothing tests; it is left in scope deliberately, since a two-year-old auth server in a file we ship as an example is worth surfacing, but it is a reasonable thing to `ignorePaths` if reviewers would rather not see it.

**Latent CI bug**

The MariaDB service health check in `pytest.yml`, `e2e.yml` and `copilot-setup-steps.yml` had no start period, so its 3-retry budget expired around 15s after container start, while 12.3.3 needs roughly 13s to finish initdb. The container was intermittently reported as failed to initialize with the server's own `ready for connections` logged immediately above the runner's error. `--health-start-period=30s` gives initdb room without counting against the retries; checks still run during the window.

`migrations.yml` and `backend/docker-compose.test.yml` allow 10 retries rather than 3, and the example compose file already sets `start_period: 30s`, so those are unaffected.

**Docs**

`docs/BACKEND_ARCHITECTURE.md` advertised MariaDB 10.5+, which no longer matches anything: 10.5 reached upstream EOL in June 2025 and 10.6 followed in July 2026, leaving 10.11 as the oldest LTS still receiving fixes and the version this PR pins as the migration floor. The table now says 10.11+, with a note recording which servers CI actually exercises. MySQL is listed as supported but has no CI coverage at all, which the note states plainly.

Only the MariaDB row changed. There is no PostgreSQL version gate anywhere in the code, so inventing a PostgreSQL floor would have misrepresented what is supported.

Worth noting for a follow-up rather than here: `backend/utils/database.py:133` still carries a pre-10.9 `JSON_OVERLAPS` fallback, which is dead under a 10.11 floor. Removing it belongs with a deliberate minimum-version bump (which would also want a startup guard), not with a CI pin change. That bump would not, however, let us delete 0082/0089/0096: those handle collations baked into columns in existing user databases, which no server-version requirement can change.

Also out of scope but worth an issue: the bundled Valkey users actually run comes from an unpinned `apk add valkey` in `docker/Dockerfile`, resolved against Alpine's package repo at build time. It is governed by `ALPINE_VERSION` and the image digests, none of which have any update tooling, and which the managers enabled here do not cover.

**Note on the dev stack**

Bumping `docker-compose.yml` crosses MariaDB majors against any existing `romm-db-dev` volume. That volume holds throwaway mock-library data, so `docker compose down -v` is the expected remedy if it does not start cleanly.

**AI assistance disclosure**

Written with Claude Code. It read the issue, verified every version claim against the working tree and Docker Hub, wrote the config and the workflow changes, and validated them with `renovate-config-validator`, a local Renovate dry run, `actionlint`, `prettier` and `markdownlint`. Reviewed by me before opening.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

Verified locally with `RENOVATE_PLATFORM=local` dry runs: 4 of 5 compose files are extracted (`examples/` correctly ignored), the custom manager finds exactly the two marked matrix legs and skips the floor leg, and valkey resolves to `"updates": []` under the `<9.1` bound. `renovate-config-validator`, `actionlint`, `prettier` and `markdownlint` are clean on every changed file. No Docker daemon was available in that environment, so the images themselves are exercised by this PR's own `pytest`, `e2e` and `migrations` runs, all three of which trigger on the workflow paths changed here. No unit tests, as the change is entirely CI, compose and documentation.

#### Screenshots (if applicable)

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwTmsb3ix4i2cVXCJXoM2m