### PR TITLE
docs: correct stale Vuetify claims in v2 skills and architecture doc

### DIFF
--- a/.claude/skills/frontend-v2-components/SKILL.md
+++ b/.claude/skills/frontend-v2-components/SKILL.md
@@ -19,9 +19,9 @@ Related skills: `frontend-v2-theming` (tokens/colors), `frontend-v2-input` (focu
 2. **Three component tiers** (below).
 3. **Shared resources are canonical.** Pinia stores, API services, OpenAPI types (`src/__generated__/`), locales, utils — v2 _imports_ them, never forks them. Additive changes to shared resources are allowed; changing a shared store API to work around a v2 call-site issue is not.
 4. **TypeScript strict.** Zero `any` (justify with a comment if unavoidable). No `as unknown as ...`; fix the source or define an intermediate type.
-5. **Universal substitution.** When an `R*` primitive exists, use it. If it doesn't, create or extend it. Never drop to raw HTML or raw Vuetify when a primitive applies.
-6. **Wrapper contract.** Wrappers around Vuetify use `defineOptions({ inheritAttrs: false })` + `v-bind="$attrs"` + slot passthrough, and accept every prop/slot of the wrapped component.
-7. **Layout via Vuetify utility classes + our wrappers, not plain CSS.** Use `d-flex`, `pa-4`, `align-center` directly. Vuetify layout components (`v-row`, `v-col`, `v-container`, `v-spacer`, `v-app`, `v-main`) get wrapped as `R*` on first use (lazy).
+5. **Universal substitution.** When an `R*` primitive exists, use it. If it doesn't, create or extend it. Never drop to raw HTML when a primitive applies.
+6. **Attribute forwarding contract.** A primitive whose root is polymorphic (`<component :is>`) or that forwards to an inner element uses `defineOptions({ inheritAttrs: false })` + `v-bind="$attrs"` + slot passthrough, so call-site attrs and listeners land on the intended node instead of vanishing silently.
+7. **Layout in scoped CSS against tokens.** v2 uses no utility-class framework and no component library: no Tailwind, no Vuetify. Write `display: flex` / `gap: var(--r-space-*)` in the component's own `<style scoped>`. Recurring structure becomes a primitive (`RList`, `RToolbar`, `RCollapsible`, `RVirtualScroller`), not a repeated block of classes.
 8. **Accessibility & performance** are requirements: semantic HTML, focus management, contrast, ARIA on icon-only controls; lazy-load heavy views, virtualize large lists, stable `:key` on every `v-for`.
 
 ---
@@ -44,7 +44,7 @@ If any fails: **shared composite** if generic across features, **feature composi
 
 ### Primitive boundaries
 
-- **Can use**: tokens, other primitives, Vue/Vuetify, generic composables (`useInput*`, `useFocus*`).
+- **Can use**: tokens, other primitives, Vue, generic composables (`useInput*`, `useFocus*`).
 - **Cannot use**: Pinia stores, API services, `emitter`, `router` (a `RouterLink` may be accepted as a prop), `i18n` directly. **No `$t()` in primitives** — text comes via props or slots.
 
 ---
@@ -105,7 +105,7 @@ import { useCan } from "@/v2/composables/useCan";
 1. Don't change shared store APIs to work around a v2 call-site issue. (Fix the call site; the Gallery lesson was calling `romsStore.reset()` from the view, not adding `_fetchSeq` to the store.)
 2. Don't drop to inline role checks — always go through `useCan` (see `frontend-v2-patterns`).
 3. Don't reinvent a surface — dialog/menu/popover/card all go through their primitive; special cases become a new prop, not a parallel surface.
-4. Don't use `v-form` directly — use `RForm`.
+4. Don't hand-roll a `<form>`; use `RForm`.
 5. Don't add backwards-compat shims inside v2: delete removed code; no `// removed`, no renamed-but-unused exports, no deprecated wrappers that just call the new function.
 6. Don't write redundant tests; don't touch v1; never `--no-verify` on commits.
 
@@ -115,10 +115,6 @@ import { useCan } from "@/v2/composables/useCan";
 
 ## Known debt (focused follow-ups)
 
-- **Virtualisation migration** — `RVirtualScroller` (`src/v2/lib/structural/`) needs to absorb `GameGrid`/`LetterGroupedGrid` (structural refactor of `Platform.vue`/`Search.vue`/`Collection.vue`); `useLetterGroups` must become index-based for AlphaStrip scroll-spy.
-- **`useGalleryFilterUrl`** — sync `galleryFilter` store fields to URL query params for bookmarkable links; mark v1 store usage `@deprecated`.
-- **Vue Router scroll restoration** — galleries scroll custom containers (`.r-v2-plat__scroll`), not window; add a Pinia `routeFullPath → offsetTop` map with per-view hooks. Bundle with the virtualisation migration.
-- **`useSocketEvent` composable** — typed socket subscriptions with mount/unmount cleanup (consumers currently wire `socket.on/off` by hand).
 - **When v1 dies**: move `uiVersion` into `UI_SETTINGS_KEYS`; drop `.r-v2-*` scope classes (tokens move to `:root`); simplify `useUISettings` sync; delete `useGameAnimation`; drop the color-string→tone collapser in `NotificationHost`; remove the Vuetify rule arrays in `stores/users.ts`.
 
 Full reference: `docs/FRONTEND_ARCHITECTURE.md`.

--- a/.claude/skills/frontend-v2-input/SKILL.md
+++ b/.claude/skills/frontend-v2-input/SKILL.md
@@ -22,7 +22,7 @@ The input system lives in `src/v2/composables/useInput/` (bus, keyboard, gamepad
 
 Buttons, list items, tabs, menu items, focusable cards, toggleable chips — all participate in spatial navigation (not optional). A new interactive primitive must:
 
-- be focusable (proper `tabindex`, or already so via a wrapped Vuetify component);
+- be focusable (a natively focusable element, or a proper `tabindex`);
 - react to logical actions (confirm/cancel) from `useInput`, in addition to native click;
 - show a modality-gated focus state.
 

--- a/.claude/skills/frontend-v2-patterns/SKILL.md
+++ b/.claude/skills/frontend-v2-patterns/SKILL.md
@@ -58,14 +58,14 @@ Name a helper for what it touches: `syncCachedRom`, not `syncRom`, when it updat
 ## E. Pagination & infinite scroll
 
 - `LoadMore` (`RBtn` + `RSpinner` + IntersectionObserver) is the canonical fallback when virtualization stalls.
-- `RVirtualScroller` (`src/v2/lib/structural/`, wrapping `v-virtual-scroll`) is the substrate for large lists/grids.
+- `RVirtualScroller` (`src/v2/lib/structural/`) is the substrate for large lists/grids: a custom windowed list that owns its offset math, not a wrapper around anything.
 - Page size lives in the store (`fetchLimit`); not user-configurable for now.
-- **Scroll restoration** on back-nav: Vue Router `scrollBehavior` + Pinia in-session offset. URL holds filters/sort/search but **not** scroll offset.
+- **Scroll restoration** on back-nav: the `scrollRestoration` Pinia store keyed by `route.fullPath`. Vue Router's `scrollBehavior` only restores `window` scroll, and galleries scroll `RVirtualScroller`'s container, so views save on `onBeforeRouteLeave` and restore in `onMounted`. URL holds filters/sort/search but **not** scroll offset.
 
 ## F. Forms & validation
 
-- Use the **`RForm` primitive** (wraps `v-form`: Enter-to-submit when valid, scroll-to-first-error after a failed `validate()`). **Never use `v-form` directly.**
-- **Native Vuetify rules** — no Zod/Yup. Rules are arrays of `(v) => true | string`.
+- Use the **`RForm` primitive** (a native `<form>` providing a registration context that descendant fields auto-enroll into: Enter-to-submit when valid, scroll-to-first-error after a failed `validate()`). **Never hand-roll a `<form>`.**
+- **Plain function rules**, no Zod/Yup and no validation library. Rules are arrays of `(v) => true | string`, run by the field primitives themselves.
 - **Reusable rules** in `src/v2/utils/validation.ts` (`required(msg?)`, `email`, `asciiOnly`, `lengthBetween`, `usernameLength/Chars`, `passwordLength`). Utility code _may_ call `i18n.global.t(...)` (the no-i18n rule covers lib primitives, not utils).
 - **Submit pattern:** `await formRef.value?.validate()` before the API call; submit button uses `:loading="submitting"`; errors → snackbar; field errors stay in-place via `:error-messages`.
 

--- a/.claude/skills/frontend-v2-patterns/SKILL.md
+++ b/.claude/skills/frontend-v2-patterns/SKILL.md
@@ -31,7 +31,7 @@ How v2 features behave. Each pattern has one canonical mechanism — don't inven
 ## C. Real-time updates (Socket.IO)
 
 - One instance: `src/services/socket.ts`. Never `new io()`.
-- New consumers go through (or build) a `useSocketEvent(event, handler)` composable for typed subscriptions with automatic mount/unmount cleanup (this composable is still debt — today consumers wire `socket.on/off` by hand).
+- Subscriptions go through `useSocketEvent(event, handler)` (`src/v2/composables/useSocketEvent/`): typed payload, auto-connect by default (`{ connect: false }` opts out), cleanup via `onScopeDispose` so it also works inside a store action or a manual `effectScope`. No v2 code wires `socket.on/off` by hand; don't start.
 - **Ownership rule:** state living only while a view is open → subscribe in the view; state that must outlive a view (e.g. scan badge in navbar) → a Pinia store subscribes globally and views just read.
 - Reconnection is socket.io's job — don't roll your own.
 

--- a/.claude/skills/frontend-v2-patterns/SKILL.md
+++ b/.claude/skills/frontend-v2-patterns/SKILL.md
@@ -60,7 +60,7 @@ Name a helper for what it touches: `syncCachedRom`, not `syncRom`, when it updat
 - `LoadMore` (`RBtn` + `RSpinner` + IntersectionObserver) is the canonical fallback when virtualization stalls.
 - `RVirtualScroller` (`src/v2/lib/structural/`) is the substrate for large lists/grids: a custom windowed list that owns its offset math, not a wrapper around anything.
 - Page size lives in the store (`fetchLimit`); not user-configurable for now.
-- **Scroll restoration** on back-nav: the `scrollRestoration` Pinia store keyed by `route.fullPath`. Vue Router's `scrollBehavior` only restores `window` scroll, and galleries scroll `RVirtualScroller`'s container, so views save on `onBeforeRouteLeave` and restore in `onMounted`. URL holds filters/sort/search but **not** scroll offset.
+- **Scroll restoration** on back-nav: the `scrollRestoration` Pinia store keyed by `route.fullPath`. Vue Router's `scrollBehavior` only restores `window` scroll, and galleries scroll `RVirtualScroller`'s container, so `GalleryShell` owns persistence: it saves the outgoing route's offset in both its `onBeforeRouteUpdate` and `onBeforeRouteLeave` guards. Views don't repeat that (their own `onBeforeRouteUpdate` just triggers the new context's load); they call the exposed `applyRestoredScroll()` at the end of their load flow. URL holds filters/sort/search but **not** scroll offset.
 
 ## F. Forms & validation
 

--- a/.claude/skills/frontend-v2-theming/SKILL.md
+++ b/.claude/skills/frontend-v2-theming/SKILL.md
@@ -33,7 +33,7 @@ v2 has **no Vuetify theme of its own**, and no Vuetify at all. `tokens.css` emit
 ### Diagnostics — when `var(--r-color-...)` resolves to nothing on an overlay
 
 1. Check `RomM.vue`'s watch on `documentElement.classList` (load-bearing).
-2. Check that the overlay still teleports to `body`. A teleport to any other target can land outside the `<html>` scope.
+2. Check that the teleport target is attached to the document. `<html>` is the document root, so any in-document target inherits the scope; a detached node resolves no `var(--r-*)` at all.
 3. **Never** "fix" it by swapping the token for a hex literal — that hides the bug and breaks the dual theme.
 
 ---

--- a/.claude/skills/frontend-v2-theming/SKILL.md
+++ b/.claude/skills/frontend-v2-theming/SKILL.md
@@ -16,9 +16,7 @@ description: Theming, design tokens, colors, and visual language in the RomM v2 
 - **`src/v2/styles/tokens.css`** — _generated_ by `scripts/build-tokens.ts` (`npm run build:tokens`, hooked into `predev`/`prebuild`). **Do not hand-edit.** This is how the vast majority of tokens are consumed: `var(--r-color-...)` in CSS.
 - **Direct JS/TS imports** of named exports (`colorCanvas`, `colorCoverArt`, `layout`, …) for the few cases needing a token value in JavaScript — baking colors into an SVG string (`utils/covers`), canvas/QR backgrounds (`Player/Ruffle.vue`, `ShowQRCodeDialog`), and the virtualiser's pixel math (`Gallery/listColumns` reading `layout`).
 
-v2 has **no Vuetify theme of its own.** `tokens.css` emits a palette block per theme under `.r-v2.r-v2-dark` / `.r-v2.r-v2-light`; `RomM.vue` toggles those classes on `<html>`. v2 surfaces never read Vuetify's runtime theme.
-
-> Caveat: a wrapped Vuetify component still resolves `color="primary"` against Vuetify's _own_ registered themes (`src/plugins/vuetify.ts`, sourced from v1's `@/styles/themes`). They mirror the brand tokens by hand (both `#8B74E8`), so they line up, but it's a parallel source. **Prefer `var(--r-...)` over the `color` prop.**
+v2 has **no Vuetify theme of its own**, and no Vuetify at all. `tokens.css` emits a palette block per theme under `.r-v2.r-v2-dark` / `.r-v2.r-v2-light`; `RomM.vue` toggles those classes on `<html>`. v2 surfaces never read Vuetify's runtime theme (`src/plugins/vuetify.ts` serves v1 only).
 
 ### Adding a new token
 
@@ -30,12 +28,12 @@ v2 has **no Vuetify theme of its own.** `tokens.css` emits a palette block per t
 
 ### Where the scope classes live — and why `<html>`
 
-`.r-v2`, `.r-v2-dark`, `.r-v2-light` go on `<html>` (`RomM.vue` toggles them whenever `uiVersion` or the active theme changes). Vuetify teleports overlays (`VDialog`, `VMenu`, `VTooltip`) to `<body> > .v-overlay-container`, **outside** `<v-app>`. Only `<html>` covers both the regular tree and the teleports — without it, overlays lose their tokens.
+`.r-v2`, `.r-v2-dark`, `.r-v2-light` go on `<html>` (`RomM.vue` toggles them whenever `uiVersion` or the active theme changes). The overlay primitives (`RDialog`, `RMenu`, `RTooltip`) `<Teleport to="body">`, landing **outside** the app root. Only `<html>` covers both the regular tree and the teleports; without it, overlays lose their tokens.
 
 ### Diagnostics — when `var(--r-color-...)` resolves to nothing on an overlay
 
 1. Check `RomM.vue`'s watch on `documentElement.classList` (load-bearing).
-2. Check that the teleported component carries a `content-class` tying it back to scope (e.g. `RDialog` uses `content-class="r-dialog"`).
+2. Check that the overlay still teleports to `body`. A teleport to any other target can land outside the `<html>` scope.
 3. **Never** "fix" it by swapping the token for a hex literal — that hides the bug and breaks the dual theme.
 
 ---
@@ -51,8 +49,7 @@ v2 has **no Vuetify theme of its own.** `tokens.css` emits a palette block per t
    - focus (modality-gated; visible only on `key`/`pad` — see `frontend-v2-input`)
    - busy/pending · disabled
 4. **Implementation gotchas:**
-   - `RDialog` ships unscoped `<style>` at the bottom that strips Vuetify defaults from `.v-overlay__content`. Load-bearing — without it the `--r-radius-card` corners disappear.
-   - Every dialog goes through `RDialog`; every menu through `RMenu`.
+   - Every dialog goes through `RDialog`; every menu through `RMenu`; every tooltip through `RTooltip`. Each owns its own teleport, scrim, and scroll lock, so don't hand-roll a parallel one.
 
 ---
 
@@ -76,4 +73,4 @@ If a literal would otherwise be needed, the answer is: **add a token** (steps ab
 
 - Scoped `<style>` by default; unscoped only for teleport overrides.
 - BEM-ish class names: `.feature__element--modifier`. Prefixes: `.r-v2-...` for app-shell surfaces outside components; `.r-...` for globally shared utilities/tokens.
-- No plain CSS where a Vuetify utility class covers the case (`d-flex`, `pa-4`, `align-center`).
+- No utility-class framework (no Tailwind, no Vuetify): layout is plain CSS in the component's scoped block, with tokens (`var(--r-space-*)`, `var(--r-radius-*)`) for every value that has one.

--- a/.claude/skills/frontend-v2-theming/SKILL.md
+++ b/.claude/skills/frontend-v2-theming/SKILL.md
@@ -49,7 +49,7 @@ v2 has **no Vuetify theme of its own**, and no Vuetify at all. `tokens.css` emit
    - focus (modality-gated; visible only on `key`/`pad` — see `frontend-v2-input`)
    - busy/pending · disabled
 4. **Implementation gotchas:**
-   - Every dialog goes through `RDialog`; every menu through `RMenu`; every tooltip through `RTooltip`. Each owns its own teleport, scrim, and scroll lock, so don't hand-roll a parallel one.
+   - Every dialog goes through `RDialog`; every menu through `RMenu`; every tooltip through `RTooltip`. Each owns its teleport and positioning, so don't hand-roll a parallel surface. The scrim and the reference-counted body scroll lock (`lib/overlays/bodyScrollLock.ts`) belong to `RDialog` and `RDrawer` only; menus and tooltips have neither.
 
 ---
 

--- a/docs/FRONTEND_ARCHITECTURE.md
+++ b/docs/FRONTEND_ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 Comprehensive documentation of the RomM frontend: a Vue 3 single-page application powering the retro gaming platform UI.
 
+> **Scope: this document describes the v1 UI** (`src/views/`, `src/components/`, `src/console/`, `src/layouts/`), which is frozen pending deletion. The v2 rewrite under `src/v2/` shares the Vue/Vite/Pinia/router/i18n/Socket.IO foundation described here, but has its own design system and uses **neither Vuetify nor Tailwind**, styling instead with generated tokens plus scoped CSS. For v2, read the `frontend-v2-components`, `frontend-v2-theming`, `frontend-v2-input`, and `frontend-v2-patterns` skills in `.claude/skills/`.
+
 ---
 
 ## Table of Contents
@@ -34,8 +36,8 @@ Comprehensive documentation of the RomM frontend: a Vue 3 single-page applicatio
 | **Framework**        | Vue 3.4.27 (Composition API, `<script setup>`) |
 | **Build Tool**       | Vite 6.4.2                                     |
 | **Language**         | TypeScript 5.7.3 (`noImplicitAny: true`)       |
-| **UI Library**       | Vuetify 3.9.2 (Material Design)                |
-| **CSS**              | Tailwind CSS 4.0.0 + Vuetify themes            |
+| **UI Library**       | Vuetify 3.9.2 (Material Design), v1 only       |
+| **CSS**              | Tailwind CSS 4.3.1 + Vuetify themes, v1 only   |
 | **State Management** | Pinia 3.0.1 (18 stores)                        |
 | **Routing**          | Vue Router 4.3.2                               |
 | **HTTP Client**      | Axios 1.15.0                                   |
@@ -889,13 +891,15 @@ Vuetify handles theme switching. Additional shared brand colors: `romm-red`, `ro
 
 ### CSS Stack
 
-| Layer     | Technology                         | Scope                  |
-| --------- | ---------------------------------- | ---------------------- |
-| Component | Vuetify classes + scoped `<style>` | Per-component          |
-| Utility   | Tailwind CSS 4.0                   | Inline utility classes |
-| Global    | `styles/common.css`                | App-wide utilities     |
-| Scrollbar | `styles/scrollbar.css`             | Custom scrollbar       |
-| Console   | `console/index.css`                | Console mode only      |
+| Layer     | Technology                         | Scope                                                                                                          |
+| --------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Component | Vuetify classes + scoped `<style>` | Per-component                                                                                                  |
+| Utility   | Tailwind CSS 4.3                   | Inline utility classes; `@import "tailwindcss"` lives in `console/index.css`, which `main.ts` imports app-wide |
+| Global    | `styles/common.css`                | App-wide utilities                                                                                             |
+| Scrollbar | `styles/scrollbar.css`             | Custom scrollbar                                                                                               |
+| Console   | `console/index.css`                | Console mode styles (plus the Tailwind import above)                                                           |
+
+v2 opts out of this stack entirely: `src/v2/styles/tokens.css` (generated from `src/v2/tokens/index.ts`) plus `global.css`, scoped under `.r-v2`, with per-component `<style scoped>`.
 
 ### Procedural Cover Generation
 

--- a/docs/FRONTEND_ARCHITECTURE.md
+++ b/docs/FRONTEND_ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 Comprehensive documentation of the RomM frontend: a Vue 3 single-page application powering the retro gaming platform UI.
 
-> **Scope: this document describes the v1 UI** (`src/views/`, `src/components/`, `src/console/`, `src/layouts/`), which is frozen pending deletion. The v2 rewrite under `src/v2/` shares the Vue/Vite/Pinia/router/i18n/Socket.IO foundation described here, but has its own design system and uses **neither Vuetify nor Tailwind**, styling instead with generated tokens plus scoped CSS. For v2, read the `frontend-v2-components`, `frontend-v2-theming`, `frontend-v2-input`, and `frontend-v2-patterns` skills in `.claude/skills/`.
+> **Scope: this document describes the v1 UI** (`src/views/`, `src/components/`, `src/console/`, `src/layouts/`), which is frozen pending deletion. The v2 rewrite under `src/v2/` shares the Vue/Vite/Pinia/router/i18n/Socket.IO foundation described here, but has its own design system: **no Vuetify, and no Tailwind utility classes** (the Tailwind stylesheet is still loaded app-wide, see CSS Stack below). It styles with generated tokens plus per-component scoped CSS. For v2, read the `frontend-v2-components`, `frontend-v2-theming`, `frontend-v2-input`, and `frontend-v2-patterns` skills in `.claude/skills/`.
 
 ---
 


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Documentation only, no runtime code touched.

The four `frontend-v2-*` skills described a Vuetify-backed component layer that v2 no longer has. `frontend/src/v2/` contains **zero** `from "vuetify"` imports and **zero** `<v-*>` tags, yet the skills instructed agents to lay out with `d-flex` / `pa-4` / `align-center`, to wrap Vuetify components, and to route forms through `v-form`. Anyone following them would write code against a layer that is gone.

Corrected across the skills:

- **Layout guidance** (`frontend-v2-components`, `frontend-v2-theming`): Vuetify utility classes replaced with what v2 actually does, scoped CSS against tokens, with recurring structure promoted to a primitive.
- **Wrapper contract**: reframed around attribute forwarding for polymorphic roots (`RBtn` renders `<button>` / `<a>` / `RouterLink`) rather than wrapping Vuetify.
- **Forms** (`frontend-v2-patterns`): `RForm` is a native `<form>` with its own field-registration context; rules are plain `(v) => true | string` functions, not "native Vuetify rules".
- **`RVirtualScroller`**: a custom windowed list owning its offset math, not a `v-virtual-scroll` wrapper.
- **Overlay scoping** (`frontend-v2-theming`): the `<html>` scope-class rationale now cites the primitives' own `<Teleport to="body">`; dropped the `RDialog` unscoped `.v-overlay__content` override, which no longer exists in the file.
- **Real-time** (`frontend-v2-patterns`): `useSocketEvent` documented as the mechanism (five consumers, no raw `socket.on/off` left in v2) instead of as outstanding debt.
- **Scroll restoration**: `GalleryShell` owns persistence via both its `onBeforeRouteUpdate` and `onBeforeRouteLeave` guards; views call the exposed `applyRestoredScroll()` at the end of their load flow.
- **Focusability** (`frontend-v2-input`): "or already so via a wrapped Vuetify component" replaced with natively focusable element or `tabindex`.

Also removed four **Known debt** entries from `frontend-v2-components` that are implemented and wired: the virtualisation migration (`Platform.vue` / `Search.vue` / `Collection.vue` all render `GalleryShell` over `RVirtualScroller`; `GameGrid`, `LetterGroupedGrid`, and `useLetterGroups` are gone), `useGalleryFilterUrl`, scroll restoration, and `useSocketEvent`. The remaining "when v1 dies" entry was verified still accurate.

`docs/FRONTEND_ARCHITECTURE.md` documents v1 exclusively (it never mentions v2) but never said so, so its Overview table reads as the repo-wide stack. Added a scope banner pointing at the v2 skills, marked the Vuetify and CSS rows v1-only, corrected the Tailwind version (4.0.0 → 4.3.1, per the lockfile), and clarified that the single `@import "tailwindcss"` lives in `console/index.css`, which `main.ts` imports app-wide, so the stylesheet ships whichever UI is active.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

<sub>Every claim was verified against the tree before editing (Vuetify imports and `v-*` tags, `RForm` / `RVirtualScroller` / `RDialog` internals, the debt items' files and their consumers, the Tailwind import graph). Prettier passes on all five files. No tests added: the change is documentation only, and there is nothing here for a unit test to cover.</sub>

#### Screenshots (if applicable)

N/A, no user-visible change.

---

<sub>**Review rounds.** Greptile and Copilot between them found five inaccuracies, all in text this PR introduced rather than in the pre-existing docs; each was verified against the code and fixed in `00fcaa77` and `9406619c`. They were: scroll-restoration ownership attributed to views instead of `GalleryShell`; scrim and body scroll lock attributed to all three overlay primitives instead of `RDialog` and `RDrawer`; the `useSocketEvent` debt claim left contradicting the entry removed from the debt list; a scope banner that said v2 uses no Tailwind, contradicting the CSS Stack note below it; and a teleport diagnostic that told the reader to check for a `body` target when, with the scope classes on `<html>`, any in-document target inherits and only a detached node fails.</sub>

**AI assistance disclosure** (per `CONTRIBUTING.md`): this PR was written by Claude Code. The staleness was found while answering a question about which UI framework the project uses; the model then verified each claim against the codebase, made the edits, worked the review feedback, and wrote this description. A human requested and directed the work; it still wants a human line-review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnHWknZwwZcm89JuXjrugK