### PR TITLE
fix(frontend-v2): left-align game card titles

### DIFF
--- a/frontend/src/v2/components/GameCard/GameCard.vue
+++ b/frontend/src/v2/components/GameCard/GameCard.vue
@@ -900,7 +900,7 @@ html[data-input="touch"] .r-gc:hover :deep(.r-v2-game-btn--action-status),
   text-overflow: ellipsis;
   transition: color 0.18s;
   padding: 0 1px;
-  text-align: center;
+  text-align: start;
 }
 html[data-input="mouse"] .r-gc:hover .r-gc__label,
 html[data-input="touch"] .r-gc:hover .r-gc__label,
@@ -930,7 +930,7 @@ html[data-input="touch"] .r-gc:hover .r-gc__label,
   font-weight: var(--r-font-weight-semibold);
   max-width: var(--r-hero-w);
   white-space: normal;
-  text-align: center;
+  text-align: start;
   text-overflow: unset;
 }
 

--- a/frontend/src/v2/components/GameCard/GameCardSkeleton.vue
+++ b/frontend/src/v2/components/GameCard/GameCardSkeleton.vue
@@ -57,7 +57,7 @@ const artHeight = computed(() =>
   width: var(--r-card-art-w);
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
 }
 .r-gcs__label {
   /* Match GameCard's `.r-gc__label`: margin-top 7px, font-size 11.5px,
@@ -78,9 +78,9 @@ const artHeight = computed(() =>
 
 /* Hero (16:9) variant — mirrors `GameCard`'s `.r-gc--hero` block. The
    art skeleton picks up its own larger size via the prop-bound CSS
-   vars; here we just widen the container so the centred label sits at
-   the right horizontal width, and bump the label's reserved height to
-   match the hero label's 13px font. */
+   vars; here we just widen the container so the label sits at the right
+   horizontal width, and bump the label's reserved height to match the
+   hero label's 13px font. */
 .r-gcs--hero {
   width: var(--r-hero-w);
 }


### PR DESCRIPTION
**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

The title under a `GameCard` was centred, but the recommendation caption that sits directly below it in the Home rows (`RecommendationReason`) is left-aligned. The two lines of the same caption block disagreed, which is visible on the Home screen under "Recommended for you".

Centring also worked against the label's own constraints. The label is pinned to the cover's exact width (`width: 0; min-width: 100%; max-width: 100%`) and ellipsises at one line, so a short title started inset while a truncated one started at the cover's edge. The text's left edge wandered from card to card instead of tracking the cover grid. Centred text also reads as "complete and balanced" while an ellipsis says the opposite.

Changes:

- `GameCard.vue`: `.r-gc__label` and `.r-gc--hero .r-gc__label` now use `text-align: start` instead of `center`. `start` rather than `left` follows the existing convention in `GameListHeader.vue` and keeps the rule direction-agnostic.
- `GameCardSkeleton.vue`: the label placeholder was centred by `align-items: center` on the skeleton root. It now uses `flex-start` so titles don't jump sideways when the real card replaces the skeleton. The neighbouring comment that described a "centred label" was updated.

This is a shared component, so the change lands consistently across the Home rows, the gallery grid, `SimilarGamesGrid` / `RelatedGamesGrid`, and the match-ROM picker.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR
- [ ] I've added unit tests that cover the changes

No unit tests were added: the change is two CSS declarations plus a flex alignment, with no logic or DOM structure to assert on. Verified visually in Storybook instead (below), and no existing test asserted on label alignment.

Verification run locally:

- `npm run typecheck` (vue-tsc) - clean
- `npm run test` - 1233 tests across 114 files, all passing
- `npm run build` - clean
- Prettier and ESLint on both changed files - clean

Note: `trunk fmt && trunk check` could not be run in this environment, as Trunk's plugin download is blocked by the session's egress policy (HTTP 403 on the `trunk-io/plugins` archive). The linters Trunk wraps were run directly on the touched files instead, and CI's `trunk-check` will cover the rest.

#### Screenshots (if applicable)

Captured from Storybook's `Media/GameCard` `Grid` and `Hero` stories, before vs. after, in both themes and at the `xs` (mobile) breakpoint. Every title now starts flush with its cover's left edge, giving the grid a single vertical text edge instead of a per-card offset.

![image](https://github.com/user-attachments/assets/1d42d07d-dc5a-4706-b262-85e157c71c34)

![image](https://github.com/user-attachments/assets/447f2a90-1836-466b-985a-6e18f32e810d)
**AI assistance disclosure**

This change was written with AI assistance (Claude Code). The alignment problem was raised by a maintainer from a mobile screenshot; the agent located the centring rules, made the change, found and fixed the matching skeleton placeholder, and ran the verification listed above. All output was reviewed by the author before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)