### PR TITLE
feat(emulatorjs): set a default core per platform in config.yml

### DIFF
--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -476,6 +476,7 @@ class Config:
     EJS_ENABLE_AUTO_SAVE_SYNC: bool
     EJS_NETPLAY_ENABLED: bool
     EJS_NETPLAY_ICE_SERVERS: list[NetplayICEServer]
+    EJS_DEFAULT_CORES: dict[str, str]  # platform_slug -> core_name
     EJS_SETTINGS: dict[str, EjsOption]  # core_name -> EjsOption
     EJS_CONTROLS: dict[str, EjsControls]  # core_name -> EjsControls
     SCAN_METADATA_PRIORITY: list[str]
@@ -763,6 +764,10 @@ class ConfigManager:
             EJS_NETPLAY_ICE_SERVERS=pydash.get(
                 self._raw_config, "emulatorjs.netplay.ice_servers", []
             ),
+            EJS_DEFAULT_CORES=pydash.get(
+                self._raw_config, "emulatorjs.default_cores", {}
+            )
+            or {},
             EJS_SETTINGS=pydash.get(self._raw_config, "emulatorjs.settings", {}),
             EJS_CONTROLS=self._get_ejs_controls(),
             SCAN_METADATA_PRIORITY=pydash.get(
@@ -895,9 +900,9 @@ class ConfigManager:
         return yaml_controls
 
     def _validated_platform_map(self, raw: Any, config_key: str) -> dict[str, str]:
-        """Check a folder name to slug mapping.
+        """Check a mapping of platform or folder names to non-empty strings.
 
-        Folder names are lowercased so lookups can ignore case.
+        Keys are lowercased so lookups can ignore case.
         """
         if not isinstance(raw, dict):
             log.critical(f"Invalid config.yml: {config_key} must be a dictionary")
@@ -1063,6 +1068,10 @@ class ConfigManager:
                 "Invalid config.yml: emulatorjs.netplay.ice_servers must be a list"
             )
             sys.exit(3)
+
+        self.config.EJS_DEFAULT_CORES = self._validated_platform_map(
+            self.config.EJS_DEFAULT_CORES, "emulatorjs.default_cores"
+        )
 
         if not isinstance(self.config.EJS_SETTINGS, dict):
             log.critical("Invalid config.yml: emulatorjs.settings must be a dictionary")
@@ -1335,6 +1344,7 @@ class ConfigManager:
                     "enabled": self.config.EJS_NETPLAY_ENABLED,
                     "ice_servers": self.config.EJS_NETPLAY_ICE_SERVERS,
                 },
+                "default_cores": self.config.EJS_DEFAULT_CORES,
                 "settings": self.config.EJS_SETTINGS,
                 "controls": self._format_ejs_controls_for_yaml(),
             },

--- a/backend/config/config_manager.py
+++ b/backend/config/config_manager.py
@@ -909,13 +909,13 @@ class ConfigManager:
             sys.exit(3)
 
         normalized: dict[str, str] = {}
-        for fs_slug, slug in raw.items():
-            if not isinstance(slug, str) or not slug:
+        for key, value in raw.items():
+            if not isinstance(value, str) or not value:
                 log.critical(
-                    f"Invalid config.yml: {config_key}.{fs_slug} must be a non-empty string"
+                    f"Invalid config.yml: {config_key}.{key} must be a non-empty string"
                 )
                 sys.exit(3)
-            normalized[str(fs_slug).lower()] = slug
+            normalized[str(key).lower()] = value
 
         return normalized
 

--- a/backend/endpoints/configs.py
+++ b/backend/endpoints/configs.py
@@ -154,6 +154,7 @@ def get_config(request: Request) -> ConfigResponse:
             cfg.EJS_NETPLAY_ICE_SERVERS if request.user.is_authenticated else []
         ),
         EJS_CONTROLS=cfg.EJS_CONTROLS,
+        EJS_DEFAULT_CORES=cfg.EJS_DEFAULT_CORES,
         EJS_SETTINGS=cfg.EJS_SETTINGS,
         SCAN_METADATA_PRIORITY=cfg.SCAN_METADATA_PRIORITY,
         SCAN_ARTWORK_PRIORITY=cfg.SCAN_ARTWORK_PRIORITY,

--- a/backend/endpoints/responses/config.py
+++ b/backend/endpoints/responses/config.py
@@ -27,6 +27,7 @@ class ConfigResponse(TypedDict):
     EJS_ENABLE_AUTO_SAVE_SYNC: bool
     EJS_NETPLAY_ENABLED: bool
     EJS_NETPLAY_ICE_SERVERS: list[NetplayICEServer]
+    EJS_DEFAULT_CORES: dict[str, str]
     EJS_SETTINGS: dict[str, dict[str, str]]
     EJS_CONTROLS: dict[str, EjsControls]
     SCAN_METADATA_PRIORITY: list[str]

--- a/backend/tests/config/fixtures/config/config.yml
+++ b/backend/tests/config/fixtures/config/config.yml
@@ -81,6 +81,9 @@ emulatorjs:
       - urls: "turn:global.relay.metered.ca:80"
         username: "user"
         credential: "password"
+  default_cores:
+    nds: desmume
+    Nintendo-DSi: melonds
   settings:
     parallel_n64:
       vsync: disabled

--- a/backend/tests/config/test_config_loader.py
+++ b/backend/tests/config/test_config_loader.py
@@ -69,6 +69,10 @@ def test_config_loader():
             "credential": "password",
         },
     ]
+    assert loader.config.EJS_DEFAULT_CORES == {
+        "nds": "desmume",
+        "nintendo-dsi": "melonds",
+    }
     assert loader.config.EJS_SETTINGS == {
         "parallel_n64": {"vsync": "disabled"},
         "snes9x": {"snes9x_region": "ntsc"},
@@ -160,6 +164,7 @@ def test_empty_config_loader():
     assert not loader.config.EJS_ENABLE_AUTO_SAVE_SYNC
     assert not loader.config.EJS_NETPLAY_ENABLED
     assert loader.config.EJS_NETPLAY_ICE_SERVERS == []
+    assert loader.config.EJS_DEFAULT_CORES == {}
     assert loader.config.EJS_SETTINGS == {}
     assert loader.config.EJS_CONTROLS == {}
     assert loader.config.SCAN_ARTWORK_PRIORITY_OVERRIDES == {}
@@ -608,6 +613,24 @@ def test_null_platforms_block_means_empty(tmp_path):
 
     assert loader.config.PLATFORMS_BINDING == {}
     assert loader.config.PLATFORMS_VERSIONS == {}
+
+
+def test_null_default_cores_block_means_empty(tmp_path):
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("emulatorjs:\n  default_cores:\n")
+
+    assert ConfigManager(str(config_file)).config.EJS_DEFAULT_CORES == {}
+
+
+@pytest.mark.parametrize("value", ['""', "5", "~"])
+def test_default_core_must_be_a_non_empty_string(tmp_path, value):
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(f"emulatorjs:\n  default_cores:\n    nds: {value}\n")
+
+    with pytest.raises(SystemExit) as excinfo:
+        ConfigManager(str(config_file))
+
+    assert excinfo.value.code == 3
 
 
 @pytest.mark.parametrize("value", ['""', "5", "~"])

--- a/backend/tests/config/test_config_loader.py
+++ b/backend/tests/config/test_config_loader.py
@@ -615,24 +615,6 @@ def test_null_platforms_block_means_empty(tmp_path):
     assert loader.config.PLATFORMS_VERSIONS == {}
 
 
-def test_null_default_cores_block_means_empty(tmp_path):
-    config_file = tmp_path / "config.yml"
-    config_file.write_text("emulatorjs:\n  default_cores:\n")
-
-    assert ConfigManager(str(config_file)).config.EJS_DEFAULT_CORES == {}
-
-
-@pytest.mark.parametrize("value", ['""', "5", "~"])
-def test_default_core_must_be_a_non_empty_string(tmp_path, value):
-    config_file = tmp_path / "config.yml"
-    config_file.write_text(f"emulatorjs:\n  default_cores:\n    nds: {value}\n")
-
-    with pytest.raises(SystemExit) as excinfo:
-        ConfigManager(str(config_file))
-
-    assert excinfo.value.code == 3
-
-
 @pytest.mark.parametrize("value", ['""', "5", "~"])
 def test_platform_binding_must_be_a_non_empty_string(tmp_path, value):
     with pytest.raises(SystemExit) as excinfo:
@@ -646,6 +628,26 @@ def test_platform_binding_lookup_ignores_case(tmp_path):
 
     loader.remove_platform_binding("GAMECUBE")
     assert loader.config.PLATFORMS_BINDING == {}
+
+
+def _write_emulatorjs_config(tmp_path: Path, emulatorjs_block: str) -> ConfigManager:
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(f"emulatorjs:\n{emulatorjs_block}")
+    return ConfigManager(str(config_file))
+
+
+def test_null_default_cores_block_means_empty(tmp_path):
+    loader = _write_emulatorjs_config(tmp_path, "  default_cores:\n")
+
+    assert loader.config.EJS_DEFAULT_CORES == {}
+
+
+@pytest.mark.parametrize("value", ['""', "5", "~"])
+def test_default_core_must_be_a_non_empty_string(tmp_path, value):
+    with pytest.raises(SystemExit) as excinfo:
+        _write_emulatorjs_config(tmp_path, f"  default_cores:\n    nds: {value}\n")
+
+    assert excinfo.value.code == 3
 
 
 @pytest.fixture

--- a/backend/tests/endpoints/test_config.py
+++ b/backend/tests/endpoints/test_config.py
@@ -33,6 +33,7 @@ def test_config(client):
         DEFAULT_EXCLUDED_MULTI_FILE_DIRS
     )
     assert config.get("PLATFORMS_BINDING") == {}
+    assert config.get("EJS_DEFAULT_CORES") == {}
     assert not config.get("SKIP_HASH_CALCULATION")
     assert config.get("GAMELIST_MEDIA_THUMBNAIL") == "box2d"
     assert config.get("GAMELIST_MEDIA_IMAGE") == "screenshot"

--- a/docs/BACKEND_ARCHITECTURE.md
+++ b/docs/BACKEND_ARCHITECTURE.md
@@ -1696,6 +1696,8 @@ scan:
 
 emulatorjs:
   debug: false
+  default_cores:
+    nds: desmume # platform slug → core preselected in the player
   netplay:
     enabled: false
     ice_servers:

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -182,6 +182,9 @@
 #   disable_batch_bootup: false
 #   disable_auto_unload: false
 #   auto_save_sync: false # Upload the save to the server whenever it changes, without Save & Quit
+#   default_cores: # Core preselected per platform, unless overridden on the device
+#     nds: desmume
+#     nintendo-dsi: melonds
 #   settings:
 #     parallel_n64: # Use the exact core name
 #       vsync: disabled

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -183,6 +183,7 @@
 #   disable_auto_unload: false
 #   auto_save_sync: false # Upload the save to the server whenever it changes, without Save & Quit
 #   default_cores: # Core preselected per platform, unless overridden on the device
+#     # Use the exact core name, as listed for the platform in the docs
 #     nds: desmume
 #     nintendo-dsi: melonds
 #   settings:

--- a/frontend/src/__generated__/models/ConfigResponse.ts
+++ b/frontend/src/__generated__/models/ConfigResponse.ts
@@ -29,6 +29,7 @@ export type ConfigResponse = {
     EJS_ENABLE_AUTO_SAVE_SYNC: boolean;
     EJS_NETPLAY_ENABLED: boolean;
     EJS_NETPLAY_ICE_SERVERS: Array<NetplayICEServer>;
+    EJS_DEFAULT_CORES: Record<string, string>;
     EJS_SETTINGS: Record<string, Record<string, string>>;
     EJS_CONTROLS: Record<string, EjsControls>;
     SCAN_METADATA_PRIORITY: Array<string>;

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -95,9 +95,7 @@ export default defineStore("config", {
       return Object.keys(this.config).includes(type);
     },
     getEJSDefaultCore(platformSlug: string): string | null {
-      return (
-        this.config.EJS_DEFAULT_CORES?.[platformSlug.toLowerCase()] ?? null
-      );
+      return this.config.EJS_DEFAULT_CORES[platformSlug.toLowerCase()] ?? null;
     },
     getEJSCoreOptions(core: string | null): Record<string, string | boolean> {
       const defaultOptions = this.config.EJS_SETTINGS["default"] || {};

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -32,6 +32,7 @@ const defaultConfig = {
   EJS_DISABLE_BATCH_BOOTUP: false,
   EJS_ENABLE_AUTO_SAVE_SYNC: false,
   EJS_NETPLAY_ICE_SERVERS: [],
+  EJS_DEFAULT_CORES: {},
   EJS_SETTINGS: {},
   EJS_CONTROLS: {},
   SCAN_METADATA_PRIORITY: [],
@@ -92,6 +93,9 @@ export default defineStore("config", {
     },
     isExclusionType(type: string): type is ExclusionType {
       return Object.keys(this.config).includes(type);
+    },
+    getEJSDefaultCore(platformSlug: string): string | null {
+      return this.config.EJS_DEFAULT_CORES[platformSlug.toLowerCase()] ?? null;
     },
     getEJSCoreOptions(core: string | null): Record<string, string | boolean> {
       const defaultOptions = this.config.EJS_SETTINGS["default"] || {};

--- a/frontend/src/stores/config.ts
+++ b/frontend/src/stores/config.ts
@@ -95,7 +95,9 @@ export default defineStore("config", {
       return Object.keys(this.config).includes(type);
     },
     getEJSDefaultCore(platformSlug: string): string | null {
-      return this.config.EJS_DEFAULT_CORES[platformSlug.toLowerCase()] ?? null;
+      return (
+        this.config.EJS_DEFAULT_CORES?.[platformSlug.toLowerCase()] ?? null
+      );
     },
     getEJSCoreOptions(core: string | null): Record<string, string | boolean> {
       const defaultOptions = this.config.EJS_SETTINGS["default"] || {};

--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -118,9 +118,6 @@ const selectedDisc = ref<DiscSelection>(null);
 const selectedCore = ref<string | null>(null);
 const selectedFirmware = ref<FirmwareSchema | null>(null);
 const supportedCores = ref<string[]>([]);
-// Written back only when the user deviates from it, so a later change to
-// the instance default isn't shadowed by a core nobody chose.
-const resolvedCore = ref<string | null>(null);
 const gameRunning = ref(false);
 const removeIOSFullscreenShim = ref<(() => void) | null>(null);
 
@@ -225,10 +222,7 @@ async function onPlay() {
   removeIOSFullscreenShim.value = installIOSFullscreenShim();
 
   if (rom.value) {
-    if (selectedCore.value !== resolvedCore.value) {
-      rememberCore(rom.value.id, rom.value.platform_slug, selectedCore.value);
-      resolvedCore.value = selectedCore.value;
-    }
+    rememberCore(rom.value.id, rom.value.platform_slug, selectedCore.value);
     rememberDisc(rom.value.id, selectedDisc.value);
   }
   gameRunning.value = true;
@@ -321,7 +315,12 @@ onMounted(async () => {
   });
   firmwareOptions.value = firmwareResponse.data;
 
-  supportedCores.value = [...getSupportedEJSCores(rom.value.platform_slug)];
+  supportedCores.value = [
+    ...getSupportedEJSCores(
+      rom.value.platform_slug,
+      configStore.config.EJS_NETPLAY_ENABLED,
+    ),
+  ];
 
   emitter?.on("saveSelected", selectSave);
   emitter?.on("stateSelected", selectState);
@@ -339,6 +338,21 @@ onMounted(async () => {
     });
   }
 
+  // Resolved before the save/state defaults below, which key off the core
+  // this game will actually boot with.
+  const configuredCore = configStore.getEJSDefaultCore(rom.value.platform_slug);
+  if (configuredCore && !supportedCores.value.includes(configuredCore)) {
+    console.warn(
+      `[Play] emulatorjs.default_cores sets ${configuredCore} for ${rom.value.platform_slug}, which does not support it`,
+    );
+  }
+  selectedCore.value = resolveRememberedCore(
+    rom.value.id,
+    rom.value.platform_slug,
+    supportedCores.value,
+    configuredCore,
+  );
+
   // Default selection — save and state are independent, so both can be
   // armed at once. The bound save is the write-back target for "Save &
   // Quit" (PUT in place), so we only auto-bind it when the choice is
@@ -346,13 +360,10 @@ onMounted(async () => {
   // there are multiple saves, since loading the state injects a different
   // SRAM timeline that would overwrite an arbitrary save the user never
   // picked. In that case the user must select the save slot explicitly.
-  const initiallyCompatibleStates = rom.value.user_states.filter(
-    (s) => !s.emulator || s.emulator === supportedCores.value[0],
-  );
-  const hasCompatibleState = initiallyCompatibleStates.length > 0;
+  const hasCompatibleState = compatibleStates.value.length > 0;
 
   if (hasCompatibleState) {
-    selectedState.value = initiallyCompatibleStates[0];
+    selectedState.value = compatibleStates.value[0];
   }
   const safeToBindSave =
     rom.value.user_saves.length === 1 || !hasCompatibleState;
@@ -365,14 +376,6 @@ onMounted(async () => {
     rom.value.id,
     bootableRomFiles.value,
   );
-
-  resolvedCore.value = resolveRememberedCore(
-    rom.value.id,
-    rom.value.platform_slug,
-    supportedCores.value,
-    configStore.getEJSDefaultCore(rom.value.platform_slug),
-  );
-  selectedCore.value = resolvedCore.value;
 
   const coreOptions = configStore.getEJSCoreOptions(selectedCore.value);
   const storedBiosID = localStorage.getItem(

--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -315,9 +315,10 @@ onMounted(async () => {
   });
   firmwareOptions.value = firmwareResponse.data;
 
+  const platformSlug = rom.value.platform_slug;
   supportedCores.value = [
     ...getSupportedEJSCores(
-      rom.value.platform_slug,
+      platformSlug,
       configStore.config.EJS_NETPLAY_ENABLED,
     ),
   ];
@@ -338,19 +339,12 @@ onMounted(async () => {
     });
   }
 
-  // Resolved before the save/state defaults below, which key off the core
-  // this game will actually boot with.
-  const configuredCore = configStore.getEJSDefaultCore(rom.value.platform_slug);
-  if (configuredCore && !supportedCores.value.includes(configuredCore)) {
-    console.warn(
-      `[Play] emulatorjs.default_cores sets ${configuredCore} for ${rom.value.platform_slug}, which does not support it`,
-    );
-  }
+  // compatibleStates filters on selectedCore, so resolve the core first.
   selectedCore.value = resolveRememberedCore(
     rom.value.id,
-    rom.value.platform_slug,
+    platformSlug,
     supportedCores.value,
-    configuredCore,
+    configStore.getEJSDefaultCore(platformSlug),
   );
 
   // Default selection — save and state are independent, so both can be
@@ -378,9 +372,7 @@ onMounted(async () => {
   );
 
   const coreOptions = configStore.getEJSCoreOptions(selectedCore.value);
-  const storedBiosID = localStorage.getItem(
-    `player:${rom.value.platform_slug}:bios_id`,
-  );
+  const storedBiosID = localStorage.getItem(`player:${platformSlug}:bios_id`);
 
   selectedFirmware.value = resolveInitialFirmware({
     options: firmwareOptions.value,

--- a/frontend/src/v2/views/Player/EmulatorJS.vue
+++ b/frontend/src/v2/views/Player/EmulatorJS.vue
@@ -118,6 +118,9 @@ const selectedDisc = ref<DiscSelection>(null);
 const selectedCore = ref<string | null>(null);
 const selectedFirmware = ref<FirmwareSchema | null>(null);
 const supportedCores = ref<string[]>([]);
+// Written back only when the user deviates from it, so a later change to
+// the instance default isn't shadowed by a core nobody chose.
+const resolvedCore = ref<string | null>(null);
 const gameRunning = ref(false);
 const removeIOSFullscreenShim = ref<(() => void) | null>(null);
 
@@ -222,7 +225,10 @@ async function onPlay() {
   removeIOSFullscreenShim.value = installIOSFullscreenShim();
 
   if (rom.value) {
-    rememberCore(rom.value.id, rom.value.platform_slug, selectedCore.value);
+    if (selectedCore.value !== resolvedCore.value) {
+      rememberCore(rom.value.id, rom.value.platform_slug, selectedCore.value);
+      resolvedCore.value = selectedCore.value;
+    }
     rememberDisc(rom.value.id, selectedDisc.value);
   }
   gameRunning.value = true;
@@ -360,11 +366,13 @@ onMounted(async () => {
     bootableRomFiles.value,
   );
 
-  selectedCore.value = resolveRememberedCore(
+  resolvedCore.value = resolveRememberedCore(
     rom.value.id,
     rom.value.platform_slug,
     supportedCores.value,
+    configStore.getEJSDefaultCore(rom.value.platform_slug),
   );
+  selectedCore.value = resolvedCore.value;
 
   const coreOptions = configStore.getEJSCoreOptions(selectedCore.value);
   const storedBiosID = localStorage.getItem(

--- a/frontend/src/v2/views/Player/coreStorage.test.ts
+++ b/frontend/src/v2/views/Player/coreStorage.test.ts
@@ -50,6 +50,26 @@ describe("coreStorage", () => {
     expect(resolveRememberedCore(ROM_ID, SLUG, ARCADE_CORES)).toBe("mame2003");
   });
 
+  it("uses the instance default when nothing is remembered", () => {
+    expect(resolveRememberedCore(ROM_ID, SLUG, ARCADE_CORES, "fbneo")).toBe(
+      "fbneo",
+    );
+  });
+
+  it("prefers a remembered core over the instance default", () => {
+    rememberCore(ROM_ID, SLUG, "mame2003_plus");
+
+    expect(resolveRememberedCore(ROM_ID, SLUG, ARCADE_CORES, "fbneo")).toBe(
+      "mame2003_plus",
+    );
+  });
+
+  it("ignores an instance default the platform does not support", () => {
+    expect(resolveRememberedCore(ROM_ID, SLUG, ARCADE_CORES, "melonds")).toBe(
+      "mame2003",
+    );
+  });
+
   it("forgets both keys when the selection is cleared", () => {
     rememberCore(ROM_ID, SLUG, "mame2003_plus");
     rememberCore(ROM_ID, SLUG, null);

--- a/frontend/src/v2/views/Player/coreStorage.ts
+++ b/frontend/src/v2/views/Player/coreStorage.ts
@@ -4,20 +4,24 @@ const gameKey = (romId: number) => `player:${romId}:core`;
 const platformKey = (platformSlug: string) => `player:${platformSlug}:core`;
 
 /**
- * The first remembered core the platform still supports, else its first core.
+ * The first remembered core the platform still supports, else the core the
+ * instance configures for it, else its first core.
  *
  * Each candidate is validated so a core that is no longer offered (renamed
- * upstream, or gated behind netplay) falls through instead of masking the next.
+ * upstream, or gated behind netplay, or a typo in config.yml) falls through
+ * instead of masking the next.
  */
 export function resolveRememberedCore(
   romId: number,
   platformSlug: string,
   supportedCores: readonly string[],
+  configuredCore?: string | null,
 ): string {
   return (
     [
       localStorage.getItem(gameKey(romId)),
       localStorage.getItem(platformKey(platformSlug)),
+      configuredCore,
     ].find((core): core is string => !!core && supportedCores.includes(core)) ??
     supportedCores[0]
   );


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD041) -->
<!-- trunk-ignore-all(markdownlint/MD033) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Closes #4434

Adds an `emulatorjs.default_cores` block that maps a platform slug to the core the player preselects for it:

```yaml
emulatorjs:
  default_cores:
    nds: desmume
    nintendo-dsi: melonds
```

This lets an instance run DS software on DeSmuME and DSi software on melonDS without every user picking a core on every device, which today means switching melonDS between DS and DSi mode per game and per device.

**Resolution order**, each candidate validated against the cores the platform actually supports so an unknown platform or a typo'd core falls through instead of masking the next:

1. the core remembered for that game on this device
2. the core remembered for that platform on this device
3. `default_cores` for that platform
4. the platform's first supported core

Step 3 is the only new one. It is a base default, not a replacement for the existing per-game and per-device memory, as the issue asks. Note the consequence for existing installs: anyone who has already played a game on a platform has step 2 populated on that device, so the configured default only reaches devices that have not played that platform yet.

Backend: `EJS_DEFAULT_CORES` on the config manager, validated by the existing platform-map validator (keys lowercased, a non-string or empty core exits with code 3), round-tripped in the YAML dump, and exposed on `GET /api/config`. Frontend types regenerated.

v1 and the console UI are left alone per the freeze in `CLAUDE.md`; v2 is the default UI. `console/views/Play.vue` carries its own inline copy of the resolution chain, so it does not honour the new key.

**Two fixes ride along**, both surfaced while reviewing the above:

- The v2 player called `getSupportedEJSCores` without `EJS_NETPLAY_ENABLED`, unlike the five other call sites. On a netplay instance that dropped the nightly-only cores (`bsnes`, `genesis_plus_gx_wide`, `picodrive`, `smsplus`, `freeintv`) from the core select, and would have silently rejected a `default_cores` entry naming one.
- The player picked its default save/state before resolving the core, then filtered states against `supportedCores[0]`. When the resolved core differed, the `watch(selectedCore)` cleared the armed state **and** deleted `player:<slug>:state_id`, destroying a stored preference on open. Resolving the core first fixes it, and lets the inline state filter be replaced by the existing `compatibleStates` computed.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Verified in a browser against a real NDS ROM with `default_cores: {nds: desmume}`, where `melonds` is the platform's first supported core:

| case | preselected core |
| --- | --- |
| configured default only | `desmume` |
| \+ `player:nds:core` remembered | `desmume2015` (device beats config) |
| \+ `player:<rom>:core` remembered | `melonds` (game beats both) |
| remembered core no longer supported | `desmume` (falls through to config) |

Also checked with a state tagged `melonds` on that ROM: `player:nds:state_id` survives opening the player, where before this branch it was deleted. Playing still writes both the game and platform core keys.

Checks run: `vue-tsc`, full Vitest suite (1208 tests), production build, i18n parity, backend config and endpoint tests, `trunk fmt && trunk check`.

**AI assistance disclosure**

This change was written with AI assistance (Claude Code): the implementation, the tests, and the browser verification above were all produced in-session, along with a security, correctness, and simplification review pass over the diff.

#### Screenshots (if applicable)

No visual change: the core dropdown renders as before, only preselected differently. Checked in both themes and at 400px width.
