### PR TITLE
fix(tasks): fill the scan counters a job's stored stats predate

### DIFF
--- a/backend/endpoints/responses/__init__.py
+++ b/backend/endpoints/responses/__init__.py
@@ -1,4 +1,4 @@
-from typing import Literal, TypedDict, Union
+from typing import Any, Final, Literal, Mapping, TypedDict, Union, cast
 
 from rq.job import JobStatus
 
@@ -18,6 +18,27 @@ class ScanStats(TypedDict):
     new_firmware: int
     updated_roms: int
     new_files: int
+
+
+# Read off the annotations so a counter added here is filled without a second
+# edit, which is the step the release that added `updated_roms` and `new_files`
+# missed.
+EMPTY_SCAN_STATS: Final[ScanStats] = cast(
+    ScanStats, dict.fromkeys(ScanStats.__annotations__, 0)
+)
+
+
+def fill_scan_stats(stats: Mapping[str, Any] | None) -> ScanStats | None:
+    """A scan's counters, with any the release that wrote them predates zeroed.
+
+    A job's meta outlives the release that stored it in Redis, so an upgrade
+    leaves stats behind that are missing every counter added since. Zero is what
+    a run that never counted one reported.
+    """
+    if stats is None:
+        return None
+
+    return cast(ScanStats, {**EMPTY_SCAN_STATS, **stats})
 
 
 class ScanTaskMeta(TypedDict):

--- a/backend/endpoints/responses/__init__.py
+++ b/backend/endpoints/responses/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Final, Literal, Mapping, TypedDict, Union, cast
+from typing import Literal, TypedDict, Union
 
 from rq.job import JobStatus
 
@@ -18,23 +18,6 @@ class ScanStats(TypedDict):
     new_firmware: int
     updated_roms: int
     new_files: int
-
-
-# Read off the annotations so a counter added here is filled without a second edit.
-EMPTY_SCAN_STATS: Final[ScanStats] = cast(
-    ScanStats, dict.fromkeys(ScanStats.__annotations__, 0)
-)
-
-
-def fill_scan_stats(stats: Mapping[str, Any] | None) -> ScanStats | None:
-    """A scan's counters, zeroing any the release that stored them predates.
-
-    A job's meta in Redis outlives the release that wrote it.
-    """
-    if stats is None:
-        return None
-
-    return cast(ScanStats, {**EMPTY_SCAN_STATS, **stats})
 
 
 class ScanTaskMeta(TypedDict):

--- a/backend/endpoints/responses/__init__.py
+++ b/backend/endpoints/responses/__init__.py
@@ -20,20 +20,16 @@ class ScanStats(TypedDict):
     new_files: int
 
 
-# Read off the annotations so a counter added here is filled without a second
-# edit, which is the step the release that added `updated_roms` and `new_files`
-# missed.
+# Read off the annotations so a counter added here is filled without a second edit.
 EMPTY_SCAN_STATS: Final[ScanStats] = cast(
     ScanStats, dict.fromkeys(ScanStats.__annotations__, 0)
 )
 
 
 def fill_scan_stats(stats: Mapping[str, Any] | None) -> ScanStats | None:
-    """A scan's counters, with any the release that wrote them predates zeroed.
+    """A scan's counters, zeroing any the release that stored them predates.
 
-    A job's meta outlives the release that stored it in Redis, so an upgrade
-    leaves stats behind that are missing every counter added since. Zero is what
-    a run that never counted one reported.
+    A job's meta in Redis outlives the release that wrote it.
     """
     if stats is None:
         return None

--- a/backend/endpoints/tasks.py
+++ b/backend/endpoints/tasks.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Any, Final
+from typing import Any, Final, Mapping, cast
 
 from fastapi import Body, HTTPException, Request
 from rq import Worker
@@ -13,13 +13,13 @@ from endpoints.responses import (
     CleanupTaskStatusResponse,
     ConversionTaskStatusResponse,
     GenericTaskStatusResponse,
+    ScanStats,
     ScanTaskStatusResponse,
     SyncTaskStatusResponse,
     TaskExecutionResponse,
     TaskStatusResponse,
     UpdateTaskStatusResponse,
     WatcherTaskStatusResponse,
-    fill_scan_stats,
 )
 from endpoints.responses.tasks import GroupedTasksDict, TaskInfo
 from handler.auth.constants import Scope
@@ -69,6 +69,23 @@ def _build_task_info(name: str, task: Task) -> TaskInfo:
     )
 
 
+# Read off the annotations so a counter added there is filled without a second edit.
+_EMPTY_SCAN_STATS: Final[ScanStats] = cast(
+    ScanStats, dict.fromkeys(ScanStats.__annotations__, 0)
+)
+
+
+def _fill_scan_stats(stats: Mapping[str, Any] | None) -> ScanStats | None:
+    """A scan's counters, zeroing any the release that stored them predates.
+
+    A job's meta in Redis outlives the release that wrote it.
+    """
+    if stats is None:
+        return None
+
+    return cast(ScanStats, {**_EMPTY_SCAN_STATS, **stats})
+
+
 def _build_task_status_response(
     job: Job,
 ) -> TaskStatusResponse:
@@ -105,7 +122,7 @@ def _build_task_status_response(
         case TaskType.SCAN:
             return ScanTaskStatusResponse(
                 task_type=TaskType.SCAN,
-                meta={"scan_stats": fill_scan_stats(job_meta.get("scan_stats"))},
+                meta={"scan_stats": _fill_scan_stats(job_meta.get("scan_stats"))},
                 **common_data,  # trunk-ignore(mypy/typeddict-item)
             )
         case TaskType.CONVERSION:

--- a/backend/endpoints/tasks.py
+++ b/backend/endpoints/tasks.py
@@ -76,7 +76,7 @@ _EMPTY_SCAN_STATS: Final[ScanStats] = cast(
 
 
 def _fill_scan_stats(stats: Mapping[str, Any] | None) -> ScanStats | None:
-    """A scan's counters, zeroing any the release that stored them predates.
+    """Zero the counters an older release's stored stats are missing.
 
     A job's meta in Redis outlives the release that wrote it.
     """

--- a/backend/endpoints/tasks.py
+++ b/backend/endpoints/tasks.py
@@ -19,6 +19,7 @@ from endpoints.responses import (
     TaskStatusResponse,
     UpdateTaskStatusResponse,
     WatcherTaskStatusResponse,
+    fill_scan_stats,
 )
 from endpoints.responses.tasks import GroupedTasksDict, TaskInfo
 from handler.auth.constants import Scope
@@ -104,7 +105,7 @@ def _build_task_status_response(
         case TaskType.SCAN:
             return ScanTaskStatusResponse(
                 task_type=TaskType.SCAN,
-                meta={"scan_stats": job_meta.get("scan_stats")},
+                meta={"scan_stats": fill_scan_stats(job_meta.get("scan_stats"))},
                 **common_data,  # trunk-ignore(mypy/typeddict-item)
             )
         case TaskType.CONVERSION:

--- a/backend/tests/endpoints/test_tasks.py
+++ b/backend/tests/endpoints/test_tasks.py
@@ -14,6 +14,8 @@ def _job_with_meta(meta: dict[str, Any]) -> Mock:
     job = Mock()
     job.id = "test-job-id-123"
     job.kwargs = {}
+    # What the response falls back to when the meta carries no task name.
+    job.func_name = "test_task"
     job.get_meta.return_value = {"task_type": TaskType.CLEANUP, **meta}
     job.get_status.return_value = "finished"
     for attr in ("created_at", "enqueued_at", "started_at", "ended_at"):

--- a/backend/tests/endpoints/test_tasks.py
+++ b/backend/tests/endpoints/test_tasks.py
@@ -470,6 +470,60 @@ class TestGetTaskById:
         assert response.json()["task_key"] == "cleanup_zip_cache"
 
     @patch("endpoints.tasks.Job.fetch")
+    def test_a_scan_predating_a_counter_reports_it_as_zero(
+        self, mock_job_fetch, client, access_token
+    ):
+        """Stats written to Redis by an older release lack the counters it predates.
+
+        The response requires every counter, so such a job used to fail the
+        whole listing rather than report the run it belongs to.
+        """
+        mock_job_fetch.return_value = _job_with_meta(
+            {
+                "task_type": TaskType.SCAN,
+                # The shape 5.2.0 stored, which had neither counter.
+                "scan_stats": {
+                    "total_platforms": 1,
+                    "total_roms": 819,
+                    "scanned_platforms": 1,
+                    "new_platforms": 1,
+                    "identified_platforms": 1,
+                    "scanned_roms": 378,
+                    "new_roms": 378,
+                    "identified_roms": 378,
+                    "scanned_firmware": 0,
+                    "new_firmware": 0,
+                },
+            }
+        )
+
+        response = client.get(
+            "/api/tasks/test-job-id-123",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        scan_stats = response.json()["meta"]["scan_stats"]
+        assert scan_stats["updated_roms"] == 0
+        assert scan_stats["new_files"] == 0
+        assert scan_stats["scanned_roms"] == 378
+
+    @patch("endpoints.tasks.Job.fetch")
+    def test_a_scan_that_never_reported_stats_keeps_none(
+        self, mock_job_fetch, client, access_token
+    ):
+        """A queued scan has no counters yet, which is not the same as zeroes."""
+        mock_job_fetch.return_value = _job_with_meta({"task_type": TaskType.SCAN})
+
+        response = client.get(
+            "/api/tasks/test-job-id-123",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["meta"]["scan_stats"] is None
+
+    @patch("endpoints.tasks.Job.fetch")
     def test_get_task_by_id_not_found(self, mock_job_fetch, client, access_token):
         """Test retrieval of a non-existent task by job ID"""
         mock_job_fetch.side_effect = Exception("Job not found")

--- a/backend/tests/endpoints/test_tasks.py
+++ b/backend/tests/endpoints/test_tasks.py
@@ -475,11 +475,7 @@ class TestGetTaskById:
     def test_a_scan_predating_a_counter_reports_it_as_zero(
         self, mock_job_fetch, client, access_token
     ):
-        """Stats written to Redis by an older release lack the counters it predates.
-
-        The response requires every counter, so such a job used to fail the
-        whole listing rather than report the run it belongs to.
-        """
+        """Stats stored by an older release lack the counters it predates."""
         mock_job_fetch.return_value = _job_with_meta(
             {
                 "task_type": TaskType.SCAN,


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Upgrading from 5.2.x with any scan in the task history breaks the Tasks view entirely:

```
{'type': 'missing', 'loc': ('response', 15, 'ScanTaskStatusResponse', 'meta', 'scan_stats', 'updated_roms'), 'msg': 'Field required',
 'input': {'total_platforms': 1, 'total_roms': 819, 'scanned_platforms': 1, 'new_platforms': 1, 'identified_platforms': 1,
           'scanned_roms': 378, 'new_roms': 378, 'identified_roms': 378, 'scanned_firmware': 0, 'new_firmware': 0}}
{'type': 'missing', 'loc': ('response', 15, 'ScanTaskStatusResponse', 'meta', 'scan_stats', 'new_files'), 'msg': 'Field required', ...}
```

That `input` is 5.2.0's `ScanStats`, exactly: ten keys, ending at `new_firmware`. 5.3.0 added `updated_roms` and `new_files` to the TypedDict as required fields, but RQ keeps each job's meta in Redis, which survives the upgrade in the `romm_redis_data` volume. `_build_task_status_response` passes that stored dict straight to the response model:

```python
meta={"scan_stats": job_meta.get("scan_stats")},
```

so one pre-upgrade scan fails validation. And since `get_tasks_status` returns a list, the failure takes out the whole response rather than the row it belongs to: the Tasks page shows nothing at all, for as long as that job stays in the finished/failed registry.

The other stats types (`ConversionStats`, `UpdateStats`, `CleanupStats`) did not change and are not affected today, but the hazard is the same shape for any of them.

**Approach.** Fill the missing counters when reading, rather than making the fields `NotRequired`. Optional fields would propagate into `frontend/src/__generated__/` and force every consumer to handle `undefined` for a value that is always present on new scans; filling keeps the API contract and the generated types exactly as they are, and needs no `npm run generate`. Zero is the honest value: a run on a release that never counted `new_files` did not find any it recorded.

The baseline is derived from `ScanStats.__annotations__` rather than hand-listed, so the next counter added to the TypedDict is covered without a second edit. That second edit is precisely what the release that added these two fields missed.

Stats a job has not reported yet stay `None`, which the UI distinguishes from a scan that counted zero.

For anyone hitting this before the fix ships, the workaround is to drop RQ's keys from Redis (`valkey-cli --scan --pattern 'rq:*' | xargs -r -n 100 valkey-cli DEL`), which costs the task history but leaves sessions signed in.

AI assistance disclosure, per `CONTRIBUTING.md`: this change was written with Claude Code (diagnosis, patch, tests and this description), reviewed before submission.

**Checklist**
<sup>Please check all that apply.</sup>

- [ ] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

Two tests in `backend/tests/endpoints/test_tasks.py`:

- `test_a_scan_predating_a_counter_reports_it_as_zero` feeds the endpoint the exact ten-key payload above and asserts a 200 with `updated_roms`/`new_files` zeroed and the counters that were stored preserved.
- `test_a_scan_that_never_reported_stats_keeps_none` pins the null case, so the fill never invents a zeroed stats block for a queued scan.

Not verified locally: no MariaDB/PostgreSQL or Python 3.14 in the environment this was written in, so the suite runs in CI. `black`, `ruff` and `isort` are clean, and the fill was exercised against the payload from the report.

#### Screenshots (if applicable)

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRP83vJP7Cws6SSdE3XZ1a

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRP83vJP7Cws6SSdE3XZ1a)_