### PR TITLE
ci: run trunk check on master pushes

### DIFF
--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -2,6 +2,9 @@ name: Run Trunk Check
 
 on:
   pull_request:
+  push:
+    branches:
+      - "master"
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
**Description**

<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

`trunk-check.yml` triggered on `pull_request` only, so nothing re-linted the tree after a merge. Every other gate already covers pushes to master: `typecheck.yml`, `frontend.yml` (vitest + build), `pytest.yml` and `e2e.yml` all carry `push: branches: [master]`. Lint was the single exception.

This matters because Trunk's PR mode is diff-scoped and gates only *new* issues. From the Trunk Check log on #4456:

```
TRUNK_CHECK_MODE: pull_request
Checked 3 modified files
3 existing issues (use --show-existing to see them)
✔ No new issues
```

A green PR check means "no new issues on the files this PR touched", not "the tree is clean". With no run on master, there was no point at which anything wider was evaluated.

The action already has a push mode (its "Run trunk check on push" step was simply being skipped), so this is only the trigger. The existing `concurrency` group handles it: `github.head_ref` is empty on push, so the group falls back to `github.run_id` and no run cancels another.

**Scope reduced after review.** This PR originally also added an `npm run lint` script and an ESLint ignore fix. Per @gantoine's review the script is gone: `trunk check` already runs ESLint on your diff and `trunk check --all` covers the whole tree, so it was a second entry point to something Trunk already does, and it exited non-zero on 84 pre-existing errors. The ignore fix was real but belongs with the ESLint-coverage work, so it moved to #4459. Both are reverted here rather than force-pushed away, so the review history stays intact; the net diff is three lines in one file.

**Checklist**

<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

Verified: the workflow parses and resolves to `{pull_request: None, push: {branches: [master]}}` with the single `trunk_check` job intact, and `prettier --check` is clean. Trunk's own `actionlint` checks the file in this PR's run, since it is a changed file, and passed.

No unit tests: one workflow trigger.

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this PR was written by Claude Code, which did the investigation, the change, and this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY64DJaHPtqSf6bokeXLyS
