### PR TITLE
fix(v2): dismiss tooltips when an overlay opens over them

### DIFF
--- a/frontend/src/v2/lib/menus/RMenu/RMenu.vue
+++ b/frontend/src/v2/lib/menus/RMenu/RMenu.vue
@@ -329,6 +329,10 @@ watch(
     if (open) pushEscapable(escEntry);
     else popEscapable(escEntry);
   },
+  // `immediate: true` so a menu that mounts already open registers too, the
+  // same reason RDialog does it: otherwise the watch never sees the initial
+  // `true` and Esc, gamepad-back and tooltip suppression all miss the panel.
+  { immediate: true },
 );
 
 onMounted(() => {

--- a/frontend/src/v2/lib/menus/RMenu/RMenu.vue
+++ b/frontend/src/v2/lib/menus/RMenu/RMenu.vue
@@ -320,6 +320,7 @@ function onDocPointerDown(evt: PointerEvent) {
 const escEntry: EscapableEntry = {
   close: () => close(),
   persistent: false,
+  panel: () => panelRef.value,
 };
 
 watch(

--- a/frontend/src/v2/lib/overlays/RDialog/RDialog.vue
+++ b/frontend/src/v2/lib/overlays/RDialog/RDialog.vue
@@ -106,6 +106,7 @@ const stackEntry: EscapableEntry = {
   get persistent() {
     return props.persistent;
   },
+  panel: () => panelRef.value,
 };
 
 watch(

--- a/frontend/src/v2/lib/overlays/RDialog/escapeStack.test.ts
+++ b/frontend/src/v2/lib/overlays/RDialog/escapeStack.test.ts
@@ -8,7 +8,11 @@ import {
 } from "./escapeStack";
 
 function entry(panel?: HTMLElement): EscapableEntry {
-  return { close: () => {}, persistent: false, panel: panel && (() => panel) };
+  return {
+    close: () => {},
+    persistent: false,
+    panel: panel ? () => panel : undefined,
+  };
 }
 
 const open: EscapableEntry[] = [];
@@ -42,7 +46,6 @@ describe("onEscapableOpen", () => {
 
     push(e);
     popEscapable(e);
-    open.splice(open.indexOf(e), 1);
     expect(listener).toHaveBeenCalledTimes(1);
 
     stop();
@@ -80,11 +83,5 @@ describe("isUnderOpenEscapable", () => {
     push(entry());
 
     expect(isUnderOpenEscapable(document.createElement("button"))).toBe(false);
-  });
-
-  it("treats a missing node as covered", () => {
-    push(entry(document.createElement("div")));
-
-    expect(isUnderOpenEscapable(null)).toBe(true);
   });
 });

--- a/frontend/src/v2/lib/overlays/RDialog/escapeStack.test.ts
+++ b/frontend/src/v2/lib/overlays/RDialog/escapeStack.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type EscapableEntry,
+  isUnderOpenEscapable,
+  onEscapableOpen,
+  popEscapable,
+  pushEscapable,
+} from "./escapeStack";
+
+function entry(panel?: HTMLElement): EscapableEntry {
+  return { close: () => {}, persistent: false, panel: panel && (() => panel) };
+}
+
+const open: EscapableEntry[] = [];
+function push(e: EscapableEntry) {
+  open.push(e);
+  pushEscapable(e);
+}
+
+afterEach(() => {
+  for (const e of open.splice(0)) popEscapable(e);
+});
+
+describe("onEscapableOpen", () => {
+  it("notifies subscribers on every push until they unsubscribe", () => {
+    const listener = vi.fn();
+    const stop = onEscapableOpen(listener);
+
+    push(entry());
+    push(entry());
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    stop();
+    push(entry());
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not notify on pop", () => {
+    const listener = vi.fn();
+    const stop = onEscapableOpen(listener);
+    const e = entry();
+
+    push(e);
+    popEscapable(e);
+    open.splice(open.indexOf(e), 1);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+});
+
+describe("isUnderOpenEscapable", () => {
+  it("is false when nothing is open", () => {
+    expect(isUnderOpenEscapable(document.createElement("div"))).toBe(false);
+  });
+
+  it("covers a node outside the topmost panel but not one inside it", () => {
+    const panel = document.createElement("div");
+    const inside = panel.appendChild(document.createElement("button"));
+    const outside = document.createElement("button");
+    push(entry(panel));
+
+    expect(isUnderOpenEscapable(outside)).toBe(true);
+    expect(isUnderOpenEscapable(inside)).toBe(false);
+  });
+
+  it("judges against the topmost panel only, so an outer overlay's own content counts as covered", () => {
+    const outer = document.createElement("div");
+    const inOuter = outer.appendChild(document.createElement("button"));
+    const inner = document.createElement("div");
+    push(entry(outer));
+    expect(isUnderOpenEscapable(inOuter)).toBe(false);
+
+    push(entry(inner));
+    expect(isUnderOpenEscapable(inOuter)).toBe(true);
+  });
+
+  it("covers nothing while an entry with no panel is on top", () => {
+    push(entry(document.createElement("div")));
+    push(entry());
+
+    expect(isUnderOpenEscapable(document.createElement("button"))).toBe(false);
+  });
+
+  it("treats a missing node as covered", () => {
+    push(entry(document.createElement("div")));
+
+    expect(isUnderOpenEscapable(null)).toBe(true);
+  });
+});

--- a/frontend/src/v2/lib/overlays/RDialog/escapeStack.ts
+++ b/frontend/src/v2/lib/overlays/RDialog/escapeStack.ts
@@ -58,7 +58,7 @@ function detachListener() {
 export function pushEscapable(entry: EscapableEntry): void {
   stack.push(entry);
   attachListener();
-  for (const listener of [...openListeners]) listener();
+  for (const listener of openListeners) listener();
 }
 
 export function popEscapable(entry: EscapableEntry): void {
@@ -81,7 +81,7 @@ export function onEscapableOpen(listener: () => void): () => void {
 export function isUnderOpenEscapable(el: Node | null): boolean {
   const panel = stack[stack.length - 1]?.panel?.();
   if (!panel) return false;
-  return !el || !panel.contains(el);
+  return !panel.contains(el);
 }
 
 /** True when at least one non-persistent escapable overlay is open.

--- a/frontend/src/v2/lib/overlays/RDialog/escapeStack.ts
+++ b/frontend/src/v2/lib/overlays/RDialog/escapeStack.ts
@@ -27,6 +27,7 @@ export interface EscapableEntry {
 }
 
 const stack: EscapableEntry[] = [];
+const openListeners = new Set<() => void>();
 
 function onWindowKeyDown(evt: KeyboardEvent) {
   if (evt.key !== "Escape") return;
@@ -50,6 +51,7 @@ function detachListener() {
 export function pushEscapable(entry: EscapableEntry): void {
   stack.push(entry);
   attachListener();
+  for (const listener of [...openListeners]) listener();
 }
 
 export function popEscapable(entry: EscapableEntry): void {
@@ -58,6 +60,14 @@ export function popEscapable(entry: EscapableEntry): void {
     stack.splice(idx, 1);
     detachListener();
   }
+}
+
+/** Subscribe to "an overlay just opened". Returns an unsubscribe function.
+ *  RTooltip listens so a hover tip never lingers over the surface it
+ *  launched; the activator's own click is not a reliable dismissal. */
+export function onEscapableOpen(listener: () => void): () => void {
+  openListeners.add(listener);
+  return () => openListeners.delete(listener);
 }
 
 /** True when at least one non-persistent escapable overlay is open.

--- a/frontend/src/v2/lib/overlays/RDialog/escapeStack.ts
+++ b/frontend/src/v2/lib/overlays/RDialog/escapeStack.ts
@@ -17,6 +17,9 @@
 // registry — `useGamepad`'s B/back action calls `hasOpenEscapable()`
 // to decide between "close the top overlay" and "router.back()", so
 // gamepad dismiss and Esc share the same source of truth.
+//
+// Pushing also notifies `onEscapableOpen` subscribers, so surfaces that
+// paint above every overlay (RTooltip) can dismiss themselves.
 
 export interface EscapableEntry {
   close: () => void;
@@ -24,6 +27,10 @@ export interface EscapableEntry {
    *  becomes a no-op for it. Outer entries do not get a chance to
    *  respond either — a persistent layer effectively swallows Esc. */
   persistent: boolean;
+  /** The surface this entry paints, for overlays that own one. Lets
+   *  `isUnderOpenEscapable` tell content inside the overlay apart from
+   *  content the overlay covers. */
+  panel?: () => HTMLElement | null;
 }
 
 const stack: EscapableEntry[] = [];
@@ -62,12 +69,19 @@ export function popEscapable(entry: EscapableEntry): void {
   }
 }
 
-/** Subscribe to "an overlay just opened". Returns an unsubscribe function.
- *  RTooltip listens so a hover tip never lingers over the surface it
- *  launched; the activator's own click is not a reliable dismissal. */
+/** Subscribe to "an overlay just opened". Returns an unsubscribe function. */
 export function onEscapableOpen(listener: () => void): () => void {
   openListeners.add(listener);
   return () => openListeners.delete(listener);
+}
+
+/** True when `el` is covered by the topmost overlay rather than living
+ *  inside it. Entries that declare no panel have no opinion, so nothing
+ *  counts as covered while one of those is on top. */
+export function isUnderOpenEscapable(el: Node | null): boolean {
+  const panel = stack[stack.length - 1]?.panel?.();
+  if (!panel) return false;
+  return !el || !panel.contains(el);
 }
 
 /** True when at least one non-persistent escapable overlay is open.

--- a/frontend/src/v2/lib/overlays/RDialog/escapeStack.ts
+++ b/frontend/src/v2/lib/overlays/RDialog/escapeStack.ts
@@ -27,9 +27,8 @@ export interface EscapableEntry {
    *  becomes a no-op for it. Outer entries do not get a chance to
    *  respond either — a persistent layer effectively swallows Esc. */
   persistent: boolean;
-  /** The surface this entry paints, for overlays that own one. Lets
-   *  `isUnderOpenEscapable` tell content inside the overlay apart from
-   *  content the overlay covers. */
+  /** The surface this entry paints, when it owns one. Read lazily: the
+   *  entry outlives the panel, which mounts only while open. */
   panel?: () => HTMLElement | null;
 }
 
@@ -76,8 +75,7 @@ export function onEscapableOpen(listener: () => void): () => void {
 }
 
 /** True when `el` is covered by the topmost overlay rather than living
- *  inside it. Entries that declare no panel have no opinion, so nothing
- *  counts as covered while one of those is on top. */
+ *  inside it. A panel-less entry has no opinion and covers nothing. */
 export function isUnderOpenEscapable(el: Node | null): boolean {
   const panel = stack[stack.length - 1]?.panel?.();
   if (!panel) return false;

--- a/frontend/src/v2/lib/overlays/RDrawer/RDrawer.vue
+++ b/frontend/src/v2/lib/overlays/RDrawer/RDrawer.vue
@@ -93,6 +93,7 @@ const escEntry: EscapableEntry = {
   get persistent() {
     return props.persistent;
   },
+  panel: () => panelRef.value,
 };
 
 watch(

--- a/frontend/src/v2/lib/structural/RTooltip/RTooltip.stories.ts
+++ b/frontend/src/v2/lib/structural/RTooltip/RTooltip.stories.ts
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/vue3-vite";
 import { expect, waitFor, within } from "storybook/test";
 import { ref } from "vue";
+import RMenu from "@/v2/lib/menus/RMenu/RMenu.vue";
+import RMenuItem from "@/v2/lib/menus/RMenuItem/RMenuItem.vue";
 import RBtn from "@/v2/lib/primitives/RBtn/RBtn.vue";
 import RIcon from "@/v2/lib/primitives/RIcon/RIcon.vue";
 import RTooltip from "./RTooltip.vue";
@@ -497,4 +499,47 @@ export const FormHelper: Story = {
       </div>
     `,
   }),
+};
+
+export const DismissedByOverlay: Story = {
+  name: "Dismissed when an overlay opens",
+  render: () => ({
+    components: { RTooltip, RMenu, RMenuItem },
+    template: `
+      <div style="padding:48px;display:flex;justify-content:center">
+        <section aria-label="Super Mario World" style="padding:24px;border:1px solid var(--r-color-border);border-radius:8px">
+          Super Mario World
+          <RMenu :offset="8">
+            <template #activator="{ props }">
+              <button type="button" v-bind="props" @click.stop>More actions</button>
+            </template>
+            <RMenuItem>Edit</RMenuItem>
+          </RMenu>
+          <RTooltip activator="parent" text="Super Mario World" :open-delay="0" />
+        </section>
+      </div>
+    `,
+  }),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+    const card = canvas.getByRole("region", { name: /super mario world/i });
+    const activator = canvas.getByRole("button", { name: /more actions/i });
+
+    await step("hovering the card reveals its tooltip", async () => {
+      firePointerEnter(card, "mouse");
+      expect(await body.findByRole("tooltip")).toHaveTextContent(
+        "Super Mario World",
+      );
+    });
+
+    await step(
+      "opening the menu dismisses it, even though the activator swallows the click",
+      async () => {
+        activator.click();
+        expect(await body.findByRole("menu")).toBeInTheDocument();
+        await waitFor(() => expect(body.queryByRole("tooltip")).toBeNull());
+      },
+    );
+  },
 };

--- a/frontend/src/v2/lib/structural/RTooltip/RTooltip.stories.ts
+++ b/frontend/src/v2/lib/structural/RTooltip/RTooltip.stories.ts
@@ -509,11 +509,15 @@ export const DismissedByOverlay: Story = {
       <div style="padding:48px;display:flex;justify-content:center">
         <section aria-label="Super Mario World" style="padding:24px;border:1px solid var(--r-color-border);border-radius:8px">
           Super Mario World
-          <RMenu :offset="8">
+          <RMenu>
             <template #activator="{ props }">
               <button type="button" v-bind="props" @click.stop>More actions</button>
             </template>
-            <RMenuItem>Edit</RMenuItem>
+            <RTooltip text="Rename this game" :open-delay="0">
+              <template #activator="{ props: tipProps }">
+                <RMenuItem v-bind="tipProps">Edit</RMenuItem>
+              </template>
+            </RTooltip>
           </RMenu>
           <RTooltip activator="parent" text="Super Mario World" :open-delay="0" />
         </section>
@@ -541,5 +545,18 @@ export const DismissedByOverlay: Story = {
         await waitFor(() => expect(body.queryByRole("tooltip")).toBeNull());
       },
     );
+
+    await step("re-hovering the covered card does not bring it back", () => {
+      firePointerEnter(card, "mouse");
+      expect(body.queryByRole("tooltip")).toBeNull();
+    });
+
+    await step("a tooltip inside the menu still opens", async () => {
+      const menu = within(await body.findByRole("menu"));
+      firePointerEnter(menu.getByRole("button", { name: /edit/i }), "mouse");
+      expect(await body.findByRole("tooltip")).toHaveTextContent(
+        "Rename this game",
+      );
+    });
   },
 };

--- a/frontend/src/v2/lib/structural/RTooltip/RTooltip.stories.ts
+++ b/frontend/src/v2/lib/structural/RTooltip/RTooltip.stories.ts
@@ -560,3 +560,44 @@ export const DismissedByOverlay: Story = {
     });
   },
 };
+
+export const PendingOpenCancelledByOverlay: Story = {
+  name: "Pending open cancelled when an overlay opens",
+  render: () => ({
+    components: { RTooltip, RMenu, RMenuItem, RBtn },
+    template: `
+      <div style="padding:48px;display:flex;justify-content:center">
+        <section aria-label="Chrono Trigger" style="padding:24px;border:1px solid var(--r-color-border);border-radius:8px">
+          Chrono Trigger
+          <RMenu>
+            <template #activator="{ props }">
+              <RBtn v-bind="props" @click.stop>More actions</RBtn>
+            </template>
+            <RMenuItem>Edit</RMenuItem>
+          </RMenu>
+          <RTooltip activator="parent" text="Chrono Trigger" />
+        </section>
+      </div>
+    `,
+  }),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+    const card = canvas.getByRole("region", { name: /chrono trigger/i });
+    const activator = canvas.getByRole("button", { name: /more actions/i });
+
+    await step("the menu opens while the reveal is still pending", async () => {
+      firePointerEnter(card, "mouse");
+      expect(body.queryByRole("tooltip")).toBeNull();
+      activator.click();
+      expect(await body.findByRole("menu")).toBeInTheDocument();
+    });
+
+    await step("the tooltip never lands once the delay elapses", async () => {
+      // Real wait: the pending timer is the thing under test, so it has to be
+      // given its full `openDelay` to fire.
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      expect(body.queryByRole("tooltip")).toBeNull();
+    });
+  },
+};

--- a/frontend/src/v2/lib/structural/RTooltip/RTooltip.stories.ts
+++ b/frontend/src/v2/lib/structural/RTooltip/RTooltip.stories.ts
@@ -504,14 +504,14 @@ export const FormHelper: Story = {
 export const DismissedByOverlay: Story = {
   name: "Dismissed when an overlay opens",
   render: () => ({
-    components: { RTooltip, RMenu, RMenuItem },
+    components: { RTooltip, RMenu, RMenuItem, RBtn },
     template: `
       <div style="padding:48px;display:flex;justify-content:center">
         <section aria-label="Super Mario World" style="padding:24px;border:1px solid var(--r-color-border);border-radius:8px">
           Super Mario World
           <RMenu>
             <template #activator="{ props }">
-              <button type="button" v-bind="props" @click.stop>More actions</button>
+              <RBtn v-bind="props" @click.stop>More actions</RBtn>
             </template>
             <RTooltip text="Rename this game" :open-delay="0">
               <template #activator="{ props: tipProps }">

--- a/frontend/src/v2/lib/structural/RTooltip/RTooltip.vue
+++ b/frontend/src/v2/lib/structural/RTooltip/RTooltip.vue
@@ -45,6 +45,7 @@ import {
   useSlots,
   watch,
 } from "vue";
+import { onEscapableOpen } from "../../overlays/RDialog/escapeStack.js";
 import RIcon from "../../primitives/RIcon/RIcon.vue";
 
 defineOptions({ inheritAttrs: false });
@@ -368,6 +369,15 @@ function detachFromParent() {
   parent.removeEventListener("click", onActivatorClick);
 }
 
+// Tooltips outrank menus in the z-index ladder, so an open tip paints over
+// any overlay that appears. The activator's click is not a reliable dismissal
+// (a nested control can stop it; keyboard and gamepad fire no pointer gesture
+// at all), so close on the overlay itself, ignoring `closeDelay`.
+const stopOverlayDismiss = onEscapableOpen(() => {
+  clearTimers();
+  setOpen(false);
+});
+
 onMounted(() => {
   // For the slot pattern, the reference is the first child rendered
   // by the slot — we read it from the wrapper span on mount.
@@ -381,6 +391,7 @@ onBeforeUnmount(() => {
   detachFromParent();
   clearTimers();
   teardownOutsideClose();
+  stopOverlayDismiss();
 });
 
 // ── Slot activator wrapper ──────────────────────────────────────

--- a/frontend/src/v2/lib/structural/RTooltip/RTooltip.vue
+++ b/frontend/src/v2/lib/structural/RTooltip/RTooltip.vue
@@ -45,7 +45,10 @@ import {
   useSlots,
   watch,
 } from "vue";
-import { onEscapableOpen } from "../../overlays/RDialog/escapeStack.js";
+import {
+  isUnderOpenEscapable,
+  onEscapableOpen,
+} from "../../overlays/RDialog/escapeStack.js";
 import RIcon from "../../primitives/RIcon/RIcon.vue";
 
 defineOptions({ inheritAttrs: false });
@@ -172,6 +175,8 @@ function clearTimers() {
 }
 function show() {
   if (props.disabled || !hasContent.value) return;
+  // A tip whose activator the overlay covers would paint on top of it.
+  if (isUnderOpenEscapable(reference.value)) return;
   clearTimers();
   const d = Number(props.openDelay) || 0;
   if (d <= 0) {
@@ -369,13 +374,11 @@ function detachFromParent() {
   parent.removeEventListener("click", onActivatorClick);
 }
 
-// Tooltips outrank menus in the z-index ladder, so an open tip paints over
-// any overlay that appears. The activator's click is not a reliable dismissal
-// (a nested control can stop it; keyboard and gamepad fire no pointer gesture
-// at all), so close on the overlay itself, ignoring `closeDelay`.
+// A tip paints above every overlay in the z-index ladder, so an overlay
+// opening dismisses it outright, ignoring `closeDelay`.
 const stopOverlayDismiss = onEscapableOpen(() => {
   clearTimers();
-  setOpen(false);
+  if (isOpen.value) setOpen(false);
 });
 
 onMounted(() => {

--- a/frontend/src/v2/lib/structural/RTooltip/RTooltip.vue
+++ b/frontend/src/v2/lib/structural/RTooltip/RTooltip.vue
@@ -376,7 +376,7 @@ function detachFromParent() {
 
 // A tip paints above every overlay in the z-index ladder, so an overlay
 // opening dismisses it outright, ignoring `closeDelay`.
-const stopOverlayDismiss = onEscapableOpen(() => {
+const unsubscribeOverlayDismiss = onEscapableOpen(() => {
   clearTimers();
   if (isOpen.value) setOpen(false);
 });
@@ -394,7 +394,7 @@ onBeforeUnmount(() => {
   detachFromParent();
   clearTimers();
   teardownOutsideClose();
-  stopOverlayDismiss();
+  unsubscribeOverlayDismiss();
 });
 
 // ── Slot activator wrapper ──────────────────────────────────────


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

Clicking a game's "more actions" button left the card's title tooltip stranded on screen, painting over the menu it had just opened.

`GameCard` attaches a full-title `RTooltip` to the card root via `activator="parent"`, so hovering anywhere on the card reveals the game name. Three things then combine:

- `GameActionBtn`'s activator carries `@click.prevent.stop`, so the click never bubbles to the card root, and a click on the activator was `RTooltip`'s only dismissal path.
- Tooltips outrank menus in the z-index ladder (`--r-z-tooltip: 2600` vs `--r-z-menu: 2500`), so the stale label paints *over* the panel. On a card low in the viewport floating-ui flips the menu above the button, straight into where the tooltip sits, and it covers a menu row outright.
- Keyboard and gamepad hit the same gap from the other side: they open the menu with no pointer gesture at all, so there is nothing to dismiss the tip. Tabbing to the button reveals *two* tooltips, and both used to survive the menu opening.

The escape stack already knows the moment any v2 overlay opens, so the fix reads that rather than adding a parallel signal:

- `escapeStack.ts` — `pushEscapable` notifies subscribers; new `onEscapableOpen(listener)` returns an unsubscribe. `EscapableEntry` gains an optional `panel` accessor, and `isUnderOpenEscapable(el)` reports whether a node is covered by the topmost overlay rather than living inside it.
- `RMenu` / `RDialog` / `RDrawer` — each entry now exposes its panel. `RMenu`'s escape-stack watch also runs immediately, so a menu that mounts already open registers (the same reason `RDialog` already does it).
- `RTooltip` — closes itself when an overlay opens, and stays shut while the topmost overlay covers its activator. Tooltips *inside* a menu or dialog keep working, since the panel contains their activator.

Both halves are load-bearing: the listener handles a tooltip that is already open (or has a pending open timer) at the moment the overlay appears; the `show()` guard handles re-hovering covered content while the overlay stays open. Neither subsumes the other.

This fixes every activator shape, not just this one button — any tooltip, however it was revealed, now gets out of the way of a menu, dialog, drawer, or the MatchRom focus overlay.

**AI assistance disclosure**

This PR was written with Claude Code. The investigation (reproducing in Chromium against the real components), the fix, the tests, and this description are all AI-authored, then reviewed and verified as described below.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [x] I've added unit tests that cover the changes

**Testing**

Reproduced in Chromium against the real `GameCard` before fixing, then re-verified after:

- Dark and light, mouse: tooltip reveals on hover, is gone before the panel paints, and returns normally once the menu closes.
- Keyboard: tabbing to the button reveals both tooltips; Enter clears both while opening the menu.
- Touch at 320px: touch-gating already suppresses tooltips; the sheet opens clean.
- Sampled every frame with an in-page `requestAnimationFrame` loop: zero frames where a tooltip is in the DOM while the panel is painted. Tooltips leave by t=44ms; the panel's first painted pixel is t=61ms.

Tests:

- `escapeStack.test.ts` (new) — 6 Vitest cases over `onEscapableOpen` and `isUnderOpenEscapable`, including the panel-less "no opinion" branch.
- `DismissedByOverlay` story with a `play()` covering reveal, dismissal past a stopped click, re-hover suppression, and a tooltip inside the menu still opening.
- `PendingOpenCancelledByOverlay` story covering the overlay opening while a default-delay (300 ms) reveal is still pending.
- Each case confirmed to fail when the specific line it guards is removed.

Gates run locally: `npm run typecheck`, `npm run test` (1241 passed / 115 files), `npm run build`, plus Prettier and ESLint clean on the touched files. Trunk could not run in that environment (its plugin download from `github.com/trunk-io/plugins` was blocked by an egress policy), so it was left to CI — where `Trunk Check` and `trunk_check` pass.

**Known follow-ups (deliberately out of scope)**

- `RSelect`, `RComboboxField` and `RDateField` render popovers at `--r-z-menu` but do not register on the escape stack, so a tooltip can still sit over them. Registering them is the right fix, but it newly exposes them to gamepad-B dismiss and `useOverlayRouteDismiss` — a behaviour change that wants its own PR and test pass.
- `escapeStack.ts` now carries Esc routing, the open broadcast, panel geometry, and the gamepad/route-dismiss registry, while still living under `lib/overlays/RDialog/` even though only one of its nine importers is `RDialog`. Worth moving to `lib/overlays/overlayStack.ts` as a mechanical rename commit.
- Two latent registration gaps, both unreachable in the current codebase and both pre-dating this change, so left alone: `RDrawer`'s escape-stack watch is explicitly `{ immediate: false }`, so a drawer mounted already open would miss Esc and tooltip suppression (its one call site mounts closed, and making it immediate would also fire `lockBodyScroll()` and a focus move on mount, which wants its own test pass); and a *controlled* `RTooltip` opened via `modelValue` bypasses `show()`, so it would skip the coverage guard (there are no `v-model` `RTooltip` usages in v2 today).

#### Screenshots (if applicable)

Captured in Chromium but not attachable from this environment, so described instead — reproducible from the `Media/GameCard` story at a viewport short enough to make the menu flip above the button (1280x620):

- **Before:** the card's "Super Mario World" title tooltip sits on top of the open menu, covering the "Manage collections" row, and stays there for as long as the pointer remains anywhere on the card.
- **After:** the same interaction leaves the menu completely clear; the tooltip returns on hover once the menu is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrZyErjpk1YXbNddKpmhgS