### PR TITLE
fix(roms): invalidate a user's gallery sidecars on rom_user writes

### DIFF
--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -194,12 +194,15 @@ def build_unscoped_sidecar_cache_key(
     order_dir: str,
     group_by_meta_id: bool,
     is_unscoped: bool,
+    *,
+    with_rom_user_version: bool = True,
 ) -> str | None:
     """Cache key for the unscoped library sidecars (char index, filter values,
     rom id index). Returns None for scoped/searched sets, which are computed live.
     The computed values depend on user, ordering and grouping, so all are part
-    of the key. RomUser-column sorts also embed a per-user version that every
-    rom_user write bumps.
+    of the key. Sets whose content reads the user's rom_user rows also embed a
+    per-user version that every rom_user write bumps; a sidecar that reads none
+    of them opts out with `with_rom_user_version=False`.
 
     What counts as unscoped differs per sidecar, so the caller decides: the char
     index and the id index narrow with every filter, while the filter-value list
@@ -208,15 +211,20 @@ def build_unscoped_sidecar_cache_key(
     if not is_unscoped:
         return None
 
+    # The query layer sorts by the lowercased key, so the per-user-version gate
+    # must normalise the same way the key text below already does.
+    order_by = order_by.lower()
+
     user_part = f"u{user_id}"
-    if sorts_by_rom_user_column(order_by):
-        # A RomUser-column sort orders by this user's own writes, so its entries
-        # rotate with the per-user version rather than the global one.
+    if with_rom_user_version and (
+        sorts_by_rom_user_column(order_by) or group_by_meta_id
+    ):
+        # These sets read the user's own rom_user rows (sort keys, or the
+        # grouped main-sibling pick), so they rotate with the per-user version.
         user_part = f"{user_part}.{rom_user_cache_version(user_id)}"
 
     return (
-        f"all:{user_part}"
-        f":o{order_by.lower()}:d{order_dir.lower()}:g{int(group_by_meta_id)}"
+        f"all:{user_part}" f":o{order_by}:d{order_dir.lower()}:g{int(group_by_meta_id)}"
     )
 
 
@@ -1000,7 +1008,14 @@ def get_roms(
             search_term=search_term,
         )
         cache_key = build_unscoped_sidecar_cache_key(
-            request.user.id, order_by, order_dir, group_by_meta_id, is_unscoped_scope
+            request.user.id,
+            order_by,
+            order_dir,
+            group_by_meta_id,
+            is_unscoped_scope,
+            # `hidden` is the only RomUser column filter values read, and it
+            # bumps the global version, so the per-user version is pure churn.
+            with_rom_user_version=False,
         )
         query_filters = db_rom_handler.with_filter_values(
             query=filter_query,

--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -65,6 +65,10 @@ from handler.database import (
     db_save_handler,
 )
 from handler.database.base_handler import sync_session
+from handler.database.roms_handler import (
+    rom_user_cache_version,
+    sorts_by_rom_user_column,
+)
 from handler.filesystem import fs_resource_handler, fs_rom_handler
 from handler.filesystem.assets_handler import validate_image_upload
 from handler.metadata import (
@@ -194,7 +198,8 @@ def build_unscoped_sidecar_cache_key(
     """Cache key for the unscoped library sidecars (char index, filter values,
     rom id index). Returns None for scoped/searched sets, which are computed live.
     The computed values depend on user, ordering and grouping, so all are part
-    of the key.
+    of the key. RomUser-column sorts also embed a per-user version that every
+    rom_user write bumps.
 
     What counts as unscoped differs per sidecar, so the caller decides: the char
     index and the id index narrow with every filter, while the filter-value list
@@ -203,8 +208,14 @@ def build_unscoped_sidecar_cache_key(
     if not is_unscoped:
         return None
 
+    user_part = f"u{user_id}"
+    if sorts_by_rom_user_column(order_by):
+        # A RomUser-column sort orders by this user's own writes, so its entries
+        # rotate with the per-user version rather than the global one.
+        user_part = f"{user_part}.{rom_user_cache_version(user_id)}"
+
     return (
-        f"all:u{user_id}"
+        f"all:{user_part}"
         f":o{order_by.lower()}:d{order_dir.lower()}:g{int(group_by_meta_id)}"
     )
 

--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -196,12 +196,10 @@ def build_unscoped_sidecar_cache_key(
     group_by_meta_id: bool,
     is_unscoped: bool,
 ) -> str | None:
-    """Cache key for the unscoped char-index / rom-id-index sidecars.
-    Returns None for scoped/searched sets, which are computed live.
-
-    The content depends on user, ordering and grouping. A RomUser-column
-    sort also embeds the per-user sort version, and a grouped set the
-    sibling version, so exactly the writes that move a set rotate its key.
+    """Cache key for the unscoped char-index / rom-id-index sidecars; None for
+    scoped/searched sets, which are computed live. Embeds the per-user sort
+    version on RomUser-column sorts and the sibling version on grouped sets,
+    so exactly the writes that move a set rotate its key.
     """
     if not is_unscoped:
         return None

--- a/backend/endpoints/roms/__init__.py
+++ b/backend/endpoints/roms/__init__.py
@@ -66,8 +66,9 @@ from handler.database import (
 )
 from handler.database.base_handler import sync_session
 from handler.database.roms_handler import (
-    rom_user_cache_version,
     sorts_by_rom_user_column,
+    user_sibling_cache_version,
+    user_sort_cache_version,
 )
 from handler.filesystem import fs_resource_handler, fs_rom_handler
 from handler.filesystem.assets_handler import validate_image_upload
@@ -194,38 +195,32 @@ def build_unscoped_sidecar_cache_key(
     order_dir: str,
     group_by_meta_id: bool,
     is_unscoped: bool,
-    *,
-    with_rom_user_version: bool = True,
 ) -> str | None:
-    """Cache key for the unscoped library sidecars (char index, filter values,
-    rom id index). Returns None for scoped/searched sets, which are computed live.
-    The computed values depend on user, ordering and grouping, so all are part
-    of the key. Sets whose content reads the user's rom_user rows also embed a
-    per-user version that every rom_user write bumps; a sidecar that reads none
-    of them opts out with `with_rom_user_version=False`.
+    """Cache key for the unscoped char-index / rom-id-index sidecars.
+    Returns None for scoped/searched sets, which are computed live.
 
-    What counts as unscoped differs per sidecar, so the caller decides: the char
-    index and the id index narrow with every filter, while the filter-value list
-    is built from a query that only applies platform / collection / search.
+    The content depends on user, ordering and grouping. A RomUser-column
+    sort also embeds the per-user sort version, and a grouped set the
+    sibling version, so exactly the writes that move a set rotate its key.
     """
     if not is_unscoped:
         return None
 
-    # The query layer sorts by the lowercased key, so the per-user-version gate
-    # must normalise the same way the key text below already does.
-    order_by = order_by.lower()
-
     user_part = f"u{user_id}"
-    if with_rom_user_version and (
-        sorts_by_rom_user_column(order_by) or group_by_meta_id
-    ):
-        # These sets read the user's own rom_user rows (sort keys, or the
-        # grouped main-sibling pick), so they rotate with the per-user version.
-        user_part = f"{user_part}.{rom_user_cache_version(user_id)}"
+    if sorts_by_rom_user_column(order_by):
+        user_part = f"{user_part}.{user_sort_cache_version(user_id)}"
+    if group_by_meta_id:
+        user_part = f"{user_part}.s{user_sibling_cache_version(user_id)}"
 
-    return (
-        f"all:{user_part}" f":o{order_by}:d{order_dir.lower()}:g{int(group_by_meta_id)}"
-    )
+    return f"all:{user_part}:o{order_by}:d{order_dir}:g{int(group_by_meta_id)}"
+
+
+def build_unscoped_filter_values_cache_key(
+    user_id: int, is_unscoped: bool
+) -> str | None:
+    """Filter values ignore ordering and grouping (their query strips both),
+    so one per-user entry serves every sort."""
+    return f"all:u{user_id}" if is_unscoped else None
 
 
 class RomUpdateForm(BaseModel):
@@ -841,10 +836,14 @@ def get_roms(
     perms = get_permissions(request)
     parsed_released_days = parse_released_days(released_days)
 
+    # Normalised once so the query layer and every cache key agree on case.
+    order_by = order_by.lower()
+    order_dir = order_dir.lower()
+
     unfiltered_query, order_by_attr = db_rom_handler.get_roms_query(
         user_id=request.user.id,
-        order_by=order_by.lower(),
-        order_dir=order_dir.lower(),
+        order_by=order_by,
+        order_dir=order_dir,
         search_term=search_term,
     )
 
@@ -963,19 +962,20 @@ def get_roms(
         or parsed_released_days
     )
 
+    # One key for both ordered sidecars: the same request must not read the
+    # char index and the id index under different per-user versions.
+    sidecar_cache_key = build_unscoped_sidecar_cache_key(
+        request.user.id, order_by, order_dir, group_by_meta_id, is_unscoped
+    )
+
     # Get the char index for the roms
     char_index_dict = {}
     if with_char_index:
-        # Switching sort direction/column (or toggling grouping) must not reuse
-        # a stale index, or the AlphaStrip highlights the wrong letters.
-        char_index_cache_key = build_unscoped_sidecar_cache_key(
-            request.user.id, order_by, order_dir, group_by_meta_id, is_unscoped
-        )
         char_index = db_rom_handler.with_char_index(
             query=query,
             order_by_attr=order_by_attr,
-            order_dir=order_dir.lower(),
-            cache_key=char_index_cache_key,
+            order_dir=order_dir,
+            cache_key=sidecar_cache_key,
         )
         char_index_dict = {char: index for (char, index) in char_index}
 
@@ -1007,19 +1007,13 @@ def get_roms(
             smart_collection_id=smart_collection_id,
             search_term=search_term,
         )
-        cache_key = build_unscoped_sidecar_cache_key(
-            request.user.id,
-            order_by,
-            order_dir,
-            group_by_meta_id,
-            is_unscoped_scope,
-            # `hidden` is the only RomUser column filter values read, and it
-            # bumps the global version, so the per-user version is pure churn.
-            with_rom_user_version=False,
-        )
+        # `hidden`, the only RomUser column filter values read, already
+        # bumps the global version, so no per-user version is embedded.
         query_filters = db_rom_handler.with_filter_values(
             query=filter_query,
-            cache_key=cache_key,
+            cache_key=build_unscoped_filter_values_cache_key(
+                request.user.id, is_unscoped_scope
+            ),
         )
         # trunk-ignore(mypy/typeddict-item)
         filter_values = RomFiltersDict(**query_filters)
@@ -1029,13 +1023,8 @@ def get_roms(
     # out with with_rom_id_index=false and avoid the full-library scan.
     rom_id_index: list[int] = []
     if with_rom_id_index:
-        # Memoise the unscoped library scan (same key scheme as the other
-        # sidecars); scoped/searched sets stay live.
-        rom_id_index_cache_key = build_unscoped_sidecar_cache_key(
-            request.user.id, order_by, order_dir, group_by_meta_id, is_unscoped
-        )
         rom_id_index = db_rom_handler.get_rom_id_index(
-            query=query, cache_key=rom_id_index_cache_key
+            query=query, cache_key=sidecar_cache_key
         )
 
     # Hydrate the requested page and its additional data

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -52,6 +52,7 @@ from config import ROMM_DB_DRIVER
 from config.config_manager import config_manager as cm
 from decorators.database import begin_session
 from handler.redis_handler import sync_cache
+from logger.logger import log
 from models.assets import Save, Screenshot, State
 from models.base import PRERELEASE_FILENAME_TAGS, compute_file_name_parts
 from models.collection import Collection, CollectionRom, SmartCollection
@@ -581,21 +582,35 @@ def _queue_user_cache_bumps(
         return
     session.info["user_cache_bumps_armed"] = True
 
+    def _consume(ending_session: Session) -> dict[int, set[str]]:
+        # Popping the state re-arms the next transaction on a reused session.
+        ending_session.info.pop("user_cache_bumps_armed", None)
+        return ending_session.info.pop("user_cache_bumps", {})
+
     @event.listens_for(session, "after_commit", once=True)
     def _flush(_session: Session) -> None:
         # No keys-set bookkeeping: entries under an old version become
         # unreachable and are reaped by the TTL or the next global bump.
-        for uid, uid_flags in bumps.items():
-            if "sort" in uid_flags:
-                sync_cache.incr(_user_sort_version_key(uid))
-            if "sib" in uid_flags:
-                sync_cache.incr(_user_sibling_version_key(uid))
-            if "feed" in uid_flags:
-                # Imported here because the recommendation package reads
-                # this module.
-                from handler.recommendation import invalidate_cached_feed
+        for uid, uid_flags in _consume(_session).items():
+            # The write is already durable, so a cache failure only logs;
+            # the stale entry falls to the TTL.
+            try:
+                if "sort" in uid_flags:
+                    sync_cache.incr(_user_sort_version_key(uid))
+                if "sib" in uid_flags:
+                    sync_cache.incr(_user_sibling_version_key(uid))
+                if "feed" in uid_flags:
+                    # Imported here because the recommendation package reads
+                    # this module.
+                    from handler.recommendation import invalidate_cached_feed
 
-                invalidate_cached_feed(uid)
+                    invalidate_cached_feed(uid)
+            except Exception:
+                log.exception("Failed to bump user %s cache versions", uid)
+
+    @event.listens_for(session, "after_rollback", once=True)
+    def _discard(_session: Session) -> None:
+        _consume(_session)
 
 
 class DBRomsHandler(DBBaseHandler):

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -311,29 +311,35 @@ def _cache_value_to_str(value: Any) -> str | None:
     return str(value)
 
 
+def _cache_version(key: str) -> str:
+    return _cache_value_to_str(sync_cache.get(key)) or "0"
+
+
 def _filter_values_cache_version() -> str:
-    return _cache_value_to_str(sync_cache.get(ROM_FILTERS_CACHE_VERSION_KEY)) or "0"
+    return _cache_version(ROM_FILTERS_CACHE_VERSION_KEY)
 
 
 def _filter_values_cache_keys_key(version: str) -> str:
     return f"filter_values:keys:v{version}"
 
 
-def _rom_user_cache_version_key(user_id: int) -> str:
-    return f"filter_values:user_ver:{user_id}"
+def _user_sort_version_key(user_id: int) -> str:
+    return f"sidecar:user_ver:{user_id}"
 
 
-def rom_user_cache_version(user_id: int) -> str:
+def _user_sibling_version_key(user_id: int) -> str:
+    return f"sidecar:user_sib_ver:{user_id}"
+
+
+def user_sort_cache_version(user_id: int) -> str:
     """Version component for one user's RomUser-sorted sidecar cache keys."""
-    return (
-        _cache_value_to_str(sync_cache.get(_rom_user_cache_version_key(user_id))) or "0"
-    )
+    return _cache_version(_user_sort_version_key(user_id))
 
 
-def _bump_rom_user_cache_version(user_id: int) -> None:
-    # No keys-set bookkeeping: entries under the old per-user version become
-    # unreachable and are reaped by the TTL or the next global bump.
-    sync_cache.incr(_rom_user_cache_version_key(user_id))
+def user_sibling_cache_version(user_id: int) -> str:
+    """Version component for one user's grouped sidecar cache keys, moved
+    only by main-sibling picks."""
+    return _cache_version(_user_sibling_version_key(user_id))
 
 
 def sorts_by_rom_user_column(order_by: str) -> bool:
@@ -553,14 +559,43 @@ RECOMMENDATION_SEED_FIELDS = frozenset(
 )
 
 
-def _invalidate_feed_if_seed_changed(user_id: int, data: dict) -> None:
-    if not RECOMMENDATION_SEED_FIELDS & data.keys():
+def _queue_user_cache_bumps(
+    session: Session,
+    user_id: int,
+    *,
+    sort_keys: bool = False,
+    siblings: bool = False,
+    feed: bool = False,
+) -> None:
+    """Queues per-user cache invalidations for after this transaction
+    commits, so a rollback bumps nothing and a concurrent reader cannot
+    cache pre-commit rows under the new version."""
+    bumps: dict[int, set[str]] = session.info.setdefault("user_cache_bumps", {})
+    flags = bumps.setdefault(user_id, set())
+    flags.update(
+        flag
+        for flag, queued in (("sort", sort_keys), ("sib", siblings), ("feed", feed))
+        if queued
+    )
+    if "user_cache_bumps_armed" in session.info:
         return
+    session.info["user_cache_bumps_armed"] = True
 
-    # Imported here because the recommendation package reads this module.
-    from handler.recommendation import invalidate_cached_feed
+    @event.listens_for(session, "after_commit", once=True)
+    def _flush(_session: Session) -> None:
+        # No keys-set bookkeeping: entries under an old version become
+        # unreachable and are reaped by the TTL or the next global bump.
+        for uid, uid_flags in bumps.items():
+            if "sort" in uid_flags:
+                sync_cache.incr(_user_sort_version_key(uid))
+            if "sib" in uid_flags:
+                sync_cache.incr(_user_sibling_version_key(uid))
+            if "feed" in uid_flags:
+                # Imported here because the recommendation package reads
+                # this module.
+                from handler.recommendation import invalidate_cached_feed
 
-    invalidate_cached_feed(user_id)
+                invalidate_cached_feed(uid)
 
 
 class DBRomsHandler(DBBaseHandler):
@@ -2269,6 +2304,9 @@ class DBRomsHandler(DBBaseHandler):
     ) -> RomUser:
         rom_user = session.merge(RomUser(rom_id=rom_id, user_id=user_id))
         session.flush()
+        # A fresh row's zero defaults replace NULL sort keys, which moves
+        # this user's RomUser-sorted order.
+        _queue_user_cache_bumps(session, user_id, sort_keys=True)
         return rom_user
 
     @begin_session
@@ -2308,16 +2346,14 @@ class DBRomsHandler(DBBaseHandler):
         if not rom_user:
             return None
 
-        _invalidate_feed_if_seed_changed(rom_user.user_id, data)
-
-        # Any RomUser column can move this user's versioned sidecar entries;
-        # bump after commit so a reader can't cache pre-commit rows under it.
-        user_id = rom_user.user_id
-        event.listen(
+        # Any non-hidden RomUser column can back a sort (hidden already bumps
+        # the global version), and main-sibling picks move grouped sets.
+        _queue_user_cache_bumps(
             session,
-            "after_commit",
-            lambda _: _bump_rom_user_cache_version(user_id),
-            once=True,
+            rom_user.user_id,
+            sort_keys=bool(data.keys() - {"hidden"}),
+            siblings="is_main_sibling" in data,
+            feed=bool(RECOMMENDATION_SEED_FIELDS & data.keys()),
         )
 
         if not data.get("is_main_sibling", False):

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
     case,
     cast,
     delete,
+    event,
     false,
     func,
 )
@@ -2309,9 +2310,15 @@ class DBRomsHandler(DBBaseHandler):
 
         _invalidate_feed_if_seed_changed(rom_user.user_id, data)
 
-        # Every RomUser column can back a gallery sort, so any write here moves
-        # this user's RomUser-sorted sidecar entries.
-        _bump_rom_user_cache_version(rom_user.user_id)
+        # Any RomUser column can move this user's versioned sidecar entries;
+        # bump after commit so a reader can't cache pre-commit rows under it.
+        user_id = rom_user.user_id
+        event.listen(
+            session,
+            "after_commit",
+            lambda _: _bump_rom_user_cache_version(user_id),
+            once=True,
+        )
 
         if not data.get("is_main_sibling", False):
             return rom_user

--- a/backend/handler/database/roms_handler.py
+++ b/backend/handler/database/roms_handler.py
@@ -318,6 +318,28 @@ def _filter_values_cache_keys_key(version: str) -> str:
     return f"filter_values:keys:v{version}"
 
 
+def _rom_user_cache_version_key(user_id: int) -> str:
+    return f"filter_values:user_ver:{user_id}"
+
+
+def rom_user_cache_version(user_id: int) -> str:
+    """Version component for one user's RomUser-sorted sidecar cache keys."""
+    return (
+        _cache_value_to_str(sync_cache.get(_rom_user_cache_version_key(user_id))) or "0"
+    )
+
+
+def _bump_rom_user_cache_version(user_id: int) -> None:
+    # No keys-set bookkeeping: entries under the old per-user version become
+    # unreachable and are reaped by the TTL or the next global bump.
+    sync_cache.incr(_rom_user_cache_version_key(user_id))
+
+
+def sorts_by_rom_user_column(order_by: str) -> bool:
+    """True when this sort key resolves to a per-user RomUser column."""
+    return hasattr(RomUser, order_by) and not hasattr(Rom, order_by)
+
+
 def _sidecar_redis_key(prefix: str, cache_key: str, version: str) -> str:
     """Every gallery sidecar key shares this shape, so none can omit the schema version."""
     return f"{prefix}:{ROM_FILTERS_CACHE_SCHEMA_VERSION}:{cache_key}:v{version}"
@@ -1684,7 +1706,7 @@ class DBRomsHandler(DBBaseHandler):
         query = self._join_rom_user(select(Rom), user_id)
 
         sort_key_is_nullable = False
-        if user_id and hasattr(RomUser, order_by) and not hasattr(Rom, order_by):
+        if user_id and sorts_by_rom_user_column(order_by):
             order_attr = getattr(RomUser, order_by)
             sort_key_is_nullable = True
         elif order_by in ROM_METADATA_ORDER_COLUMNS:
@@ -2286,6 +2308,10 @@ class DBRomsHandler(DBBaseHandler):
             return None
 
         _invalidate_feed_if_seed_changed(rom_user.user_id, data)
+
+        # Every RomUser column can back a gallery sort, so any write here moves
+        # this user's RomUser-sorted sidecar entries.
+        _bump_rom_user_cache_version(rom_user.user_id)
 
         if not data.get("is_main_sibling", False):
             return rom_user

--- a/backend/tests/endpoints/roms/test_rom_sidecar_cache.py
+++ b/backend/tests/endpoints/roms/test_rom_sidecar_cache.py
@@ -17,7 +17,9 @@ These tests pin the split gate:
      since both narrow with it,
   4. RomUser-column sorts key on a per-user version, so a rom_user write
      refreshes that user's sorted index without touching other users'
-     entries or the name-sorted one, and `hidden` still bumps globally.
+     entries or the name-sorted one, and `hidden` still bumps globally,
+  5. grouped sets join the same per-user version (the representative is the
+     user's main sibling), while filter values opt out of it.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -306,6 +308,53 @@ def test_play_session_ingest_refreshes_last_played_sorted_index(
 
     second = _get_roms(client, access_token, order_by="last_played", order_dir="desc")
     assert second["rom_id_index"] == [second_rom.id, played_rom.id]
+
+
+def test_cache_key_normalises_order_by_case():
+    """A mixed-case RomUser sort must land on the same versioned key as lowercase."""
+    mixed_case_key = build_unscoped_sidecar_cache_key(
+        1, "Last_Played", "desc", False, True
+    )
+    assert mixed_case_key == _last_played_sort_key(1)
+
+
+def test_rom_user_write_refreshes_grouped_entry(
+    client: TestClient, access_token: str, admin_user: User, rom: Rom
+):
+    """Grouped sets pick the user's main sibling, so any rom_user write must
+    refresh the grouped index even under the default name sort."""
+    key = build_unscoped_sidecar_cache_key(admin_user.id, "", "asc", True, True)
+    assert key is not None
+    version = _filter_values_cache_version()
+    redis_key = _rom_id_index_redis_key(key, version)
+    _store_versioned_cache(redis_key, version, [424242])
+
+    first = _get_roms(client, access_token, group_by_meta_id=True)
+    assert first["rom_id_index"] == [424242]
+
+    _put_props(client, access_token, rom.id, body={"is_main_sibling": True})
+
+    second = _get_roms(client, access_token, group_by_meta_id=True)
+    assert second["rom_id_index"] == [rom.id]
+
+
+def test_rom_user_write_keeps_filter_values_entry(
+    client: TestClient, access_token: str, admin_user: User, rom: Rom
+):
+    """Filter values read no sortable RomUser column, so a play must not rotate them."""
+    version = _filter_values_cache_version()
+    key = build_unscoped_sidecar_cache_key(
+        admin_user.id, "last_played", "desc", False, True, with_rom_user_version=False
+    )
+    assert key is not None
+    _store_versioned_cache(
+        _filter_values_redis_key(key, version), version, SENTINEL_FILTER_VALUES
+    )
+
+    _put_props(client, access_token, rom.id, update_last_played=True)
+
+    body = _get_roms(client, access_token, order_by="last_played", order_dir="desc")
+    assert body["filter_values"]["genres"] == ["Sentinel Genre"]
 
 
 def test_rom_user_write_keeps_name_sorted_entry(

--- a/backend/tests/endpoints/roms/test_rom_sidecar_cache.py
+++ b/backend/tests/endpoints/roms/test_rom_sidecar_cache.py
@@ -14,9 +14,13 @@ These tests pin the split gate:
   1. a row-level filter reads and writes the shared filter-values entry,
   2. a scope filter (platform / collection / search) does neither,
   3. the char index and the id index stay live under any row-level filter,
-     since both narrow with it.
+     since both narrow with it,
+  4. RomUser-column sorts key on a per-user version, so a rom_user write
+     refreshes that user's sorted index without touching other users'
+     entries or the name-sorted one, and `hidden` still bumps globally.
 """
 
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
@@ -220,3 +224,134 @@ def test_unfiltered_request_still_reads_unscoped_char_index_cache(
     body = _get_roms(client, access_token)
 
     assert body["char_index"] == {"Z": 41}
+
+
+def _put_props(
+    client: TestClient,
+    access_token: str,
+    rom_id: int,
+    body: dict[str, Any] | None = None,
+    **params: Any,
+) -> None:
+    response = client.put(
+        f"/api/roms/{rom_id}/props",
+        headers={"Authorization": f"Bearer {access_token}"},
+        params=params,
+        json=body or {},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+
+def _last_played_sort_key(user_id: int) -> str:
+    key = build_unscoped_sidecar_cache_key(user_id, "last_played", "desc", False, True)
+    assert key is not None
+    return key
+
+
+@pytest.fixture
+def played_rom(rom: Rom, admin_user: User) -> Rom:
+    """The shared rom with an old `last_played`, so a later play must reorder past it."""
+    rom_user = db_rom_handler.get_rom_user(rom.id, admin_user.id)
+    assert rom_user is not None
+    db_rom_handler.update_rom_user(
+        rom_user.id, {"last_played": datetime(2020, 1, 1, tzinfo=timezone.utc)}
+    )
+    return rom
+
+
+def test_props_write_refreshes_last_played_sorted_index(
+    client: TestClient,
+    access_token: str,
+    admin_user: User,
+    played_rom: Rom,
+    second_rom: Rom,
+):
+    """A play recorded through /props reorders the next last_played-sorted index."""
+    first = _get_roms(client, access_token, order_by="last_played", order_dir="desc")
+    assert first["rom_id_index"] == [played_rom.id, second_rom.id]
+
+    _put_props(client, access_token, second_rom.id, update_last_played=True)
+
+    second = _get_roms(client, access_token, order_by="last_played", order_dir="desc")
+    assert second["rom_id_index"] == [second_rom.id, played_rom.id]
+
+
+def test_play_session_ingest_refreshes_last_played_sorted_index(
+    client: TestClient,
+    access_token: str,
+    admin_user: User,
+    played_rom: Rom,
+    second_rom: Rom,
+):
+    """The play-session path writes `last_played` through the same choke point."""
+    first = _get_roms(client, access_token, order_by="last_played", order_dir="desc")
+    assert first["rom_id_index"] == [played_rom.id, second_rom.id]
+
+    end = datetime.now(timezone.utc).replace(microsecond=0)
+    response = client.post(
+        "/api/play-sessions",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={
+            "sessions": [
+                {
+                    "rom_id": second_rom.id,
+                    "start_time": (end - timedelta(minutes=30)).isoformat(),
+                    "end_time": end.isoformat(),
+                    "duration_ms": 30 * 60 * 1000,
+                }
+            ]
+        },
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+    second = _get_roms(client, access_token, order_by="last_played", order_dir="desc")
+    assert second["rom_id_index"] == [second_rom.id, played_rom.id]
+
+
+def test_rom_user_write_keeps_name_sorted_entry(
+    client: TestClient, access_token: str, admin_user: User, rom: Rom
+):
+    """A rating write must not rotate or delete the user's name-sorted entry."""
+    version = _filter_values_cache_version()
+    redis_key = _rom_id_index_redis_key(_unscoped_key(admin_user.id), version)
+    _store_versioned_cache(redis_key, version, [424242])
+
+    _put_props(client, access_token, rom.id, body={"rating": 8})
+
+    body = _get_roms(client, access_token)
+    assert body["rom_id_index"] == [424242]
+
+
+def test_rom_user_write_leaves_other_users_sorted_entries_alone(
+    client: TestClient,
+    access_token: str,
+    admin_user: User,
+    editor_user: User,
+    rom: Rom,
+):
+    """One user's play rotates only their own key; another user's entry stays."""
+    writer_key = _last_played_sort_key(admin_user.id)
+    other_key = _last_played_sort_key(editor_user.id)
+    version = _filter_values_cache_version()
+    other_redis_key = _rom_id_index_redis_key(other_key, version)
+    _store_versioned_cache(other_redis_key, version, [424242])
+
+    _put_props(client, access_token, rom.id, update_last_played=True)
+
+    assert _last_played_sort_key(editor_user.id) == other_key
+    assert sync_cache.get(other_redis_key) is not None
+    assert _last_played_sort_key(admin_user.id) != writer_key
+
+
+def test_hidden_write_still_bumps_the_global_version(
+    client: TestClient, access_token: str, admin_user: User, rom: Rom
+):
+    """`hidden` keeps its global invalidation on top of the per-user bump."""
+    old_version = _filter_values_cache_version()
+    redis_key = _rom_id_index_redis_key(_unscoped_key(admin_user.id), old_version)
+    _store_versioned_cache(redis_key, old_version, [424242])
+
+    _put_props(client, access_token, rom.id, body={"hidden": True})
+
+    assert int(_filter_values_cache_version()) == int(old_version) + 1
+    assert sync_cache.get(redis_key) is None

--- a/backend/tests/endpoints/roms/test_rom_sidecar_cache.py
+++ b/backend/tests/endpoints/roms/test_rom_sidecar_cache.py
@@ -15,11 +15,13 @@ These tests pin the split gate:
   2. a scope filter (platform / collection / search) does neither,
   3. the char index and the id index stay live under any row-level filter,
      since both narrow with it,
-  4. RomUser-column sorts key on a per-user version, so a rom_user write
-     refreshes that user's sorted index without touching other users'
-     entries or the name-sorted one, and `hidden` still bumps globally,
-  5. grouped sets join the same per-user version (the representative is the
-     user's main sibling), while filter values opt out of it.
+  4. RomUser-column sorts key on a per-user sort version, so a rom_user
+     write refreshes that user's sorted index without touching other
+     users' entries or the name-sorted one, and `hidden` still bumps
+     globally,
+  5. grouped sets key on a per-user sibling version moved only by
+     main-sibling picks, and filter values use one order-free per-user
+     entry.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -29,7 +31,10 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
-from endpoints.roms import build_unscoped_sidecar_cache_key
+from endpoints.roms import (
+    build_unscoped_filter_values_cache_key,
+    build_unscoped_sidecar_cache_key,
+)
 from handler.database import db_rom_handler
 from handler.database.roms_handler import (
     _char_index_redis_key,
@@ -69,17 +74,32 @@ def missing_rom(rom: Rom) -> Rom:
     return db_rom
 
 
-def _unscoped_key(user_id: int) -> str:
-    """The shared sidecar key for a default (no order, no grouping) request."""
-    key = build_unscoped_sidecar_cache_key(user_id, "", "asc", False, True)
+def _unscoped_key(
+    user_id: int, order_by: str = "", order_dir: str = "asc", group: bool = False
+) -> str:
+    """The shared sidecar key for an unscoped request."""
+    key = build_unscoped_sidecar_cache_key(user_id, order_by, order_dir, group, True)
+    assert key is not None
+    return key
+
+
+def _filter_values_key(user_id: int) -> str:
+    key = build_unscoped_filter_values_cache_key(user_id, True)
     assert key is not None
     return key
 
 
 def _seed_filter_values(user_id: int) -> str:
     version = _filter_values_cache_version()
-    redis_key = _filter_values_redis_key(_unscoped_key(user_id), version)
+    redis_key = _filter_values_redis_key(_filter_values_key(user_id), version)
     _store_versioned_cache(redis_key, version, SENTINEL_FILTER_VALUES)
+    return redis_key
+
+
+def _seed_rom_id_index(cache_key: str, ids: list[int]) -> str:
+    version = _filter_values_cache_version()
+    redis_key = _rom_id_index_redis_key(cache_key, version)
+    _store_versioned_cache(redis_key, version, ids)
     return redis_key
 
 
@@ -109,7 +129,7 @@ def test_row_filter_writes_unscoped_filter_values_cache(
 ):
     """A row-filtered request also warms the shared entry for everyone else."""
     version = _filter_values_cache_version()
-    redis_key = _filter_values_redis_key(_unscoped_key(admin_user.id), version)
+    redis_key = _filter_values_redis_key(_filter_values_key(admin_user.id), version)
     assert sync_cache.get(redis_key) is None
 
     _get_roms(client, access_token, missing=True)
@@ -184,12 +204,7 @@ def test_row_filter_does_not_read_unscoped_rom_id_index_cache(
     client: TestClient, access_token: str, admin_user: User, rom: Rom
 ):
     """Same for the id index: it is the filtered result set, not the library."""
-    version = _filter_values_cache_version()
-    _store_versioned_cache(
-        _rom_id_index_redis_key(_unscoped_key(admin_user.id), version),
-        version,
-        [424242],
-    )
+    _seed_rom_id_index(_unscoped_key(admin_user.id), [424242])
 
     body = _get_roms(client, access_token, missing=True)
 
@@ -200,12 +215,7 @@ def test_length_filter_does_not_read_unscoped_rom_id_index_cache(
     client: TestClient, access_token: str, admin_user: User, rom: Rom
 ):
     """A HowLongToBeat range narrows the result set like any other row filter."""
-    version = _filter_values_cache_version()
-    _store_versioned_cache(
-        _rom_id_index_redis_key(_unscoped_key(admin_user.id), version),
-        version,
-        [424242],
-    )
+    _seed_rom_id_index(_unscoped_key(admin_user.id), [424242])
 
     body = _get_roms(client, access_token, hltb_main_story_max=3600)
 
@@ -244,12 +254,6 @@ def _put_props(
     assert response.status_code == status.HTTP_200_OK
 
 
-def _last_played_sort_key(user_id: int) -> str:
-    key = build_unscoped_sidecar_cache_key(user_id, "last_played", "desc", False, True)
-    assert key is not None
-    return key
-
-
 @pytest.fixture
 def played_rom(rom: Rom, admin_user: User) -> Rom:
     """The shared rom with an old `last_played`, so a later play must reorder past it."""
@@ -261,34 +265,7 @@ def played_rom(rom: Rom, admin_user: User) -> Rom:
     return rom
 
 
-def test_props_write_refreshes_last_played_sorted_index(
-    client: TestClient,
-    access_token: str,
-    admin_user: User,
-    played_rom: Rom,
-    second_rom: Rom,
-):
-    """A play recorded through /props reorders the next last_played-sorted index."""
-    first = _get_roms(client, access_token, order_by="last_played", order_dir="desc")
-    assert first["rom_id_index"] == [played_rom.id, second_rom.id]
-
-    _put_props(client, access_token, second_rom.id, update_last_played=True)
-
-    second = _get_roms(client, access_token, order_by="last_played", order_dir="desc")
-    assert second["rom_id_index"] == [second_rom.id, played_rom.id]
-
-
-def test_play_session_ingest_refreshes_last_played_sorted_index(
-    client: TestClient,
-    access_token: str,
-    admin_user: User,
-    played_rom: Rom,
-    second_rom: Rom,
-):
-    """The play-session path writes `last_played` through the same choke point."""
-    first = _get_roms(client, access_token, order_by="last_played", order_dir="desc")
-    assert first["rom_id_index"] == [played_rom.id, second_rom.id]
-
+def _ingest_play_session(client: TestClient, access_token: str, rom_id: int) -> None:
     end = datetime.now(timezone.utc).replace(microsecond=0)
     response = client.post(
         "/api/play-sessions",
@@ -296,7 +273,7 @@ def test_play_session_ingest_refreshes_last_played_sorted_index(
         json={
             "sessions": [
                 {
-                    "rom_id": second_rom.id,
+                    "rom_id": rom_id,
                     "start_time": (end - timedelta(minutes=30)).isoformat(),
                     "end_time": end.isoformat(),
                     "duration_ms": 30 * 60 * 1000,
@@ -306,28 +283,34 @@ def test_play_session_ingest_refreshes_last_played_sorted_index(
     )
     assert response.status_code == status.HTTP_201_CREATED
 
+
+@pytest.mark.parametrize("trigger", ["props", "play_session"])
+def test_last_played_write_refreshes_the_sorted_index(
+    client: TestClient,
+    access_token: str,
+    played_rom: Rom,
+    second_rom: Rom,
+    trigger: str,
+):
+    """Both `last_played` writers reorder the next sorted index."""
+    first = _get_roms(client, access_token, order_by="last_played", order_dir="desc")
+    assert first["rom_id_index"] == [played_rom.id, second_rom.id]
+
+    if trigger == "props":
+        _put_props(client, access_token, second_rom.id, update_last_played=True)
+    else:
+        _ingest_play_session(client, access_token, second_rom.id)
+
     second = _get_roms(client, access_token, order_by="last_played", order_dir="desc")
     assert second["rom_id_index"] == [second_rom.id, played_rom.id]
 
 
-def test_cache_key_normalises_order_by_case():
-    """A mixed-case RomUser sort must land on the same versioned key as lowercase."""
-    mixed_case_key = build_unscoped_sidecar_cache_key(
-        1, "Last_Played", "desc", False, True
-    )
-    assert mixed_case_key == _last_played_sort_key(1)
-
-
-def test_rom_user_write_refreshes_grouped_entry(
+def test_main_sibling_write_refreshes_grouped_entry(
     client: TestClient, access_token: str, admin_user: User, rom: Rom
 ):
-    """Grouped sets pick the user's main sibling, so any rom_user write must
-    refresh the grouped index even under the default name sort."""
-    key = build_unscoped_sidecar_cache_key(admin_user.id, "", "asc", True, True)
-    assert key is not None
-    version = _filter_values_cache_version()
-    redis_key = _rom_id_index_redis_key(key, version)
-    _store_versioned_cache(redis_key, version, [424242])
+    """Grouped sets pick the user's main sibling, so that write refreshes
+    the grouped index even under the default name sort."""
+    _seed_rom_id_index(_unscoped_key(admin_user.id, group=True), [424242])
 
     first = _get_roms(client, access_token, group_by_meta_id=True)
     assert first["rom_id_index"] == [424242]
@@ -338,18 +321,24 @@ def test_rom_user_write_refreshes_grouped_entry(
     assert second["rom_id_index"] == [rom.id]
 
 
+def test_non_sibling_write_keeps_the_grouped_entry(
+    client: TestClient, access_token: str, admin_user: User, rom: Rom
+):
+    """A play must not rotate the default grouped gallery's whole-library
+    index; only main-sibling picks move a name-sorted grouped set."""
+    _seed_rom_id_index(_unscoped_key(admin_user.id, group=True), [424242])
+
+    _put_props(client, access_token, rom.id, update_last_played=True)
+
+    body = _get_roms(client, access_token, group_by_meta_id=True)
+    assert body["rom_id_index"] == [424242]
+
+
 def test_rom_user_write_keeps_filter_values_entry(
     client: TestClient, access_token: str, admin_user: User, rom: Rom
 ):
     """Filter values read no sortable RomUser column, so a play must not rotate them."""
-    version = _filter_values_cache_version()
-    key = build_unscoped_sidecar_cache_key(
-        admin_user.id, "last_played", "desc", False, True, with_rom_user_version=False
-    )
-    assert key is not None
-    _store_versioned_cache(
-        _filter_values_redis_key(key, version), version, SENTINEL_FILTER_VALUES
-    )
+    _seed_filter_values(admin_user.id)
 
     _put_props(client, access_token, rom.id, update_last_played=True)
 
@@ -361,35 +350,29 @@ def test_rom_user_write_keeps_name_sorted_entry(
     client: TestClient, access_token: str, admin_user: User, rom: Rom
 ):
     """A rating write must not rotate or delete the user's name-sorted entry."""
-    version = _filter_values_cache_version()
-    redis_key = _rom_id_index_redis_key(_unscoped_key(admin_user.id), version)
-    _store_versioned_cache(redis_key, version, [424242])
+    redis_key = _seed_rom_id_index(_unscoped_key(admin_user.id), [424242])
 
     _put_props(client, access_token, rom.id, body={"rating": 8})
 
     body = _get_roms(client, access_token)
     assert body["rom_id_index"] == [424242]
+    assert sync_cache.get(redis_key) is not None
 
 
 def test_rom_user_write_leaves_other_users_sorted_entries_alone(
-    client: TestClient,
-    access_token: str,
-    admin_user: User,
-    editor_user: User,
-    rom: Rom,
+    client: TestClient, access_token: str, admin_user: User, rom: Rom
 ):
     """One user's play rotates only their own key; another user's entry stays."""
-    writer_key = _last_played_sort_key(admin_user.id)
-    other_key = _last_played_sort_key(editor_user.id)
-    version = _filter_values_cache_version()
-    other_redis_key = _rom_id_index_redis_key(other_key, version)
-    _store_versioned_cache(other_redis_key, version, [424242])
+    other_user_id = admin_user.id + 1
+    writer_key = _unscoped_key(admin_user.id, "last_played", "desc")
+    other_key = _unscoped_key(other_user_id, "last_played", "desc")
+    other_redis_key = _seed_rom_id_index(other_key, [424242])
 
     _put_props(client, access_token, rom.id, update_last_played=True)
 
-    assert _last_played_sort_key(editor_user.id) == other_key
+    assert _unscoped_key(other_user_id, "last_played", "desc") == other_key
     assert sync_cache.get(other_redis_key) is not None
-    assert _last_played_sort_key(admin_user.id) != writer_key
+    assert _unscoped_key(admin_user.id, "last_played", "desc") != writer_key
 
 
 def test_hidden_write_still_bumps_the_global_version(
@@ -397,8 +380,7 @@ def test_hidden_write_still_bumps_the_global_version(
 ):
     """`hidden` keeps its global invalidation on top of the per-user bump."""
     old_version = _filter_values_cache_version()
-    redis_key = _rom_id_index_redis_key(_unscoped_key(admin_user.id), old_version)
-    _store_versioned_cache(redis_key, old_version, [424242])
+    redis_key = _seed_rom_id_index(_unscoped_key(admin_user.id), [424242])
 
     _put_props(client, access_token, rom.id, body={"hidden": True})
 

--- a/backend/tests/handler/database/test_roms_filter_cache.py
+++ b/backend/tests/handler/database/test_roms_filter_cache.py
@@ -9,10 +9,12 @@ actually delete the old entries instead of leaking them until TTL.
 These tests pin down that machinery:
   1. storing a value also registers its key in the version set,
   2. a cache hit returns the exact same shape as the cache miss that filled it,
-  3. `invalidate_filter_values_cache()` deletes the prior version's keys.
+  3. `invalidate_filter_values_cache()` deletes the prior version's keys,
+  4. a rom_user write bumps only the writing user's per-user version.
 """
 
 import json
+from datetime import datetime, timezone
 from typing import cast
 
 import pytest
@@ -29,9 +31,11 @@ from handler.database.roms_handler import (
     _filter_values_redis_key,
     _rom_id_index_redis_key,
     _store_versioned_cache,
+    rom_user_cache_version,
 )
 from handler.redis_handler import sync_cache
 from models.rom import Rom
+from models.user import User
 
 
 @pytest.fixture(autouse=True)
@@ -237,6 +241,34 @@ class TestFilterValuesSchemaDrift:
         assert result["genres"] == ["RPG"]
         # ...and the fresh entry lands under the schema-namespaced key.
         assert sync_cache.get(_filter_values_redis_key(cache_key, version)) is not None
+
+
+class TestRomUserCacheVersion:
+    def test_update_rom_user_bumps_only_that_users_version(
+        self, rom: Rom, admin_user: User, editor_user: User
+    ):
+        rom_user = db_rom_handler.get_rom_user(rom.id, admin_user.id)
+        assert rom_user is not None
+        assert rom_user_cache_version(admin_user.id) == "0"
+
+        db_rom_handler.update_rom_user(
+            rom_user.id, {"last_played": datetime(2020, 1, 1, tzinfo=timezone.utc)}
+        )
+
+        assert rom_user_cache_version(admin_user.id) == "1"
+        assert rom_user_cache_version(editor_user.id) == "0"
+
+    def test_missing_rom_user_does_not_bump(self, admin_user: User):
+        assert db_rom_handler.update_rom_user(424242, {"rating": 8}) is None
+        assert rom_user_cache_version(admin_user.id) == "0"
+
+    def test_bump_leaves_the_global_version_alone(self, rom: Rom, admin_user: User):
+        rom_user = db_rom_handler.get_rom_user(rom.id, admin_user.id)
+        assert rom_user is not None
+
+        db_rom_handler.update_rom_user(rom_user.id, {"rating": 8})
+
+        assert _filter_values_cache_version() == "0"
 
 
 class TestInvalidateFilterValuesCache:

--- a/backend/tests/handler/database/test_roms_filter_cache.py
+++ b/backend/tests/handler/database/test_roms_filter_cache.py
@@ -31,7 +31,8 @@ from handler.database.roms_handler import (
     _filter_values_redis_key,
     _rom_id_index_redis_key,
     _store_versioned_cache,
-    rom_user_cache_version,
+    user_sibling_cache_version,
+    user_sort_cache_version,
 )
 from handler.redis_handler import sync_cache
 from models.rom import Rom
@@ -243,32 +244,76 @@ class TestFilterValuesSchemaDrift:
         assert sync_cache.get(_filter_values_redis_key(cache_key, version)) is not None
 
 
+# The rom fixtures call add_rom_user, which itself bumps, so every
+# assertion here is a delta from the version the setup left behind.
 class TestRomUserCacheVersion:
-    def test_update_rom_user_bumps_only_that_users_version(
-        self, rom: Rom, admin_user: User, editor_user: User
+    def test_update_rom_user_bumps_only_that_users_sort_version(
+        self, rom: Rom, admin_user: User
     ):
         rom_user = db_rom_handler.get_rom_user(rom.id, admin_user.id)
         assert rom_user is not None
-        assert rom_user_cache_version(admin_user.id) == "0"
+        before = int(user_sort_cache_version(admin_user.id))
+        sibling_before = user_sibling_cache_version(admin_user.id)
 
         db_rom_handler.update_rom_user(
             rom_user.id, {"last_played": datetime(2020, 1, 1, tzinfo=timezone.utc)}
         )
 
-        assert rom_user_cache_version(admin_user.id) == "1"
-        assert rom_user_cache_version(editor_user.id) == "0"
+        assert int(user_sort_cache_version(admin_user.id)) == before + 1
+        # Another user, the sibling counter, and the global version stay put.
+        assert user_sort_cache_version(admin_user.id + 1) == "0"
+        assert user_sibling_cache_version(admin_user.id) == sibling_before
+        assert _filter_values_cache_version() == "0"
 
-    def test_missing_rom_user_does_not_bump(self, admin_user: User):
-        assert db_rom_handler.update_rom_user(424242, {"rating": 8}) is None
-        assert rom_user_cache_version(admin_user.id) == "0"
-
-    def test_bump_leaves_the_global_version_alone(self, rom: Rom, admin_user: User):
+    def test_main_sibling_write_bumps_the_sibling_version(
+        self, rom: Rom, admin_user: User
+    ):
         rom_user = db_rom_handler.get_rom_user(rom.id, admin_user.id)
         assert rom_user is not None
+        before = int(user_sibling_cache_version(admin_user.id))
 
-        db_rom_handler.update_rom_user(rom_user.id, {"rating": 8})
+        db_rom_handler.update_rom_user(rom_user.id, {"is_main_sibling": True})
 
-        assert _filter_values_cache_version() == "0"
+        assert int(user_sibling_cache_version(admin_user.id)) == before + 1
+
+    def test_hidden_only_write_skips_the_sort_version(self, rom: Rom, admin_user: User):
+        # `hidden` rotates every key through the global bump already.
+        rom_user = db_rom_handler.get_rom_user(rom.id, admin_user.id)
+        assert rom_user is not None
+        before = user_sort_cache_version(admin_user.id)
+
+        db_rom_handler.update_rom_user(rom_user.id, {"hidden": True})
+
+        assert user_sort_cache_version(admin_user.id) == before
+
+    def test_add_rom_user_bumps_the_sort_version(self, rom: Rom, admin_user: User):
+        # The `rom` fixture already pairs itself with admin_user, so a fresh
+        # row needs a rom of its own.
+        with session_factory.begin() as s:
+            bare_rom = Rom(
+                platform_id=rom.platform_id,
+                name="Bare",
+                slug="bare-slug",
+                fs_name="bare.zip",
+                fs_name_no_tags="bare",
+                fs_name_no_ext="bare",
+                fs_extension="zip",
+                fs_path=rom.fs_path,
+            )
+            s.add(bare_rom)
+            s.flush()
+            bare_rom_id = bare_rom.id
+        before = int(user_sort_cache_version(admin_user.id))
+
+        # A fresh row's zero defaults replace NULL sort keys.
+        db_rom_handler.add_rom_user(rom_id=bare_rom_id, user_id=admin_user.id)
+
+        assert int(user_sort_cache_version(admin_user.id)) == before + 1
+
+    def test_missing_rom_user_does_not_bump(self, admin_user: User):
+        before = user_sort_cache_version(admin_user.id)
+        assert db_rom_handler.update_rom_user(424242, {"rating": 8}) is None
+        assert user_sort_cache_version(admin_user.id) == before
 
 
 class TestInvalidateFilterValuesCache:

--- a/backend/tests/handler/database/test_roms_filter_cache.py
+++ b/backend/tests/handler/database/test_roms_filter_cache.py
@@ -315,6 +315,33 @@ class TestRomUserCacheVersion:
         assert db_rom_handler.update_rom_user(424242, {"rating": 8}) is None
         assert user_sort_cache_version(admin_user.id) == before
 
+    def test_reused_session_bumps_on_every_commit(self, rom: Rom, admin_user: User):
+        rom_user = db_rom_handler.get_rom_user(rom.id, admin_user.id)
+        assert rom_user is not None
+        before = int(user_sort_cache_version(admin_user.id))
+
+        with session_factory() as session:
+            db_rom_handler.update_rom_user(rom_user.id, {"rating": 4}, session=session)
+            session.commit()
+            db_rom_handler.update_rom_user(rom_user.id, {"rating": 5}, session=session)
+            session.commit()
+
+        assert int(user_sort_cache_version(admin_user.id)) == before + 2
+
+    def test_rolled_back_write_does_not_bump(self, rom: Rom, admin_user: User):
+        rom_user = db_rom_handler.get_rom_user(rom.id, admin_user.id)
+        assert rom_user is not None
+        before = user_sort_cache_version(admin_user.id)
+
+        with session_factory() as session:
+            db_rom_handler.update_rom_user(rom_user.id, {"rating": 4}, session=session)
+            session.rollback()
+            # An empty commit after the rollback must not flush the
+            # discarded bumps.
+            session.commit()
+
+        assert user_sort_cache_version(admin_user.id) == before
+
 
 class TestInvalidateFilterValuesCache:
     def test_deletes_prior_version_keys_and_set(self, rom_with_metadata: Rom):


### PR DESCRIPTION
**Description**

Fixes #4448

The cached gallery sidecars (char index, rom id index) embed the sort order in their key, but a `rom_user` write (rating a game, marking last played, picking a main sibling) never rotated those keys, so a user sorting by their own columns kept reading a stale index until the global version bumped or the TTL expired.

This change versions the sidecars per user:

- Two Redis counters per user: `sidecar:user_ver:{id}` moves on any sort-relevant `rom_user` write, and `sidecar:user_sib_ver:{id}` moves only on `is_main_sibling` picks. The cache key embeds the sort counter when the sort resolves to a `RomUser` column and the sibling counter when the gallery is grouped, so exactly the writes that move a set rotate its key (lazy expiry, no keys-set bookkeeping; old entries fall to the TTL).
- Bumps are queued in `session.info` and flushed once from an `after_commit` listener, deduped per user, so a rollback bumps nothing and a concurrent reader cannot cache pre-commit rows under the new version. The recommendation-feed invalidation rides the same queue.
- `add_rom_user` bumps too (a fresh row's zero defaults replace NULL sort keys); `hidden`-only updates skip the per-user bump since `hidden` already bumps the global version.
- Filter values get their own per-user key builder (`all:u{id}`): their query strips ordering and grouping, so one entry serves every sort.
- `order_by`/`order_dir` are normalized once at the top of `get_roms`, and both ordered sidecars share one hoisted key so a single request cannot read them under different versions.

Ran the full pr-ready gauntlet (security-audit: clean; code-review xhigh; simplify; review-polish), one commit per pass. 164 tests across the five affected files pass, trunk is clean. Backend-only, no migrations, no API shape change. The key namespace rename is safe because the per-user counters were never released.

Deliberately not done, noted for reviewers: threading the version reads through one MGET (two extra Redis GETs per gallery request is noise next to the query), and per-rom bump granularity on play-session ingest (the per-user counter already collapses batch writes into one rotation per commit).

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**AI disclosure:** This PR was implemented and reviewed end to end with Claude Code (implementation, the four-pass review gauntlet, and tests), directed and supervised by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ldi4YaXJWDDmFdbKfQay8L