### PR TITLE
ci: gate the preview-build report job on the build-preview label

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -211,10 +211,15 @@ jobs:
           docker buildx imagetools create "${tags[@]}" "${sources[@]}"
 
   # The only writer of the final comment, and it needs `prepare`, so the opening
-  # "under way" message can never land on top of the result.
+  # "under way" message can never land on top of the result. The label gate is
+  # the same one the build jobs carry: any label starts a run, and without it
+  # this job would read their `skipped` as a failure.
   report:
     needs: [prepare, build, merge]
-    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+    if: |
+      !cancelled() &&
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'build-preview')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Any PR that receives any label, without also carrying `build-preview`, gets a false `❌ Preview build failed.` sticky comment. One landed on #4474 when the `on-hold` label was added ([diagnosis](https://github.com/rommapp/romm/pull/4474#issuecomment-5647367311)); [run 34706931907](https://github.com/rommapp/romm/actions/runs/34706931907) concluded **success** with zero failed jobs.

`.github/workflows/test-build.yml` triggers on `pull_request: types: [labeled]`, so adding *any* label starts a run. `prepare`, `build` and `merge` are each gated on `contains(github.event.pull_request.labels.*.name, 'build-preview')` and are correctly skipped when it is absent. `report` was not:

```yaml
report:
  needs: [prepare, build, merge]
  if: ${{ !cancelled() && github.event_name == 'pull_request' }}
```

So it ran on its own, evaluated `needs.merge.result != 'success'` (it was `'skipped'`, not a failure), and posted the failure comment.

This gates `report` on the same label as the jobs it reports on, written in the same `if: |` block style those jobs use. Behaviour after the change:

| Situation | `report` |
| --- | --- |
| `build-preview` present, build succeeds | runs, posts success (unchanged) |
| `build-preview` present, build fails | runs, posts failure (unchanged) |
| Any other label, no `build-preview` | skipped, no comment (**fixed**) |
| `workflow_dispatch` | skipped, already excluded by the event check (unchanged) |
| Run cancelled | skipped via `!cancelled()` (unchanged) |

The `report` job is the only place in `.github/workflows/` with this pattern, so there is no sibling instance to fix.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

<sub>Verified with the same linters CI runs on this file: `actionlint` 1.7.11, `yamllint` 1.38.0 against `.trunk/configs/.yamllint.yaml`, and `prettier` 3, all clean. The job matrix above was reasoned through case by case against the workflow. No tests added: GitHub Actions `if` conditions are not unit-testable in this repo, and the change is a one-condition CI fix.</sub>

#### Screenshots (if applicable)

N/A, no user-visible change. The visible effect is the absence of a spurious PR comment.

---

**AI assistance disclosure** (per `CONTRIBUTING.md`): this PR was written by Claude Code. A human pointed at the diagnosis comment on #4474 and asked for the fix; the model re-verified the diagnosis against the current workflow file, made the edit, ran the linters, and wrote this description. It wants a human line-review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBBbdsDv9BiYJnKwcCGE6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBBbdsDv9BiYJnKwcCGE6A)_