### PR TITLE
fix(migrations): make the full_path_hash migration re-runnable

### DIFF
--- a/backend/alembic/versions/0126_unique_rom_full_path.py
+++ b/backend/alembic/versions/0126_unique_rom_full_path.py
@@ -23,41 +23,64 @@ down_revision = "0125_drop_redundant_indexes"
 branch_labels = None
 depends_on = None
 
+COLUMN_NAME = "full_path_hash"
 LOOKUP_INDEX_NAME = "idx_roms_platform_id_fs_name"
 UNIQUE_INDEX_NAME = "idx_roms_platform_id_full_path_hash"
 
 
 def upgrade() -> None:
-    op.add_column(
-        "roms",
-        sa.Column("full_path_hash", sa.String(length=FULL_PATH_HASH_LENGTH)),
-    )
     connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    column = next(
+        (
+            column
+            for column in inspector.get_columns("roms")
+            if column["name"] == COLUMN_NAME
+        ),
+        None,
+    )
+    indexes = {index["name"]: index for index in inspector.get_indexes("roms")}
+
+    # Every step is guarded so a re-run after a partial failure recovers
+    # cleanly. MySQL/MariaDB auto-commit each DDL statement, so a crash
+    # mid-migration leaves the column behind without advancing the alembic
+    # version, and an unguarded ADD COLUMN then fails every start after it.
+    if column is None:
+        op.add_column(
+            "roms",
+            sa.Column(COLUMN_NAME, sa.String(length=FULL_PATH_HASH_LENGTH)),
+        )
+
     connection.execute(
         sa.text(
-            f"UPDATE roms SET full_path_hash = {full_path_digest_sql(connection)}"  # nosec B608
+            f"UPDATE roms SET {COLUMN_NAME} = {full_path_digest_sql(connection)} "  # nosec B608
+            f"WHERE {COLUMN_NAME} IS NULL"
         )
     )
 
     with op.batch_alter_table("roms", schema=None) as batch_op:
-        batch_op.alter_column(
-            "full_path_hash",
-            existing_type=sa.String(length=FULL_PATH_HASH_LENGTH),
-            nullable=False,
-        )
-        batch_op.create_index(
-            UNIQUE_INDEX_NAME,
-            ["platform_id", "full_path_hash"],
-            unique=True,
-            if_not_exists=True,
-        )
-        batch_op.drop_index(LOOKUP_INDEX_NAME, if_exists=True)
-        batch_op.create_index(
-            LOOKUP_INDEX_NAME,
-            ["platform_id", "fs_name"],
-            unique=False,
-            if_not_exists=True,
-        )
+        if column is None or column["nullable"]:
+            batch_op.alter_column(
+                COLUMN_NAME,
+                existing_type=sa.String(length=FULL_PATH_HASH_LENGTH),
+                nullable=False,
+            )
+        if UNIQUE_INDEX_NAME not in indexes:
+            batch_op.create_index(
+                UNIQUE_INDEX_NAME,
+                ["platform_id", COLUMN_NAME],
+                unique=True,
+                if_not_exists=True,
+            )
+        # 0091 made this index unique; the digest carries that role now.
+        if LOOKUP_INDEX_NAME not in indexes or indexes[LOOKUP_INDEX_NAME]["unique"]:
+            batch_op.drop_index(LOOKUP_INDEX_NAME, if_exists=True)
+            batch_op.create_index(
+                LOOKUP_INDEX_NAME,
+                ["platform_id", "fs_name"],
+                unique=False,
+                if_not_exists=True,
+            )
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/0126_unique_rom_full_path.py
+++ b/backend/alembic/versions/0126_unique_rom_full_path.py
@@ -41,10 +41,9 @@ def upgrade() -> None:
     )
     indexes = {index["name"]: index for index in inspector.get_indexes("roms")}
 
-    # Every step is guarded so a re-run after a partial failure recovers
-    # cleanly. MySQL/MariaDB auto-commit each DDL statement, so a crash
-    # mid-migration leaves the column behind without advancing the alembic
-    # version, and an unguarded ADD COLUMN then fails every start after it.
+    # MySQL/MariaDB auto-commit each DDL statement, so a crash mid-migration
+    # keeps the column while the alembic version stays behind. Every step is
+    # guarded so the replay resumes where it stopped.
     if column is None:
         op.add_column(
             "roms",

--- a/backend/alembic/versions/0128_hltb_main_story_column.py
+++ b/backend/alembic/versions/0128_hltb_main_story_column.py
@@ -16,6 +16,7 @@ Create Date: 2026-09-08 00:00:00.000000
 
 """
 
+import sqlalchemy as sa
 from alembic import op  # type: ignore[attr-defined]
 
 from utils.database import is_postgresql
@@ -47,11 +48,18 @@ _POSTGRES_EXPR = (
 
 
 def upgrade() -> None:
-    expr = _POSTGRES_EXPR if is_postgresql(op.get_bind()) else _MARIA_EXPR
-    op.execute(  # nosec B608
-        f"ALTER TABLE roms ADD COLUMN {COLUMN_NAME} BIGINT "
-        f"GENERATED ALWAYS AS ({expr}) STORED"
-    )
+    connection = op.get_bind()
+    columns = {column["name"] for column in sa.inspect(connection).get_columns("roms")}
+
+    # MySQL/MariaDB auto-commit each DDL statement, so a run that dies on the
+    # index keeps the column without advancing the alembic version.
+    if COLUMN_NAME not in columns:
+        expr = _POSTGRES_EXPR if is_postgresql(connection) else _MARIA_EXPR
+        op.execute(  # nosec B608
+            f"ALTER TABLE roms ADD COLUMN {COLUMN_NAME} BIGINT "
+            f"GENERATED ALWAYS AS ({expr}) STORED"
+        )
+
     op.create_index(INDEX_NAME, "roms", [COLUMN_NAME], if_not_exists=True)
 
 

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -137,9 +137,8 @@ def _roms_column(connection: sa.Connection, name: str) -> ReflectedColumn:
     )
 
 
-# MySQL/MariaDB auto-commit each DDL statement, so a run that dies partway keeps
-# what it created while the alembic version stays behind, and the next start
-# replays the revision over its own leftovers.
+# MySQL/MariaDB auto-commit each DDL statement, so the next start replays a
+# revision over the leftovers of the run that died partway through it.
 @pytest.mark.parametrize(
     "filename",
     ["0126_unique_rom_full_path.py", "0128_hltb_main_story_column.py"],
@@ -152,18 +151,17 @@ def test_a_migration_replayed_over_a_migrated_schema_is_a_no_op(filename: str):
         with Operations.context(MigrationContext.configure(connection)):
             migration.upgrade()
 
-        indexes = _roms_indexes(connection)
+        columns = {
+            column["name"] for column in sa.inspect(connection).get_columns("roms")
+        }
 
-    assert indexes["idx_roms_platform_id_full_path_hash"]["unique"]
-    assert not indexes["idx_roms_platform_id_fs_name"]["unique"]
-    assert "idx_roms_hltb_main_story" in indexes
+    assert migration.COLUMN_NAME in columns
 
 
 def test_the_full_path_hash_migration_resumes_an_interrupted_run(rom: Rom):
     """0126 finishes a run that died right after its ADD COLUMN.
 
-    The column survives the failure without a digest, a NOT NULL or either
-    index, which is the state a restart mid-backfill leaves behind.
+    That run leaves the column with no digest, no NOT NULL and neither index.
     """
     migration = _load_migration("0126_unique_rom_full_path.py")
 

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -6,6 +6,7 @@ not the other goes unnoticed until autogenerate proposes dropping it.
 
 import importlib.util
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 import sqlalchemy as sa
@@ -13,11 +14,12 @@ from alembic.autogenerate import compare_metadata
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 from sqlalchemy import Table, UniqueConstraint
+from sqlalchemy.engine.interfaces import ReflectedColumn, ReflectedIndex
 
 import models
 from handler.database.base_handler import sync_engine
 from models.base import BaseModel
-from models.rom import compute_full_path_hash
+from models.rom import FULL_PATH_HASH_LENGTH, Rom, compute_full_path_hash
 from utils.database import (
     AUTOGENERATE_EXEMPT_INDEX_NAMES,
     POSTGRESQL_FK_INDEXES,
@@ -110,31 +112,94 @@ def test_the_migrated_full_path_digest_matches_the_models(
     assert digest == compute_full_path_hash(fs_path, fs_name)
 
 
-def test_the_full_path_hash_migration_survives_a_re_run():
-    """0126 replayed over a schema it already migrated is a no-op.
-
-    MySQL/MariaDB auto-commit each DDL statement, so a run that dies partway
-    keeps the column without advancing the alembic version, and every restart
-    after that replays the revision from the top.
-    """
-    path = (
-        Path(__file__).parent.parent
-        / "alembic"
-        / "versions"
-        / "0126_unique_rom_full_path.py"
-    )
+def _load_migration(filename: str) -> ModuleType:
+    """Import a revision by file name, which no package path can reach."""
+    path = Path(__file__).parent.parent / "alembic" / "versions" / filename
     spec = importlib.util.spec_from_file_location(path.stem, path)
     assert spec and spec.loader
     migration = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(migration)
 
+    return migration
+
+
+def _roms_indexes(connection: sa.Connection) -> dict[str, ReflectedIndex]:
+    return {
+        index["name"]: index for index in sa.inspect(connection).get_indexes("roms")
+    }
+
+
+def _roms_column(connection: sa.Connection, name: str) -> ReflectedColumn:
+    return next(
+        column
+        for column in sa.inspect(connection).get_columns("roms")
+        if column["name"] == name
+    )
+
+
+# MySQL/MariaDB auto-commit each DDL statement, so a run that dies partway keeps
+# what it created while the alembic version stays behind, and the next start
+# replays the revision over its own leftovers.
+@pytest.mark.parametrize(
+    "filename",
+    ["0126_unique_rom_full_path.py", "0128_hltb_main_story_column.py"],
+)
+def test_a_migration_replayed_over_a_migrated_schema_is_a_no_op(filename: str):
+    """Neither revision's ADD COLUMN fires again on a schema that has the column."""
+    migration = _load_migration(filename)
+
     with sync_engine.begin() as connection:
         with Operations.context(MigrationContext.configure(connection)):
             migration.upgrade()
 
-        indexes = {
-            index["name"]: index for index in sa.inspect(connection).get_indexes("roms")
-        }
+        indexes = _roms_indexes(connection)
 
+    assert indexes["idx_roms_platform_id_full_path_hash"]["unique"]
+    assert not indexes["idx_roms_platform_id_fs_name"]["unique"]
+    assert "idx_roms_hltb_main_story" in indexes
+
+
+def test_the_full_path_hash_migration_resumes_an_interrupted_run(rom: Rom):
+    """0126 finishes a run that died right after its ADD COLUMN.
+
+    The column survives the failure without a digest, a NOT NULL or either
+    index, which is the state a restart mid-backfill leaves behind.
+    """
+    migration = _load_migration("0126_unique_rom_full_path.py")
+
+    with sync_engine.begin() as connection:
+        with Operations.context(MigrationContext.configure(connection)) as operations:
+            migration.downgrade()
+            operations.add_column(
+                "roms",
+                sa.Column(
+                    migration.COLUMN_NAME, sa.String(length=FULL_PATH_HASH_LENGTH)
+                ),
+            )
+            migration.upgrade()
+
+        indexes = _roms_indexes(connection)
+        column = _roms_column(connection, migration.COLUMN_NAME)
+        digest = connection.execute(
+            sa.text("SELECT full_path_hash FROM roms WHERE id = :rom_id"),
+            {"rom_id": rom.id},
+        ).scalar_one()
+
+    assert not column["nullable"]
     assert indexes[migration.UNIQUE_INDEX_NAME]["unique"]
     assert not indexes[migration.LOOKUP_INDEX_NAME]["unique"]
+    assert digest == compute_full_path_hash(rom.fs_path, rom.fs_name)
+
+
+def test_the_hltb_migration_resumes_an_interrupted_run():
+    """0128 keeps the generated column it already added and builds its index."""
+    migration = _load_migration("0128_hltb_main_story_column.py")
+
+    with sync_engine.begin() as connection:
+        with Operations.context(MigrationContext.configure(connection)) as operations:
+            operations.drop_index(migration.INDEX_NAME, table_name="roms")
+            migration.upgrade()
+
+        indexes = _roms_indexes(connection)
+
+    assert migration.INDEX_NAME in indexes

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -4,10 +4,14 @@ The test database is built from the migrations, so an index declared in one but
 not the other goes unnoticed until autogenerate proposes dropping it.
 """
 
+import importlib.util
+from pathlib import Path
+
 import pytest
 import sqlalchemy as sa
 from alembic.autogenerate import compare_metadata
 from alembic.migration import MigrationContext
+from alembic.operations import Operations
 from sqlalchemy import Table, UniqueConstraint
 
 import models
@@ -84,9 +88,12 @@ def test_postgresql_fk_indexes_cover_every_unindexed_foreign_key():
         ("roms/nes/Hacks & Tra'nslations", "Zelda [T-Eng].nes"),
         ("roms/nes/Ünïcøde", "Pokémon Édition Rouge.gb"),
         ("", ""),
+        (None, None),
     ],
 )
-def test_the_migrated_full_path_digest_matches_the_models(fs_path: str, fs_name: str):
+def test_the_migrated_full_path_digest_matches_the_models(
+    fs_path: str | None, fs_name: str | None
+):
     """0126 backfills `full_path_hash` in SQL; the app writes it from Python.
 
     A mismatch would make every pre-existing rom look new to the unique index.
@@ -101,3 +108,33 @@ def test_the_migrated_full_path_digest_matches_the_models(fs_path: str, fs_name:
         ).scalar_one()
 
     assert digest == compute_full_path_hash(fs_path, fs_name)
+
+
+def test_the_full_path_hash_migration_survives_a_re_run():
+    """0126 replayed over a schema it already migrated is a no-op.
+
+    MySQL/MariaDB auto-commit each DDL statement, so a run that dies partway
+    keeps the column without advancing the alembic version, and every restart
+    after that replays the revision from the top.
+    """
+    path = (
+        Path(__file__).parent.parent
+        / "alembic"
+        / "versions"
+        / "0126_unique_rom_full_path.py"
+    )
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec and spec.loader
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+
+    with sync_engine.begin() as connection:
+        with Operations.context(MigrationContext.configure(connection)):
+            migration.upgrade()
+
+        indexes = {
+            index["name"]: index for index in sa.inspect(connection).get_indexes("roms")
+        }
+
+    assert indexes[migration.UNIQUE_INDEX_NAME]["unique"]
+    assert not indexes[migration.LOOKUP_INDEX_NAME]["unique"]

--- a/backend/utils/database.py
+++ b/backend/utils/database.py
@@ -81,9 +81,14 @@ def full_path_digest_sql(conn: sa.Connection) -> str:
 
     `test_migrations` pins this to the Python function it mirrors.
     """
+    # COALESCE because the Python side reads a NULL as "", while both dialects
+    # would fold the whole concatenation to NULL and fail 0126's NOT NULL step.
     if is_postgresql(conn):
-        return "encode(sha256(convert_to(fs_path || '/' || fs_name, 'UTF8')), 'hex')"
-    return "SHA2(CONCAT(fs_path, '/', fs_name), 256)"
+        return (
+            "encode(sha256(convert_to(COALESCE(fs_path, '') || '/' || "
+            "COALESCE(fs_name, ''), 'UTF8')), 'hex')"
+        )
+    return "SHA2(CONCAT(COALESCE(fs_path, ''), '/', COALESCE(fs_name, '')), 256)"
 
 
 def json_array_contains_value(


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Upgrading to the 5.3.0 alpha can fail on every start with:

```
sqlalchemy.exc.OperationalError: (mariadb.OperationalError) Duplicate column name 'full_path_hash'
[SQL: ALTER TABLE roms ADD COLUMN full_path_hash VARCHAR(64)]
```

That error is a symptom, not the cause. MariaDB and MySQL auto-commit each DDL statement, so a run of `0126_unique_rom_full_path` that dies after its `ADD COLUMN` (a container restart, a timeout on the whole-table backfill, or a failure on the `NOT NULL` alter or either index) keeps the column while `alembic_version` stays at `0125`. Every start after that replays `0126` from the top and dies on the first statement, which hides whatever actually stopped the upgrade. The init script logs the failure and starts the app anyway, so the instance keeps running on a half-migrated schema.

`0127` was already written against this hazard ("MySQL/MariaDB auto-commit each DDL statement, so a crash mid-migration leaves objects behind without advancing the alembic version"); `0126` and `0128` were not.

- `0126` now reflects the `roms` schema first and guards each step: add the column only if it is absent, backfill only the rows still missing a digest, apply `NOT NULL` only while the column is nullable, and rebuild `idx_roms_platform_id_fs_name` only while it is still unique. A replay resumes where the previous run stopped, so an interrupted upgrade recovers on the next start and, if the original failure was a real one, it surfaces its own error instead of the duplicate-column one.
- `0128` adds `generated_hltb_main_story` the same unguarded way, so it gets the same column guard.
- `full_path_digest_sql` now coalesces a NULL `fs_path`/`fs_name`, matching `compute_full_path_hash`. Both columns are declared NOT NULL, but where the two spellings disagreed the SQL folded the whole row to NULL and the backfill would abort `0126` at the `NOT NULL` step, which is exactly how a database ends up in the state above.

Both migrations were already applied in an alpha, so their revision ids are unchanged: an install that got through them sees no-ops, and an install stuck mid-`0126` completes it.

AI assistance disclosure, per `CONTRIBUTING.md`: this change was written with Claude Code (diagnosis, patch, tests and this description), reviewed before submission.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Three tests in `backend/tests/test_migrations.py`, all passing under `pytest (mariadb)` and `pytest (postgresql)`:

- `test_a_migration_replayed_over_a_migrated_schema_is_a_no_op`, parametrized over `0126` and `0128` — the replay that produces the duplicate-column error today.
- `test_the_full_path_hash_migration_resumes_an_interrupted_run` builds the real intermediate state (downgrade, then re-add the bare column): column present with no digest, no `NOT NULL`, neither index rebuilt. Asserts the replay completes all three and backfills the digest the model computes in Python.
- `test_the_hltb_migration_resumes_an_interrupted_run` drops `0128`'s index, keeps the generated column, and asserts the replay restores it.

Plus a NULL case on the existing digest parity test.

The migration chain itself is exercised end to end by `migrate-mariadb` (10.11.19 and 12.3.3, `utf8mb4_general_ci` and `utf8mb3_unicode_ci`) and `migrate-postgres`, all green.

#### Screenshots (if applicable)

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRP83vJP7Cws6SSdE3XZ1a