### PR TITLE
ci: build each arch on a native runner and cache layers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
   release:
     types: [published]
 
-# Every job below grants itself what it needs; this is only the fallback.
 permissions:
   contents: read
 
@@ -123,6 +122,8 @@ jobs:
           labels: ${{ steps.meta-slim.outputs.labels }}
           target: slim-image
           outputs: type=image,name=${{ env.DIGEST_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # Deliberately not seeded from the preview cache: those layers are
+          # built from PR head content and must not reach a release image.
           cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:release-${{ matrix.arch }}
           build-args: |
             SCREENSCRAPER_DEV_ID=${{ secrets.SCREENSCRAPER_DEV_ID }}
@@ -193,9 +194,6 @@ jobs:
           path: /tmp/digests/full
           pattern: digest-full-*
           merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to Docker Hub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -277,7 +275,7 @@ jobs:
     permissions: {}
     needs: merge
     runs-on: ubuntu-latest
-    if: needs.merge.result == 'success' && github.event.release.prerelease == false
+    if: github.event.release.prerelease == false
     steps:
       - name: Trigger docs build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,15 @@ on:
   release:
     types: [published]
 
+# Every job below grants itself what it needs; this is only the fallback.
 permissions:
-  id-token: write
-  contents: write
-  packages: write
-  actions: write
+  contents: read
 
 jobs:
   validate-tag-semver:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       valid: ${{ steps.check_tag.outputs.valid }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,28 +24,40 @@ jobs:
         run: |
           TAG="${{ github.event.release.tag_name }}"
           if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-alpha\.[0-9]+|-beta\.[0-9]+|-rc\.[0-9]+)?$ ]]; then
-            echo "valid=true" >> $GITHUB_OUTPUT
+            echo "valid=true" >>"$GITHUB_OUTPUT"
           else
-            echo "valid=false" >> $GITHUB_OUTPUT
+            echo "valid=false" >>"$GITHUB_OUTPUT"
           fi
 
+  # Each architecture builds on a runner of its own architecture and pushes
+  # untagged, digest-addressed images; `merge` then stitches them into one index
+  # per variant. Emulating arm64 under QEMU made the C/C++ stages dominate the
+  # build. The full image is `FROM` the slim one, so the two targets share
+  # almost all of their work within a single job.
   build:
     needs: validate-tag-semver
-    runs-on: ubuntu-latest
     if: needs.validate-tag-semver.outputs.valid == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       id-token: write
-      contents: write
+      contents: read
       packages: write
+    env:
+      DIGEST_IMAGE: ghcr.io/${{ github.repository_owner }}/romm
+      CACHE_IMAGE: ghcr.io/${{ github.repository_owner }}/romm-buildcache
     steps:
-      - name: Run only once per release
-        run: echo "Triggered by ${{ github.event_name }}"
-
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -104,42 +116,164 @@ jobs:
         run: |
           sed -i 's/<version>/${{ steps.meta.outputs.version }}/' backend/__version__.py
 
-      - name: Build slim image
+      - name: Build and push slim image by digest
         id: build-slim
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           file: docker/Dockerfile
           context: .
-          push: true
-          platforms: linux/arm64,linux/amd64
-          tags: ${{ steps.meta-slim.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta-slim.outputs.labels }}
           target: slim-image
+          outputs: type=image,name=${{ env.DIGEST_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:release-${{ matrix.arch }}
           build-args: |
             SCREENSCRAPER_DEV_ID=${{ secrets.SCREENSCRAPER_DEV_ID }}
             SCREENSCRAPER_DEV_PASSWORD=${{ secrets.SCREENSCRAPER_DEV_PASSWORD }}
 
-      - name: Build full image
+      # Only the full build writes the cache: it is a superset of the slim one,
+      # so a single `mode=max` export covers every stage either target needs.
+      - name: Build and push full image by digest
         id: build-full
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           file: docker/Dockerfile
           context: .
-          push: true
-          platforms: linux/arm64,linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           target: full-image
+          outputs: type=image,name=${{ env.DIGEST_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:release-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.CACHE_IMAGE }}:release-${{ matrix.arch }},mode=max
           build-args: |
             SCREENSCRAPER_DEV_ID=${{ secrets.SCREENSCRAPER_DEV_ID }}
             SCREENSCRAPER_DEV_PASSWORD=${{ secrets.SCREENSCRAPER_DEV_PASSWORD }}
 
+      - name: Export digests
+        env:
+          SLIM_DIGEST: ${{ steps.build-slim.outputs.digest }}
+          FULL_DIGEST: ${{ steps.build-full.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests/slim /tmp/digests/full
+          touch "/tmp/digests/slim/${SLIM_DIGEST#sha256:}"
+          touch "/tmp/digests/full/${FULL_DIGEST#sha256:}"
+
+      - name: Upload slim digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digest-slim-${{ matrix.arch }}
+          path: /tmp/digests/slim/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload full digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digest-full-${{ matrix.arch }}
+          path: /tmp/digests/full/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    env:
+      DIGEST_IMAGE: ghcr.io/${{ github.repository_owner }}/romm
+    steps:
+      - name: Download slim digests
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: /tmp/digests/slim
+          pattern: digest-slim-*
+          merge-multiple: true
+
+      - name: Download full digests
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: /tmp/digests/full
+          pattern: digest-full-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docker metadata (slim)
+        id: meta-slim
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: |
+            name=rommapp/romm
+            name=ghcr.io/rommapp/romm
+          flavor: |
+            latest=auto
+            suffix=-slim,onlatest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Generate Docker metadata (full)
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: |
+            name=rommapp/romm
+            name=ghcr.io/rommapp/romm
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      # Tags spanning both registries are fine here: `imagetools create` copies
+      # the blobs over when a target sits in a different registry than the digests.
+      - name: Create manifest lists and push
+        env:
+          SLIM_METADATA: ${{ steps.meta-slim.outputs.json }}
+          FULL_METADATA: ${{ steps.meta.outputs.json }}
+        run: |
+          push_variant() {
+            local dir="$1" metadata="$2"
+
+            local tags=()
+            while IFS= read -r tag; do
+              tags+=(--tag "$tag")
+            done < <(jq -r '.tags[]' <<<"$metadata")
+
+            local sources=()
+            local digest
+            for digest in "$dir"/*; do
+              sources+=("${DIGEST_IMAGE}@sha256:$(basename "$digest")")
+            done
+
+            docker buildx imagetools create "${tags[@]}" "${sources[@]}"
+          }
+
+          push_variant /tmp/digests/slim "$SLIM_METADATA"
+          push_variant /tmp/digests/full "$FULL_METADATA"
+
   trigger-docs-and-web:
     permissions:
       actions: write
-    needs: build
+    needs: merge
     runs-on: ubuntu-latest
-    if: needs.build.result == 'success' && github.event.release.prerelease == false
+    if: needs.merge.result == 'success' && github.event.release.prerelease == false
     steps:
       - name: Trigger docs build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+# `build` pushes digests here and `merge` tags them from here; the two must agree.
+env:
+  DIGEST_IMAGE: ghcr.io/${{ github.repository_owner }}/romm
+
 jobs:
   validate-tag-semver:
     runs-on: ubuntu-latest
@@ -49,7 +53,6 @@ jobs:
       contents: read
       packages: write
     env:
-      DIGEST_IMAGE: ghcr.io/${{ github.repository_owner }}/romm
       CACHE_IMAGE: ghcr.io/${{ github.repository_owner }}/romm-buildcache
     steps:
       - name: Checkout code
@@ -178,8 +181,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    env:
-      DIGEST_IMAGE: ghcr.io/${{ github.repository_owner }}/romm
     steps:
       - name: Download slim digests
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,19 +21,17 @@ jobs:
     steps:
       - name: Check if tag follows SemVer
         id: check_tag
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
           if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-alpha\.[0-9]+|-beta\.[0-9]+|-rc\.[0-9]+)?$ ]]; then
             echo "valid=true" >>"$GITHUB_OUTPUT"
           else
             echo "valid=false" >>"$GITHUB_OUTPUT"
           fi
 
-  # Each architecture builds on a runner of its own architecture and pushes
-  # untagged, digest-addressed images; `merge` then stitches them into one index
-  # per variant. Emulating arm64 under QEMU made the C/C++ stages dominate the
-  # build. The full image is `FROM` the slim one, so the two targets share
-  # almost all of their work within a single job.
+  # Each architecture builds natively and pushes untagged, digest-addressed
+  # images; `merge` stitches them into one index per variant.
   build:
     needs: validate-tag-semver
     if: needs.validate-tag-semver.outputs.valid == 'true'
@@ -49,7 +47,6 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     permissions:
-      id-token: write
       contents: read
       packages: write
     env:
@@ -178,7 +175,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
       packages: write
     env:
@@ -259,8 +255,16 @@ jobs:
             local sources=()
             local digest
             for digest in "$dir"/*; do
-              sources+=("${DIGEST_IMAGE}@sha256:$(basename "$digest")")
+              [[ -f "$digest" ]] || continue
+              sources+=("${DIGEST_IMAGE}@sha256:${digest##*/}")
             done
+
+            # Without both lists `imagetools create` would push an untagged
+            # index and still exit 0, publishing a release nobody can pull.
+            if [[ ${#tags[@]} -eq 0 || ${#sources[@]} -eq 0 ]]; then
+              echo "::error::${dir}: ${#tags[@]} tag(s), ${#sources[@]} digest(s)"
+              return 1
+            fi
 
             docker buildx imagetools create "${tags[@]}" "${sources[@]}"
           }
@@ -269,8 +273,8 @@ jobs:
           push_variant /tmp/digests/full "$FULL_METADATA"
 
   trigger-docs-and-web:
-    permissions:
-      actions: write
+    # Dispatches into other repositories with a PAT; GITHUB_TOKEN is unused.
+    permissions: {}
     needs: merge
     runs-on: ubuntu-latest
     if: needs.merge.result == 'success' && github.event.release.prerelease == false

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -23,28 +23,29 @@ on:
 permissions:
   contents: read
 
+# One preview per branch: overlapping runs would interleave their writes to the
+# shared sticky comment and to the per-arch layer cache.
+concurrency:
+  group: preview-build-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   prepare:
     if: |
-      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request' &&
       contains(github.event.pull_request.labels.*.name, 'build-preview')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
       - name: PR comment build starting
-        if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: preview-build
           message: 🔨 Preview build is under way...
 
-  # Each architecture builds on a runner of its own architecture and pushes an
-  # untagged, digest-addressed image; `merge` then stitches them into one index.
-  # Emulating arm64 under QEMU made the C/C++ stages dominate the build.
-  #
-  # Deliberately not `needs: prepare`: the two are independent, and a hiccup
-  # posting the comment should not cancel the build.
+  # Each architecture builds natively and pushes an untagged, digest-addressed
+  # image; `merge` stitches them into one index.
   build:
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -63,6 +64,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest-repo: ${{ steps.repo.outputs.ref }}
     env:
       USE_GHCR: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.registry == 'ghcr' || github.event.inputs.registry == 'both' }}
       USE_DOCKERHUB: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.registry == 'dockerhub' || github.event.inputs.registry == 'both') }}
@@ -138,9 +141,8 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Waits on `prepare` as well, so a late "under way" comment cannot land on top
-  # of the completed one. Its result is not required though: failing to post a
-  # comment should not leave a pushed image untagged.
+  # Waits on `prepare` too, so a late "under way" comment cannot overwrite the
+  # completed one; its result is not required.
   merge:
     needs: [prepare, build]
     if: ${{ !cancelled() && needs.build.result == 'success' }}
@@ -188,23 +190,12 @@ jobs:
           tags: |
             type=raw,value=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
 
-      - name: Resolve digest repository
-        id: repo
-        env:
-          OWNER: ${{ github.repository_owner }}
-        run: |
-          if [[ "${USE_GHCR}" == "true" ]]; then
-            echo "ref=ghcr.io/${OWNER}/romm-testing" >>"$GITHUB_OUTPUT"
-          else
-            echo "ref=${DOCKERHUB_NAMESPACE}/romm-testing" >>"$GITHUB_OUTPUT"
-          fi
-
       # Cross-registry tags are fine here: `imagetools create` copies the blobs
       # over when a target sits in a different registry than the digests.
       - name: Create manifest list and push
         working-directory: /tmp/digests
         env:
-          DIGEST_REF: ${{ steps.repo.outputs.ref }}
+          DIGEST_REF: ${{ needs.build.outputs.digest-repo }}
           METADATA: ${{ steps.meta.outputs.json }}
         run: |
           tags=()
@@ -214,14 +205,21 @@ jobs:
 
           sources=()
           for digest in *; do
+            [[ -f "$digest" ]] || continue
             sources+=("${DIGEST_REF}@sha256:${digest}")
           done
 
+          # Without both lists `imagetools create` would push an untagged index
+          # and still exit 0, leaving the preview image unreachable by tag.
+          if [[ ${#tags[@]} -eq 0 || ${#sources[@]} -eq 0 ]]; then
+            echo "::error::${#tags[@]} tag(s), ${#sources[@]} digest(s)"
+            exit 1
+          fi
+
           docker buildx imagetools create "${tags[@]}" "${sources[@]}"
 
-      # PR builds always push to GHCR only, so the image link is hardcoded to GHCR.
-      # The branch name is not a usable tag on its own: `metadata-action` rewrites
-      # characters Docker forbids, `/` among them.
+      # PR builds push to GHCR only. Use the metadata tag, not the raw branch:
+      # `metadata-action` rewrites characters Docker forbids, `/` among them.
       - name: Comment PR with GHCR image link
         if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
@@ -231,3 +229,20 @@ jobs:
             ✅ Preview build completed!
 
             Docker image: `ghcr.io/${{ github.repository_owner }}/romm-testing:${{ steps.meta.outputs.version }}`
+
+  # Without this the sticky comment would sit on "under way..." forever.
+  report-failure:
+    needs: [build, merge]
+    if: ${{ failure() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment PR with the failure
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: preview-build
+          message: |
+            ❌ Preview build failed.
+
+            [View the run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -19,12 +19,9 @@ on:
           - dockerhub
           - both
 
+# Every job below grants itself what it needs; this is only the fallback.
 permissions:
-  id-token: write
-  contents: write
-  packages: write
-  actions: write
-  pull-requests: write
+  contents: read
 
 jobs:
   prepare:
@@ -77,7 +74,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
-          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -34,28 +34,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    outputs:
-      comment-id: ${{ steps.build-comment.outputs.comment-id }}
     steps:
       - name: PR comment build starting
         if: github.event_name == 'pull_request'
-        id: build-comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
-          script: |
-            const comment = await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `🔨 Preview build is under way...`
-            });
-            core.setOutput('comment-id', comment.data.id);
+          header: preview-build
+          message: 🔨 Preview build is under way...
 
   # Each architecture builds on a runner of its own architecture and pushes an
   # untagged, digest-addressed image; `merge` then stitches them into one index.
   # Emulating arm64 under QEMU made the C/C++ stages dominate the build.
+  #
+  # Deliberately not `needs: prepare`: the two are independent, and a hiccup
+  # posting the comment should not cancel the build.
   build:
-    needs: prepare
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'build-preview')
     strategy:
       fail-fast: false
       matrix:
@@ -147,7 +143,7 @@ jobs:
           retention-days: 1
 
   merge:
-    needs: [prepare, build]
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -224,20 +220,14 @@ jobs:
           docker buildx imagetools create "${tags[@]}" "${sources[@]}"
 
       # PR builds always push to GHCR only, so the image link is hardcoded to GHCR.
+      # The branch name is not a usable tag on its own: `metadata-action` rewrites
+      # characters Docker forbids, `/` among them.
       - name: Comment PR with GHCR image link
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          # The branch name is not a usable tag on its own: `metadata-action`
-          # rewrites characters Docker forbids, `/` among them.
-          IMAGE_TAG: ${{ steps.meta.outputs.version }}
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
-          script: |
-            const owner = context.repo.owner;
-            const tag = process.env.IMAGE_TAG;
-            github.rest.issues.updateComment({
-              comment_id: ${{ needs.prepare.outputs.comment-id }},
-              owner: owner,
-              repo: context.repo.repo,
-              body: `✅ Preview build completed!\n\nDocker image: \`ghcr.io/${owner}/romm-testing:${tag}\``
-            })
+          header: preview-build
+          message: |
+            ✅ Preview build completed!
+
+            Docker image: `ghcr.io/${{ github.repository_owner }}/romm-testing:${{ steps.meta.outputs.version }}`

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -19,12 +19,11 @@ on:
           - dockerhub
           - both
 
-# Every job below grants itself what it needs; this is only the fallback.
 permissions:
   contents: read
 
-# One preview per branch: overlapping runs would interleave their writes to the
-# shared sticky comment and to the per-arch layer cache.
+# One preview per branch, so re-labelling cannot leave two runs writing the same
+# sticky comment.
 concurrency:
   group: preview-build-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
   cancel-in-progress: true
@@ -81,8 +80,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
-      # Always authenticated, even for a Docker Hub-only run: the layer cache
-      # lives in GHCR regardless of where the image itself is published.
+      # The layer cache lives in GHCR even when the image is published elsewhere.
       - name: Login to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -141,16 +139,14 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Waits on `prepare` too, so a late "under way" comment cannot overwrite the
-  # completed one; its result is not required.
   merge:
-    needs: [prepare, build]
-    if: ${{ !cancelled() && needs.build.result == 'success' }}
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-      pull-requests: write
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
     env:
       USE_GHCR: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.registry == 'ghcr' || github.event.inputs.registry == 'both' }}
       USE_DOCKERHUB: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.registry == 'dockerhub' || github.event.inputs.registry == 'both') }}
@@ -162,9 +158,6 @@ jobs:
           path: /tmp/digests
           pattern: digest-*
           merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -218,27 +211,29 @@ jobs:
 
           docker buildx imagetools create "${tags[@]}" "${sources[@]}"
 
-      # PR builds push to GHCR only. Use the metadata tag, not the raw branch:
-      # `metadata-action` rewrites characters Docker forbids, `/` among them.
-      - name: Comment PR with GHCR image link
-        if: github.event_name == 'pull_request'
+  # The only writer of the final comment, and it needs `prepare`, so the opening
+  # "under way" message can never land on top of the result.
+  report:
+    needs: [prepare, build, merge]
+    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      # The branch name is not a usable tag: `metadata-action` rewrites
+      # characters Docker forbids, `/` among them.
+      - name: Report success
+        if: needs.merge.result == 'success'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: preview-build
           message: |
             ✅ Preview build completed!
 
-            Docker image: `ghcr.io/${{ github.repository_owner }}/romm-testing:${{ steps.meta.outputs.version }}`
+            Docker image: `ghcr.io/${{ github.repository_owner }}/romm-testing:${{ needs.merge.outputs.version }}`
 
-  # Without this the sticky comment would sit on "under way..." forever.
-  report-failure:
-    needs: [build, merge]
-    if: ${{ failure() && github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Comment PR with the failure
+      - name: Report failure
+        if: needs.merge.result != 'success'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: preview-build

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -138,8 +138,12 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # Waits on `prepare` as well, so a late "under way" comment cannot land on top
+  # of the completed one. Its result is not required though: failing to post a
+  # comment should not leave a pushed image untagged.
   merge:
-    needs: build
+    needs: [prepare, build]
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -115,7 +115,6 @@ jobs:
           platforms: ${{ matrix.platform }}
           target: full-image
           outputs: type=image,name=${{ steps.repo.outputs.ref }},push-by-digest=true,name-canonical=true,push=true
-          # Seed from the previous preview, falling back to the last release.
           cache-from: |
             type=registry,ref=${{ env.CACHE_IMAGE }}:preview-${{ matrix.arch }}
             type=registry,ref=${{ env.CACHE_IMAGE }}:release-${{ matrix.arch }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -228,11 +228,13 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          HEAD_REF: ${{ github.head_ref }}
+          # The branch name is not a usable tag on its own: `metadata-action`
+          # rewrites characters Docker forbids, `/` among them.
+          IMAGE_TAG: ${{ steps.meta.outputs.version }}
         with:
           script: |
             const owner = context.repo.owner;
-            const tag = process.env.HEAD_REF;
+            const tag = process.env.IMAGE_TAG;
             github.rest.issues.updateComment({
               comment_id: ${{ needs.prepare.outputs.comment-id }},
               owner: owner,

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -27,31 +27,16 @@ permissions:
   pull-requests: write
 
 jobs:
-  build:
+  prepare:
     if: |
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'build-preview')
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: write
-      packages: write
       pull-requests: write
-    env:
-      USE_GHCR: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.registry == 'ghcr' || github.event.inputs.registry == 'both' }}
-      USE_DOCKERHUB: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.registry == 'dockerhub' || github.event.inputs.registry == 'both') }}
-      # Key the Docker Hub namespace off the push credential rather than the GitHub owner.
-      DOCKERHUB_NAMESPACE: ${{ secrets.DOCKER_NAMESPACE || secrets.DOCKER_USERNAME || github.repository_owner }}
+    outputs:
+      comment-id: ${{ steps.build-comment.outputs.comment-id }}
     steps:
-      - name: Run only once per workflow
-        run: echo "Triggered by ${{ github.event_name }}"
-
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
-          fetch-depth: 0
-
       - name: PR comment build starting
         if: github.event_name == 'pull_request'
         id: build-comment
@@ -66,14 +51,124 @@ jobs:
             });
             core.setOutput('comment-id', comment.data.id);
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
+  # Each architecture builds on a runner of its own architecture and pushes an
+  # untagged, digest-addressed image; `merge` then stitches them into one index.
+  # Emulating arm64 under QEMU made the C/C++ stages dominate the build.
+  build:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    env:
+      USE_GHCR: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.registry == 'ghcr' || github.event.inputs.registry == 'both' }}
+      USE_DOCKERHUB: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.registry == 'dockerhub' || github.event.inputs.registry == 'both') }}
+      # Key the Docker Hub namespace off the push credential rather than the GitHub owner.
+      DOCKERHUB_NAMESPACE: ${{ secrets.DOCKER_NAMESPACE || secrets.DOCKER_USERNAME || github.repository_owner }}
+      CACHE_IMAGE: ghcr.io/${{ github.repository_owner }}/romm-buildcache
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      # Always authenticated, even for a Docker Hub-only run: the layer cache
+      # lives in GHCR regardless of where the image itself is published.
+      - name: Login to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: env.USE_DOCKERHUB == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Resolve digest repository
+        id: repo
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          if [[ "${USE_GHCR}" == "true" ]]; then
+            echo "ref=ghcr.io/${OWNER}/romm-testing" >>"$GITHUB_OUTPUT"
+          else
+            echo "ref=${DOCKERHUB_NAMESPACE}/romm-testing" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          file: docker/Dockerfile
+          context: .
+          platforms: ${{ matrix.platform }}
+          target: full-image
+          outputs: type=image,name=${{ steps.repo.outputs.ref }},push-by-digest=true,name-canonical=true,push=true
+          # Seed from the previous preview, falling back to the last release.
+          cache-from: |
+            type=registry,ref=${{ env.CACHE_IMAGE }}:preview-${{ matrix.arch }}
+            type=registry,ref=${{ env.CACHE_IMAGE }}:release-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.CACHE_IMAGE }}:preview-${{ matrix.arch }},mode=max
+          build-args: |
+            SCREENSCRAPER_DEV_ID=${{ secrets.SCREENSCRAPER_DEV_ID }}
+            SCREENSCRAPER_DEV_PASSWORD=${{ secrets.SCREENSCRAPER_DEV_PASSWORD }}
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+    env:
+      USE_GHCR: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.registry == 'ghcr' || github.event.inputs.registry == 'both' }}
+      USE_DOCKERHUB: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.registry == 'dockerhub' || github.event.inputs.registry == 'both') }}
+      DOCKERHUB_NAMESPACE: ${{ secrets.DOCKER_NAMESPACE || secrets.DOCKER_USERNAME || github.repository_owner }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to GHCR
-        if: env.USE_GHCR == 'true'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -97,19 +192,36 @@ jobs:
           tags: |
             type=raw,value=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.head_ref }}
 
-      - name: Build full image
-        id: build-full
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          file: docker/Dockerfile
-          context: .
-          push: true
-          platforms: linux/arm64,linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          target: full-image
-          build-args: |
-            SCREENSCRAPER_DEV_ID=${{ secrets.SCREENSCRAPER_DEV_ID }}
-            SCREENSCRAPER_DEV_PASSWORD=${{ secrets.SCREENSCRAPER_DEV_PASSWORD }}
+      - name: Resolve digest repository
+        id: repo
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          if [[ "${USE_GHCR}" == "true" ]]; then
+            echo "ref=ghcr.io/${OWNER}/romm-testing" >>"$GITHUB_OUTPUT"
+          else
+            echo "ref=${DOCKERHUB_NAMESPACE}/romm-testing" >>"$GITHUB_OUTPUT"
+          fi
+
+      # Cross-registry tags are fine here: `imagetools create` copies the blobs
+      # over when a target sits in a different registry than the digests.
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        env:
+          DIGEST_REF: ${{ steps.repo.outputs.ref }}
+          METADATA: ${{ steps.meta.outputs.json }}
+        run: |
+          tags=()
+          while IFS= read -r tag; do
+            tags+=(--tag "$tag")
+          done < <(jq -r '.tags[]' <<<"$METADATA")
+
+          sources=()
+          for digest in *; do
+            sources+=("${DIGEST_REF}@sha256:${digest}")
+          done
+
+          docker buildx imagetools create "${tags[@]}" "${sources[@]}"
 
       # PR builds always push to GHCR only, so the image link is hardcoded to GHCR.
       - name: Comment PR with GHCR image link
@@ -122,7 +234,7 @@ jobs:
             const owner = context.repo.owner;
             const tag = process.env.HEAD_REF;
             github.rest.issues.updateComment({
-              comment_id: ${{ steps.build-comment.outputs.comment-id }},
+              comment_id: ${{ needs.prepare.outputs.comment-id }},
               owner: owner,
               repo: context.repo.repo,
               body: `✅ Preview build completed!\n\nDocker image: \`ghcr.io/${owner}/romm-testing:${tag}\``

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,12 +58,10 @@ FROM ghcr.io/astral-sh/uv:${UV_VERSION}-python${PYTHON_VERSION}-alpine@sha256:${
 # BACKEND PYTHON BUILD
 FROM python-alias AS backend-build
 
-# git is needed to install streaming-form-data fork
 # libpq-dev is needed to build psycopg-c
 # mariadb-connector-c-dev is needed to build mariadb-connector
 RUN apk add --no-cache \
     gcc \
-    git \
     libpq-dev \
     mariadb-connector-c-dev \
     musl-dev

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,6 @@ FROM python:${PYTHON_VERSION}-alpine${ALPINE_VERSION}@sha256:${PYTHON_ALPINE_SHA
 # FRONTEND BUILD
 # Built on the native build platform: the output (/front/dist) is static JS/CSS,
 # fully architecture-independent, so there is no need to emulate the target arch.
-# This avoids running `npm ci`/Node under QEMU arm64 emulation, which hangs.
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION}-alpine${ALPINE_VERSION}@sha256:${NODE_ALPINE_SHA256} AS frontend-build
 WORKDIR /front
 


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Docker image builds took ~20 minutes, and the cause was not the C libraries.

Both `build.yml` and `test-build.yml` built `linux/arm64,linux/amd64` on a single `ubuntu-latest` (x86) runner, so the entire arm64 half ran under QEMU user-mode emulation. That penalty landed squarely on the expensive stages: `rahasher-build` (C++ with libchdr), `sigil-build` (CMake + submodules + cffi), `nginx-build` (mod_zip), and the Python C extensions. Neither workflow set `cache-from`/`cache-to`, so every run recompiled all of it from scratch even though those stages are driven by pinned `ARG`s that change a few times a year.

**Native per-arch runners.** Both workflows now use a matrix: `ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64 (GA and free for public repos). Each job pushes an untagged, digest-addressed image, and a `merge` job stitches the digests into a manifest list with `docker buildx imagetools create`. QEMU is gone entirely, `setup-qemu-action` is removed, and the two architectures build in parallel.

`build.yml` keeps both variants: each matrix job builds `slim-image` then `full-image` (the latter is `FROM` the former, so they share nearly all their work inside one job), exports both digests, and the merge job creates one manifest list per variant. Cross-registry tagging still works because `imagetools create` copies blobs when a target sits in a different registry than the source digests, so Docker Hub tags are created from the GHCR digests.

**Registry layer cache.** A dedicated `ghcr.io/<owner>/romm-buildcache` package, keyed by arch:

- releases read and write `release-<arch>`
- preview builds read `preview-<arch>` and `release-<arch>`, and write only `preview-<arch>`

so a preview build can never overwrite the release cache. Only the full build exports the cache, since it is a superset of the slim one. GHCR login is now unconditional in `test-build.yml`, because the cache lives there even for a Docker Hub-only dispatch.

**Sticky preview comment.** The two `github-script` blocks and the `comment-id` passed between jobs are replaced by a comment keyed on a header, so the status updates in place across re-runs instead of appending a new comment each time. With the id plumbing gone, `build` and `merge` no longer depend on `prepare`: the gate moved onto `build` directly, so the build starts alongside the comment rather than behind it, and a failure posting the comment can no longer cancel it.

This also fixes a latent bug. The old comment interpolated the raw branch name, but `metadata-action` rewrites characters Docker forbids in a tag, so a branch like `claude/admiring-sagan-3447xr` publishes as `claude-admiring-sagan-3447xr` and the advertised reference 404s.

**Least-privilege permissions.** These were the only two workflows granting themselves `contents: write` and `actions: write` at the top level; every other workflow in the repo is `read-all`. Nothing here pushes commits or dispatches a workflow in this repo (the docs trigger authenticates to another repo with a PAT), and `validate-tag-semver` was inheriting the whole set to run a regex. Each job already declares what it needs, so the top-level grant is now a read-only fallback. `trigger-docs-and-web` keeps its own `actions: write` rather than my guessing at a release-only job.

The preview checkout also fetched full git history for a build that reads none, once per architecture now that the matrix has two of them. Nothing in the frontend or backend build reads git metadata, so it is gone.

**Dockerfile.** Dropped `git` from `backend-build`. The comment said it was needed for a streaming-form-data fork, but that is an ordinary PyPI dependency now and `uv.lock` has no git sources at all.

**Results**

| Build | Wall clock |
| --- | --- |
| Before (QEMU, one runner, no cache) | 20m 45s |
| After, cold cache | 4m 47s |
| After, warm cache | ~65s |

~65s is the best case, where only workflow YAML changed and every layer hits. A PR touching `backend/` or `frontend/` invalidates from that layer down, so expect something between the two figures in normal use; 4m 47s is the honest floor for a from-scratch build.

**On using prebuilt binaries instead**

Mostly not available, and it matters much less once QEMU is out of the picture. RetroAchievements ships RALibretro for Windows only, and we patch its source before building anyway; nobody publishes a musl `ngx_http_zip_module.so` for a specific nginx version. The one real opportunity is `sigil`, which is our own `rommforge/argosy-sigil`: publishing cibuildwheel musllinux + manylinux wheels there would let this Dockerfile install a wheel and delete the whole CMake stage. Left as a follow-up. On the Python side only `mariadb`, `psycopg-c` and `streaming-form-data` build from source (plus `psutil`/`memray` in the dev image); everything else already resolves to a musllinux aarch64 wheel, and `psycopg[binary]` would be a no-op because psycopg-binary publishes no musllinux wheels.

**Note:** pushing by digest leaves untagged manifests in the `romm`/`romm-testing` packages, which a GHCR cleanup policy can prune.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

**What is and is not proven**

`test-build.yml` has been exercised end to end by four real preview runs on this branch. The published index was inspected directly from GHCR rather than inferred from a green check, and is a correct flat OCI index carrying `linux/amd64` and `linux/arm64` plus both provenance attestations, each re-pointed at its image digest. Leaving provenance at its default is deliberate: buildx flattens the per-arch indexes correctly, so `provenance: false` would have needlessly dropped attestations we publish today.

**`build.yml` has never executed.** It shares the same matrix-and-merge pattern, but nothing triggers it except a published release, so its first real run will push to Docker Hub and GHCR under the project's identity. That is the part worth a careful read; the slim/full digest split and the cross-registry `imagetools create` are the specific things to check.

`actionlint` (with its shellcheck integration) and `prettier --check` are clean on both workflows. No unit tests, as the change is entirely CI and Dockerfile.

#### Screenshots (if applicable)

n/a

---

AI assistance disclosure: written by Claude Code (agentic, effectively all of the diff and this description), driven and reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQKGy6yG6bMwEQGe5bp3ad