### PR TITLE
ci: lint .vue files with ESLint

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -63,6 +63,14 @@ lint:
     - linters: [mypy]
       paths:
         - backend/alembic/**
+    # The v1 UI is frozen and slated for deletion, and the freeze check blocks
+    # changes to these paths, so ESLint findings here cannot lead to fixes.
+    - linters: [eslint]
+      paths:
+        - frontend/src/views/**
+        - frontend/src/components/**
+        - frontend/src/console/**
+        - frontend/src/layouts/**
   files:
     - name: vue
       extensions: [vue]
@@ -71,6 +79,7 @@ lint:
       files:
         - javascript
         - typescript
+        - vue
       commands:
         - name: lint
           run_from: ${root_or_parent_with_any_config}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -14,7 +14,17 @@ export default tseslint.config(
   // Storybook config files live outside `src/` and aren't part of the
   // app tsconfig, so type-aware linting can't resolve them.
   {
-    ignores: [".storybook/**", "src/__generated__/**"],
+    ignores: [
+      ".storybook/**",
+      "src/__generated__/**",
+      // Build and coverage output: generated, so nothing here is fixable in
+      // source. These only take effect in an `ignores`-only config object.
+      "dist/**",
+      "dist-ssr/**",
+      "dev-dist/**",
+      "storybook-static/**",
+      "coverage/**",
+    ],
   },
   {
     ignores: [
@@ -27,9 +37,6 @@ export default tseslint.config(
       "lerna-debug.log*",
       "node_modules",
       ".DS_Store",
-      "dist",
-      "dist-ssr",
-      "coverage",
       "*.local",
       "*.config.js",
       "src/plugins/*.d.ts",

--- a/frontend/src/v2/components/Gallery/ScanPlatformDialog.vue
+++ b/frontend/src/v2/components/Gallery/ScanPlatformDialog.vue
@@ -25,10 +25,7 @@ import type { Platform } from "@/stores/platforms";
 import { useScanProviders } from "@/v2/composables/useScanProviders";
 import { useScanTrigger } from "@/v2/composables/useScanTrigger";
 import { useSnackbar } from "@/v2/composables/useSnackbar";
-import {
-  scanNeedsMetadataSource,
-  type ScanType as SharedScanType,
-} from "@/v2/types/scan";
+import { type ScanType as SharedScanType } from "@/v2/types/scan";
 
 defineOptions({ inheritAttrs: false });
 

--- a/frontend/src/v2/views/Jukebox/BrowseMode.vue
+++ b/frontend/src/v2/views/Jukebox/BrowseMode.vue
@@ -59,7 +59,7 @@ const pager = useTrackPager((items) => favorites.merge(items));
 let entriesToken = 0;
 let searchTimer: ReturnType<typeof setTimeout> | undefined;
 
-async function loadEntries(term: string) {
+async function fetchEntries(term: string) {
   const token = ++entriesToken;
   loadingEntries.value = true;
   entriesFailed.value = false;
@@ -88,7 +88,7 @@ function loadTracks(key: string) {
 
 watch(search, (term) => {
   clearTimeout(searchTimer);
-  searchTimer = setTimeout(() => void loadEntries(term.trim()), 250);
+  searchTimer = setTimeout(() => void fetchEntries(term.trim()), 250);
 });
 
 watch(
@@ -98,13 +98,13 @@ watch(
 );
 
 // A delete also changes the sidebar's counts, and may empty the picked
-// entry entirely (loadEntries then falls back to the first one).
+// entry entirely (fetchEntries then falls back to the first one).
 watch(
   () => props.refreshToken,
-  () => void loadEntries(search.value.trim()),
+  () => void fetchEntries(search.value.trim()),
 );
 
-void loadEntries("");
+void fetchEntries("");
 
 const panelTracks = computed(() => panelTracksFromCatalog(pager.tracks.value));
 

--- a/frontend/src/v2/views/Jukebox/index.vue
+++ b/frontend/src/v2/views/Jukebox/index.vue
@@ -21,8 +21,7 @@ const { t } = useI18n();
 const canEdit = useCan("rom.edit");
 const soundtrackActions = useSoundtrackActions();
 
-const { mode, search, artist, genre, platform, decade, game, selectedDecade } =
-  useJukeboxUrlState();
+const { mode, artist, genre, platform, decade, game } = useJukeboxUrlState();
 
 interface BrowseConfig {
   icon: string;
@@ -131,11 +130,11 @@ const headerTitle = computed(() =>
 );
 
 const SESSION_MODES = ["play-all", "station", "favorite", "recent"] as const;
-type SessionMode = (typeof SESSION_MODES)[number];
+type SessionModeKey = (typeof SESSION_MODES)[number];
 
 const sessionMode = computed(() =>
   (SESSION_MODES as readonly string[]).includes(mode.value)
-    ? (mode.value as SessionMode)
+    ? (mode.value as SessionModeKey)
     : null,
 );
 

--- a/frontend/src/v2/views/Player/Stream.vue
+++ b/frontend/src/v2/views/Player/Stream.vue
@@ -926,7 +926,7 @@ async function performSaveAndExit(): Promise<void> {
     return;
   }
   isSavingAndExiting.value = true;
-  let saved = false;
+  let saved: boolean | undefined;
   let released = false;
   try {
     await pushStreamFrame();
@@ -1637,6 +1637,7 @@ onBeforeUnmount(() => {
         </div>
       </template>
       <template #footer>
+        <!-- eslint-disable vuejs-accessibility/no-autofocus -- RDialog reads [autofocus] to place initial focus, and focusing the dialog's action on open is intentional modal UX -->
         <RBtn
           autofocus
           color="primary"
@@ -1645,6 +1646,7 @@ onBeforeUnmount(() => {
         >
           {{ t("play.back-to-game-details") }}
         </RBtn>
+        <!-- eslint-enable vuejs-accessibility/no-autofocus -->
       </template>
     </RDialog>
 
@@ -1666,7 +1668,9 @@ onBeforeUnmount(() => {
         </p>
       </template>
       <template #footer>
+        <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- arrow keys rove focus between this container's real buttons, which stay the interactive elements; the listener sits here to catch keydowns bubbling from either of them -->
         <div class="r-v2-stream__exit-actions" @keydown="onExitDialogKeydown">
+          <!-- eslint-disable vuejs-accessibility/no-autofocus -- RDialog reads [autofocus] to place initial focus, and the least destructive action is the intended target -->
           <RBtn
             autofocus
             variant="text"
@@ -1675,6 +1679,7 @@ onBeforeUnmount(() => {
           >
             {{ t("play.keep-playing") }}
           </RBtn>
+          <!-- eslint-enable vuejs-accessibility/no-autofocus -->
           <RBtn
             v-if="isJoining"
             color="error"


### PR DESCRIPTION
**Description**

<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

> **Known consequence of merging this.** 4 ESLint errors remain in 3 v2 `.vue` files that this PR does not touch (listed at the bottom), so its own CI is green. Per the measurement below, whoever next edits one of those files will have those errors fail their PR. That is the ratchet working as intended, but it is a trap if it is a surprise, hence this note.

Trunk's `eslint` definition covered only the `typescript` and `javascript` file types, so **505 `.vue` files were never ESLint-checked**. `eslint-plugin-vue` and `eslint-plugin-vuejs-accessibility` are configured in `eslint.config.js` and did nothing in CI:

```console
$ trunk check --filter=eslint frontend/src/v2/views/Jukebox/BrowseMode.vue
Found no applicable linters for the requested path
```

The `vue` file type already exists (added for Prettier) and `eslint.config.js` already sets `extraFileExtensions: [".vue"]`, so the fix is one entry in the definition's `files:` list.

**Why the frozen v1 UI needs an explicit ignore.** I expected Trunk's hold-the-line behaviour to keep pre-existing findings dormant, as it does elsewhere ("3 existing issues … ✔ No new issues" on #4456). It does not work that way here. Trunk computes its baseline using the *upstream* config, where ESLint does not apply to `.vue` at all, so every finding in a touched `.vue` file counts as new. Measured with a no-op edit to one file:

```console
$ trunk check --filter=eslint --upstream=<base>
frontend/src/v2/views/Player/Stream.vue:929:7   high  ... eslint/no-useless-assignment
                                    1641:11  high  ... eslint/vuejs-accessibility/no-autofocus
                                    1669:9   high  ... eslint/vuejs-accessibility/no-static-element-interactions
                                    1671:13  high  ... eslint/vuejs-accessibility/no-autofocus
Checked 2 modified files
✖ 4 new lint issues
```

So the 68 errors across 32 files in `src/{views,components,console,layouts}` would fail any v1 bug fix. Those are unfixable by policy: `frontend-v1-frozen.yml` fails PRs touching those paths without the `allow-v1-changes` label, which is reserved for critical fixes. Hence a scoped `eslint` ignore for the four frozen directories, following the pattern already used for mypy and Alembic. Verified with a no-op edit to `src/components/Details/Personal.vue`, which carries 3 known errors:

```console
Checked 5 modified files
✔ No issues
```

**v2 fixes in this PR** (11 errors, 4 files, all now ESLint-clean):

- `Gallery/ScanPlatformDialog.vue` — dead `scanNeedsMetadataSource` import.
- `Jukebox/index.vue` — `search` and `selectedDecade` destructured from `useJukeboxUrlState()` and never used; local `type SessionMode` collided with the `SessionMode.vue` component import, renamed to `SessionModeKey`.
- `Jukebox/BrowseMode.vue` — local `loadEntries` shadowed the prop of the same name it calls, renamed to `fetchEntries`. ESLint flagged this as `vue/no-dupe-keys`, a real collision between script scope and the instance.
- `Player/Stream.vue` — four findings, two of them false positives:
  - `no-useless-assignment`: `saved` was initialised to `false` and never read at that value. There is no `catch`, so a throw skips the checks after the `try`, and the `finally` block reads only `released`. Typed as optional instead, which is behaviourally identical since `!undefined` and `!false` agree.
  - `no-autofocus` ×2: `RDialog` queries `[autofocus]` inside its panel to place initial focus (`RDialog.vue:123-132`), falling back to document order, which its own comment notes "would always land on the header close button". The attribute is the primitive's focus hook, not browser page-load autofocus, so removing it would move focus off "Keep playing" and onto the close button. Rule scoped off with a justification, matching `MemoryCardNameDialog` and `CreateSmartCollectionDialog`.
  - `no-static-element-interactions`: `onExitDialogKeydown` only handles arrow keys and moves focus between `button:not([disabled])` inside the container. The buttons are the interactive elements and stay focusable; the div hosts the listener and depends on `event.currentTarget` for its lookup. Scoped off with that reasoning.

Per the v2 constitution these are deletions and renames, not `_`-prefixed suppressions.

**Also here:** the build-output ignore fix moved from #4457, where it was only needed to serve a script that review dropped. `dist`, `dist-ssr` and `coverage` were already listed in `eslint.config.js` and ESLint walked into them anyway, because that list sits in a config object carrying `rules`, which makes it a per-config exclusion rather than a global ignore; `dev-dist` and `storybook-static` were missing outright. Planting a file with two redeclarations in each of the five directories produced 6 errors before the fix and none after, and a full `eslint .` now reaches 0 files under any of them.

**Checklist**

<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

Verified on Node 24.16.0 / npm 11.13.0: `vue-tsc --noEmit` clean; `npm test` 112 files / 1208 tests passing; `prettier --check` clean; ESLint clean on every touched file including `Stream.vue`; both Trunk behaviours above measured rather than assumed.

No unit tests: one linter file-type entry, ignore entries, dead-code removal, two renames, one type change, and three scoped rule disables, all covered by the lint and type runs.

**Left for a follow-up** (4 errors, 3 files). These change focus and assistive-technology behaviour, so they want browser verification across themes and input modalities per the `frontend-v2-input` skill:

| file | errors | note |
| --- | --- | --- |
| `v2/lib/forms/RDateField/RDateField.vue` | `interactive-supports-focus`, `role-has-required-aria-props` | `combobox` role needs `tabindex` plus its required ARIA; shared input primitive, so its story wants exercising |
| `v2/components/GameDetails/MarkdownViewer.vue` | `anchor-has-content` | |
| `v2/components/GameDetails/TextViewer.vue` | `anchor-has-content` | |

**Base branch:** stacked on `claude/eslint-trunk-prettier-conflicts-chd35j` (#4456) so the diff reads cleanly, since enabling `.vue` linting without that PR also surfaces its 813 formatting warnings. Retarget to `master` once #4456 merges.

**AI assistance disclosure**

Per `CONTRIBUTING.md`: this PR was written by Claude Code, which did the investigation, the measurements, the changes, and this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY64DJaHPtqSf6bokeXLyS
