### PR TITLE
chore(ci): drop the docs and website release triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Docker Image and Trigger Docs/Website
+name: Build Docker Image
 
 on:
   # push:
@@ -270,30 +270,3 @@ jobs:
 
           push_variant /tmp/digests/slim "$SLIM_METADATA"
           push_variant /tmp/digests/full "$FULL_METADATA"
-
-  trigger-docs-and-web:
-    # Dispatches into other repositories with a PAT; GITHUB_TOKEN is unused.
-    permissions: {}
-    needs: merge
-    runs-on: ubuntu-latest
-    if: github.event.release.prerelease == false
-    steps:
-      - name: Trigger docs build
-        run: |
-          curl -L -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${DOCS_PAT}" \
-            "https://api.github.com/repos/rommapp/docs/actions/workflows/deploy.yml/dispatches" \
-            -d '{"ref":"main", "inputs": {"version": "${{ github.event.release.tag_name }}"}}'
-        env:
-          DOCS_PAT: ${{ secrets.DOCS_PAT }}
-
-      - name: Trigger website build
-        run: |
-          curl -L -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${DOCS_PAT}" \
-            "https://api.github.com/repos/rommapp/marketing-site/actions/workflows/deploy.yml/dispatches" \
-            -d '{"ref":"main", "inputs": {"version": "${{ github.event.release.tag_name }}"}}'
-        env:
-          DOCS_PAT: ${{ secrets.DOCS_PAT }}


### PR DESCRIPTION
Removes the `trigger-docs-and-web` job from `.github/workflows/build.yml`. On every non-prerelease publish it fired a `workflow_dispatch` at `deploy.yml` in `rommapp/docs` and in `rommapp/marketing-site`. Both are released by hand now, so the job is doing work nobody wants.

It was the last job in the file and nothing depended on it, so the rest of the graph is untouched: `validate-tag-semver` → `build` → `merge`.

Two follow-ons:

- `DOCS_PAT` was referenced only by this job, so the secret is now unused and can be revoked in repo settings.
- The workflow was named "Build Docker Image and Trigger Docs/Website". It no longer does the second half, so it is now just "Build Docker Image". That renames the check as it appears in the Actions UI, and any branch protection rule pinned to the old name needs updating.

Verified the file still parses and the three remaining jobs keep their `needs` edges. No references to `DOCS_PAT`, `rommapp/docs`, or `marketing-site` are left anywhere under `.github/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)