### PR TITLE
chore(env): add the 5.3 physical-game and recommendation vars to env.template

### DIFF
--- a/env.template
+++ b/env.template
@@ -83,6 +83,11 @@ TGDB_API_ENABLED=false  # Enable TheGamesDB API integration
 # SCREENSCRAPER_DEV_ID=
 # SCREENSCRAPER_DEV_PASSWORD=
 
+# Physical Games
+UPC_LOOKUP_ENABLED=true  # Look a barcode up by UPC when adding a physical game
+UPC_LOOKUP_API_KEY=  # Key for the UPC lookup service, if your plan needs one
+UPC_LOOKUP_URL=https://api.upcitemdb.com/prod/trial/lookup  # UPC lookup endpoint
+
 # Scans & Tasks
 SCAN_TIMEOUT=14400  # Timeout for background scan/rescan tasks in seconds
 SCAN_WORKERS=4  # How many ROMs a scan processes at once
@@ -103,6 +108,8 @@ ENABLE_SCHEDULED_CLEANUP_ORPHANED_RESOURCES=false  # Enable scheduled cleanup of
 SCHEDULED_CLEANUP_ORPHANED_RESOURCES_CRON=0 5 * * *  # Cron expression for scheduled orphaned resource cleanup
 ENABLE_SCHEDULED_RETROACHIEVEMENTS_PROGRESS_SYNC=false  # Enable scheduled RetroAchievements progress sync
 SCHEDULED_RETROACHIEVEMENTS_PROGRESS_SYNC_CRON=0 4 * * *  # Cron expression for scheduled RetroAchievements sync
+ENABLE_SCHEDULED_BUILD_RECOMMENDATIONS=true  # Enable the scheduled rebuild of the recommendations index
+SCHEDULED_BUILD_RECOMMENDATIONS_CRON=30 5 * * *  # Cron expression for the recommendations index rebuild
 
 # Sync
 ENABLE_SYNC_FOLDER_WATCHER=false  # Watch the sync folder and trigger scans on change


### PR DESCRIPTION
`UPC_LOOKUP_ENABLED`, `UPC_LOOKUP_API_KEY`, `UPC_LOOKUP_URL`, `ENABLE_SCHEDULED_BUILD_RECOMMENDATIONS` and `SCHEDULED_BUILD_RECOMMENDATIONS_CRON` all ship in 5.3 and are read in `backend/config/__init__.py`, but none of them reached `env.template`.

That matters beyond the template itself: the docs generators in [rommapp/docs](https://github.com/rommapp/docs) treat `env.template` as the source of truth. The five are missing from the environment-variable reference, and `gen_scheduled_tasks.py` fails outright rather than print a cron default it cannot verify, so the whole scheduled-tasks table is stuck until this lands.

Defaults match `backend/config/__init__.py`:

| Variable | Default |
| --- | --- |
| `UPC_LOOKUP_ENABLED` | `true` |
| `UPC_LOOKUP_API_KEY` | *(unset)* |
| `UPC_LOOKUP_URL` | `https://api.upcitemdb.com/prod/trial/lookup` |
| `ENABLE_SCHEDULED_BUILD_RECOMMENDATIONS` | `true` |
| `SCHEDULED_BUILD_RECOMMENDATIONS_CRON` | `30 5 * * *` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)