### PR TITLE
docs(examples): drop the gc override from the config example

### DIFF
--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -62,8 +62,8 @@
 # system:
 #   # Asociate different platform names to your current file system platform names
 #   # [your custom platform folder name]: [RomM platform name]
-#   # Matched case-insensitively. The folder names Batocera, RetroBat and ES-DE use
-#   # are already recognised, so only name the ones RomM doesn't know.
+#   # Matched case-insensitively. Batocera, RetroBat and ES-DE folder names are
+#   # recognised already; bind names RomM doesn't know or resolves to the wrong platform.
 #   platforms:
 #     ps1: psx
 #     super_nintendo: snes

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -62,10 +62,11 @@
 # system:
 #   # Asociate different platform names to your current file system platform names
 #   # [your custom platform folder name]: [RomM platform name]
-#   # In this example if you have a 'gc' folder, RomM will treat it like the 'ngc' folder
+#   # Matched case-insensitively. The folder names Batocera, RetroBat and ES-DE use
+#   # are already recognised, so only name the ones RomM doesn't know.
 #   platforms:
-#     gc: ngc
 #     ps1: psx
+#     super_nintendo: snes
 
 #   # Asociate one platform to it's main version (IGDB only)
 #   versions:

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -62,8 +62,7 @@
 # system:
 #   # Asociate different platform names to your current file system platform names
 #   # [your custom platform folder name]: [RomM platform name]
-#   # Matched case-insensitively. Batocera, RetroBat and ES-DE folder names are
-#   # recognised already; bind names RomM doesn't know or resolves to the wrong platform.
+#   # Case-insensitive. Batocera, RetroBat and ES-DE folders are already recognised.
 #   platforms:
 #     ps1: psx
 #     super_nintendo: snes


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

`examples/config.example.yml` illustrates `system.platforms` with `gc: ngc`, but `gc` is a built-in folder alias now, so the example demonstrates a binding that changes nothing. Swap it for `super_nintendo: snes` (not an alias, so it still needs a binding), keep `ps1: psx`, and note in the comment that folder names are matched case-insensitively and that the Batocera/RetroBat/ES-DE names are already recognised.

Comment-only change to an example file, no runtime behaviour touched. The Batocera and ES-DE example configs already carry the equivalent note from the alias PRs.

The corresponding docs-site update is rommapp/docs#137.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

<sup>No tests: the file is a commented-out example. `backend/tests/utils/test_platform_aliases.py` already derives the overrides the Batocera/ES-DE examples need from the alias table.</sup>

**AI assistance disclosure**

Written with Claude Code. The claim that `gc` is an alias and `ps1`/`super_nintendo` are not was checked against `backend/utils/platform_aliases.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172ovkiqiK6JgEYCmi3uqe2

---
_Generated by [Claude Code](https://claude.ai/code/session_0172ovkiqiK6JgEYCmi3uqe2)_