### PR TITLE
fix(roms): sort unset per-user and metadata keys last on every engine

### DIFF
--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -58,7 +58,6 @@ from models.music import MusicFavoriteTrack, MusicPlaylistTrack
 from models.platform import Platform
 from models.rom import (
     METADATA_SOURCE_COLUMNS,
-    ROM_USER_ZERO_IS_UNSET_COLUMNS,
     Rom,
     RomFacets,
     RomFile,
@@ -176,14 +175,33 @@ ROM_FILE_HASH_COLUMNS_BY_DIGEST_LENGTH: dict[int, tuple[QueryableAttribute, ...]
     40: (RomFile.sha1_hash, RomFile.chd_sha1_hash),
 }
 
-# Every column here is indexed on `roms`, so the sort key needs no join to the
-# view (descending sorts still read the index order on MariaDB/MySQL).
+# Every column here is indexed on `roms`, so the sort key needs no join to
+# the view.
 ROM_METADATA_ORDER_COLUMNS: dict[str, QueryableAttribute] = {
     "first_release_date": Rom.generated_first_release_date,
     "average_rating": Rom.generated_average_rating,
     "player_count": Rom.generated_player_count,
     "hltb_main_story": Rom.generated_hltb_main_story,
 }
+
+
+def _nulls_last_ordering(
+    sort_key: Any, descending: bool
+) -> tuple[ColumnElement[bool] | None, ColumnElement[Any]]:
+    """NULL sort keys land last on every engine.
+
+    Returns:
+        A leading IS NULL term (or None) and the directed sort clause.
+    """
+    # PostgreSQL says it natively; the other engines place NULLs last on
+    # DESC already, so only their ascending case needs the emulation term.
+    order_clause = sort_key.desc() if descending else sort_key.asc()
+    if ROMM_DB_DRIVER == "postgresql":
+        return None, order_clause.nulls_last()
+    if descending:
+        return None, order_clause
+    return sort_key.is_(None), order_clause
+
 
 # Filter dropdowns read the narrow `roms_facets` mirror instead of `roms`,
 # whose rows carry the raw metadata blobs. Column order matches the unpacking
@@ -1665,18 +1683,17 @@ class DBRomsHandler(DBBaseHandler):
     ) -> tuple[Query[Rom], Any]:
         query = self._join_rom_user(select(Rom), user_id)
 
-        sorts_by_rom_user = False
-        sorts_by_metadata = False
+        sort_key_is_nullable = False
         if user_id and hasattr(RomUser, order_by) and not hasattr(Rom, order_by):
             order_attr = getattr(RomUser, order_by)
-            sorts_by_rom_user = True
+            sort_key_is_nullable = True
         elif order_by in ROM_METADATA_ORDER_COLUMNS:
             order_attr = ROM_METADATA_ORDER_COLUMNS[order_by]
-            sorts_by_metadata = True
+            sort_key_is_nullable = True
         elif hasattr(RomMetadata, order_by) and not hasattr(Rom, order_by):
             order_attr = getattr(RomMetadata, order_by)
             query = query.outerjoin(RomMetadata, RomMetadata.rom_id == Rom.id)
-            sorts_by_metadata = True
+            sort_key_is_nullable = True
         elif hasattr(Rom, order_by):
             order_attr = getattr(Rom, order_by)
         else:
@@ -1690,22 +1707,19 @@ class DBRomsHandler(DBBaseHandler):
 
         order_attr_column = order_attr
 
-        # 0 renders as unset, so NULLIF folds it into the NULL bucket.
-        if sorts_by_rom_user and order_by in ROM_USER_ZERO_IS_UNSET_COLUMNS:
-            order_attr = func.nullif(order_attr, 0)
+        # NULLIF folds the marked zero-as-unset metrics into the NULL bucket.
+        sort_key = (
+            func.nullif(order_attr_column, 0)
+            if getattr(order_attr_column, "info", {}).get("zero_is_unset")
+            else order_attr_column
+        )
 
-        sort_key = order_attr
         descending = order_dir.lower() == "desc"
-        order_attr = order_attr.desc() if descending else order_attr.asc()
-
-        # NULL keys sort last on every engine. MariaDB/MySQL do it natively on
-        # DESC; ASC takes a leading IS NULL term (costing metadata index order).
-        nulls_last_clause = None
-        if sorts_by_rom_user or sorts_by_metadata:
-            if ROMM_DB_DRIVER == "postgresql":
-                order_attr = order_attr.nulls_last()
-            elif not descending:
-                nulls_last_clause = sort_key.is_(None)
+        if sort_key_is_nullable:
+            nulls_last_clause, order_clause = _nulls_last_ordering(sort_key, descending)
+        else:
+            nulls_last_clause = None
+            order_clause = sort_key.desc() if descending else sort_key.asc()
 
         # Ties are common on every sort key here and the gallery pages by
         # offset, so without a unique final key a rom can repeat in one window
@@ -1725,9 +1739,9 @@ class DBRomsHandler(DBBaseHandler):
         # An explicit sort wins with relevance breaking ties; with no sort
         # selected, relevance leads and name is the tiebreaker.
         ordering = (
-            (nulls_last_clause, order_attr, relevance_clause, tiebreaker)
+            (nulls_last_clause, order_clause, relevance_clause, tiebreaker)
             if order_by
-            else (relevance_clause, order_attr, tiebreaker)
+            else (relevance_clause, order_clause, tiebreaker)
         )
         order_clauses = [clause for clause in ordering if clause is not None]
 
@@ -2824,11 +2838,14 @@ class DBRomsHandler(DBBaseHandler):
         if playlist_id is not None:
             order_map["position"] = MusicPlaylistTrack.position
         col = order_map.get(order_by, TrackMeta.title)
-        direction = col.desc() if order_dir == "desc" else col.asc()
+        nulls_last_clause, direction = _nulls_last_ordering(col, order_dir == "desc")
+        track_ordering = [
+            clause
+            for clause in (nulls_last_clause, direction, TrackMeta.rom_file_id)
+            if clause is not None
+        ]
         rows = session.execute(
-            base.order_by(col.is_(None), direction, TrackMeta.rom_file_id)
-            .limit(limit)
-            .offset(offset)
+            base.order_by(*track_ordering).limit(limit).offset(offset)
         ).all()
         return rows, total
 

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -183,6 +183,10 @@ ROM_METADATA_ORDER_COLUMNS: dict[str, QueryableAttribute] = {
     "hltb_main_story": Rom.generated_hltb_main_story,
 }
 
+# `rom_user` columns that are NOT NULL with default 0, where 0 renders as
+# unset in the UI, exactly like having no `rom_user` row at all.
+ROM_USER_ZERO_IS_UNSET_COLUMNS = frozenset({"rating", "difficulty", "completion"})
+
 # Filter dropdowns read the narrow `roms_facets` mirror instead of `roms`,
 # whose rows carry the raw metadata blobs. Column order matches the unpacking
 # in `_collect_filter_values`.
@@ -1664,14 +1668,17 @@ class DBRomsHandler(DBBaseHandler):
         query = self._join_rom_user(select(Rom), user_id)
 
         sorts_by_rom_user = False
+        sorts_by_metadata = False
         if user_id and hasattr(RomUser, order_by) and not hasattr(Rom, order_by):
             order_attr = getattr(RomUser, order_by)
             sorts_by_rom_user = True
         elif order_by in ROM_METADATA_ORDER_COLUMNS:
             order_attr = ROM_METADATA_ORDER_COLUMNS[order_by]
+            sorts_by_metadata = True
         elif hasattr(RomMetadata, order_by) and not hasattr(Rom, order_by):
             order_attr = getattr(RomMetadata, order_by)
             query = query.outerjoin(RomMetadata, RomMetadata.rom_id == Rom.id)
+            sorts_by_metadata = True
         elif hasattr(Rom, order_by):
             order_attr = getattr(Rom, order_by)
         else:
@@ -1685,12 +1692,26 @@ class DBRomsHandler(DBBaseHandler):
 
         order_attr_column = order_attr
 
+        # 0 renders as unset, so NULLIF folds it into the NULL bucket and both
+        # kinds of unset sort together.
+        if sorts_by_rom_user and order_by in ROM_USER_ZERO_IS_UNSET_COLUMNS:
+            order_attr = func.nullif(order_attr, 0)
+
         # MariaDB/MySQL have no NULLS LAST, so a leading IS NULL term keeps NULL
         # keys (no rom_user row, or an unset field) last in both directions.
-        nulls_last_clause = order_attr_column.is_(None) if sorts_by_rom_user else None
+        nulls_last_clause = order_attr.is_(None) if sorts_by_rom_user else None
 
         descending = order_dir.lower() == "desc"
         order_attr = order_attr.desc() if descending else order_attr.asc()
+
+        if sorts_by_metadata:
+            # NULL metadata keys (unmatched roms) sort last too. PostgreSQL says
+            # it natively; MariaDB/MySQL place NULLs last on DESC already, so
+            # only ASC needs the IS NULL term (which costs the index order).
+            if ROMM_DB_DRIVER == "postgresql":
+                order_attr = order_attr.nulls_last()
+            elif not descending:
+                nulls_last_clause = order_attr_column.is_(None)
 
         # Ties are common on every sort key here and the gallery pages by
         # offset, so without a unique final key a rom can repeat in one window

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -58,6 +58,7 @@ from models.music import MusicFavoriteTrack, MusicPlaylistTrack
 from models.platform import Platform
 from models.rom import (
     METADATA_SOURCE_COLUMNS,
+    ROM_USER_ZERO_IS_UNSET_COLUMNS,
     Rom,
     RomFacets,
     RomFile,
@@ -175,17 +176,14 @@ ROM_FILE_HASH_COLUMNS_BY_DIGEST_LENGTH: dict[int, tuple[QueryableAttribute, ...]
     40: (RomFile.sha1_hash, RomFile.chd_sha1_hash),
 }
 
-# Every column here is indexed on `roms`, so the sort walks the index and stops at the page.
+# Every column here is indexed on `roms`, so the sort key needs no join to the
+# view (descending sorts still read the index order on MariaDB/MySQL).
 ROM_METADATA_ORDER_COLUMNS: dict[str, QueryableAttribute] = {
     "first_release_date": Rom.generated_first_release_date,
     "average_rating": Rom.generated_average_rating,
     "player_count": Rom.generated_player_count,
     "hltb_main_story": Rom.generated_hltb_main_story,
 }
-
-# `rom_user` columns that are NOT NULL with default 0, where 0 renders as
-# unset in the UI, exactly like having no `rom_user` row at all.
-ROM_USER_ZERO_IS_UNSET_COLUMNS = frozenset({"rating", "difficulty", "completion"})
 
 # Filter dropdowns read the narrow `roms_facets` mirror instead of `roms`,
 # whose rows carry the raw metadata blobs. Column order matches the unpacking
@@ -1692,26 +1690,22 @@ class DBRomsHandler(DBBaseHandler):
 
         order_attr_column = order_attr
 
-        # 0 renders as unset, so NULLIF folds it into the NULL bucket and both
-        # kinds of unset sort together.
+        # 0 renders as unset, so NULLIF folds it into the NULL bucket.
         if sorts_by_rom_user and order_by in ROM_USER_ZERO_IS_UNSET_COLUMNS:
             order_attr = func.nullif(order_attr, 0)
 
-        # MariaDB/MySQL have no NULLS LAST, so a leading IS NULL term keeps NULL
-        # keys (no rom_user row, or an unset field) last in both directions.
-        nulls_last_clause = order_attr.is_(None) if sorts_by_rom_user else None
-
+        sort_key = order_attr
         descending = order_dir.lower() == "desc"
         order_attr = order_attr.desc() if descending else order_attr.asc()
 
-        if sorts_by_metadata:
-            # NULL metadata keys (unmatched roms) sort last too. PostgreSQL says
-            # it natively; MariaDB/MySQL place NULLs last on DESC already, so
-            # only ASC needs the IS NULL term (which costs the index order).
+        # NULL keys sort last on every engine. MariaDB/MySQL do it natively on
+        # DESC; ASC takes a leading IS NULL term (costing metadata index order).
+        nulls_last_clause = None
+        if sorts_by_rom_user or sorts_by_metadata:
             if ROMM_DB_DRIVER == "postgresql":
                 order_attr = order_attr.nulls_last()
             elif not descending:
-                nulls_last_clause = order_attr_column.is_(None)
+                nulls_last_clause = sort_key.is_(None)
 
         # Ties are common on every sort key here and the gallery pages by
         # offset, so without a unique final key a rom can repeat in one window

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -1266,6 +1266,11 @@ class RomNote(BaseModel):
     user: Mapped[User] = relationship(lazy="joined", back_populates="notes")
 
 
+# `rom_user` columns that are NOT NULL with default 0, where 0 renders as
+# unset in the UI, exactly like having no `rom_user` row at all.
+ROM_USER_ZERO_IS_UNSET_COLUMNS = frozenset({"rating", "difficulty", "completion"})
+
+
 class RomUser(BaseModel):
     __tablename__ = "rom_user"
     __table_args__ = (

--- a/backend/models/rom.py
+++ b/backend/models/rom.py
@@ -1266,11 +1266,6 @@ class RomNote(BaseModel):
     user: Mapped[User] = relationship(lazy="joined", back_populates="notes")
 
 
-# `rom_user` columns that are NOT NULL with default 0, where 0 renders as
-# unset in the UI, exactly like having no `rom_user` row at all.
-ROM_USER_ZERO_IS_UNSET_COLUMNS = frozenset({"rating", "difficulty", "completion"})
-
-
 class RomUser(BaseModel):
     __tablename__ = "rom_user"
     __table_args__ = (
@@ -1289,9 +1284,11 @@ class RomUser(BaseModel):
     backlogged: Mapped[bool] = mapped_column(default=False)
     now_playing: Mapped[bool] = mapped_column(default=False)
     hidden: Mapped[bool] = mapped_column(default=False)
-    rating: Mapped[int] = mapped_column(default=0)
-    difficulty: Mapped[int] = mapped_column(default=0)
-    completion: Mapped[int] = mapped_column(default=0)
+    # `zero_is_unset`: 0 renders as unset in the UI, exactly like having no
+    # `rom_user` row at all; sorts fold it into the NULL bucket.
+    rating: Mapped[int] = mapped_column(default=0, info={"zero_is_unset": True})
+    difficulty: Mapped[int] = mapped_column(default=0, info={"zero_is_unset": True})
+    completion: Mapped[int] = mapped_column(default=0, info={"zero_is_unset": True})
     status: Mapped[RomUserStatus | None] = mapped_column(
         Enum(RomUserStatus), default=None
     )

--- a/backend/tests/endpoints/test_music.py
+++ b/backend/tests/endpoints/test_music.py
@@ -224,6 +224,55 @@ def test_tracks_order_and_paginate(
     assert body["items"][0]["duration_seconds"] == 20.0
 
 
+@pytest.mark.parametrize("order_dir", ["asc", "desc"])
+def test_tracks_sort_null_keys_last(
+    client: TestClient,
+    access_token: str,
+    admin_user: User,
+    music_library,
+    order_dir: str,
+):
+    """An untagged track (NULL duration) trails both sort directions."""
+    pa = music_library["platform_a"]
+    rom = db_rom_handler.add_rom(
+        Rom(
+            platform_id=pa.id,
+            name="Untagged",
+            slug="untagged-slug",
+            fs_name="Untagged.zip",
+            fs_name_no_tags="Untagged",
+            fs_name_no_ext="Untagged",
+            fs_extension="zip",
+            fs_path=f"{pa.slug}/roms",
+        )
+    )
+    db_rom_handler.add_rom_user(rom_id=rom.id, user_id=admin_user.id)
+    db_rom_handler.add_rom_file(
+        RomFile(
+            rom_id=rom.id,
+            file_name="untitled.mp3",
+            file_path=f"{rom.fs_path}/Untagged/soundtrack",
+            file_size_bytes=2048,
+            category=RomFileCategory.SOUNDTRACK,
+            track_meta=TrackMeta(
+                rom_id=rom.id, title="Untagged", has_embedded_cover=False
+            ),
+        )
+    )
+
+    body = client.get(
+        f"/api/music/tracks?order_by=duration&order_dir={order_dir}",
+        headers=_auth(access_token),
+    ).json()
+
+    durations = [i["duration_seconds"] for i in body["items"][:-1]]
+    assert durations == (
+        [20.0, 90.0, 120.0] if order_dir == "asc" else [120.0, 90.0, 20.0]
+    )
+    assert body["items"][-1]["title"] == "Untagged"
+    assert body["items"][-1]["duration_seconds"] is None
+
+
 # ---------- facets ----------
 
 

--- a/backend/tests/handler/database/conftest.py
+++ b/backend/tests/handler/database/conftest.py
@@ -1,0 +1,16 @@
+"""Driver fixtures for query-shape tests: the suite runs one database at a
+time, so dialect branches are pinned by patching the handler's constant."""
+
+import pytest
+
+_DRIVER_ATTR = "handler.database.roms_handler.ROMM_DB_DRIVER"
+
+
+@pytest.fixture
+def mariadb_driver(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_DRIVER_ATTR, "mariadb")
+
+
+@pytest.fixture
+def postgres_driver(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_DRIVER_ATTR, "postgresql")

--- a/backend/tests/handler/database/test_roms_hltb_length.py
+++ b/backend/tests/handler/database/test_roms_hltb_length.py
@@ -1,9 +1,10 @@
 """Sorting and range-filtering the gallery by HowLongToBeat main-story time.
 
 `generated_hltb_main_story` (migration 0128) materializes the seconds buried in
-the `hltb_metadata` blob so the length sort walks an index and the range filter
-composes into SQL. A rom with no HowLongToBeat time derives NULL, which is what
-keeps it out of a filtered result.
+the `hltb_metadata` blob so the length sort reads a `roms` column and the range
+filter composes into SQL. A rom with no HowLongToBeat time derives NULL, which
+is what keeps it out of a filtered result. The sort's query shape is pinned
+with the other metadata sorts in `test_roms_metadata_sort.py`.
 """
 
 import pytest
@@ -72,16 +73,6 @@ class TestGeneratedColumn:
 
 
 class TestLengthSort:
-    def test_orders_by_the_indexed_roms_column(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setattr("handler.database.roms_handler.ROMM_DB_DRIVER", "mariadb")
-        query, order_column = db_rom_handler.get_roms_query(order_by="hltb_main_story")
-
-        assert (
-            "ORDER BY roms.generated_hltb_main_story IS NULL, "
-            "roms.generated_hltb_main_story ASC"
-        ) in str(query)
-        assert order_column is Rom.generated_hltb_main_story
-
     @pytest.mark.parametrize("order_dir", ["asc", "desc"])
     def test_breaks_ties_on_the_primary_key(self, order_dir: str):
         """Length ties are common (every rom without a HowLongToBeat time is

--- a/backend/tests/handler/database/test_roms_hltb_length.py
+++ b/backend/tests/handler/database/test_roms_hltb_length.py
@@ -72,10 +72,14 @@ class TestGeneratedColumn:
 
 
 class TestLengthSort:
-    def test_orders_by_the_indexed_roms_column(self):
+    def test_orders_by_the_indexed_roms_column(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr("handler.database.roms_handler.ROMM_DB_DRIVER", "mariadb")
         query, order_column = db_rom_handler.get_roms_query(order_by="hltb_main_story")
 
-        assert "ORDER BY roms.generated_hltb_main_story ASC" in str(query)
+        assert (
+            "ORDER BY roms.generated_hltb_main_story IS NULL, "
+            "roms.generated_hltb_main_story ASC"
+        ) in str(query)
         assert order_column is Rom.generated_hltb_main_story
 
     @pytest.mark.parametrize("order_dir", ["asc", "desc"])
@@ -109,10 +113,9 @@ class TestLengthSort:
         ordered = [
             rom.name
             for rom in db_rom_handler.get_roms_scalar(order_by="hltb_main_story")
-            if rom.generated_hltb_main_story is not None
         ]
 
-        assert ordered == ["short", "medium", "long"]
+        assert ordered == ["short", "medium", "long", "unknown"]
 
     def test_descending(self, length_roms: None):
         ordered = [
@@ -120,18 +123,9 @@ class TestLengthSort:
             for rom in db_rom_handler.get_roms_scalar(
                 order_by="hltb_main_story", order_dir="desc"
             )
-            if rom.generated_hltb_main_story is not None
         ]
 
-        assert ordered == ["long", "medium", "short"]
-
-    def test_roms_without_a_length_are_still_returned(self, length_roms: None):
-        names = {
-            rom.name
-            for rom in db_rom_handler.get_roms_scalar(order_by="hltb_main_story")
-        }
-
-        assert names == {"short", "medium", "long", "unknown"}
+        assert ordered == ["long", "medium", "short", "unknown"]
 
 
 class TestLengthFilter:

--- a/backend/tests/handler/database/test_roms_metadata_sort.py
+++ b/backend/tests/handler/database/test_roms_metadata_sort.py
@@ -7,10 +7,8 @@ joined table: the database cannot read that from an index, so it filesorts the
 whole library on every page. The generated columns are indexed on `roms`, so
 these tests pin both the ordering results and the query reading them directly.
 
-NULL sort keys (unmatched roms) land last on every engine and both directions.
-Descending stays on the index (MariaDB/MySQL place NULLs last on DESC natively,
-PostgreSQL gets an explicit NULLS LAST); ascending on MariaDB/MySQL takes a
-leading IS NULL term and gives up the index order.
+NULL sort keys (unmatched roms) land last on every engine and both directions;
+on MariaDB/MySQL the ascending sort pays a leading IS NULL term for it.
 """
 
 import pytest
@@ -52,6 +50,7 @@ class TestMetadataSortQueryShape:
             ("first_release_date", "generated_first_release_date"),
             ("average_rating", "generated_average_rating"),
             ("player_count", "generated_player_count"),
+            ("hltb_main_story", "generated_hltb_main_story"),
         ],
     )
     def test_orders_by_the_roms_column_with_nulls_last(
@@ -164,8 +163,7 @@ class TestMetadataSortResults:
     def test_roms_without_metadata_stay_in_the_result_and_sort_last(
         self, platform: Platform, order_dir: str
     ):
-        """An unmatched rom has no release date; it must not be filtered out,
-        and it trails the dated roms in both directions on every engine."""
+        """An unmatched rom stays in the result and trails the dated roms."""
         _make_rom(platform, "dated", igdb_metadata={"first_release_date": "100000000"})
         _make_rom(platform, "undated")
 

--- a/backend/tests/handler/database/test_roms_metadata_sort.py
+++ b/backend/tests/handler/database/test_roms_metadata_sort.py
@@ -6,6 +6,11 @@ view back in, which re-joins `roms` to itself and leaves the sort key on the
 joined table: the database cannot read that from an index, so it filesorts the
 whole library on every page. The generated columns are indexed on `roms`, so
 these tests pin both the ordering results and the query reading them directly.
+
+NULL sort keys (unmatched roms) land last on every engine and both directions.
+Descending stays on the index (MariaDB/MySQL place NULLs last on DESC natively,
+PostgreSQL gets an explicit NULLS LAST); ascending on MariaDB/MySQL takes a
+leading IS NULL term and gives up the index order.
 """
 
 import pytest
@@ -49,24 +54,52 @@ class TestMetadataSortQueryShape:
             ("player_count", "generated_player_count"),
         ],
     )
-    def test_orders_by_the_indexed_roms_column(
-        self, order_by: str, expected_column: str
+    def test_orders_by_the_roms_column_with_nulls_last(
+        self, monkeypatch: pytest.MonkeyPatch, order_by: str, expected_column: str
     ):
+        monkeypatch.setattr("handler.database.roms_handler.ROMM_DB_DRIVER", "mariadb")
         query, order_column = db_rom_handler.get_roms_query(order_by=order_by)
         sql = str(query)
 
-        assert f"ORDER BY roms.{expected_column} ASC" in sql
+        assert (
+            f"ORDER BY roms.{expected_column} IS NULL, roms.{expected_column} ASC"
+        ) in sql
         assert order_column is getattr(Rom, expected_column)
         # `Rom.metadatum` is a `lazy="joined"` eager load, so one join to the
         # view is expected; the sort must not add a second one.
         assert sql.count("JOIN roms_metadata") == 1
 
-    def test_descending_metadata_sort_keeps_the_roms_column(self):
+    def test_descending_metadata_sort_stays_on_the_index(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr("handler.database.roms_handler.ROMM_DB_DRIVER", "mariadb")
         query, _ = db_rom_handler.get_roms_query(
             order_by="first_release_date", order_dir="desc"
         )
+        order_sql = str(query).split("ORDER BY")[-1]
 
-        assert "ORDER BY roms.generated_first_release_date DESC" in str(query)
+        # MariaDB/MySQL place NULLs last on DESC natively; without a leading
+        # IS NULL term the sort keeps reading the column's index.
+        assert order_sql.strip().startswith("roms.generated_first_release_date DESC")
+        assert "IS NULL" not in order_sql
+
+    @pytest.mark.parametrize("order_dir", ["asc", "desc"])
+    def test_postgres_sorts_with_native_nulls_last(
+        self, monkeypatch: pytest.MonkeyPatch, order_dir: str
+    ):
+        monkeypatch.setattr(
+            "handler.database.roms_handler.ROMM_DB_DRIVER", "postgresql"
+        )
+        query, _ = db_rom_handler.get_roms_query(
+            order_by="first_release_date", order_dir=order_dir
+        )
+        order_sql = str(query).split("ORDER BY")[-1]
+
+        assert (
+            f"roms.generated_first_release_date {order_dir.upper()} NULLS LAST"
+            in order_sql
+        )
+        assert "IS NULL" not in order_sql
 
     def test_rom_column_sort_is_unchanged(self):
         query, order_column = db_rom_handler.get_roms_query(order_by="fs_size_bytes")
@@ -127,15 +160,34 @@ class TestMetadataSortResults:
             "four",
         ]
 
-    def test_roms_without_metadata_are_still_returned(self, platform: Platform):
-        """An unmatched rom has no release date, and must not be filtered out."""
+    @pytest.mark.parametrize("order_dir", ["asc", "desc"])
+    def test_roms_without_metadata_stay_in_the_result_and_sort_last(
+        self, platform: Platform, order_dir: str
+    ):
+        """An unmatched rom has no release date; it must not be filtered out,
+        and it trails the dated roms in both directions on every engine."""
         _make_rom(platform, "dated", igdb_metadata={"first_release_date": "100000000"})
         _make_rom(platform, "undated")
 
-        names = _ordered_names(order_by="first_release_date", order_dir="asc")
+        names = _ordered_names(order_by="first_release_date", order_dir=order_dir)
 
-        # NULL ordering differs per engine, so only membership is asserted.
-        assert sorted(names) == ["dated", "undated"]
+        assert names == ["dated", "undated"]
+
+    def test_null_bucket_ties_break_on_the_rom_id(self, platform: Platform):
+        _make_rom(platform, "undated_first")
+        _make_rom(platform, "undated_second")
+        _make_rom(platform, "dated", igdb_metadata={"first_release_date": "100000000"})
+
+        assert _ordered_names(order_by="first_release_date", order_dir="asc") == [
+            "dated",
+            "undated_first",
+            "undated_second",
+        ]
+        assert _ordered_names(order_by="first_release_date", order_dir="desc") == [
+            "dated",
+            "undated_second",
+            "undated_first",
+        ]
 
     def test_sort_matches_the_values_the_view_exposes(self, platform: Platform):
         rom = _make_rom(

--- a/backend/tests/handler/database/test_roms_metadata_sort.py
+++ b/backend/tests/handler/database/test_roms_metadata_sort.py
@@ -54,9 +54,8 @@ class TestMetadataSortQueryShape:
         ],
     )
     def test_orders_by_the_roms_column_with_nulls_last(
-        self, monkeypatch: pytest.MonkeyPatch, order_by: str, expected_column: str
+        self, mariadb_driver: None, order_by: str, expected_column: str
     ):
-        monkeypatch.setattr("handler.database.roms_handler.ROMM_DB_DRIVER", "mariadb")
         query, order_column = db_rom_handler.get_roms_query(order_by=order_by)
         sql = str(query)
 
@@ -68,37 +67,39 @@ class TestMetadataSortQueryShape:
         # view is expected; the sort must not add a second one.
         assert sql.count("JOIN roms_metadata") == 1
 
-    def test_descending_metadata_sort_stays_on_the_index(
-        self, monkeypatch: pytest.MonkeyPatch
+    # One dialect matrix for the shared NULL-placement block; the rom_user
+    # family proves its branch separately through the NULLIF shape test.
+    @pytest.mark.parametrize(
+        ("driver", "order_dir", "expected"),
+        [
+            (
+                "mariadb",
+                "asc",
+                "roms.generated_first_release_date IS NULL, "
+                "roms.generated_first_release_date ASC",
+            ),
+            ("mariadb", "desc", "roms.generated_first_release_date DESC"),
+            ("postgres", "asc", "roms.generated_first_release_date ASC NULLS LAST"),
+            ("postgres", "desc", "roms.generated_first_release_date DESC NULLS LAST"),
+        ],
+    )
+    def test_null_placement_per_dialect(
+        self,
+        request: pytest.FixtureRequest,
+        driver: str,
+        order_dir: str,
+        expected: str,
     ):
-        monkeypatch.setattr("handler.database.roms_handler.ROMM_DB_DRIVER", "mariadb")
-        query, _ = db_rom_handler.get_roms_query(
-            order_by="first_release_date", order_dir="desc"
-        )
-        order_sql = str(query).split("ORDER BY")[-1]
-
-        # MariaDB/MySQL place NULLs last on DESC natively; without a leading
-        # IS NULL term the sort keeps reading the column's index.
-        assert order_sql.strip().startswith("roms.generated_first_release_date DESC")
-        assert "IS NULL" not in order_sql
-
-    @pytest.mark.parametrize("order_dir", ["asc", "desc"])
-    def test_postgres_sorts_with_native_nulls_last(
-        self, monkeypatch: pytest.MonkeyPatch, order_dir: str
-    ):
-        monkeypatch.setattr(
-            "handler.database.roms_handler.ROMM_DB_DRIVER", "postgresql"
-        )
+        request.getfixturevalue(f"{driver}_driver")
         query, _ = db_rom_handler.get_roms_query(
             order_by="first_release_date", order_dir=order_dir
         )
         order_sql = str(query).split("ORDER BY")[-1]
 
-        assert (
-            f"roms.generated_first_release_date {order_dir.upper()} NULLS LAST"
-            in order_sql
-        )
-        assert "IS NULL" not in order_sql
+        assert order_sql.strip().startswith(expected)
+        # The emulation term appears only where the engine needs it.
+        emulated = driver == "mariadb" and order_dir == "asc"
+        assert ("IS NULL" in order_sql) == emulated
 
     def test_rom_column_sort_is_unchanged(self):
         query, order_column = db_rom_handler.get_roms_query(order_by="fs_size_bytes")
@@ -159,19 +160,9 @@ class TestMetadataSortResults:
             "four",
         ]
 
-    @pytest.mark.parametrize("order_dir", ["asc", "desc"])
-    def test_roms_without_metadata_stay_in_the_result_and_sort_last(
-        self, platform: Platform, order_dir: str
-    ):
-        """An unmatched rom stays in the result and trails the dated roms."""
-        _make_rom(platform, "dated", igdb_metadata={"first_release_date": "100000000"})
-        _make_rom(platform, "undated")
-
-        names = _ordered_names(order_by="first_release_date", order_dir=order_dir)
-
-        assert names == ["dated", "undated"]
-
     def test_null_bucket_ties_break_on_the_rom_id(self, platform: Platform):
+        """Unmatched roms stay in the result, trail the dated ones in both
+        directions, and tie inside the bucket on the rom id."""
         _make_rom(platform, "undated_first")
         _make_rom(platform, "undated_second")
         _make_rom(platform, "dated", igdb_metadata={"first_release_date": "100000000"})

--- a/backend/tests/handler/database/test_roms_rom_user_sort.py
+++ b/backend/tests/handler/database/test_roms_rom_user_sort.py
@@ -1,7 +1,8 @@
 """Ordering the gallery by a per-user `rom_user` field.
 
 Sorting on one must keep every rom in the results and in the count, with the
-unset keys last in both directions.
+unset keys last in both directions. Rating, difficulty and completion default
+to 0 in an existing row, which renders as unset and sorts as unset.
 """
 
 from datetime import datetime, timezone
@@ -67,6 +68,20 @@ class TestRomUserSortQueryShape:
             f"rom_user.last_played {order_dir.upper()}"
         ) in str(query)
 
+    @pytest.mark.parametrize("order_by", ["rating", "difficulty", "completion"])
+    def test_zero_default_columns_fold_zero_into_the_null_bucket(self, order_by: str):
+        query, order_column = db_rom_handler.get_roms_query(
+            order_by=order_by, user_id=1
+        )
+
+        # NULLIF turns the 0 default into a NULL sort key, so a touched but
+        # unset rom lands in the same trailing bucket as an untouched one.
+        assert (
+            f"ORDER BY nullif(rom_user.{order_by}, :nullif_1) IS NULL, "
+            f"nullif(rom_user.{order_by}, :nullif_1) ASC"
+        ) in str(query)
+        assert order_column is getattr(RomUser, order_by)
+
 
 class TestRomUserSortResults:
     @pytest.fixture
@@ -90,13 +105,42 @@ class TestRomUserSortResults:
             },
         )
         _make_rom(platform, "untouched")
+        # Touched (the rom_user row exists) but explicitly unrated: the 0 must
+        # sort with the untouched bucket, not before the real ratings.
+        _set_rom_user_fields(
+            _make_rom(platform, "played_unrated"),
+            admin_user,
+            {
+                "rating": 0,
+                "last_played": datetime(2022, 1, 1, tzinfo=timezone.utc),
+            },
+        )
 
+    # Unset keys always trail; ties inside the unset bucket follow the rom id
+    # in the sort direction (untouched was created before played_unrated).
     @pytest.mark.parametrize(
         ("order_by", "order_dir", "expected"),
         [
-            ("last_played", "asc", ["barely_touched", "well_loved", "untouched"]),
-            ("last_played", "desc", ["well_loved", "barely_touched", "untouched"]),
-            ("rating", "asc", ["barely_touched", "well_loved", "untouched"]),
+            (
+                "last_played",
+                "asc",
+                ["barely_touched", "played_unrated", "well_loved", "untouched"],
+            ),
+            (
+                "last_played",
+                "desc",
+                ["well_loved", "played_unrated", "barely_touched", "untouched"],
+            ),
+            (
+                "rating",
+                "asc",
+                ["barely_touched", "well_loved", "untouched", "played_unrated"],
+            ),
+            (
+                "rating",
+                "desc",
+                ["well_loved", "barely_touched", "played_unrated", "untouched"],
+            ),
         ],
     )
     def test_unset_user_fields_sort_last(
@@ -116,7 +160,7 @@ class TestRomUserSortResults:
             order_by="rating", user_id=admin_user.id
         )
 
-        assert db_rom_handler.get_rom_count(query=query) == 3
+        assert db_rom_handler.get_rom_count(query=query) == 4
 
     @pytest.mark.parametrize("order_by", ["last_played", "status"])
     def test_char_index_skips_non_lexical_sorts(

--- a/backend/tests/handler/database/test_roms_rom_user_sort.py
+++ b/backend/tests/handler/database/test_roms_rom_user_sort.py
@@ -57,60 +57,22 @@ class TestRomUserSortQueryShape:
         assert "rom_user.user_id" not in str(query.whereclause or "")
         assert order_column is RomUser.last_played
 
-    def test_mariadb_ascending_leads_with_is_null(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        monkeypatch.setattr("handler.database.roms_handler.ROMM_DB_DRIVER", "mariadb")
-        query, _ = db_rom_handler.get_roms_query(order_by="last_played", user_id=1)
-
-        assert (
-            "ORDER BY rom_user.last_played IS NULL, rom_user.last_played ASC"
-        ) in str(query)
-
-    def test_mariadb_descending_uses_native_null_placement(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        monkeypatch.setattr("handler.database.roms_handler.ROMM_DB_DRIVER", "mariadb")
-        query, _ = db_rom_handler.get_roms_query(
-            order_by="last_played", order_dir="desc", user_id=1
-        )
-        order_sql = str(query).split("ORDER BY")[-1]
-
-        # MariaDB/MySQL place NULLs last on DESC without a leading IS NULL term.
-        assert order_sql.strip().startswith("rom_user.last_played DESC")
-        assert "IS NULL" not in order_sql
-
-    @pytest.mark.parametrize("order_dir", ["asc", "desc"])
-    def test_postgres_sorts_with_native_nulls_last(
-        self, monkeypatch: pytest.MonkeyPatch, order_dir: str
-    ):
-        monkeypatch.setattr(
-            "handler.database.roms_handler.ROMM_DB_DRIVER", "postgresql"
-        )
-        query, _ = db_rom_handler.get_roms_query(
-            order_by="last_played", order_dir=order_dir, user_id=1
-        )
-        order_sql = str(query).split("ORDER BY")[-1]
-
-        assert f"rom_user.last_played {order_dir.upper()} NULLS LAST" in order_sql
-        assert "IS NULL" not in order_sql
-
-    @pytest.mark.parametrize("order_by", ["rating", "difficulty", "completion"])
+    # The dialect matrix for the shared NULL-placement block lives in
+    # test_roms_metadata_sort.py; this pins the rom_user branch's shape.
     def test_zero_default_columns_fold_zero_into_the_null_bucket(
-        self, monkeypatch: pytest.MonkeyPatch, order_by: str
+        self, mariadb_driver: None
     ):
-        monkeypatch.setattr("handler.database.roms_handler.ROMM_DB_DRIVER", "mariadb")
         query, order_column = db_rom_handler.get_roms_query(
-            order_by=order_by, user_id=1
+            order_by="rating", user_id=1
         )
 
         # NULLIF turns the 0 default into a NULL sort key, so a touched but
         # unset rom lands in the same trailing bucket as an untouched one.
         assert (
-            f"ORDER BY nullif(rom_user.{order_by}, :nullif_1) IS NULL, "
-            f"nullif(rom_user.{order_by}, :nullif_1) ASC"
+            "ORDER BY nullif(rom_user.rating, :nullif_1) IS NULL, "
+            "nullif(rom_user.rating, :nullif_1) ASC"
         ) in str(query)
-        assert order_column is getattr(RomUser, order_by)
+        assert order_column is RomUser.rating
 
 
 class TestRomUserSortResults:
@@ -192,9 +154,7 @@ class TestRomUserSortResults:
         assert db_rom_handler.get_rom_count(query=query) == 4
 
     @pytest.mark.parametrize("order_by", ["last_played", "status"])
-    def test_char_index_skips_non_lexical_sorts(
-        self, admin_user: User, library: None, order_by: str
-    ):
+    def test_char_index_skips_non_lexical_sorts(self, admin_user: User, order_by: str):
         query, order_column = db_rom_handler.get_roms_query(
             order_by=order_by, user_id=admin_user.id
         )

--- a/backend/tests/handler/database/test_roms_rom_user_sort.py
+++ b/backend/tests/handler/database/test_roms_rom_user_sort.py
@@ -57,19 +57,49 @@ class TestRomUserSortQueryShape:
         assert "rom_user.user_id" not in str(query.whereclause or "")
         assert order_column is RomUser.last_played
 
+    def test_mariadb_ascending_leads_with_is_null(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr("handler.database.roms_handler.ROMM_DB_DRIVER", "mariadb")
+        query, _ = db_rom_handler.get_roms_query(order_by="last_played", user_id=1)
+
+        assert (
+            "ORDER BY rom_user.last_played IS NULL, rom_user.last_played ASC"
+        ) in str(query)
+
+    def test_mariadb_descending_uses_native_null_placement(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr("handler.database.roms_handler.ROMM_DB_DRIVER", "mariadb")
+        query, _ = db_rom_handler.get_roms_query(
+            order_by="last_played", order_dir="desc", user_id=1
+        )
+        order_sql = str(query).split("ORDER BY")[-1]
+
+        # MariaDB/MySQL place NULLs last on DESC without a leading IS NULL term.
+        assert order_sql.strip().startswith("rom_user.last_played DESC")
+        assert "IS NULL" not in order_sql
+
     @pytest.mark.parametrize("order_dir", ["asc", "desc"])
-    def test_nulls_lead_the_order_clause(self, order_dir: str):
+    def test_postgres_sorts_with_native_nulls_last(
+        self, monkeypatch: pytest.MonkeyPatch, order_dir: str
+    ):
+        monkeypatch.setattr(
+            "handler.database.roms_handler.ROMM_DB_DRIVER", "postgresql"
+        )
         query, _ = db_rom_handler.get_roms_query(
             order_by="last_played", order_dir=order_dir, user_id=1
         )
+        order_sql = str(query).split("ORDER BY")[-1]
 
-        assert (
-            "ORDER BY rom_user.last_played IS NULL, "
-            f"rom_user.last_played {order_dir.upper()}"
-        ) in str(query)
+        assert f"rom_user.last_played {order_dir.upper()} NULLS LAST" in order_sql
+        assert "IS NULL" not in order_sql
 
     @pytest.mark.parametrize("order_by", ["rating", "difficulty", "completion"])
-    def test_zero_default_columns_fold_zero_into_the_null_bucket(self, order_by: str):
+    def test_zero_default_columns_fold_zero_into_the_null_bucket(
+        self, monkeypatch: pytest.MonkeyPatch, order_by: str
+    ):
+        monkeypatch.setattr("handler.database.roms_handler.ROMM_DB_DRIVER", "mariadb")
         query, order_column = db_rom_handler.get_roms_query(
             order_by=order_by, user_id=1
         )
@@ -116,8 +146,7 @@ class TestRomUserSortResults:
             },
         )
 
-    # Unset keys always trail; ties inside the unset bucket follow the rom id
-    # in the sort direction (untouched was created before played_unrated).
+    # Ties inside the unset bucket follow the rom id in the sort direction.
     @pytest.mark.parametrize(
         ("order_by", "order_dir", "expected"),
         [

--- a/backend/tests/handler/database/test_roms_verified_filter.py
+++ b/backend/tests/handler/database/test_roms_verified_filter.py
@@ -123,10 +123,7 @@ class TestVerifiedPostgresPredicate:
     compiling it (the suite runs on a single driver at a time)."""
 
     @pytest.fixture
-    def postgres_handler(self, monkeypatch: pytest.MonkeyPatch) -> DBRomsHandler:
-        monkeypatch.setattr(
-            "handler.database.roms_handler.ROMM_DB_DRIVER", "postgresql"
-        )
+    def postgres_handler(self, postgres_driver: None) -> DBRomsHandler:
         return db_rom_handler
 
     @pytest.mark.parametrize("verified", [True, False])


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Two NULL-placement bugs in the gallery sort, fixed through one mechanism.

Fixes #4449
Fixes #4450

- **#4449**: `rating`/`difficulty`/`completion` are NOT NULL with default 0, so ascending sorts split visually identical "unrated" games into two buckets (touched-but-unrated first, never-touched last). The three columns now carry a `zero_is_unset` marker on their `mapped_column(info=...)`, and the sort key folds them through `NULLIF(col, 0)` so both unset shapes share the trailing bucket, tiebroken by rom id. The marker lives one line from the `default=0` it describes, so a future zero-default metric cannot silently miss the rule.
- **#4450**: metadata sorts (`first_release_date`, `average_rating`, `player_count`, `hltb_main_story`) kept each engine's default NULL placement (MariaDB led ascending sorts with the wall of unmatched roms; PostgreSQL differed on the opposite direction). NULLs now land last on every engine in both directions.

**The mechanism, priced with EXPLAIN before shipping** (30k-rom MariaDB): one `_nulls_last_ordering()` helper emits per dialect — PostgreSQL uses native `NULLS LAST` (`nulls_last()` is not portable: the generic compiler emits the literal and MariaDB/MySQL reject it at parse time), MariaDB/MySQL DESC already places NULLs last on a plain index read (verified live, `type=index rows=72` preserved), and only MariaDB/MySQL ASC pays the leading `IS NULL` term and its filesort (~51ms index read to ~150ms at 30k), the one case the engine cannot serve from a single-column index. The escape hatch (stored is-null mirrors + composite indexes via migration) was judged disproportionate and is documented in the review notes. The music-track ordering now shares the helper and gains index-order reads in the three cases that never needed the emulation term.

This went through the full pr-ready gauntlet (security audit: clean; code review at xhigh, 13 findings; simplify; review polish), one commit per pass. Known follow-up material from the reviews: `RomMetadata.rating_count` has the same 0-as-unset semantics and is not folded (API-only sort key); PG-DESC metadata sorts filesort where a dialect-guarded `(col DESC NULLS LAST)` index could serve them; source installs reporting version "development" can serve pre-fix sidecar caches until a write or the TTL; smart-collection cover strips recompute on their next refresh.

**AI disclosure:** developed with AI assistance (Claude Code) end to end: implementation, EXPLAIN measurement, tests, and the multi-pass review gauntlet, with human direction and final review by the repo owner.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

#### Screenshots (if applicable)

N/A (backend only). Verified on MariaDB: 108 tests across the sort/shape/cache/music suites plus 271 endpoint tests; the dialect matrix is pinned by driver-patched shape tests so the PostgreSQL CI leg exercises the same assertions. No migrations, no API shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ldi4YaXJWDDmFdbKfQay8L