### PR TITLE
fix(migrations): let the revisions that add columns be replayed

### DIFF
--- a/backend/alembic/versions/0098_generated_metadata_columns.py
+++ b/backend/alembic/versions/0098_generated_metadata_columns.py
@@ -34,7 +34,7 @@ Create Date: 2026-07-19 00:00:00.000000
 import sqlalchemy as sa
 from alembic import op  # type: ignore[attr-defined]
 
-from utils.database import is_postgresql
+from utils.database import has_column, is_postgresql
 
 # revision identifiers, used by Alembic.
 revision = "0098_generated_metadata_columns"
@@ -468,14 +468,22 @@ def upgrade() -> None:
     else:
         columns = _mysql_columns()
 
-    adds = ",\n".join(
-        f"ADD COLUMN {name} {type_} GENERATED ALWAYS AS ({expr}) STORED"
+    missing = [
+        (name, type_, expr)
         for name, type_, expr in columns
-    )
-    op.execute(f"ALTER TABLE roms\n{adds}")  # nosec B608
+        if not has_column(connection, "roms", name)
+    ]
+    if missing:
+        adds = ",\n".join(
+            f"ADD COLUMN {name} {type_} GENERATED ALWAYS AS ({expr}) STORED"
+            for name, type_, expr in missing
+        )
+        op.execute(f"ALTER TABLE roms\n{adds}")  # nosec B608
 
+    existing = {index["name"] for index in sa.inspect(connection).get_indexes("roms")}
     for col in _INDEXED_COLUMNS:
-        op.create_index(f"idx_roms_{col}", "roms", [col])
+        if f"idx_roms_{col}" not in existing:
+            op.create_index(f"idx_roms_{col}", "roms", [col])
 
     op.execute(_thin_view_sql(pg))
 

--- a/backend/alembic/versions/0108_roms_primary_region.py
+++ b/backend/alembic/versions/0108_roms_primary_region.py
@@ -31,7 +31,7 @@ Create Date: 2026-08-21 00:00:00.000000
 
 from alembic import op  # type: ignore[attr-defined]
 
-from utils.database import is_postgresql
+from utils.database import has_column, is_postgresql
 
 # revision identifiers, used by Alembic.
 revision = "0108_roms_primary_region"
@@ -74,11 +74,14 @@ def _rebuild_index(columns: list[str]) -> None:
 
 
 def upgrade() -> None:
-    expr = _POSTGRES_EXPR if is_postgresql(op.get_bind()) else _MARIA_EXPR
-    op.execute(
-        f"ALTER TABLE roms ADD COLUMN {COLUMN_NAME} VARCHAR({COLUMN_LENGTH}) "  # nosec B608
-        f"GENERATED ALWAYS AS ({expr}) STORED"
-    )
+    connection = op.get_bind()
+    if not has_column(connection, "roms", COLUMN_NAME):
+        expr = _POSTGRES_EXPR if is_postgresql(connection) else _MARIA_EXPR
+        op.execute(
+            f"ALTER TABLE roms ADD COLUMN {COLUMN_NAME} VARCHAR({COLUMN_LENGTH}) "  # nosec B608
+            f"GENERATED ALWAYS AS ({expr}) STORED"
+        )
+
     _rebuild_index(NEW_INDEX_COLUMNS)
 
 

--- a/backend/alembic/versions/0111_physical_roms.py
+++ b/backend/alembic/versions/0111_physical_roms.py
@@ -9,6 +9,8 @@ Create Date: 2026-07-04 00:00:00.000000
 import sqlalchemy as sa
 from alembic import op
 
+from utils.database import has_column
+
 # revision identifiers, used by Alembic.
 revision = "0111_physical_roms"
 down_revision = "0110_walkthrough_docs"
@@ -17,16 +19,22 @@ depends_on = None
 
 
 def upgrade() -> None:
+    connection = op.get_bind()
+
+    # A batch emits one ALTER per column on MySQL/MariaDB, so the second can
+    # fail with the first already committed.
     with op.batch_alter_table("roms", schema=None) as batch_op:
-        batch_op.add_column(
-            sa.Column(
-                "is_physical",
-                sa.Boolean(),
-                nullable=False,
-                server_default=sa.false(),
+        if not has_column(connection, "roms", "is_physical"):
+            batch_op.add_column(
+                sa.Column(
+                    "is_physical",
+                    sa.Boolean(),
+                    nullable=False,
+                    server_default=sa.false(),
+                )
             )
-        )
-        batch_op.add_column(sa.Column("upc", sa.String(length=64), nullable=True))
+        if not has_column(connection, "roms", "upc"):
+            batch_op.add_column(sa.Column("upc", sa.String(length=64), nullable=True))
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/0112_publisher_developer_split.py
+++ b/backend/alembic/versions/0112_publisher_developer_split.py
@@ -24,7 +24,7 @@ Create Date: 2026-07-23 00:00:00.000000
 import sqlalchemy as sa
 from alembic import op  # type: ignore[attr-defined]
 
-from utils.database import CustomJSON, is_postgresql
+from utils.database import CustomJSON, has_column, is_postgresql
 
 # revision identifiers, used by Alembic.
 revision = "0112_publisher_developer_split"
@@ -72,11 +72,20 @@ def _postgres_array_expr(key: str) -> str:
 
 
 def _add_generated_columns(pg: bool) -> None:
+    connection = op.get_bind()
+    missing = [
+        (name, key)
+        for name, key in _NEW_GENERATED
+        if not has_column(connection, "roms", name)
+    ]
+    if not missing:
+        return
+
     json_type = "JSONB" if pg else "JSON"
     expr = _postgres_array_expr if pg else _maria_array_expr
     adds = ",\n".join(
         f"ADD COLUMN {name} {json_type} GENERATED ALWAYS AS ({expr(key)}) STORED"
-        for name, key in _NEW_GENERATED
+        for name, key in missing
     )
     op.execute(f"ALTER TABLE roms\n{adds}")  # nosec B608
 
@@ -380,8 +389,9 @@ def upgrade() -> None:
     _add_generated_columns(pg)
     _rebuild_roms_metadata_view(pg, include_new=True)
 
-    op.add_column("roms_facets", sa.Column("publishers", CustomJSON(), nullable=True))
-    op.add_column("roms_facets", sa.Column("developers", CustomJSON(), nullable=True))
+    for facet in ("publishers", "developers"):
+        if not has_column(op.get_bind(), "roms_facets", facet):
+            op.add_column("roms_facets", sa.Column(facet, CustomJSON(), nullable=True))
     _rebuild_facets_triggers(pg, include_new=True)
     _rebuild_vc_triggers(pg, _VC_ALL_TYPES)
 

--- a/backend/alembic/versions/0121_state_disc_file.py
+++ b/backend/alembic/versions/0121_state_disc_file.py
@@ -9,6 +9,8 @@ Create Date: 2026-08-14 00:00:00.000000
 import sqlalchemy as sa
 from alembic import op
 
+from utils.database import has_column
+
 # revision identifiers, used by Alembic.
 revision = "0121_state_disc_file"
 down_revision = "0120_container_adoptions"
@@ -17,18 +19,26 @@ depends_on = None
 
 
 def upgrade() -> None:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    # No `has_foreign_key` to match `has_index`, so this one is reflected by hand.
+    foreign_keys = {key["name"] for key in inspector.get_foreign_keys("states")}
+
     with op.batch_alter_table("states", schema=None) as batch_op:
-        batch_op.add_column(sa.Column("disc_file_id", sa.Integer(), nullable=True))
+        if not has_column(connection, "states", "disc_file_id"):
+            batch_op.add_column(sa.Column("disc_file_id", sa.Integer(), nullable=True))
         # Postgres indexes no FK column on its own, and the SET NULL cascade
         # scans this on every rom_files delete.
-        batch_op.create_index("ix_states_disc_file_id", ["disc_file_id"])
-        batch_op.create_foreign_key(
-            "fk_states_disc_file_id",
-            "rom_files",
-            ["disc_file_id"],
-            ["id"],
-            ondelete="SET NULL",
-        )
+        if not inspector.has_index("states", "ix_states_disc_file_id"):
+            batch_op.create_index("ix_states_disc_file_id", ["disc_file_id"])
+        if "fk_states_disc_file_id" not in foreign_keys:
+            batch_op.create_foreign_key(
+                "fk_states_disc_file_id",
+                "rom_files",
+                ["disc_file_id"],
+                ["id"],
+                ondelete="SET NULL",
+            )
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/0123_recommendation_metadata.py
+++ b/backend/alembic/versions/0123_recommendation_metadata.py
@@ -36,7 +36,7 @@ Create Date: 2026-08-08 00:00:00.000000
 import sqlalchemy as sa
 from alembic import op  # type: ignore[attr-defined]
 
-from utils.database import CustomJSON, is_postgresql
+from utils.database import CustomJSON, has_column, is_postgresql
 
 # revision identifiers, used by Alembic.
 revision = "0123_recommendation_metadata"
@@ -625,7 +625,8 @@ def _refresh_steam_collections(pg: bool) -> None:
 
 
 def upgrade() -> None:
-    pg = is_postgresql(op.get_bind())
+    connection = op.get_bind()
+    pg = is_postgresql(connection)
 
     _rebuild_columns(
         pg,
@@ -636,7 +637,8 @@ def upgrade() -> None:
     )
 
     for _, facet in _TAG_COLUMNS:
-        op.add_column("roms_facets", sa.Column(facet, CustomJSON(), nullable=True))
+        if not has_column(connection, "roms_facets", facet):
+            op.add_column("roms_facets", sa.Column(facet, CustomJSON(), nullable=True))
 
     _sync_facets(pg, _FACET_COLUMNS)
     _rebuild_triggers(pg, _MIRRORED_COLUMNS)

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -4,10 +4,15 @@ The test database is built from the migrations, so an index declared in one but
 not the other goes unnoticed until autogenerate proposes dropping it.
 """
 
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
 import pytest
 import sqlalchemy as sa
 from alembic.autogenerate import compare_metadata
 from alembic.migration import MigrationContext
+from alembic.operations import Operations
 from sqlalchemy import Table, UniqueConstraint
 
 import models
@@ -18,6 +23,8 @@ from utils.database import (
     AUTOGENERATE_EXEMPT_INDEX_NAMES,
     POSTGRESQL_FK_INDEXES,
     full_path_digest_sql,
+    has_column,
+    is_postgresql,
 )
 
 # `compare_metadata` yields flat tuples for schema-level diffs, and a list of
@@ -101,3 +108,66 @@ def test_the_migrated_full_path_digest_matches_the_models(fs_path: str, fs_name:
         ).scalar_one()
 
     assert digest == compute_full_path_hash(fs_path, fs_name)
+
+
+def _load_migration(filename: str) -> ModuleType:
+    """Import a revision by file name, which no package path can reach."""
+    path = Path(__file__).parent.parent / "alembic" / "versions" / filename
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec and spec.loader
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+
+    return migration
+
+
+@pytest.mark.parametrize(
+    "table,column,expected",
+    [
+        ("roms", "generated_publishers", True),
+        ("roms_facets", "developers", True),
+        ("states", "disc_file_id", True),
+        ("roms", "no_such_column", False),
+    ],
+)
+def test_has_column_reflects_the_migrated_schema(
+    table: str, column: str, expected: bool
+):
+    """The guard every replayed column add is skipped by."""
+    with sync_engine.connect() as connection:
+        assert has_column(connection, table, column) is expected
+
+
+def test_the_publisher_split_column_add_replays():
+    """0112's generated columns are added once, however often it runs.
+
+    A run that dies on its trigger DDL (error 1419 on a binlog-enabled server
+    without SUPER) leaves these committed, and the replay used to die on the
+    duplicate column rather than resuming at the triggers.
+    """
+    migration = _load_migration("0112_publisher_developer_split.py")
+
+    with sync_engine.begin() as connection:
+        with Operations.context(MigrationContext.configure(connection)):
+            migration._add_generated_columns(is_postgresql(connection))
+
+        assert has_column(connection, "roms", "generated_publishers")
+        assert has_column(connection, "roms", "generated_developers")
+
+
+def test_the_state_disc_file_migration_replays():
+    """0121 touches only its own column, index and foreign key, so it replays whole."""
+    migration = _load_migration("0121_state_disc_file.py")
+
+    with sync_engine.begin() as connection:
+        with Operations.context(MigrationContext.configure(connection)):
+            migration.upgrade()
+
+        inspector = sa.inspect(connection)
+        column = has_column(connection, "states", "disc_file_id")
+        index = inspector.has_index("states", "ix_states_disc_file_id")
+        foreign_keys = {key["name"] for key in inspector.get_foreign_keys("states")}
+
+    assert column
+    assert index
+    assert "fk_states_disc_file_id" in foreign_keys

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -155,12 +155,30 @@ def test_the_publisher_split_column_add_replays():
         assert has_column(connection, "roms", "generated_developers")
 
 
-def test_the_state_disc_file_migration_replays():
-    """0121 touches only its own column, index and foreign key, so it replays whole."""
+@pytest.mark.parametrize(
+    "drop_column",
+    [False, True],
+    ids=["died before the index", "died before the column"],
+)
+def test_the_state_disc_file_migration_resumes_an_interrupted_run(drop_column: bool):
+    """0121 completes whatever a run that died partway left behind.
+
+    Nothing else in the schema references these, so the interrupted states can
+    be built for real: the foreign key and index missing, or all three.
+    """
     migration = _load_migration("0121_state_disc_file.py")
 
     with sync_engine.begin() as connection:
-        with Operations.context(MigrationContext.configure(connection)):
+        with Operations.context(MigrationContext.configure(connection)) as operations:
+            # The foreign key goes first: MariaDB refuses to drop a column it
+            # still needs, and an index it still sits on.
+            operations.drop_constraint(
+                "fk_states_disc_file_id", "states", type_="foreignkey"
+            )
+            operations.drop_index("ix_states_disc_file_id", table_name="states")
+            if drop_column:
+                operations.drop_column("states", "disc_file_id")
+
             migration.upgrade()
 
         inspector = sa.inspect(connection)

--- a/backend/utils/database.py
+++ b/backend/utils/database.py
@@ -76,6 +76,22 @@ def is_mariadb(conn: sa.Connection, min_version: tuple[int, ...] | None = None) 
     return is_db_version_compatible(conn, min_version=min_version)
 
 
+def has_column(conn: sa.Connection, table: str, column: str) -> bool:
+    """Whether `table` already carries `column`, which `Inspector` cannot answer.
+
+    Args:
+        conn: Connection to reflect through.
+        table: Table to look in.
+        column: Column to look for.
+
+    Returns:
+        True when a replayed revision should skip adding it.
+    """
+    return any(
+        reflected["name"] == column for reflected in sa.inspect(conn).get_columns(table)
+    )
+
+
 def full_path_digest_sql(conn: sa.Connection) -> str:
     """`models.rom.compute_full_path_hash` spelled in SQL, for 0126's backfill.
 


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

MySQL and MariaDB auto-commit each DDL statement, so a revision that dies after adding a column keeps the column while `alembic_version` stays behind. The next start replays the revision and dies on a duplicate column — an error that says nothing about what actually stopped the upgrade, and that no amount of fixing the real cause will clear.

**`0112_publisher_developer_split` and `0123_recommendation_metadata` are the ones that matter**, because their failure mode isn't hypothetical:

1. Each adds columns — four in `0112`, three `roms_facets` tag columns in `0123` — with no guard.
2. Each then creates triggers. On a server with binary logging enabled where the app user lacks `SUPER`/`BINLOG ADMIN` and `log_bin_trust_function_creators` is off, MariaDB refuses all trigger DDL with error 1419 — including the `DROP TRIGGER IF EXISTS`. This is [#3932](https://github.com/rommapp/romm/issues/3932), reported against `0100`, closed with the remedy (`SET GLOBAL log_bin_trust_function_creators = 1`, or grant `BINLOG ADMIN`).
3. So an affected user hits 1419, applies exactly that remedy, restarts — and is met by `Duplicate column name 'generated_publishers'` (or `'keywords'`), with nothing to indicate their privilege fix worked.

Everything in both revisions from the triggers onward was already idempotent (`DROP TRIGGER IF EXISTS` + `CREATE`, `INSERT IGNORE` / `ON CONFLICT DO NOTHING`). The only non-idempotent statements are the column adds, and they run first — ahead of the step most likely to fail.

**What's guarded here**

| Revision | Guarded | Why it can strand |
|---|---|---|
| `0112` | two generated columns on `roms`, two on `roms_facets` | trigger rebuild follows |
| `0123` | three `roms_facets` tag columns | backfill, trigger rebuild and Steam refresh follow |
| `0098` | the generated-column `ALTER`, plus the `create_index` loop after it | indexes follow; its view already uses `CREATE OR REPLACE` |
| `0108` | the generated column | index rebuild follows (already idempotent itself) |
| `0121` | the column, its index, and its foreign key | three separate statements |
| `0111` | both columns | a batch emits one `ALTER` per column, so the second can fail with the first committed |

`0116` needed nothing — it has used `add_column(..., if_not_exists=True)` from the start.

**Residual, stated honestly.** Several older revisions still add a column with nothing after it. Their only window is between the auto-committed DDL and alembic's version-row write — real, but microseconds wide, against `0112`/`0123` where the following statement fails reliably on a whole class of servers. I have not churned those here. The systematic answer is a convention that every revision be replay-safe plus a test that enforces it, which belongs in its own change.

**On the helper.** `has_column` is new in `utils/database.py` because SQLAlchemy's `Inspector` offers `has_table`, `has_index`, `has_schema` and `has_sequence` but no column equivalent (checked against 2.0.52), and Alembic's `Operations` has none either. Where the library *does* provide one, this uses it — `0121` calls `inspector.has_index`.

**Why not `op.add_column(..., if_not_exists=True)` instead of reflecting?** Two reasons, neither of which is "it can't express these columns" — `sa.Computed(expr, persisted=True)` renders `GENERATED ALWAYS AS (...) STORED` on both dialects, so in principle it could:

- It renders `ADD COLUMN IF NOT EXISTS`, which MariaDB and PostgreSQL accept and **MySQL 8 does not** — narrowing a dialect this project claims support for, on the very revisions meant to make recovery universal.
- `op.add_column` emits one `ALTER` per column. `0098` and `0112` add their generated columns in a single batched `ALTER` on purpose: "Each STORED generated column costs a full table rebuild, so they are batched" (`0123`, `_swap_generated_columns`). Converting them would turn one rebuild of `roms` into several.

Reflecting first keeps the emitted DDL of these already-shipped revisions byte-identical and works on every dialect.

**Not addressed here:** the privilege prerequisite itself. Nothing in this repo documents that trigger-creating revisions need `log_bin_trust_function_creators=1` or `BINLOG ADMIN` on binlog-enabled servers; a user asked for quickstart notes on #3932 and got no follow-up. That's a docs change, or a pre-flight check that fails with a message naming the flag, and it's a design call rather than a bug fix — happy to do either on request.

AI assistance disclosure, per `CONTRIBUTING.md`: this change was written with Claude Code (diagnosis, patch, tests and this description), reviewed before submission.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

In `backend/tests/test_migrations.py`:

- `test_has_column_reflects_the_migrated_schema` pins the shared guard against the live schema, present and absent.
- `test_the_state_disc_file_migration_resumes_an_interrupted_run` builds two real interrupted states for `0121` — foreign key and index dropped with the column left behind, and all three dropped — and asserts the replay rebuilds each.
- `test_the_publisher_split_column_add_replays` calls `0112`'s `_add_generated_columns` against a schema that already has the columns.

The chain itself is exercised end to end by `migrate-mariadb` (10.11.19 and 12.3.3, `utf8mb4_general_ci` and `utf8mb3_unicode_ci`) and `migrate-postgres` — so guarding six already-shipped revisions did not change what a fresh install builds.

**A deliberate limit worth reviewing:** `0098`, `0108`, `0112` and `0123` are *not* replayed whole, and their partial states are not carved out of the session database. Each rebuilds a shared object at its own era's definition — `roms_metadata`, the facets triggers, or `idx_roms_sibling_cover`, which `0127` has since rebuilt with `steam_id` — so a replay against a head schema would regress that object for every later test in the xdist worker. Dropping one of their columns to simulate a partial state has the same problem: PostgreSQL refuses while a view depends on it, MariaDB allows it and leaves the view and triggers pointing at a missing column. Covering those branches honestly needs a schema fixture isolated from the session database, serving all four together.

**Overlaps [#4479](https://github.com/rommapp/romm/pull/4479)**, which fixes the same class of bug in `0126`/`0128` and adds an identical `_load_migration` helper to the same test file. Whichever lands second needs a small merge: keep one copy of that helper, and point `0128`'s inline column check at `has_column`. I'll handle it.

#### Screenshots (if applicable)

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRP83vJP7Cws6SSdE3XZ1a