### PR TITLE
ci: pin the amd64 image build to ubuntu-24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         include:
           - platform: linux/amd64
             arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - platform: linux/arm64
             arch: arm64
             runner: ubuntu-24.04-arm

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -55,7 +55,7 @@ jobs:
         include:
           - platform: linux/amd64
             arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - platform: linux/arm64
             arch: arm64
             runner: ubuntu-24.04-arm


### PR DESCRIPTION
**Description**

<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The multi-arch image matrix pinned one leg and floated the other:

```yaml
          - platform: linux/amd64
            arch: amd64
            runner: ubuntu-latest     # floating
          - platform: linux/arm64
            arch: arm64
            runner: ubuntu-24.04-arm  # pinned
```

`ubuntu-latest` resolves to 24.04 today, so the two legs happen to match. When GitHub rolls that label forward, the amd64 half of an image index would build on a new host OS while the arm64 half stays on 24.04, with no diff and no signal in this repo. This names an explicit version on both legs so they move together, deliberately, in a reviewable commit.

Applied identically in `build.yml` (release builds) and `test-build.yml` (preview builds).

Scope: the native-per-arch design from #4437 is unchanged, and the `merge` job that stitches the digests into one index is untouched. The image contents are already well insulated from the host, since the Dockerfile builds inside digest-pinned containers (`node:${NODE_VERSION}-alpine${ALPINE_VERSION}@sha256:...`); what the host version actually determines is the Docker/buildx and runner toolchain. So this is reproducibility hygiene rather than a bug fix.

The ~15 other `runs-on: ubuntu-latest` jobs (lint, typecheck, tests, e2e, pytest, migrations, i18n) are left alone on purpose. They produce no arch-specific artifact, and letting disposable check jobs track the latest image while the release-critical build stays pinned seems like the right split. Happy to pin those too if you'd rather have it uniform.

**Checklist**

<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

Verified: both workflows parse, and the build matrix resolves to `[('amd64', 'ubuntu-24.04'), ('arm64', 'ubuntu-24.04-arm')]` in each. `prettier --check` clean on both files. Trunk's `actionlint` covers them in this PR's run, since both are changed files.

Note that neither workflow runs here: `build.yml` fires on `release: published`, and `test-build.yml` needs the `build-preview` label or a `workflow_dispatch`. So the runner change itself is exercised on the next release or preview build, not by this PR's checks. Adding `build-preview` to this PR would exercise it end to end if you want that confirmation before merging.

No unit tests: two runner labels.

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this PR was written by Claude Code, which did the investigation, the change, and this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY64DJaHPtqSf6bokeXLyS


---
_Generated by [Claude Code](https://claude.ai/code/session_01GY64DJaHPtqSf6bokeXLyS)_